### PR TITLE
Fixed significand size calculation in Evaluate method

### DIFF
--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -2391,7 +2391,7 @@ namespace Microsoft.Boogie.SMTLib
             BigInteger exp = getBvVal(expExpr);
             int expSize = getBvSize(expExpr);
             BigInteger sig = getBvVal(sigExpr);
-            int sigSize = getBvSize(expExpr);
+            int sigSize = getBvSize(sigExpr);
             return new Basetypes.BigFloat(isNeg, sig, exp, sigSize, expSize);
         }
         if (resp.Name == "_" && resp.ArgCount == 3)


### PR DESCRIPTION
This fixes an issue where Boogie would incorrectly calculate the significand size using the exponent part of floating-point expressions instead of the significand part.