### PR TITLE
Dafny bug fix

### DIFF
--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -1133,7 +1133,8 @@ namespace VC {
         }
         if (returnBlocks > 1) {
           string unifiedExitLabel = "GeneratedUnifiedExit";
-          Block unifiedExit = new Block(new Token(-17, -4), unifiedExitLabel, new List<Cmd>(), new ReturnCmd(Token.NoToken));
+          Block unifiedExit;
+          unifiedExit = new Block(new Token(-17, -4), unifiedExitLabel, new List<Cmd>(), new ReturnCmd(impl.StructuredStmts != null ? impl.StructuredStmts.EndCurly : Token.NoToken));         
           Contract.Assert(unifiedExit != null);
           foreach (Block b in impl.Blocks) {
             if (b.TransferCmd is ReturnCmd) {

--- a/Test/test2/BadLineNumber.bpl
+++ b/Test/test2/BadLineNumber.bpl
@@ -1,0 +1,15 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure p();
+  ensures false;
+
+implementation p()
+{
+    if (*)
+    {
+    }
+    else
+    {
+    }
+}

--- a/Test/test2/BadLineNumber.bpl.expect
+++ b/Test/test2/BadLineNumber.bpl.expect
@@ -1,0 +1,7 @@
+BadLineNumber.bpl(15,1): Error BP5003: A postcondition might not hold on this return path.
+BadLineNumber.bpl(5,3): Related location: This is the postcondition that might not hold.
+Execution trace:
+    BadLineNumber.bpl(9,5): anon0
+    BadLineNumber.bpl(14,5): anon3_Else
+
+Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
Instead of using NoToken for the ReturnCmd, use the EndCurly, if it exists, when
creating unifiedExit.