### PR TITLE
Fix #80: Return correct return type for floating-point expressions

### DIFF
--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -1712,7 +1712,27 @@ namespace Microsoft.Boogie.VCExprAST {
       //Contract.Requires(cce.NonNullElements(typeArgs));
       //Contract.Requires(cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
-      return Type.GetFloatType(Significand, Exponent);
+      switch (op)
+      {
+        case ("+"):
+        case ("-"):
+        case ("*"):
+        case ("/"):
+        case ("rem"):
+          return Type.GetFloatType(Significand, Exponent);
+        case ("min"):
+        case ("max"):
+        case ("<="):
+        case ("<"):
+        case (">="):
+        case (">"):
+        case ("=="):
+        case ("!="):
+          return Type.Bool;
+        default:
+          Contract.Assert(false);
+          throw new cce.UnreachableException();
+      }
     }
 
     [Pure]

--- a/Test/floats/git-issue80.bpl
+++ b/Test/floats/git-issue80.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -noVerify "%s" > "%t"
+// RUN: %boogie -proverWarnings:1 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type Ref;


### PR DESCRIPTION
The return type of floating-point expressions was always computed to be a float. However, the return type of some floating-point expressions will be a bool (fp.eq, fp.lt, fp.geq, etc.). This is fixed by returning the correct type based on the operator in the floating-point expression.