### PR TITLE
simplify CIVL logic using C# 7.0 pattern matching

### DIFF
--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -251,9 +251,8 @@ namespace Microsoft.Boogie
 
             // We process triggers of quantifer expressions here, because otherwise the
             // substitutions for bound variables have to be leaked outside this procedure.
-            if (node is QuantifierExpr)
+            if (node is QuantifierExpr quantifierExpr)
             {
-                QuantifierExpr quantifierExpr = (QuantifierExpr)node;
                 if (quantifierExpr.Triggers != null)
                 {
                     ((QuantifierExpr)expr).Triggers = this.VisitTrigger(quantifierExpr.Triggers);
@@ -436,8 +435,7 @@ namespace Microsoft.Boogie
                 if (kv.Key != CivlAttributes.LAYER) continue;
                 foreach (var o in kv.Params)
                 {
-                    LiteralExpr l = o as LiteralExpr;
-                    if (l != null && l.isBigNum)
+                    if (o is LiteralExpr l && l.isBigNum)
                     {
                         layers.Add(l.asBigNum.ToIntSafe);
                     }
@@ -951,9 +949,9 @@ namespace Microsoft.Boogie
                     {
                         var target = procToYieldingProc[call.Proc];
                         int x = target.upperLayer + 1;
-                        if (target is ActionProc)
+                        if (target is ActionProc actionProc)
                         {
-                            x = Math.Max(x, ((ActionProc)target).refinedAction.asyncFreeLayer);
+                            x = Math.Max(x, actionProc.refinedAction.asyncFreeLayer);
                         }
                         if (x > a.asyncFreeLayer)
                         {
@@ -981,8 +979,7 @@ namespace Microsoft.Boogie
                     {
                         Debug.Assert(callCmd.IsAsync);
 
-                        ActionProc calleeProc = procToYieldingProc[callCmd.Proc] as ActionProc;
-                        if (calleeProc != null && layer > calleeProc.upperLayer)
+                        if (procToYieldingProc[callCmd.Proc] is ActionProc calleeProc && layer > calleeProc.upperLayer)
                         {
                             graph.AddEdge(action, calleeProc.refinedAction);
                         }
@@ -1505,8 +1502,7 @@ namespace Microsoft.Boogie
                     }
                     else
                     {
-                        var actionProc = calleeProc as ActionProc;
-                        if (actionProc != null && actionProc.refinedAction.asyncFreeLayer > callerProc.upperLayer)
+                        if (calleeProc is ActionProc actionProc && actionProc.refinedAction.asyncFreeLayer > callerProc.upperLayer)
                         {
                             ctc.Error(call, "Disappearing layer of caller cannot be lower than async-free layer of callee");
                         }

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -124,8 +124,7 @@ namespace Microsoft.Boogie
 
         private void FlattenAnd(Expr x, List<Expr> xs)
         {
-            NAryExpr naryExpr = x as NAryExpr;
-            if (naryExpr != null && naryExpr.Fun.FunctionName == "&&")
+            if (x is NAryExpr naryExpr && naryExpr.Fun.FunctionName == "&&")
             {
                 FlattenAnd(naryExpr.Args[0], xs);
                 FlattenAnd(naryExpr.Args[1], xs);
@@ -147,14 +146,13 @@ namespace Microsoft.Boogie
             List<Expr> pathExprs = new List<Expr>();
             foreach (Cmd cmd in cmdStack)
             {
-                if (cmd is AssumeCmd)
+                if (cmd is AssumeCmd assumeCmd)
                 {
-                    AssumeCmd assumeCmd = cmd as AssumeCmd;
                     FlattenAnd(assumeCmd.Expr, pathExprs);
                 }
                 else if (cmd is AssignCmd)
                 {
-                    AssignCmd assignCmd = (cmd as AssignCmd).AsSimpleAssignCmd;
+                    AssignCmd assignCmd = ((AssignCmd)cmd).AsSimpleAssignCmd;
                     Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
                     for (int k = 0; k < assignCmd.Lhss.Count; k++)
                     {
@@ -180,8 +178,7 @@ namespace Microsoft.Boogie
             {
                 var expr = path.varToExpr[v];
                 usedExistsVars.UnionWith(VariableCollector.Collect(expr).Intersect(allExistsVars));
-                IdentifierExpr ie = expr as IdentifierExpr;
-                if (ie != null && IsExistsVar(ie.Decl) && !existsSubstitutionMap.ContainsKey(ie.Decl))
+                if (expr is IdentifierExpr ie && IsExistsVar(ie.Decl) && !existsSubstitutionMap.ContainsKey(ie.Decl))
                 {
                     existsSubstitutionMap[ie.Decl] = Expr.Ident(v);
                 }
@@ -261,12 +258,7 @@ namespace Microsoft.Boogie
 
         private bool IsMapStoreExpr(Expr expr)
         {
-            NAryExpr naryExpr = expr as NAryExpr;
-            if (naryExpr == null)
-            {
-                return false;
-            }
-            return naryExpr.Fun is MapStore;
+            return (expr is NAryExpr naryExpr && naryExpr.Fun is MapStore);
         }
 
         private IEnumerable<NAryExpr> FilterEqualities(IEnumerable<Expr> exprs)
@@ -295,14 +287,12 @@ namespace Microsoft.Boogie
             {
                 Variable eVar = null;
                 Expr eVarSubstExpr = null;
-                IdentifierExpr arg0 = eqExpr.Args[0] as IdentifierExpr;
-                IdentifierExpr arg1 = eqExpr.Args[1] as IdentifierExpr;
-                if (arg0 != null && IsExistsVar(arg0.Decl))
+                if (eqExpr.Args[0] is IdentifierExpr arg0 && IsExistsVar(arg0.Decl))
                 {
                     eVar = arg0.Decl;
                     eVarSubstExpr = eqExpr.Args[1];
                 }
-                else if (arg1 != null && IsExistsVar(arg1.Decl))
+                else if (eqExpr.Args[1] is IdentifierExpr arg1 && IsExistsVar(arg1.Decl))
                 {
                     eVar = arg1.Decl;
                     eVarSubstExpr = eqExpr.Args[0];

--- a/Source/Concurrency/YieldTypeChecker.cs
+++ b/Source/Concurrency/YieldTypeChecker.cs
@@ -301,9 +301,9 @@ namespace Microsoft.Boogie
                     edgeLabels[new Tuple<Absy, Absy>(block, blockEntry)] = P;
 
                     // Block exit edges
-                    if (block.TransferCmd is GotoCmd)
+                    if (block.TransferCmd is GotoCmd gotoCmd)
                     {
-                        foreach (Block successor in ((GotoCmd)block.TransferCmd).labelTargets)
+                        foreach (Block successor in gotoCmd.labelTargets)
                         {
                             edgeLabels[new Tuple<Absy, Absy>(block.TransferCmd, successor)] = P;
                         }
@@ -319,13 +319,13 @@ namespace Microsoft.Boogie
                         Cmd cmd = block.Cmds[i];
                         Absy next = (i + 1 == block.Cmds.Count) ? (Absy)block.TransferCmd : block.Cmds[i + 1];
                         Tuple<Absy, Absy> edge = new Tuple<Absy, Absy>(cmd, next);
-                        if (cmd is CallCmd)
+                        if (cmd is CallCmd callCmd)
                         {
-                            edgeLabels[edge] = CallCmdLabel((CallCmd)cmd);
+                            edgeLabels[edge] = CallCmdLabel(callCmd);
                         }
-                        else if (cmd is ParCallCmd)
+                        else if (cmd is ParCallCmd parCallCmd)
                         {
-                            edgeLabels[edge] = ParCallCmdLabel((ParCallCmd)cmd);
+                            edgeLabels[edge] = ParCallCmdLabel(parCallCmd);
                         }
                         else if (cmd is YieldCmd)
                         {


### PR DESCRIPTION
This avoids a lot of casting in the CIVL code, which makes it cleaner and easier to read.

There is no change in functionality, but can somebody check if it compiles on other setups? On my Ubuntu machine running Mono 5.18 everything is fine.