### PR TITLE
Fixes crash when @FILE@ expands to path with ':'

### DIFF
--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Boogie {
       if (pattern != null) {
         pattern = pattern.Replace("@PREFIX@", logPrefix).Replace("@TIME@", fileTimestamp);
         string fn = Files.Count == 0 ? "" : Files[Files.Count - 1];
-        fn = fn.Replace('/', '-').Replace('\\', '-');
+        fn = fn.Replace(':', '-').Replace('/', '-').Replace('\\', '-');
         pattern = pattern.Replace("@FILE@", fn);
       }
     }


### PR DESCRIPTION
fixes https://github.com/boogie-org/boogie/issues/129