### PR TITLE
Fixed floating-point issues with Corral

### DIFF
--- a/Source/Basetypes/BigFloat.cs
+++ b/Source/Basetypes/BigFloat.cs
@@ -157,57 +157,6 @@ namespace Microsoft.Basetypes
       return new BigFloat(isNeg, sig, exp, sigSize, expSize);
     }
 
-    [Pure]
-    public static BigFloat FromBVString(String s)
-    {
-      /*
-       * String must be either of the format (fp (_ bv* *) (_ bv* *) (_ bv* *))
-       * or of the special value format: (_ val * *)
-       * Where * indicates an integer value
-       * and val is one of the special values: NaN, +oo, -oo, zero, -zero
-       */
-
-      if (s.IndexOf('_') == 1)
-      {
-        s = s.Substring(0, s.Length - 1);
-        String[] args = s.Split(' ');
-        int sigSize = int.Parse(args[3]);
-        int expSize = int.Parse(args[2]);
-        if (sigSize <= 0 || expSize <= 0)
-          throw new FormatException("Significand and Exponent sizes must be greater than 0");
-        return new BigFloat(args[1], sigSize, expSize);
-      }
-      else
-      {
-        String[] args = s.Split('_');
-
-        int expIndex = args[2].IndexOf(' ', args[2].IndexOf(' ') + 1);
-        int sigIndex = args[3].IndexOf(' ', args[3].IndexOf(' ') + 1);
-
-        bool isNeg = args[1][3] == '1';
-        BIM exp = BIM.Parse(args[2].Substring(3, expIndex - 3));
-        int expSize = int.Parse(args[2].Substring(expIndex + 1, args[2].Length - expIndex - 4));
-        BIM sig = BIM.Parse(args[3].Substring(3, sigIndex - 3));
-        int sigSize = int.Parse(args[3].Substring(sigIndex + 1, args[3].Length - sigIndex - 3));
-        if (sigSize <= 0 || expSize <= 0)
-          throw new FormatException("Significand and Exponent sizes must be greater than 0");
-
-        if (sig < 0)
-          throw new FormatException("Significand must be greater than 0");
-
-        if (exp < 0)
-          throw new FormatException("Exponent must be greater than 0");
-
-        if (exp >= BIM.Pow(new BIM(2), expSize))
-          throw new FormatException("The given exponent " + exp + " cannot fit in the bit size " + expSize);
-
-        if (sig >= BIM.Pow(new BIM(2), sigSize))
-          throw new FormatException("The given significand " + sig + " cannot fit in the bit size " + (sigSize + 1));
-
-        return new BigFloat(isNeg, sig, exp, sigSize, expSize);
-      }
-    }
-
     public BigFloat(bool isNeg, BIM significand, BIM exponent, int significandSize, int exponentSize) {
       this.exponentSize = exponentSize;
       this.exponent = exponent;

--- a/Source/Basetypes/BigFloat.cs
+++ b/Source/Basetypes/BigFloat.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Basetypes
     [Pure]
     public override string/*!*/ ToString() {
       Contract.Ensures(Contract.Result<string>() != null);
-      return value == "" ? String.Format("{0}{1}e{2}f{3}e{4}", isNeg ? "-" : "", significand.ToString(), exponent.ToString(), significandSize.ToString(), exponentSize.ToString()) : value;
+      return value == "" ? String.Format("{0}{1}e{2}f{3}e{4}", isNeg ? "-" : "", significand.ToString(), exponent.ToString(), significandSize.ToString(), exponentSize.ToString()) : String.Format("0{0}{1}e{2}", value, significandSize.ToString(), exponentSize.ToString());
     }
 
 

--- a/Source/Basetypes/BigFloat.cs
+++ b/Source/Basetypes/BigFloat.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Basetypes
     [Pure]
     public override string/*!*/ ToString() {
       Contract.Ensures(Contract.Result<string>() != null);
-      return value=="" ? String.Format("{0}x2^{1}", significand.ToString(), Exponent.ToString()) : value;
+      return value == "" ? String.Format("{0}{1}e{2}f{3}e{4}", isNeg ? "-" : "", significand.ToString(), exponent.ToString(), significandSize.ToString(), exponentSize.ToString()) : value;
     }
 
 

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -2380,6 +2380,8 @@ namespace Microsoft.Boogie.SMTLib
         if (resp.Name == "_" && resp.ArgCount == 2 && resp.Arguments[0].Name.StartsWith("bv")) // bitvector
             return new BvConst(Microsoft.Basetypes.BigNum.FromString(resp.Arguments[0].Name.Substring("bv".Length)),
                 int.Parse(resp.Arguments[1].Name));
+        if ((resp.Name == "_" || resp.Name == "fp") && resp.ArgCount == 3) //float
+            return Microsoft.Basetypes.BigFloat.FromBVString(resp.ToString());
         var ary = GetArrayFromProverResponse(resp);
         if (ary != null)
             return ary;

--- a/Source/Provers/SMTLib/SMTLib.csproj
+++ b/Source/Provers/SMTLib/SMTLib.csproj
@@ -162,6 +162,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The ToString method of the BigFloat class was not returning a syntactically correct string representation of floating-point literals. As a result, program.Emit would not print out a program that is semantically equivalent to the in-memory program, which is what Corral expects.

In addition, a VCExprEvaluationException was being thrown in the Evaluate method due to it not being capable of handling floating-point variables.