### PR TITLE
Extracting map values from error models.

### DIFF
--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -2359,13 +2359,13 @@ namespace VC {
         return newCounterexample;
       }
 
-      private String GenerateTraceValue(Model model, Model.Element element) {
+      private String GenerateTraceValue(Model.Element element) {
         var str = new StringWriter();
         if (element is Model.DatatypeValue) {
           var val = (Model.DatatypeValue) element;
           if (val.ConstructorName == "_" && val.Arguments[0].ToString() == "(as-array)") {
             var parens = val.Arguments[1].ToString();
-            var func = model.TryGetFunc(parens.Substring(1, parens.Length - 2));
+            var func = element.Model.TryGetFunc(parens.Substring(1, parens.Length - 2));
             if (func != null) {
               str.Write("{");
               var appCount = 0;
@@ -2377,14 +2377,14 @@ namespace VC {
                 foreach (var arg in app.Args) {
                   if (argCount++ > 0)
                     str.Write(", ");
-                  str.Write(GenerateTraceValue(model, arg));
+                  str.Write(GenerateTraceValue(arg));
                 }
-                str.Write("]: {0}", GenerateTraceValue(model, app.Result));
+                str.Write("]: {0}", GenerateTraceValue(app.Result));
               }
               if (func.Else != null) {
                 if (func.AppCount > 0)
                   str.Write(", ");
-                str.Write("*: {0}", GenerateTraceValue(model, func.Else));
+                str.Write("*: {0}", GenerateTraceValue(func.Else));
               }
               str.Write("}");
             }
@@ -2483,7 +2483,7 @@ namespace VC {
                       Model.Func f = errModel.TryGetFunc(name);
                       if (f != null)
                       {
-                          args.Add(GenerateTraceValue(errModel, f.GetConstant()));
+                          args.Add(GenerateTraceValue(f.GetConstant()));
                       }
                   }
                   else


### PR DESCRIPTION
For many purposes, including replaying counterexample traces, it would be useful to extract map-typed values from Boogie and Corral counterexample traces. This pull request addresses that by extending Corral’s `boogie_si_record` mechanism.

Consider the following program `a.bpl`:
````
procedure boogie_si_record_int(x:int);
procedure boogie_si_record_map(x:[int]int);

procedure {:entrypoint} main()
{
  var M: [int] int;
  var x: int;
  assume M[0] == 0;
  assume M[1] == 11;
  call boogie_si_record_int(x);
  call boogie_si_record_map(M);
  assert false;
}
````
Without the modifications of this pull request, we observe the following behavior:
````
$ Boogie.exe a.bpl /stratifiedInline:1
Boogie program verifier version 2.3.0.61016, Copyright (c) 2003-2014, Microsoft.
b.bpl(12,3): Error BP5001: This assertion might not hold.
Execution trace:
    b.bpl(8,3): anon0
    value = 2
    value = (_ (as-array) (k!0))

Boogie program verifier finished with 0 verified, 1 error
````
Note that the map-type value simply refers to the identifier `k!0` of the Z3 model. With the modifications of this pull request, we get the following instead:
````
$ Boogie.exe b.bpl /stratifiedInline:1
Boogie program verifier version 2.3.0.61016, Copyright (c) 2003-2014, Microsoft.
b.bpl(12,3): Error BP5001: This assertion might not hold.
Execution trace:
    b.bpl(8,3): anon0
    value = 2
    value = {[1]: 11, [0]: 0, *: 11}

Boogie program verifier finished with 0 verified, 1 error
````
The proposed format for map-type values is:
````
{ [x1, x2, …]: x, [y1, y2, …]: y, …, *: z }
````
where applications are comma separated inside braces `{…}` containing comma-separated arguments inside brackets `[…]`, and the default value is guarded with an asterisk `*`.