### PR TITLE
Fixed BigFloat construction of the returned FP constants

### DIFF
--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -2456,7 +2456,7 @@ namespace Microsoft.Boogie.SMTLib
             BigInteger exp = getBvVal(expExpr);
             int expSize = getBvSize(expExpr);
             BigInteger sig = getBvVal(sigExpr);
-            int sigSize = getBvSize(sigExpr);
+            int sigSize = getBvSize(sigExpr)+1;
             return new Basetypes.BigFloat(isNeg, sig, exp, sigSize, expSize);
         }
         if (resp.Name == "_" && resp.ArgCount == 3)


### PR DESCRIPTION
It turns out the the FP constants returned by the solver may have the following syntax: `(fp (_ BitVec 1) (_ BitVec eb) (_ BitVec i) (_ FloatingPoint eb sb))`, where `i=sb-1`. This PR sets the correct significand sizes.