### PR TITLE
Fixed sign bit not being parsed correctly from floating-point expressions.

### DIFF
--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -2383,13 +2383,15 @@ namespace Microsoft.Boogie.SMTLib
                 int.Parse(resp.Arguments[1].Name));
         if (resp.Name == "fp" && resp.ArgCount == 3) 
         {
-            bool isNeg = int.Parse(resp.Arguments[0].Arguments[1].Name) == 1;
+            Func<SExpr,BigInteger> getBvVal = e => BigInteger.Parse(e.Arguments[0].Name.Substring("bv".Length));
+            Func<SExpr,int> getBvSize = e => int.Parse(e.Arguments[1].ToString());
+            bool isNeg = getBvVal(resp.Arguments[0]).IsOne;
             var expExpr = resp.Arguments[1];
             var sigExpr = resp.Arguments[2];
-            BigInteger exp = BigInteger.Parse(expExpr.Arguments[0].Name.Substring("bv".Length));
-            int expSize = int.Parse(expExpr.Arguments[1].ToString());
-            BigInteger sig = BigInteger.Parse(sigExpr.Arguments[0].Name.Substring("bv".Length));
-            int sigSize = int.Parse(sigExpr.Arguments[1].ToString());
+            BigInteger exp = getBvVal(expExpr);
+            int expSize = getBvSize(expExpr);
+            BigInteger sig = getBvVal(sigExpr);
+            int sigSize = getBvSize(expExpr);
             return new Basetypes.BigFloat(isNeg, sig, exp, sigSize, expSize);
         }
         if (resp.Name == "_" && resp.ArgCount == 3)

--- a/Test/floats/EvaluateSignBit.bpl
+++ b/Test/floats/EvaluateSignBit.bpl
@@ -1,0 +1,15 @@
+// RUN: %boogie -proverWarnings:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+procedure foo()
+{
+  var a : float53e11;
+  var b : float53e11;
+  var c : float53e11;
+  a := 2533274790395904e1028f53e11; //50.0
+  b := 3483252836794368e1023f53e11; //1.99
+  c := -3483252836794368e1023f53e11; //-1.99
+  b := (b * a) / a;
+  c := (c * a) / a;
+  assert (b > 0e0f53e11); //b should be positive
+  assert (c < 0e0f53e11); //c should be negative
+}

--- a/Test/floats/EvaluateSignBit.bpl.expect
+++ b/Test/floats/EvaluateSignBit.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
The Evaluate method was not parsing out the sign bit correctly from floating-point expressions due to using an incorrect argument. For example, given the expression "(fp (_ bv0 1) (_ bv2 8) (_ bv2 23))", containing the argument "(_ bv0 1)", the "1" would be interpreted as the sign bit. However, the sign bit is actually the "0" portion of the "bv0" string.