### PR TITLE
Changes visibility of LinearTypeEraser to public

### DIFF
--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -983,7 +983,7 @@ namespace Microsoft.Boogie
         }
     }
 
-    class LinearTypeEraser : ReadOnlyVisitor
+    public class LinearTypeEraser : ReadOnlyVisitor
     {
         public override Variable VisitVariable(Variable node)
         {


### PR DESCRIPTION
This increases the visibility of the LinearTypeEraser class in order for Corral to have access to it.