### PR TITLE
Don't force the exit code to 0 by default

### DIFF
--- a/Source/BoogieDriver/BoogieDriver.cs
+++ b/Source/BoogieDriver/BoogieDriver.cs
@@ -89,8 +89,14 @@ namespace Microsoft.Boogie {
           goto END;
         }
       }
-      ExecutionEngine.ProcessFiles(fileList);
-      return 0;
+      
+      int retv = ExecutionEngine.ProcessFiles(fileList);
+      if (CommandLineOptions.Clo.CountVerificationErrors == 0) {
+          return 0;
+      }
+      else {
+          return retv;
+      }
 
     END:
       if (CommandLineOptions.Clo.XmlSink != null) {

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -412,6 +412,7 @@ namespace Microsoft.Boogie {
     public string PrintFile = null;
     public int PrintUnstructured = 0;
     public bool UseBaseNameForFileName = false;
+    public int CountVerificationErrors = 1;
     public int DoomStrategy = -1;
     public bool DoomRestartTP = false;
     public bool PrintDesugarings = false;
@@ -530,6 +531,7 @@ namespace Microsoft.Boogie {
       Contract.Invariant(0 <= ModifiesDefault && ModifiesDefault < 7);
       Contract.Invariant((0 <= PrintErrorModel && PrintErrorModel <= 2) || PrintErrorModel == 4);
       Contract.Invariant(0 <= EnhancedErrorMessages && EnhancedErrorMessages < 2);
+      Contract.Invariant(0 <= CountVerificationErrors && CountVerificationErrors < 2);
       Contract.Invariant(0 <= StepsBeforeWidening && StepsBeforeWidening <= 9);
       Contract.Invariant(-1 <= this.bracketIdsInVC && this.bracketIdsInVC <= 1);
       Contract.Invariant(cce.NonNullElements(this.proverOptions));
@@ -1037,6 +1039,10 @@ namespace Microsoft.Boogie {
 
         case "enhancedErrorMessages":
           ps.GetNumericArgument(ref EnhancedErrorMessages, 2);
+          return true;
+
+        case "countVerificationErrors":
+          ps.GetNumericArgument(ref CountVerificationErrors, 2);
           return true;
 
         case "printCFG":
@@ -1879,6 +1885,11 @@ namespace Microsoft.Boogie {
 
   /useBaseNameForFileName : When parsing use basename of file for tokens instead
                             of the path supplied on the command line
+
+  /CountVerificationErrors:<n>
+                0 - Always set exit code to 0 after verification.
+                1 (default) - Set exit code to non-zero value if errors were
+                              encoutered during verification.
 
   ---- Inference options -----------------------------------------------------
 

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -96,7 +96,8 @@ if os.name == 'posix':
 boogieExecutable += ' -nologo'
 
 # We do not want absolute or relative paths in error messages, just the basename of the file
-boogieExecutable += ' -useBaseNameForFileName'
+# We also want to force error codes to 0
+boogieExecutable += ' -useBaseNameForFileName -countVerificationErrors:0'
 
 # Allow user to provide extra arguments to Boogie
 boogieParams = lit_config.params.get('boogie_params','')


### PR DESCRIPTION
Although it's convenient to force the exit code to zero for lit testing,
it is more conventional (and better for interfacing with other systems)
to return a non-zero error if verification fail: at the moment, the only
way (IIUC) to find out whether verification succeeded (on the command
line) was to parse the textual output of Boogie.

This patch adds a CountVerificationErrors option, and enables it by
default. The patch also sets this option to zero for tests, lest lit get
confused in test cases where verification actually fails.
