### PR TITLE
Fixed an issue with floating-point type expansions

### DIFF
--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -1746,11 +1746,11 @@ namespace Microsoft.Boogie {
           if (arg0type.Unify(Type.Real) && arg1type.Unify(Type.Real)) {
             return Type.Real;
           }
-          if (arg0type.IsFloat && arg0type.Unify(arg1type)) {
-            return Type.GetFloatType(arg0.Type.FloatSignificand, arg0.Type.FloatExponent);
-          }
-          if (arg1type.IsFloat && arg1type.Unify(arg0type)) {
-            return Type.GetFloatType(arg1.Type.FloatSignificand, arg1.Type.FloatExponent);
+          if (arg0type.IsFloat && arg1type.IsFloat) {
+            if (arg0type.FloatExponent == arg1type.FloatExponent && arg0type.FloatSignificand == arg1type.FloatSignificand) {
+              //So we never call arg0type.Unify, but it should be ok
+              return Type.GetFloatType(arg0type.FloatSignificand, arg0type.FloatExponent);
+            }
           }
           goto BAD_TYPE;
         case Opcode.Div:
@@ -1764,11 +1764,11 @@ namespace Microsoft.Boogie {
               (arg1type.Unify(Type.Int) || arg1type.Unify(Type.Real))) {
             return Type.Real;
           }
-          if (arg0type.IsFloat && arg0type.Unify(arg1type)) {
-            return Type.GetFloatType(arg0.Type.FloatSignificand, arg0.Type.FloatExponent);
-          }
-          if (arg1type.IsFloat && arg1type.Unify(arg0type)) {
-            return Type.GetFloatType(arg1.Type.FloatSignificand, arg1.Type.FloatExponent);
+          if (arg0type.IsFloat && arg1type.IsFloat) {
+            if (arg0type.FloatExponent == arg1type.FloatExponent && arg0type.FloatSignificand == arg1type.FloatSignificand) {
+              //So we never call arg0type.Unify, but it should be ok
+              return Type.GetFloatType(arg0type.FloatSignificand, arg0type.FloatExponent);
+            }
           }
           goto BAD_TYPE;
         case Opcode.Pow:
@@ -1802,8 +1802,10 @@ namespace Microsoft.Boogie {
           if (arg0type.Unify(Type.Real) && arg1type.Unify(Type.Real)) {
             return Type.Bool;
           }
-          if ((arg0type.IsFloat && arg0type.Unify(arg1type)) || (arg1type.IsFloat && arg1type.Unify(arg0type))) {
-            return Type.Bool;
+          if (arg0type.IsFloat && arg1type.IsFloat) {
+            if (arg0type.FloatExponent == arg1type.FloatExponent && arg0type.FloatSignificand == arg1type.FloatSignificand) {
+              return Type.Bool;
+            }
           }
           goto BAD_TYPE;
         case Opcode.And:
@@ -2291,8 +2293,7 @@ namespace Microsoft.Boogie {
   public class ArithmeticCoercion : IAppliable {
     public enum CoercionType {
       ToInt,
-      ToReal,
-      ToFloat
+      ToReal
     }
 
     private IToken/*!*/ tok;

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -2122,6 +2122,23 @@ Contract.Requires(that != null);
         return p != null && p.IsFloat;
       }
     }
+    public override int FloatExponent {
+        get {
+          Type p = ProxyFor;
+          if (p == null || !p.IsFloat)
+            return base.FloatExponent; //Shouldn't happen, so get an unreachable exception
+          return p.FloatExponent;
+        }
+    }
+    public override int FloatSignificand {
+        get {
+          Type p = ProxyFor;
+          if (p == null || !p.IsFloat)
+            return base.FloatSignificand; //Shouldn't happen, so get an unreachable exception
+          return p.FloatSignificand;
+        }
+    }
+
     public override bool IsBool {
       get {
         Type p = ProxyFor;
@@ -2984,6 +3001,22 @@ Contract.Requires(that != null);
         return ExpandedType.IsFloat;
       }
     }
+    public override int FloatExponent 
+    {
+      get 
+      {
+        return ExpandedType.FloatExponent;
+      }
+    }
+
+    public override int FloatSignificand 
+    {
+      get 
+      {
+        return ExpandedType.FloatSignificand;
+      }
+    }
+
     public override bool IsBool {
       get {
         return ExpandedType.IsBool;

--- a/Test/floats/float15.bpl
+++ b/Test/floats/float15.bpl
@@ -1,0 +1,18 @@
+// RUN: %boogie -proverWarnings:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type float = float24e8;
+type f = float;
+
+procedure foo(x : float) returns (r : f)
+{
+	r := 0e128f24e8;
+	r := 1e127f24e8;
+	r := x;
+	r := x * 1e127f24e8;
+	r := x + 1e127f24e8;
+	r := 0e127f24e8 + 0e127f24e8;
+	assert(r == 0e128f24e8);
+	
+	return;
+}

--- a/Test/floats/float15.bpl
+++ b/Test/floats/float15.bpl
@@ -1,16 +1,19 @@
 // RUN: %boogie -proverWarnings:1 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-type float = float24e8;
-type f = float;
+type fl = float24e8;
+type float = fl;
+type do = float53e11;
+type double = do;
 
-procedure foo(x : float) returns (r : f)
+
+procedure foo(x : double) returns (r : float)
 {
 	r := 0e128f24e8;
 	r := 1e127f24e8;
-	r := x;
-	r := x * 1e127f24e8;
-	r := x + 1e127f24e8;
+	r := x; //Error
+	r := x * 1e127f24e8; //Error
+	r := x + 1e127f24e8; //Error
 	r := 0e127f24e8 + 0e127f24e8;
 	assert(r == 0e128f24e8);
 	

--- a/Test/floats/float15.bpl.expect
+++ b/Test/floats/float15.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/floats/float15.bpl.expect
+++ b/Test/floats/float15.bpl.expect
@@ -1,2 +1,4 @@
-
-Boogie program verifier finished with 1 verified, 0 errors
+float15.bpl(14,1): Error: mismatched types in assignment command (cannot assign double to float)
+float15.bpl(15,8): Error: invalid argument types (double and float24e8) to binary operator *
+float15.bpl(16,8): Error: invalid argument types (double and float24e8) to binary operator +
+3 type checking errors detected in float15.bpl

--- a/Test/floats/float16.bpl
+++ b/Test/floats/float16.bpl
@@ -1,0 +1,18 @@
+// RUN: %boogie -proverWarnings:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type float = float24e8;
+type f = float;
+
+procedure foo(x : float) returns (r : f)
+{
+	r := 0e128f24e8;
+	r := 1e127f24e8;
+	r := x;
+	r := x * 1e127f24e8;
+	r := x + 1e127f24e8;
+	r := 0e127f24e8 + 0e127f24e8;
+	assert(r == 0e128f24e8);
+	
+	return;
+}

--- a/Test/floats/float16.bpl.expect
+++ b/Test/floats/float16.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
As the title suggests, this fixes a bug where Boogie would crash when the floating-point type was expanded.  Also adds associated tests.
