### PR TITLE
Unsat Core Extraction Added.

### DIFF
--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -490,6 +490,7 @@ namespace Microsoft.Boogie {
     public string Z3ExecutableName = null;
     public string CVC4ExecutablePath = null;
     public int KInductionDepth = -1;
+    public int EnableUnSatCoreExtract = 0;
 
     private string/*!*/ _logPrefix = "";
 
@@ -1352,6 +1353,12 @@ namespace Microsoft.Boogie {
             RecursionBound = Int32.Parse(cce.NonNull(args[ps.i]));
           }
           return true;
+        case "enableUnSatCoreExtraction":
+            if (ps.ConfirmArgumentCount(1))
+            {
+                EnableUnSatCoreExtract = Int32.Parse(cce.NonNull(args[ps.i]));
+            }
+            return true;
         case "stackDepthBound":
           if (ps.ConfirmArgumentCount(1))
           {
@@ -1531,8 +1538,7 @@ namespace Microsoft.Boogie {
 			UseSmtOutputFormat = true;
 		  }
 	      return true;
-		}
-		
+		}        
         case "z3opt":
           if (ps.ConfirmArgumentCount(1)) {
             AddZ3Option(cce.NonNull(args[ps.i]));

--- a/Source/VCGeneration/Check.cs
+++ b/Source/VCGeneration/Check.cs
@@ -571,10 +571,16 @@ namespace Microsoft.Boogie {
     }
 
     // (assert vc)
-    public virtual void Assert(VCExpr vc, bool polarity, bool isSoft = false, int weight = 1)
+    public virtual void Assert(VCExpr vc, bool polarity, bool isSoft = false, int weight = 1, string name = null)
     {
         throw new NotImplementedException();
     }
+
+    public virtual List<string> UnsatCore()
+    {
+        throw new NotImplementedException();
+    }
+
 
     // (assert implicit-axioms)
     public virtual void AssertAxioms()


### PR DESCRIPTION
set-option :produce-unsat-cores true is set by /enableUnSatCoreExtraction:1 at command line. 