### PR TITLE
Enabling string operations.

### DIFF
--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -373,6 +373,11 @@ namespace Microsoft.Boogie {
       Contract.Ensures(Contract.Result<LiteralExpr>() != null);
       return new LiteralExpr(Token.NoToken, value);
     }
+    public static LiteralExpr Literal(String value)
+    {
+      Contract.Ensures(Contract.Result<LiteralExpr>() != null);
+      return new LiteralExpr(Token.NoToken, value);
+    }
 
     private static LiteralExpr/*!*/ true_ = Literal(true);
     public static LiteralExpr/*!*/ True {
@@ -645,6 +650,21 @@ namespace Microsoft.Boogie {
         CachedHashCode = ComputeHashCode();
     }
 
+    /// <summary>
+    /// Creates a literal expression for the string value "v".
+    /// </summary>
+    /// <param name="tok"></param>
+    /// <param name="v"></param>
+    public LiteralExpr(IToken/*!*/ tok, String v, bool immutable = false)
+      : base(tok, immutable)
+    {
+      Contract.Requires(tok != null);
+      Val = v;
+      Type = Type.String;
+      if (immutable)
+        CachedHashCode = ComputeHashCode();
+    }
+
     [Pure]
     [Reads(ReadsAttribute.Reads.Nothing)]
     public override bool Equals(object obj) {
@@ -818,6 +838,23 @@ namespace Microsoft.Boogie {
       {
         Contract.Assert(isRoundingMode);
         return (RoundingMode)cce.NonNull(Val);
+      }
+    }
+
+    public bool isString
+    {
+      get
+      {
+        return Val is String;
+      }
+    }
+
+    public String asString
+    {
+      get
+      {
+        Contract.Assert(isString);
+        return (String)cce.NonNull(Val);
       }
     }
 

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -695,6 +695,8 @@ namespace Microsoft.Boogie {
       stream.SetToken(this);
       if (this.Val is bool) {
         stream.Write((bool)this.Val ? "true" : "false"); // correct capitalization
+      } else if (Type.IsString) {
+        stream.Write("\"" + cce.NonNull(this.Val.ToString()) + "\"");
       } else {
         stream.Write(cce.NonNull(this.Val.ToString()));
       }

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -730,6 +730,8 @@ namespace Microsoft.Boogie {
           return Type.GetBvType(((BvConst)Val).Bits);
         } else if (Val is RoundingMode) {
           return Type.RMode;
+        } else if (Val is String) {
+          return Type.String;
         } else {
           {
             Contract.Assert(false);

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -264,6 +264,11 @@ namespace Microsoft.Boogie {
         return false;
       }
     }
+    public virtual bool IsRegEx {
+      get {
+        return false;
+      }
+    }
 
     public virtual bool IsVariable {
       get {
@@ -377,6 +382,7 @@ namespace Microsoft.Boogie {
     public static readonly Type/*!*/ Bool = new BasicType(SimpleType.Bool);
     public static readonly Type/*!*/ RMode = new BasicType(SimpleType.RMode);
     public static readonly Type/*!*/ String = new BasicType(SimpleType.String);
+    public static readonly Type/*!*/ RegEx = new BasicType(SimpleType.RegEx);
     private static BvType[] bvtypeCache;
 
     static public BvType GetBvType(int sz) {
@@ -925,6 +931,8 @@ namespace Microsoft.Boogie {
           return "rmode";
         case SimpleType.String:
           return "string";
+        case SimpleType.RegEx:
+          return "regex";
       }
       Debug.Assert(false, "bad type " + T);
       {
@@ -1062,6 +1070,13 @@ namespace Microsoft.Boogie {
       get
       {
         return this.T == SimpleType.String;
+      }
+    }
+    public override bool IsRegEx
+    {
+      get
+      {
+        return this.T == SimpleType.RegEx;
       }
     }
 
@@ -1511,7 +1526,7 @@ Contract.Requires(that != null);
     public override Type ResolveType(ResolutionContext rc) {
       //Contract.Requires(rc != null);
       Contract.Ensures(Contract.Result<Type>() != null);
-      // first case: the type name denotes a bitvector-type, float-type, rmode-type, or string-type
+      // first case: the type name denotes a bitvector-type, float-type, rmode-type, string-type, or regex-type
 
       if (Name.StartsWith("bv") && Name.Length > 2) {
         bool is_bv = true;
@@ -1573,6 +1588,17 @@ Contract.Requires(that != null);
                    Name);
         }
         return Type.String;
+      }
+
+      if (Name.Equals("regex"))
+      {
+        if (Arguments.Count > 0)
+        {
+          rc.Error(this,
+                   "regex type must not be applied to arguments: {0}",
+                   Name);
+        }
+        return Type.RegEx;
       }
 
       // second case: the identifier is resolved to a type variable
@@ -2213,6 +2239,14 @@ Contract.Requires(that != null);
       {
         Type p = ProxyFor;
         return p != null && p.IsString;
+      }
+    }
+    public override bool IsRegEx
+    {
+      get
+      {
+        Type p = ProxyFor;
+        return p != null && p.IsRegEx;
       }
     }
 
@@ -3102,6 +3136,11 @@ Contract.Requires(that != null);
         return ExpandedType.IsString;
       }
     }
+    public override bool IsRegEx {
+      get {
+        return ExpandedType.IsRegEx;
+      }
+    }
 
     public override bool IsVariable {
       get {
@@ -3873,7 +3912,8 @@ Contract.Ensures(Contract.ValueAtReturn(out tpInstantiation) != null);
     Real,
     Bool,
     RMode,
-    String
+    String,
+    RegEx
   };
 
 

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -259,6 +259,11 @@ namespace Microsoft.Boogie {
         return false;
       }
     }
+    public virtual bool IsString {
+      get {
+        return false;
+      }
+    }
 
     public virtual bool IsVariable {
       get {
@@ -371,6 +376,7 @@ namespace Microsoft.Boogie {
     public static readonly Type/*!*/ Real = new BasicType(SimpleType.Real);
     public static readonly Type/*!*/ Bool = new BasicType(SimpleType.Bool);
     public static readonly Type/*!*/ RMode = new BasicType(SimpleType.RMode);
+    public static readonly Type/*!*/ String = new BasicType(SimpleType.String);
     private static BvType[] bvtypeCache;
 
     static public BvType GetBvType(int sz) {
@@ -917,6 +923,8 @@ namespace Microsoft.Boogie {
           return "bool";
         case SimpleType.RMode:
           return "rmode";
+        case SimpleType.String:
+          return "string";
       }
       Debug.Assert(false, "bad type " + T);
       {
@@ -1047,6 +1055,13 @@ namespace Microsoft.Boogie {
       get
       {
         return this.T == SimpleType.RMode;
+      }
+    }
+    public override bool IsString
+    {
+      get
+      {
+        return this.T == SimpleType.String;
       }
     }
 
@@ -1496,7 +1511,7 @@ Contract.Requires(that != null);
     public override Type ResolveType(ResolutionContext rc) {
       //Contract.Requires(rc != null);
       Contract.Ensures(Contract.Result<Type>() != null);
-      // first case: the type name denotes a bitvector-type, float-type, or rmode-type
+      // first case: the type name denotes a bitvector-type, float-type, rmode-type, or string-type
 
       if (Name.StartsWith("bv") && Name.Length > 2) {
         bool is_bv = true;
@@ -1547,6 +1562,17 @@ Contract.Requires(that != null);
                    Name);
         }
         return Type.RMode;
+      }
+
+      if (Name.Equals("string"))
+      {
+        if (Arguments.Count > 0)
+        {
+          rc.Error(this,
+                   "string type must not be applied to arguments: {0}",
+                   Name);
+        }
+        return Type.String;
       }
 
       // second case: the identifier is resolved to a type variable
@@ -2179,6 +2205,14 @@ Contract.Requires(that != null);
       {
         Type p = ProxyFor;
         return p != null && p.IsRMode;
+      }
+    }
+    public override bool IsString
+    {
+      get
+      {
+        Type p = ProxyFor;
+        return p != null && p.IsString;
       }
     }
 
@@ -3063,6 +3097,11 @@ Contract.Requires(that != null);
         return ExpandedType.IsRMode;
       }
     }
+    public override bool IsString {
+      get {
+        return ExpandedType.IsString;
+      }
+    }
 
     public override bool IsVariable {
       get {
@@ -3833,7 +3872,8 @@ Contract.Ensures(Contract.ValueAtReturn(out tpInstantiation) != null);
     Int,
     Real,
     Bool,
-    RMode
+    RMode,
+    String
   };
 
 

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -1281,6 +1281,7 @@ AtomExpression<out Expr/*!*/ e>
   | Dec<out bd>            (. e = new LiteralExpr(t, bd); .)
 		| Float<out bf>            (. e = new LiteralExpr(t, bf); .)
   | BvLit<out bn, out n> (. e = new LiteralExpr(t, bn, n); .)
+  | string                  (. e = new LiteralExpr(t, t.val.Trim('"')); .)
 
   | Ident<out x>            (. id = new IdentifierExpr(x, x.val);  e = id; .)
     [ "("

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -1800,6 +1800,11 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, bn, n); 
 			break;
 		}
+    case 4: {
+      Get();
+      e = new LiteralExpr(t, t.val.Trim('"'));
+      break;
+    }
 		case 1: {
 			Ident(out x);
 			id = new IdentifierExpr(x, x.val);  e = id; 
@@ -2098,7 +2103,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			Get();
 			Expect(1);
 			key = t.val;  parameters = new List<object/*!*/>(); 
-			if (StartOf(16)) {
+			if (StartOf(9)) {
 				AttributeParameter(out param);
 				parameters.Add(param); 
 				while (la.kind == 13) {
@@ -2201,14 +2206,13 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_T, _T,_T,_T,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_T, _T,_T,_x,_T, _x,_x,_T,_T, _T,_T,_T,_x, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_T,_x, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
-		{_x,_T,_T,_T, _x,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
-		{_x,_T,_T,_T, _x,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
-		{_x,_T,_T,_T, _x,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x}
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x}
 
 	};
 } // end Parser

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -220,6 +220,11 @@ namespace Microsoft.Boogie.SMTLib
         RoundingMode lit = ((VCExprRModeLit)node).Val;
         wr.Write(lit.ToString());
       }
+      else if (node is VCExprStringLit)
+      {
+        String lit = ((VCExprStringLit)node).Val;
+        wr.Write("\"" + lit.ToString() + "\"");
+      }
       else {
         Contract.Assert(false);
         throw new cce.UnreachableException();

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -151,8 +151,10 @@ namespace Microsoft.Boogie.SMTLib
         return "(_ BitVec " + t.BvBits + ")";
       else if (t.IsRMode)
         return "RoundingMode";
-      else if (t.IsString) {
+      else if (t.IsString)
         return "String";
+      else if (t.IsRegEx) {
+        return "(RegEx String)";
       } else {
         StringBuilder sb = new StringBuilder();        
         TypeToStringHelper(t, sb);

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Boogie.SMTLib
           }
           sb.Append(']');
           TypeToStringHelper(m.Result, sb);
-        } else if (t.IsBool || t.IsInt || t.IsReal || t.IsFloat || t.IsBv || t.IsRMode) {
+        } else if (t.IsBool || t.IsInt || t.IsReal || t.IsFloat || t.IsBv || t.IsRMode || t.IsString) {
           sb.Append(TypeToString(t));
         } else {
           System.IO.StringWriter buffer = new System.IO.StringWriter();
@@ -149,8 +149,10 @@ namespace Microsoft.Boogie.SMTLib
         return "(_ FloatingPoint " + t.FloatExponent + " " + t.FloatSignificand + ")";
       else if (t.IsBv)
         return "(_ BitVec " + t.BvBits + ")";
-      else if (t.IsRMode) {
+      else if (t.IsRMode)
         return "RoundingMode";
+      else if (t.IsString) {
+        return "String";
       } else {
         StringBuilder sb = new StringBuilder();        
         TypeToStringHelper(t, sb);

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -316,7 +316,7 @@ void ObjectInvariant()
         return;
       }
 
-      if (type.IsBool || type.IsInt || type.IsReal || type.IsBv || type.IsFloat || type.IsRMode || type.IsString)
+      if (type.IsBool || type.IsInt || type.IsReal || type.IsBv || type.IsFloat || type.IsRMode || type.IsString || type.IsRegEx)
         return;
 
       CtorType ctorType = type as CtorType;

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -316,7 +316,7 @@ void ObjectInvariant()
         return;
       }
 
-      if (type.IsBool || type.IsInt || type.IsReal || type.IsBv || type.IsFloat || type.IsRMode)
+      if (type.IsBool || type.IsInt || type.IsReal || type.IsBv || type.IsFloat || type.IsRMode || type.IsString)
         return;
 
       CtorType ctorType = type as CtorType;

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -338,6 +338,8 @@ namespace Microsoft.Boogie.VCExprAST {
         return Gen.Float(node.asBigFloat);
       } else if (node.Val is RoundingMode) {
         return Gen.RMode(node.asRoundingMode);
+      } else if (node.Val is String) {
+        return Gen.String(node.asString);
       }
       else if (node.Val is BvConst) {
         return Gen.Bitvector((BvConst)node.Val);

--- a/Source/VCExpr/TypeErasure.cs
+++ b/Source/VCExpr/TypeErasure.cs
@@ -464,6 +464,7 @@ namespace Microsoft.Boogie.TypeErasure {
       GetBasicTypeRepr(Type.Bool);
       GetBasicTypeRepr(Type.RMode);
       GetBasicTypeRepr(Type.String);
+      GetBasicTypeRepr(Type.RegEx);
     }
 
     // constructor to allow cloning
@@ -568,6 +569,7 @@ namespace Microsoft.Boogie.TypeErasure {
       GetTypeCasts(Type.Bool);
       GetTypeCasts(Type.RMode);
       GetTypeCasts(Type.String);
+      GetTypeCasts(Type.RegEx);
 
     }
 
@@ -689,7 +691,7 @@ namespace Microsoft.Boogie.TypeErasure {
     [Pure]
     public override bool UnchangedType(Type type) {
       //Contract.Requires(type != null);
-      return type.IsInt || type.IsReal || type.IsBool || type.IsBv || type.IsFloat || type.IsRMode || type.IsString || (type.IsMap && CommandLineOptions.Clo.MonomorphicArrays);
+      return type.IsInt || type.IsReal || type.IsBool || type.IsBv || type.IsFloat || type.IsRMode || type.IsString || type.IsRegEx || (type.IsMap && CommandLineOptions.Clo.MonomorphicArrays);
     }
 
     public VCExpr Cast(VCExpr expr, Type toType) {
@@ -1086,7 +1088,7 @@ namespace Microsoft.Boogie.TypeErasure {
       Contract.Requires(bindings != null);
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
-      Contract.Assume(node.Type == Type.Bool || node.Type == Type.Int || node.Type == Type.Real || node.Type == Type.RMode || node.Type == Type.String);
+      Contract.Assume(node.Type == Type.Bool || node.Type == Type.Int || node.Type == Type.Real || node.Type == Type.RMode || node.Type == Type.String || node.Type == Type.RegEx);
       return node;
     }
 

--- a/Source/VCExpr/TypeErasure.cs
+++ b/Source/VCExpr/TypeErasure.cs
@@ -463,6 +463,7 @@ namespace Microsoft.Boogie.TypeErasure {
       GetBasicTypeRepr(Type.Real);
       GetBasicTypeRepr(Type.Bool);
       GetBasicTypeRepr(Type.RMode);
+      GetBasicTypeRepr(Type.String);
     }
 
     // constructor to allow cloning
@@ -566,6 +567,7 @@ namespace Microsoft.Boogie.TypeErasure {
       GetTypeCasts(Type.Real);
       GetTypeCasts(Type.Bool);
       GetTypeCasts(Type.RMode);
+      GetTypeCasts(Type.String);
 
     }
 
@@ -687,7 +689,7 @@ namespace Microsoft.Boogie.TypeErasure {
     [Pure]
     public override bool UnchangedType(Type type) {
       //Contract.Requires(type != null);
-      return type.IsInt || type.IsReal || type.IsBool || type.IsBv || type.IsFloat || type.IsRMode || (type.IsMap && CommandLineOptions.Clo.MonomorphicArrays);
+      return type.IsInt || type.IsReal || type.IsBool || type.IsBv || type.IsFloat || type.IsRMode || type.IsString || (type.IsMap && CommandLineOptions.Clo.MonomorphicArrays);
     }
 
     public VCExpr Cast(VCExpr expr, Type toType) {
@@ -1084,7 +1086,7 @@ namespace Microsoft.Boogie.TypeErasure {
       Contract.Requires(bindings != null);
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
-      Contract.Assume(node.Type == Type.Bool || node.Type == Type.Int || node.Type == Type.Real || node.Type == Type.RMode);
+      Contract.Assume(node.Type == Type.Bool || node.Type == Type.Int || node.Type == Type.Real || node.Type == Type.RMode || node.Type == Type.String);
       return node;
     }
 

--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -69,6 +69,13 @@ namespace Microsoft.Boogie {
       return new VCExprRModeLit(x);
     }
 
+    public VCExpr/*!*/ String(String x)
+    {
+      Contract.Ensures(Contract.Result<VCExpr>() != null);
+
+      return new VCExprStringLit(x);
+    }
+
     public VCExpr/*!*/ Function(VCExprOp/*!*/ op,
                             List<VCExpr/*!*/>/*!*/ arguments,
                             List<Type/*!*/>/*!*/ typeArguments) {
@@ -938,6 +945,30 @@ namespace Microsoft.Boogie.VCExprAST {
     }
   }
 
+  public class VCExprStringLit : VCExprLiteral
+  {
+    public readonly String Val;
+    internal VCExprStringLit(String val)
+      : base(Type.RMode)
+    {
+      this.Val = val;
+    }
+    [Pure]
+    [Reads(ReadsAttribute.Reads.Nothing)]
+    public override bool Equals(object that)
+    {
+      if (Object.ReferenceEquals(this, that))
+        return true;
+      if (that is VCExprStringLit)
+        return Val == ((VCExprStringLit)that).Val;
+      return false;
+    }
+    [Pure]
+    public override int GetHashCode()
+    {
+      return Val.GetHashCode() * 72321;
+    }
+  }
   /////////////////////////////////////////////////////////////////////////////////
   // Operator expressions with fixed arity
   [ContractClassFor(typeof(VCExprNAry))]

--- a/Test/strings/BasicOperators.bpl
+++ b/Test/strings/BasicOperators.bpl
@@ -1,0 +1,43 @@
+// RUN: %boogie -proverWarnings:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:builtin "str.++"} concat(string, string): string;
+function {:builtin "str.len"} len(string): int;
+function {:builtin "str.substr"} substr(string, int, int): string;
+function {:builtin "str.indexof"} indexOf(string, string): int;
+function {:builtin "str.indexof"} indexOfFromOffset(string, string, int): int;
+function {:builtin "str.at"} at(string, int): string;
+function {:builtin "str.contains"} contains(string, string): bool;
+function {:builtin "str.prefixof"} prefixOf(string, string): bool;
+function {:builtin "str.suffixof"} suffixOf(string, string): bool;
+function {:builtin "str.replace"} replace(string, string, string): string;
+function {:builtin "str.to.int"} stringToInt(string): int;
+function {:builtin "int.to.str"} intToString(int): string;
+
+procedure main() {
+    var s1, s2, s3: string;
+
+    assume len(s1) == 3;
+    assume len(s3) == 3;
+    assume concat(s1,s2) == s3;
+
+    assert len(s1) + len(s2) == len(s3);
+
+    assert substr(s3, len(s1), len(s2)) == s2;
+
+    assert indexOf(s3, s1) == 0;
+
+    assert indexOfFromOffset(s3, s1, 0) == 0;
+
+    assert at(s3, 2) == at(s1, 2);
+
+    assert contains(s3, s1);
+
+    assert prefixOf(s1, s3);
+
+    assert suffixOf(s2, s3);
+
+    assert replace(s3, s1, s2) == concat(s2, s2);
+
+    assert intToString(stringToInt(s1)) == s1;
+}

--- a/Test/strings/BasicOperators.bpl.expect
+++ b/Test/strings/BasicOperators.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/strings/BasicRegExOperators.bpl
+++ b/Test/strings/BasicRegExOperators.bpl
@@ -16,18 +16,27 @@ function {:builtin "re.inter"} intersection(regex, regex): regex;
 
 procedure main() {
     var s1: string;
+    var r1: regex;
 
-    /// needs a concrete instance of s1
-    // assert stringInRegEx(s1, stringToRegEx(s1));
+    s1 := "abcd";
+    r1 := stringToRegEx(s1);
+
+    assert stringInRegEx(s1, stringToRegEx(s1));
+    assert !stringInRegEx(s1, stringToRegEx("ABCD"));
 
     assert stringInRegEx(s1, star(allChar()));
+
     assert !stringInRegEx(s1, noString());
+
     assert !stringInRegEx(s1, concat(noString(), noString()));
+
     assert stringInRegEx(s1, option(plus(allChar())));
+
+    assert !stringInRegEx(s1, loop(noString(), 0, 5));
+    assert stringInRegEx(s1, loop(allChar(), 0, 5));
+
     assert !stringInRegEx(s1, union(noString(), noString()));
     assert stringInRegEx(s1, intersection(star(allChar()), star(allChar())));
 
-    /// not clear when this will work
-    // assert !stringInRegEx(s1, loop(noString(), 0, 3));
 }
 

--- a/Test/strings/BasicRegExOperators.bpl
+++ b/Test/strings/BasicRegExOperators.bpl
@@ -1,0 +1,33 @@
+// RUN: %boogie -proverWarnings:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:builtin "str.to.re"} stringToRegEx(string): regex;
+function {:builtin "str.in.re"} stringInRegEx(string, regex): bool;
+function {:builtin "re.allchar"} allChar(): regex;
+function {:builtin "re.nostr"} noString(): regex;
+function {:builtin "re.range"} range(string, string): regex;
+function {:builtin "re.++"} concat(regex, regex): regex;
+function {:builtin "re.*"} star(regex): regex;
+function {:builtin "re.+"} plus(regex): regex;
+function {:builtin "re.opt"} option(regex): regex;
+function {:builtin "re.loop"} loop(regex, int, int): regex;
+function {:builtin "re.union"} union(regex, regex): regex;
+function {:builtin "re.inter"} intersection(regex, regex): regex;
+
+procedure main() {
+    var s1: string;
+
+    /// needs a concrete instance of s1
+    // assert stringInRegEx(s1, stringToRegEx(s1));
+
+    assert stringInRegEx(s1, star(allChar()));
+    assert !stringInRegEx(s1, noString());
+    assert !stringInRegEx(s1, concat(noString(), noString()));
+    assert stringInRegEx(s1, option(plus(allChar())));
+    assert !stringInRegEx(s1, union(noString(), noString()));
+    assert stringInRegEx(s1, intersection(star(allChar()), star(allChar())));
+
+    /// not clear when this will work
+    // assert !stringInRegEx(s1, loop(noString(), 0, 3));
+}
+

--- a/Test/strings/BasicRegExOperators.bpl.expect
+++ b/Test/strings/BasicRegExOperators.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/strings/Literals.bpl
+++ b/Test/strings/Literals.bpl
@@ -1,0 +1,47 @@
+// RUN: %boogie -proverWarnings:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:builtin "str.++"} concat(string, string): string;
+function {:builtin "str.len"} len(string): int;
+function {:builtin "str.substr"} substr(string, int, int): string;
+function {:builtin "str.indexof"} indexOf(string, string): int;
+function {:builtin "str.indexof"} indexOfFromOffset(string, string, int): int;
+function {:builtin "str.at"} at(string, int): string;
+function {:builtin "str.contains"} contains(string, string): bool;
+function {:builtin "str.prefixof"} prefixOf(string, string): bool;
+function {:builtin "str.suffixof"} suffixOf(string, string): bool;
+function {:builtin "str.replace"} replace(string, string, string): string;
+function {:builtin "str.to.int"} stringToInt(string): int;
+function {:builtin "int.to.str"} intToString(int): string;
+
+procedure main() {
+    assert concat("abc", "def") == "abcdef";
+
+    assert len("abcd") == 4;
+
+    assert substr("abcd", 1, 2) == "bc";
+
+    assert indexOf("abcd", "cd") == 2;
+    assert indexOf("abcd", "dc") == -1;
+
+    assert indexOfFromOffset("abcdabcd", "cd", 0) == 2;
+    assert indexOfFromOffset("abcdabcd", "cd", 3) == 6;
+    assert indexOfFromOffset("abcdabcd", "dc", 1) == -1;
+
+    assert at("abcd", 2) == "c";
+
+    assert contains("abcd", "bc");
+    assert !contains("abcd", "BC");
+
+    assert prefixOf("ab", "abcd");
+    assert !prefixOf("AB", "abcd");
+
+    assert suffixOf("cd", "abcd");
+    assert !suffixOf("CD", "abcd");
+
+    assert replace("aBCd", "BC", "bc") == "abcd";
+
+    assert stringToInt("42") == 42;
+
+    assert intToString(42) == "42";
+}

--- a/Test/strings/Literals.bpl.expect
+++ b/Test/strings/Literals.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
This PR adds native `string` and `regex` types, along with string literals, so that [Z3 string reasoning](https://rise4fun.com/z3/tutorialcontent/sequences#h21) can be leveraged at the Boogie level.

As an example, this allows verification of the following program.
```
procedure main() {
    var s: string;
    s := "a";
    assert in(concat(s,s), star(s2re(s)));
}

function {:builtin "str.in.re"} in(string, regex): bool;
function {:builtin "str.++"} concat(string, string): string;
function {:builtin "re.*"} star(regex): regex;
function {:builtin "str.to.re"} s2re(string): regex;
```