### PR TITLE
Fixes bugs and cleans code in BigFloat.cs

### DIFF
--- a/Source/Basetypes/BigFloat.cs
+++ b/Source/Basetypes/BigFloat.cs
@@ -317,27 +317,20 @@ namespace Microsoft.Basetypes
     // Basic arithmetic operations
 
     [Pure]
-    public BigFloat Negate {
-      get {
-        if (value != "") {
-          if (value[0] == '-') {
-            return new BigFloat("+oo", significandSize, exponentSize);
-          }
-
-          if (value[0] == '+') {
-            return new BigFloat("-oo", significandSize, exponentSize);
-          }
-
-          return new BigFloat("NaN", significandSize, exponentSize);
+    public static BigFloat operator -(BigFloat x) {
+      if (x.value != "") {
+        if (x.value[0] == '-') {
+          return new BigFloat("+oo", x.significandSize, x.exponentSize);
         }
 
-        return new BigFloat(!isSignBitSet, significand, exponent, significandSize, exponentSize);
-      }
-    }
+        if (x.value[0] == '+') {
+          return new BigFloat("-oo", x.significandSize, x.exponentSize);
+        }
 
-    [Pure]
-    public static BigFloat operator -(BigFloat x) {
-      return x.Negate;
+        return new BigFloat("NaN", x.significandSize, x.exponentSize);
+      }
+
+      return new BigFloat(!x.isSignBitSet, x.significand, x.exponent, x.significandSize, x.exponentSize);
     }
 
     [Pure]
@@ -429,7 +422,7 @@ namespace Microsoft.Basetypes
 
     [Pure]
     public static BigFloat operator -(BigFloat x, BigFloat y) {
-      return x + y.Negate;
+      return x + -y;
     }
 
     [Pure]

--- a/Source/Basetypes/BigFloat.cs
+++ b/Source/Basetypes/BigFloat.cs
@@ -500,6 +500,12 @@ namespace Microsoft.Basetypes
       }
     }
 
+    /// <summary>
+    /// This method follows the specification for C#'s Single.CompareTo method.
+    /// As a result, it handles NaNs differently than how the ==, !=, <, >, <=, and >= operators do.
+    /// For example, the expression (0.0f / 0.0f).CompareTo(0.0f / 0.0f) should return 0,
+    /// whereas the expression (0.0f / 0.0f) == (0.0f / 0.0f) should return false.
+    /// </summary>
     [Pure]
     public int CompareTo(BigFloat that) {
       Contract.Requires(exponentSize == that.exponentSize);

--- a/Source/Basetypes/BigFloat.cs
+++ b/Source/Basetypes/BigFloat.cs
@@ -5,19 +5,17 @@
 //-----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
-using System.Diagnostics.Contracts;
-using System.Diagnostics;
 
 namespace Microsoft.Basetypes
 {
   using BIM = System.Numerics.BigInteger;
 
   /// <summary>
-  /// A representation of a 32-bit floating point value
-  /// Note that this value has a 1-bit sign, 8-bit exponent, and 24-bit significand
+  /// A representation of a floating-point value
+  /// Note that this value has a 1-bit sign, along with an exponent and significand whose sizes must be greater than 1
   /// </summary>
   public struct BigFloat
   {
@@ -25,23 +23,11 @@ namespace Microsoft.Basetypes
 
     // the internal representation
     internal readonly BIM significand; //Note that the significand arrangement matches standard fp arrangement (most significant bit is farthest left)
-    internal readonly int significandSize;
+    internal readonly int significandSize; //The bit size of the significand
     internal readonly BIM exponent; //The value of the exponent is always positive as per fp representation requirements
     internal readonly int exponentSize; //The bit size of the exponent
     internal readonly String value; //Only used with second syntax
-    internal readonly bool isNeg;
-
-    public BIM Significand {
-      get {
-        return significand;
-      }
-    }
-
-    public BIM Exponent {
-      get {
-        return exponent;
-      }
-    }
+    internal readonly bool isSignBitSet; //Stores the sign bit in the fp representaiton
 
     public int SignificandSize {
       get {
@@ -55,29 +41,7 @@ namespace Microsoft.Basetypes
       }
     }
 
-    public bool IsNegative {
-      get {
-        return this.isNeg;
-      }
-    }
-
-    public String Value {
-      get {
-        return value;
-      }
-    }
-
     public static BigFloat ZERO = new BigFloat(false, BIM.Zero, BIM.Zero, 24, 8); //Does not include negative zero
-
-    private static readonly BIM two = new BIM(2);
-    private static readonly BIM one = new BIM(1);
-    private static BIM two_n(int n) {
-      BIM toReturn = one;
-      for (int i = 0; i < n; i++)
-        toReturn = toReturn * two;
-      return toReturn;
-    }
-
 
     ////////////////////////////////////////////////////////////////////////////
     // Constructors
@@ -90,28 +54,8 @@ namespace Microsoft.Basetypes
       return new BigFloat(v.ToString(), 24, 8);
     }
 
-    public static BigFloat FromInt(int v, int significandSize, int exponentSize)
-    {
+    public static BigFloat FromBigInt(BIM v, int significandSize, int exponentSize) {
       return new BigFloat(v.ToString(), significandSize, exponentSize);
-    }
-
-    public static BigFloat FromBigInt(BIM v) {
-      return new BigFloat(v.ToString(), 24, 8);
-    }
-
-    public static BigFloat FromBigInt(BIM v, int significandSize, int exponentSize)
-    {
-      return new BigFloat(v.ToString(), significandSize, exponentSize);
-    }
-
-    public static BigFloat FromBigDec(BigDec v)
-    {
-      return new BigFloat(v.ToDecimalString(), 24, 8);
-    }
-
-    public static BigFloat FromBigDec(BigDec v, int significandSize, int exponentSize)
-    {
-      return new BigFloat(v.ToDecimalString(), significandSize, exponentSize);
     }
 
     [Pure]
@@ -144,7 +88,7 @@ namespace Microsoft.Basetypes
         return new BigFloat(s.Substring(1, 3), sigSize, expSize);
       }
 
-      bool isNeg = s[0] == '-';
+      bool isSignBitSet = s[0] == '-';
 
       int posX = s.IndexOf('x');
       int posSecondLastE = s.LastIndexOf('e', posLastE - 1);
@@ -166,19 +110,19 @@ namespace Microsoft.Basetypes
       int posLastOne = binSig.LastIndexOf('1');
 
       if (posFirstOne == -1) {
-        return new BigFloat(isNeg, 0, 0, sigSize, expSize);
+        return new BigFloat(isSignBitSet, 0, 0, sigSize, expSize);
       }
 
       binSig = binSig.Substring(posFirstOne, posLastOne - posFirstOne + 1);
 
-      BIM bias = two_n(expSize - 1) - 1;
+      BIM bias = BIM.Pow(2, expSize - 1) - 1;
       BIM upperBound = 2 * bias + 1;
 
       BIM newExp = 4 * oldExp + bias + (posDec - posFirstOne - 1);
 
       if (newExp <= 0) {
         if (-newExp <= (sigSize - 1) - binSig.Length) {
-          binSig = new string('0', (int)-newExp) + binSig;
+          binSig = new string('0', (int) -newExp) + binSig;
           newExp = 0;
         }
       } else {
@@ -203,15 +147,15 @@ namespace Microsoft.Basetypes
         }
       }
 
-      return new BigFloat(isNeg, newSig, newExp, sigSize, expSize);
+      return new BigFloat(isSignBitSet, newSig, newExp, sigSize, expSize);
     }
 
-    public BigFloat(bool isNeg, BIM significand, BIM exponent, int significandSize, int exponentSize) {
+    public BigFloat(bool isSignBitSet, BIM significand, BIM exponent, int significandSize, int exponentSize) {
       this.exponentSize = exponentSize;
       this.exponent = exponent;
       this.significand = significand;
       this.significandSize = significandSize;
-      this.isNeg = isNeg;
+      this.isSignBitSet = isSignBitSet;
       this.value = "";
     }
 
@@ -221,21 +165,12 @@ namespace Microsoft.Basetypes
       this.exponent = BIM.Zero;
       this.significand = BIM.Zero;
       this.value = value;
-      if (value.Equals("nan"))
+      if (value.Equals("nan")) {
         this.value = "NaN";
-      this.isNeg = value[0] == '-';
+      }
+
+      this.isSignBitSet = value[0] == '-';
     }
-
-    private BIM maxsignificand()
-    {
-      BIM result = one;
-      for (int i = 0; i < significandSize; i++)
-        result = result * two;
-      return result - one;
-    }
-    private int maxExponent() { return (int)Math.Pow(2, exponentSize) - 1; }
-
-
 
     ////////////////////////////////////////////////////////////////////////////
     // Basic object operations
@@ -243,17 +178,20 @@ namespace Microsoft.Basetypes
     [Pure]
     [Reads(ReadsAttribute.Reads.Nothing)]
     public override bool Equals(object obj) {
-      if (obj == null)
+      if (obj == null) {
         return false;
-      if (!(obj is BigFloat))
-        return false;
+      }
 
-      return (this == (BigFloat)obj);
+      if (!(obj is BigFloat)) {
+        return false;
+      }
+
+      return (this == (BigFloat) obj);
     }
 
     [Pure]
     public override int GetHashCode() {
-      return significand.GetHashCode() * 13 + Exponent.GetHashCode();
+      return significand.GetHashCode() * 13 + exponent.GetHashCode();
     }
 
     [Pure]
@@ -270,19 +208,19 @@ namespace Microsoft.Basetypes
         }
 
         for (int i = significandSize - 2; i >= 0; --i) { //little endian
-         if (i / 8 < sigBytes.Length) {
+          if (i / 8 < sigBytes.Length) {
             binSig.Append((char) ('0' + ((sigBytes[i / 8] >> (i % 8)) & 1)));
           } else {
             binSig.Append('0');
           }
         }
 
-        BIM bias = two_n(exponentSize - 1) - 1;
+        BIM bias = BIM.Pow(2, exponentSize - 1) - 1;
         if (exponent == 0) {
           --bias;
         }
 
-        int moveDec = ((int)((exponent - bias) % 4) + 4) % 4;
+        int moveDec = ((int) ((exponent - bias) % 4) + 4) % 4;
         BIM finalExp = (exponent - bias - moveDec) / 4;
 
         string leftBinSig = binSig.ToString().Substring(0, moveDec + 1);
@@ -301,7 +239,7 @@ namespace Microsoft.Basetypes
           rightHexSig.AppendFormat("{0:X}", Convert.ToByte(rightBinSig.Substring(i * 4, 4), 2));
         }
 
-        return String.Format("{0}0x{1}.{2}e{3}f{4}e{5}", isNeg ? "-" : "", leftHexSig, rightHexSig, finalExp, significandSize, exponentSize);
+        return String.Format("{0}0x{1}.{2}e{3}f{4}e{5}", isSignBitSet ? "-" : "", leftHexSig, rightHexSig, finalExp, significandSize, exponentSize);
       }
       return String.Format("0{0}{1}e{2}", value, significandSize, exponentSize);
     }
@@ -310,178 +248,90 @@ namespace Microsoft.Basetypes
     ////////////////////////////////////////////////////////////////////////////
     // Conversion operations
 
-    /// <summary>
-    /// NOTE: THIS METHOD MAY NOT WORK AS EXPECTED!!!
-    /// Converts the given decimal value (provided as a string) to the nearest floating point approximation
-    /// the returned fp assumes the given significand and exponent size
-    /// </summary>
-    /// <param name="value"></param>
-    /// <param name="significandSize"></param>
-    /// <param name="exponentSize"></param>
-    /// <returns></returns>
-    public static BigFloat Round(String value, int exponentSize, int significandSize)
-    {
-      int i = value.IndexOf('.');
-      if (i == -1)
-        return Round(BIM.Parse(value), BIM.Zero, exponentSize, significandSize);
-      return Round(i == 0 ? BIM.Zero : BIM.Parse(value.Substring(0, i)), BIM.Parse(value.Substring(i + 1, value.Length - i - 1)), exponentSize, significandSize);
-    }
-
-    /// <summary>
-    /// NOTE:  THIS METHOD MAY NOT WORK AS EXPECTED!!!!
-    /// Converts value.dec_value to a the closest float approximation with the given significandSize, exponentSize
-    /// Returns the result of this calculation
-    /// </summary>
-    /// <param name="value"></param>
-    /// <param name="power"></param>
-    /// <param name="significandSize"></param>
-    /// <param name="exponentSize"></param>
-    /// <returns></returns>
-    public static BigFloat Round(BIM value, BIM dec_value, int exponentSize, int significandSize)
-    {
-      int exp = 0;
-      BIM one = new BIM(1);
-      BIM ten = new BIM(10);
-      BIM dec_max = new BIM(0); //represents the order of magnitude of dec_value for carrying during calculations
-
-      //First, determine the exponent
-      while (value > one) { //Divide by two, increment exponent by 1
-        if (!(value % two).IsZero) { //Add "1.0" to the decimal
-          dec_max = new BIM(10);
-          while (dec_max < dec_value)
-            dec_max = dec_max * ten;
-          dec_value = dec_value + dec_max;
-        }
-        value = value / two;
-        if (!(dec_value % ten).IsZero)
-          dec_value = dec_value * ten; //Creates excess zeroes to avoid losing data during division
-        dec_value = dec_value / two;
-        exp++;
-      }
-      if (value.IsZero && !dec_value.IsZero) {
-        dec_max = new BIM(10);
-        while (dec_max < dec_value)
-          dec_max = dec_max * ten;
-        while (value.IsZero) {//Multiply by two, decrement exponent by 1
-          dec_value = dec_value * two;
-          if (dec_value >= dec_max) {
-            dec_value = dec_value - dec_max;
-            value = value + one;
-          }
-          exp--;
-        }
-      }
-
-      //Second, calculate the significand
-      value = new BIM(0); //remove implicit bit
-      dec_max = new BIM(10);
-      while (dec_max < dec_value)
-        dec_max = dec_max * ten;
-      for (int i = significandSize; i > 0 && !dec_value.IsZero; i--) { //Multiply by two until the significand is fully calculated
-        dec_value = dec_value * two;
-        if (dec_value >= dec_max) {
-          dec_value = dec_value - dec_max;
-          value = value + two_n(i); //Note that i is decrementing so that the most significant bit is left-most in the representation
-        }
-      }
-
-      return new BigFloat(false, BIM.Zero, BIM.Parse(value.ToString()), exponentSize, significandSize); //Sign not actually checked...
-    }
-
     // ``floor`` rounds towards negative infinity (like SMT-LIBv2's to_int).
     /// <summary>
-    /// NOTE:  This may give wrong results, it hasn't been tested extensively
-    /// If you're getting weird bugs, you may want to check this function out...
     /// Computes the floor and ceiling of this BigFloat. Note the choice of rounding towards negative
     /// infinity rather than zero for floor is because SMT-LIBv2's to_int function floors this way.
     /// </summary>
-    /// <param name="floor">The Floor (rounded towards negative infinity)</param>
+    /// <param name="floor">Floor (rounded towards negative infinity)</param>
     /// <param name="ceiling">Ceiling (rounded towards positive infinity)</param>
-    public void FloorCeiling(out BIM floor, out BIM ceiling)
-    {
-      BIM two = new BIM(2);
+    public void FloorCeiling(out BIM floor, out BIM ceiling) {
+      Contract.Requires(value == "");
 
-      BIM sig = Significand + BIM.Pow(two, SignificandSize); //Add hidden bit
-      BIM exp = Exponent - BIM.Pow(two, ExponentSize-1) + 1;
+      BIM sig = significand;
+      BIM exp = exponent;
 
-      while (exp > BIM.Zero) {
-        exp--;
-        sig = sig << 1;
-      }
+      BIM hiddenBitPow = BIM.Pow(2, significandSize - 1);
 
-      sig = sig >> SignificandSize;
-
-      if (isNeg) {
-        ceiling = -sig + 1;
-        floor = -sig;
-      }
-      else {
-        ceiling = sig + 1;
-        floor = sig;
-      }
-    }
-
-    [Pure]
-    public String ToDecimalString(int maxDigits) {
-      //TODO: fix for fp functionality 
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public String ToBVString(){
-      if (this.IsSpecialType) {
-        return "_ " + this.value + " " + this.exponentSize + " " + this.significandSize;
-      }
-      else if (this.Value == "") {
-        return "fp (_ bv" + (this.isNeg ? "1" : "0") + " 1) (_ bv" + this.exponent + " " + this.exponentSize + ") (_ bv" + this.significand + " " + (this.significandSize-1) + ")";
-      }
-      else {
-        return "(_ to_fp " + this.exponentSize + " " + this.significandSize + ") (_ bv" + this.value + " " + (this.exponentSize + this.significandSize).ToString() + ")";
-      }
-    }
-
-    [Pure]
-    public string ToDecimalString() {
-      Contract.Ensures(Contract.Result<string>() != null);
-      return value=="" ? String.Format("{0}x2^{1}", significand.ToString(), Exponent.ToString()) : value;
-    }
-
-    [Pure]
-    public static string Zeros(int n) {
-      //TODO: fix for fp functionality
-      Contract.Requires(0 <= n);
-      if (n <= 10) {
-        var tenZeros = "0000000000";
-        return tenZeros.Substring(0, n);
+      if (exponent > 0) {
+        sig += hiddenBitPow;
       } else {
-        var d = n / 2;
-        var s = Zeros(d);
-        if (n % 2 == 0) {
-          return s + s;
+        ++exp;
+      }
+
+      exp -= (BIM.Pow(2, exponentSize - 1) - 1) + (significandSize - 1);
+
+      if (exp >= BIM.Zero) {
+        while (exp >= int.MaxValue) {
+          sig <<= int.MaxValue;
+          exp -= int.MaxValue;
+        }
+
+        sig <<= (int) exp;
+        floor = ceiling = (isSignBitSet ? -sig : sig);
+      } else {
+        exp = -exp;
+
+        if (exp > significandSize) {
+          if (sig == 0) {
+            floor = ceiling = 0;
+          } else {
+            ceiling = isSignBitSet ? 0 : 1;
+            floor = ceiling - 1;
+          }
         } else {
-          return s + s + "0";
+          BIM frac = sig & ((BIM.One << (int) exp) - 1);
+          sig >>= (int) exp; //Guaranteed to fit in a 32-bit integer
+
+          if (frac == 0) {
+            floor = ceiling = (isSignBitSet ? -sig : sig);
+          } else {
+            ceiling = isSignBitSet ? -sig : sig + 1;
+            floor = ceiling - 1;
+          }
         }
       }
     }
 
+    public String ToBVString() {
+      if (value != "") {
+        return "_ " + value + " " + exponentSize + " " + significandSize;
+      } else if (value == "") {
+        return "fp (_ bv" + (isSignBitSet ? "1" : "0") + " 1) (_ bv" + exponent + " " + exponentSize + ") (_ bv" + significand + " " + (significandSize - 1) + ")";
+      } else {
+        return "(_ to_fp " + exponentSize + " " + significandSize + ") (_ bv" + value + " " + (exponentSize + significandSize).ToString() + ")";
+      }
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     // Basic arithmetic operations
 
     [Pure]
-    public BigFloat Abs {
-      get {
-        return new BigFloat(true, Significand, Exponent, SignificandSize, ExponentSize);
-      }
-    }
-
-    [Pure]
     public BigFloat Negate {
       get {
-        if (value != "")
-          return value[0] == '-' ? new BigFloat(value.Remove(0, 1), significandSize, ExponentSize) : new BigFloat("-" + value, significandSize, ExponentSize);
-        return new BigFloat(!isNeg, Significand, Exponent, SignificandSize, ExponentSize);
+        if (value != "") {
+          if (value[0] == '-') {
+            return new BigFloat("+oo", significandSize, exponentSize);
+          }
+
+          if (value[0] == '+') {
+            return new BigFloat("-oo", significandSize, exponentSize);
+          }
+
+          return new BigFloat("NaN", significandSize, exponentSize);
+        }
+
+        return new BigFloat(!isSignBitSet, significand, exponent, significandSize, exponentSize);
       }
     }
 
@@ -492,28 +342,89 @@ namespace Microsoft.Basetypes
 
     [Pure]
     public static BigFloat operator +(BigFloat x, BigFloat y) {
-      //TODO: Modify for correct fp functionality
-      Contract.Requires(x.ExponentSize == y.ExponentSize);
-      Contract.Requires(x.SignificandSize == y.SignificandSize);
-      BIM m1 = x.significand;
-      BIM e1 = x.Exponent;
-      BIM m2 = y.significand;
-      BIM e2 = y.Exponent;
-      m1 = m1 + two_n(x.significandSize + 1); //Add implicit bit
-      m2 = m2 + two_n(y.significandSize + 1);
-      if (e2 > e1) {
-        m1 = y.significand;
-        e1 = y.Exponent;
-        m2 = x.significand;
-        e2 = x.Exponent;
+      Contract.Requires(x.exponentSize == y.exponentSize);
+      Contract.Requires(x.significandSize == y.significandSize);
+
+      if (x.value != "" || y.value != "") {
+        if (x.value == "NaN" || y.value == "NaN" || x.value == "+oo" && y.value == "-oo" || x.value == "-oo" && y.value == "+oo") {
+          return new BigFloat("NaN", x.significandSize, x.exponentSize);
+        }
+
+        if (x.value != "") {
+          return new BigFloat(x.value, x.significandSize, x.exponentSize);
+        }
+
+        return new BigFloat(y.value, y.significandSize, y.exponentSize);
       }
 
-      while (e2 < e1) {
-        m2 = m2 / two;
-        e2 = e2 + one;
+      if (x.exponent > y.exponent) {
+        BigFloat temp = x;
+        x = y;
+        y = temp;
       }
 
-      return new BigFloat(false, e1, m1 + m2, x.significandSize, x.ExponentSize);
+      BIM xsig = x.significand, ysig = y.significand;
+      BIM xexp = x.exponent, yexp = y.exponent;
+
+      if (yexp - xexp > x.significandSize) //One of the numbers is relatively insignificant
+      {
+        return new BigFloat(y.isSignBitSet, y.significand, y.exponent, y.significandSize, y.exponentSize);
+      }
+
+      BIM hiddenBitPow = BIM.Pow(2, x.significandSize - 1);
+
+      if (xexp > 0) {
+        xsig += hiddenBitPow;
+      } else {
+        ++xexp;
+      }
+
+      if (yexp > 0) {
+        ysig += hiddenBitPow;
+      } else {
+        ++yexp;
+      }
+
+      if (x.isSignBitSet) {
+        xsig = -xsig;
+      }
+      if (y.isSignBitSet) {
+        ysig = -ysig;
+      }
+
+      xsig >>= (int) (yexp - xexp); //Guaranteed to fit in a 32-bit integer
+
+      ysig += xsig;
+
+      bool isNeg = ysig < 0;
+
+      ysig = BIM.Abs(ysig);
+
+      if (ysig == 0) {
+        return new BigFloat(x.isSignBitSet && y.isSignBitSet, 0, 0, x.significandSize, x.exponentSize);
+      }
+
+      if (ysig >= hiddenBitPow * 2) {
+        ysig >>= 1;
+        ++yexp;
+      }
+
+      while (ysig < hiddenBitPow && yexp > 1) {
+        ysig <<= 1;
+        --yexp;
+      }
+
+      if (ysig < hiddenBitPow) {
+        yexp = 0;
+      } else {
+        ysig -= hiddenBitPow;
+      }
+
+      if (yexp >= BIM.Pow(2, x.exponentSize) - 1) {
+        return new BigFloat(y.isSignBitSet ? "-oo" : "+oo", x.significandSize, x.exponentSize);
+      }
+
+      return new BigFloat(isNeg, ysig, yexp, x.significandSize, x.exponentSize);
     }
 
     [Pure]
@@ -523,73 +434,158 @@ namespace Microsoft.Basetypes
 
     [Pure]
     public static BigFloat operator *(BigFloat x, BigFloat y) {
-      Contract.Requires(x.ExponentSize == y.ExponentSize);
-      Contract.Requires(x.SignificandSize == y.SignificandSize);
-      return new BigFloat(x.isNeg ^ y.isNeg, x.significand * y.significand, x.Exponent + y.Exponent, x.significandSize, x.ExponentSize);
+      Contract.Requires(x.exponentSize == y.exponentSize);
+      Contract.Requires(x.significandSize == y.significandSize);
+
+      if (x.value == "NaN" || y.value == "NaN" || (x.value == "+oo" || x.value == "-oo") && y.IsZero || (y.value == "+oo" || y.value == "-oo") && x.IsZero) {
+        return new BigFloat("NaN", x.significandSize, x.exponentSize);
+      }
+
+      if (x.value != "" || y.value != "") {
+        bool xSignBitSet = x.value == "" ? x.isSignBitSet : x.value[0] == '-';
+        bool ySignBitSet = y.value == "" ? y.isSignBitSet : y.value[0] == '-';
+        return new BigFloat((xSignBitSet ^ ySignBitSet ? "-" : "+") + "oo", x.significandSize, x.exponentSize);
+      }
+
+      BIM xsig = x.significand, ysig = y.significand;
+      BIM xexp = x.exponent, yexp = y.exponent;
+
+      BIM hiddenBitPow = BIM.Pow(2, x.significandSize - 1);
+
+      if (xexp > 0) {
+        xsig += hiddenBitPow;
+      } else {
+        ++xexp;
+      }
+
+      if (yexp > 0) {
+        ysig += hiddenBitPow;
+      } else {
+        ++yexp;
+      }
+
+      ysig *= xsig;
+      yexp += xexp - (BIM.Pow(2, x.exponentSize - 1) - 1) - (x.significandSize - 1);
+
+      while (ysig >= hiddenBitPow * 2 || yexp <= 0) {
+        ysig >>= 1;
+        ++yexp;
+      }
+
+      while (ysig < hiddenBitPow && yexp > 1) {
+        ysig <<= 1;
+        --yexp;
+      }
+
+      if (ysig < hiddenBitPow) {
+        yexp = 0;
+      } else {
+        ysig -= hiddenBitPow;
+      }
+
+      if (yexp >= BIM.Pow(2, x.exponentSize) - 1) {
+        return new BigFloat(x.isSignBitSet ^ y.isSignBitSet ? "-oo" : "+oo", x.significandSize, x.exponentSize);
+      }
+
+      return new BigFloat(x.isSignBitSet ^ y.isSignBitSet, ysig, yexp, x.significandSize, x.exponentSize);
     }
 
 
     ////////////////////////////////////////////////////////////////////////////
     // Some basic comparison operations
 
-    public bool IsSpecialType {
-      get {
-        if (value == "")
-          return false;
-        return (value.Equals("NaN") || value.Equals("+oo") || value.Equals("-oo"));
-      }
-    }
-
-    public bool IsPositive {
-      get {
-        return !IsNegative;
-      }
-    }
-
     public bool IsZero {
       get {
-        return significand.Equals(BigNum.ZERO) && Exponent == BIM.Zero;
+        return value == "" && significand.IsZero && exponent.IsZero;
       }
     }
 
     [Pure]
     public int CompareTo(BigFloat that) {
-      if (this.exponent > that.exponent)
-        return 1;
-      if (this.exponent < that.exponent)
-        return -1;
-      if (this.significand == that.significand)
+      Contract.Requires(exponentSize == that.exponentSize);
+      Contract.Requires(significandSize == that.significandSize);
+
+      if (value == "" && that.value == "") {
+        int cmpThis = IsZero ? 0 : isSignBitSet ? -1 : 1;
+        int cmpThat = that.IsZero ? 0 : that.isSignBitSet ? -1 : 1;
+
+        if (cmpThis == cmpThat) {
+          if (exponent == that.exponent) {
+            return cmpThis * significand.CompareTo(that.significand);
+          }
+
+          return cmpThis * exponent.CompareTo(that.exponent);
+        }
+
+        if (cmpThis == 0) {
+          return -cmpThat;
+        }
+
+        return cmpThis;
+      }
+
+      if (value == that.value) {
         return 0;
-      return this.significand > that.significand ? 1 : -1;
+      }
+
+      if (value == "NaN" || that.value == "+oo" || value == "-oo" && that.value != "NaN") {
+        return -1;
+      }
+
+      return 1;
     }
 
     [Pure]
     public static bool operator ==(BigFloat x, BigFloat y) {
+      if (x.value == "NaN" || y.value == "NaN") {
+        return false;
+      }
+
       return x.CompareTo(y) == 0;
     }
 
     [Pure]
     public static bool operator !=(BigFloat x, BigFloat y) {
+      if (x.value == "NaN" || y.value == "NaN") {
+        return true;
+      }
+
       return x.CompareTo(y) != 0;
     }
 
     [Pure]
     public static bool operator <(BigFloat x, BigFloat y) {
+      if (x.value == "NaN" || y.value == "NaN") {
+        return false;
+      }
+
       return x.CompareTo(y) < 0;
     }
 
     [Pure]
     public static bool operator >(BigFloat x, BigFloat y) {
+      if (x.value == "NaN" || y.value == "NaN") {
+        return false;
+      }
+
       return x.CompareTo(y) > 0;
     }
 
     [Pure]
     public static bool operator <=(BigFloat x, BigFloat y) {
+      if (x.value == "NaN" || y.value == "NaN") {
+        return false;
+      }
+
       return x.CompareTo(y) <= 0;
     }
 
     [Pure]
     public static bool operator >=(BigFloat x, BigFloat y) {
+      if (x.value == "NaN" || y.value == "NaN") {
+        return false;
+      }
+
       return x.CompareTo(y) >= 0;
     }
   }


### PR DESCRIPTION
This pull request does the following:
-Removes many unused properties, methods, and constructors in `BigFloat.cs`
-Fixes the implementation of the `+, *, ==, !=, <=, >=, <, >` operators, the `IsZero` property, and the `FloorCeiling` and `CompareTo` methods
-The two_n method was removed and replaced with calls to `BigInteger.Pow(2, n)`
-The entire class was reformatted to have a consistent code style; changes
include added braces in if/else blocks and inserted spaces after casts
-Added comment in front of `significandSize` field
-Modified comment above `BigFloat` struct to reflect that it can have arbitrary
exponent and significand sizes
-Changed name of `isNeg` field to `isSignBitSet`