### PR TITLE
Fix predication for procedure calls

### DIFF
--- a/Source/Predication/UniformityAnalyser.cs
+++ b/Source/Predication/UniformityAnalyser.cs
@@ -204,6 +204,10 @@ namespace Microsoft.Boogie
                     {
                         newIns.Add(s);
                     }
+                    foreach (string s in outParameters[Proc.Name])
+                    {
+                        newIns.Add("_V" + s);
+                    }
                     inParameters[Proc.Name] = newIns;
                 }
             }
@@ -236,7 +240,7 @@ namespace Microsoft.Boogie
                 foreach (Block b in Impl.Blocks) {
                   Analyse(Impl, b.Cmds, false);
                 }
-                        
+
                 return;
             }
 


### PR DESCRIPTION
If a predicated procedure was called with the predicate
set to false, it would havoc the return values, because
in that case the return values were never assigned in the
predicated procedure. This lead to problems with command
sequences such as:

  p := true;
  x := foo(p);
  x := bar(!p);

where the parameter of both procedures is the predicate.
Instead preserving x, the call to bar would havoc x. To
mitigate this problem, pass the assigned variables to the
predicated procedures, and use the passed value to preserve
the assigned variables in the case the predicate was false.

The above is achieved by transforming, e.g., the procedure

procedure bar() returns (ret : T)
{
  entry:
    [some code]

  [some blocks]
}

into

procedure bar(_P : bool, _Vret : T) returns (ret : T);
  ensures !_P ==> _Vret == ret;

implementation bar(_P : bool, _Vret : T) returns (ret : T)
{
  entry:
    ret := (if _P then ret else _Vret);
    [predicated version of some code]

  [predicated version of some blocks]
}