### PR TITLE
JSON format form map-type values in counterexample traces.

### DIFF
--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -2294,7 +2294,6 @@ namespace Microsoft.Boogie.SMTLib
       var curr = resp;
       while (curr != null) {
         if (curr.Name == "store") {
-          Console.WriteLine("Got store: {0}", curr);
           var ary = curr.Arguments[0];
           var indices = curr.Arguments.Skip(1).Take(curr.ArgCount - 2).Select(ParseValueFromProver).ToArray();
           var val = curr.Arguments[curr.ArgCount - 1];
@@ -2302,7 +2301,6 @@ namespace Microsoft.Boogie.SMTLib
           curr = ary;
 
         } else if (curr.Name == "" && curr.ArgCount == 2 && curr.Arguments[0].Name == "as") {
-          Console.WriteLine("Got ary: {0}", curr);
           var val = curr.Arguments[1];
           dict.Add("*", ParseValueFromProver(val));
           curr = null;

--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -2371,27 +2371,27 @@ namespace VC {
               var appCount = 0;
               foreach (var app in func.Apps) {
                 if (appCount++ > 0)
-                  str.Write(", ");
-                str.Write("[");
+                  str.Write(",");
+                str.Write("\"");
                 var argCount = 0;
                 foreach (var arg in app.Args) {
                   if (argCount++ > 0)
-                    str.Write(", ");
+                    str.Write(",");
                   str.Write(GenerateTraceValue(arg));
                 }
-                str.Write("]: {0}", GenerateTraceValue(app.Result));
+                str.Write("\":{0}", GenerateTraceValue(app.Result));
               }
               if (func.Else != null) {
                 if (func.AppCount > 0)
-                  str.Write(", ");
-                str.Write("*: {0}", GenerateTraceValue(func.Else));
+                  str.Write(",");
+                str.Write("\"*\":{0}", GenerateTraceValue(func.Else));
               }
               str.Write("}");
             }
           }
         }
         if (str.ToString() == "")
-          str.Write(element.ToString());
+          str.Write(element.ToString().Replace(" ","").Replace("(","").Replace(")",""));
         return str.ToString();
       }
 


### PR DESCRIPTION
Switching to JSON format for map-type values in counterexample traces (see PR #64 and #66) for simplified parsing. For example, given the following code in `a.bpl`
````
procedure boogie_si_record_int(x:int);
procedure boogie_si_record_map(x:[int,bool]int);

procedure {:entrypoint} main()
{
  var M: [int,bool] int;
  var x: int;
  M := M[-2,true := 3][3,false := -5];
  call boogie_si_record_int(x);
  call boogie_si_record_map(M);
  assert false;
}
````
we observe the following
````
$ Boogie.exe a.bpl /doModSetAnalysis /stratifiedInline:1
Boogie program verifier version 2.3.0.61016, Copyright (c) 2003-2014, Microsoft.
a.bpl(11,3): Error BP5001: This assertion might not hold.
Execution trace:
    a.bpl(8,5): anon0
    value = 1
    value = {"3,false":-5,"-2,true":3,"*":0}

Boogie program verifier finished with 0 verified, 1 error
````
and similarly with the `/useProverEvaluate` option.