### PR TITLE
Fixed regression to properly reflect behavior of RNA rounding mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 solution: "Source/Boogie.sln"
 env:
   global:
-    - Z3URL=https://github.com/Z3Prover/z3/releases/download/z3-4.5.0/z3-4.5.0-x64-ubuntu-14.04.zip
+    - Z3URL=https://github.com/Z3Prover/z3/releases/download/z3-4.8.4/z3-4.8.4.d6df51951f4c-x64-ubuntu-14.04.zip
   matrix:
     - BOOGIE_CONFIG=Debug
     - BOOGIE_CONFIG=Release

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can also report issues on our [issue tracker](https://github.com/boogie-org/
 ### Requirements
 
 - [NuGet](https://www.nuget.org/)
-- [Z3](https://github.com/Z3Prover/z3) 4.5.0 (earlier versions may also work, but the test suite assumes 4.5.0 to produce the expected output) or [CVC4](http://cvc4.cs.nyu.edu/web/) **FIXME_VERSION** (note
+- [Z3](https://github.com/Z3Prover/z3) 4.8.4 (earlier versions may also work, but the test suite assumes 4.8.4 to produce the expected output) or [CVC4](http://cvc4.cs.nyu.edu/web/) **FIXME_VERSION** (note
   CVC4 support is experimental)
 
 #### Windows specific

--- a/Test/floats/RoundingMode2.bpl
+++ b/Test/floats/RoundingMode2.bpl
@@ -28,9 +28,13 @@ procedure Main()
   rm := RNA;
   assert D2I(rm,R2D(RNE,2.3)) == 2bv64;
   assert D2I(rm,R2D(RNE,2.5)) == 3bv64;
-  assert D2I(rm,R2D(RNE,3.5)) == 4bv64;
   assert D2I(rm,R2D(RNE,-2.3)) == 18446744073709551614bv64;
   assert D2I(rm,R2D(RNE,-2.5)) == 18446744073709551613bv64;
+
+  // These assertions should pass.
+  // They were broken in a previous version of Z3 (4.5.0),
+  // but work correctly with Z3 4.8.4.
+  assert D2I(rm,R2D(RNE,3.5)) == 4bv64;
   assert D2I(rm,R2D(RNE,-3.5)) == 18446744073709551612bv64;
 
   rm := RTP;

--- a/Test/floats/RoundingMode2.bpl
+++ b/Test/floats/RoundingMode2.bpl
@@ -28,10 +28,10 @@ procedure Main()
   rm := RNA;
   assert D2I(rm,R2D(RNE,2.3)) == 2bv64;
   assert D2I(rm,R2D(RNE,2.5)) == 3bv64;
-  assert D2I(rm,R2D(RNE,3.5)) == 3bv64;
+  assert D2I(rm,R2D(RNE,3.5)) == 4bv64;
   assert D2I(rm,R2D(RNE,-2.3)) == 18446744073709551614bv64;
   assert D2I(rm,R2D(RNE,-2.5)) == 18446744073709551613bv64;
-  assert D2I(rm,R2D(RNE,-3.5)) == 18446744073709551613bv64;
+  assert D2I(rm,R2D(RNE,-3.5)) == 18446744073709551612bv64;
 
   rm := RTP;
   assert D2I(rm,R2D(RNE,2.3)) == 3bv64;


### PR DESCRIPTION
Some assertions in RoundingMode2.bpl were not accurately reflecting the behavior of the RoundNearestTiesToAway (RNA) rounding mode. The original assertions were passing (incorrectly) under Z3 4.5.0. However, under Z3 4.8.4, the updated assertions pass.