### PR TITLE
Fix for Issue #71: Repeated modifies clause crash.

### DIFF
--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -479,7 +479,10 @@ namespace Microsoft.Boogie {
         LocalVariable localVar = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, GetProcVarName(proc.Name, mVar.Name), mVar.TypedIdent.Type));
         newLocalVars.Add(localVar);
         IdentifierExpr ie = new IdentifierExpr(Token.NoToken, localVar);
-        substMapOld.Add(mVar, ie);
+        if (!substMapOld.ContainsKey(mVar)) {
+          substMapOld.Add(mVar, ie);
+        }
+
         // FIXME why are we doing this? the modifies list should already include them.
         // add the modified variable to the modifies list of the procedure
         if (!newModifies.Contains(mie)) {


### PR DESCRIPTION
This is a fix for Issue #71 on github, which solves a boogie crash that occurs when an inlined procedure has multiple modifies clauses for the same variable. This fix silently ignores the repeated clause.