### PR TITLE
Lambda lifting based on maximally large bound-var-free subexpressions

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Boogie {
       this.topLevelDeclarations.Emit(stream);
     }
 
-    public void ProcessDatatypeConstructors() {
+    public void ProcessDatatypeConstructors(Errors errors) {
       Dictionary<string, DatatypeConstructor> constructors = new Dictionary<string, DatatypeConstructor>();
       List<Declaration> prunedTopLevelDeclarations = new List<Declaration>();
       foreach (Declaration decl in TopLevelDeclarations) {
@@ -358,14 +358,22 @@ namespace Microsoft.Boogie {
           prunedTopLevelDeclarations.Add(decl);
           continue;
         }
-        if (constructors.ContainsKey(func.Name)) continue;
+        if (constructors.ContainsKey(func.Name))
+        {
+          errors.SemErr(func.tok, string.Format("more than one declaration of datatype constructor name: {0}", func.Name));
+          continue;
+        }
         DatatypeConstructor constructor = new DatatypeConstructor(func);
         constructors.Add(func.Name, constructor);
         prunedTopLevelDeclarations.Add(constructor);
       }
+      if (errors.count > 0)
+      {
+        return;
+      }
+
       ClearTopLevelDeclarations();
       AddTopLevelDeclarations(prunedTopLevelDeclarations);
-    
       foreach (DatatypeConstructor f in constructors.Values) {
         for (int i = 0; i < f.InParams.Count; i++) {
           DatatypeSelector selector = new DatatypeSelector(f, i);

--- a/Source/Core/AbsyQuant.cs
+++ b/Source/Core/AbsyQuant.cs
@@ -575,8 +575,15 @@ namespace Microsoft.Boogie {
       }
     }
 
+    // todo (MR) this was implemented to throw an error; is this bad?
     public override int GetHashCode() {
-      throw new NotImplementedException();
+      int hash = 17;
+      hash = hash * 23 + tr.GetHashCode();
+      hash = hash * 23 + Pos.GetHashCode();
+      if (Next != null) {
+        hash = hash * 23 + Next.GetHashCode();
+      }
+      return hash;
     }
   }
 

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -416,6 +416,7 @@ namespace Microsoft.Boogie {
     public int DoomStrategy = -1;
     public bool DoomRestartTP = false;
     public bool PrintDesugarings = false;
+    public bool FreeVarLambdaLifting = false;
     public string SimplifyLogFilePath = null;
     public bool PrintInstrumented = false;
     public bool InstrumentWithAsserts = false;
@@ -1650,7 +1651,8 @@ namespace Microsoft.Boogie {
               ps.CheckBooleanFlag("verifySeparately", ref VerifySeparately) ||
               ps.CheckBooleanFlag("trustAtomicityTypes", ref TrustAtomicityTypes) ||
               ps.CheckBooleanFlag("trustNonInterference", ref TrustNonInterference) ||
-              ps.CheckBooleanFlag("useBaseNameForFileName", ref UseBaseNameForFileName)
+              ps.CheckBooleanFlag("useBaseNameForFileName", ref UseBaseNameForFileName) ||
+              ps.CheckBooleanFlag("freeVarLambdaLifting", ref FreeVarLambdaLifting)
               ) {
             // one of the boolean flags matched
             return true;
@@ -1910,6 +1912,13 @@ namespace Microsoft.Boogie {
                    identifies variables
   /printUnstructured : with /print option, desugars all structured statements
   /printDesugared : with /print option, desugars calls
+
+  /freeVarLambdaLifting : Boogie's lambda lifting transforms the bodies of lambda
+                         expressions into templates with holes. By default, holes
+                         are maximally large subexpressions that do not contain
+                         bound variables (see Section 8 of Boogie 3 paper).
+                         This option performs a form of lambda lifting
+                         in which holes are the lambda's free variables. 
 
   /overlookTypeErrors : skip any implementation with resolution or type
                         checking errors

--- a/Source/Core/Core.csproj
+++ b/Source/Core/Core.csproj
@@ -177,6 +177,9 @@
     <Compile Include="Duplicator.cs" />
     <Compile Include="Inline.cs" />
     <Compile Include="LambdaHelper.cs" />
+    <Compile Include="MaxHolesLambdaLifter.cs" />
+    <Compile Include="LambdaLiftingMaxHolesFiller.cs" />
+    <Compile Include="LambdaLiftingTemplate.cs" />
     <Compile Include="LoopUnroll.cs" />
     <Compile Include="OOLongUtil.cs" />
     <Compile Include="Parser.cs" />

--- a/Source/Core/LambdaHelper.cs
+++ b/Source/Core/LambdaHelper.cs
@@ -3,13 +3,13 @@
 // Copyright (C) Microsoft Corporation.  All Rights Reserved.
 //
 //-----------------------------------------------------------------------------
+
+using Core;
+
 namespace Microsoft.Boogie {
 
   using System;
-  using System.IO;
-  using System.Collections;
   using System.Collections.Generic;
-  using System.Diagnostics;
   using System.Diagnostics.Contracts;
   using Set = GSet<object>;  // for the purposes here, "object" really means "either Variable or TypeVariable"
 
@@ -37,6 +37,38 @@ namespace Microsoft.Boogie {
       return program;
     }
 
+    /// <summary>
+    /// Performs lambda lifting on all anonymous functions in a program.
+    /// Lambda lifting transforms a lambda abstraction <c>(lambda x : T :: t)</c> of type <c>T -> U</c>
+    /// into a Boogie map of type <c>[T] U</c> as follows:
+    /// <list type="number">
+    /// <item>
+    ///   Certain subexpressions <c>e1</c>, ..., <c>e_n</c> (which have types <c>T1</c>, ..., <c>T_n</c>)
+    ///   of the lambda body [t] are replaced with bound variables <c>b1</c>, ..., <c>b_n</c> of the same types,
+    ///   yielding a new lambda body [u], which represents a lifted lambda <c>(lambda x : T :: u)</c>.
+    /// </item>
+    /// <item>
+    ///   The original lambda is replaced with a function call <c>f(e1, ..., en)</c> where <c>f</c> is a function
+    ///   with <c>n</c> parameters and return type <c>[T] U</c> (i.e. the function returns a map).
+    /// </item>
+    /// <item>
+    ///   The implementation of the lambda is defined through an axiom that states that
+    ///   <c>f(b1, ..., b_n)[x] == u</c>.
+    /// </item>
+    /// </list>
+    /// Lambda lifting algorithms differ based on what kind of subexpressions <c>E_i</c> are "lifted" out
+    /// of the lambda:
+    /// <list type="bullet"></list>
+    /// <item>
+    ///   <see cref="LambdaVisitor.LambdaLiftingFreeVars"/> lifts all free variables of a lambda;
+    /// </item>
+    /// <item>
+    ///   <c>LambdaVisitor.LambdaLifterMaxHoles()</c> lifts a lambda's maximally large subexpressions that are
+    ///   free of bound variables.
+    /// </item>
+    /// <see cref="LambdaVisitor.LambdaLifterMaxHoles"/> is used by default whereas <c>LambdaLiftingFreeVars</c>
+    /// is used with the command-line option <c>/freeVarLambdaLifting</c>.
+    /// </summary>
     public static void ExpandLambdas(Program prog) {
       Contract.Requires(prog != null);
       List<Expr/*!*/>/*!*/ axioms;
@@ -52,6 +84,7 @@ namespace Microsoft.Boogie {
     }
 
     private class LambdaVisitor : StandardVisitor {
+      // todo (MR) why are we not using this map as a cache for lifted lambdas? why are we recomputing them?
       private readonly Dictionary<Expr, FunctionCall> liftedLambdas = 
         new Dictionary<Expr, FunctionCall>(new AlphaEquality());
 
@@ -76,6 +109,32 @@ namespace Microsoft.Boogie {
         if (lambda == null) {
           return baseResult;  // apparently, the base visitor already turned the lambda into something else
         }
+
+        return CommandLineOptions.Clo.FreeVarLambdaLifting ? LiftLambdaFreeVars(lambda) : LiftLambdaMaxHoles(lambda);
+      }
+      
+      /// <summary>
+      /// Performs lambda lifting (see <see cref="LambdaHelper.ExpandLambdas"/>) by replacing the lambda's
+      /// free variables with bound ones.
+      /// </summary>
+      /// <param name="lambda">A lambda expression
+      ///   <code>(lambda x1: T1 ... x_n: T_n => t)</code>
+      /// where <c>t</c> contains the free variables <c>y1</c>, ..., <c>y_m</c>.
+      /// </param>
+      /// <returns>
+      /// <list type="bullet">
+      ///   <item>
+      ///     A function application <c>f(y1, ..., y_m)</c> where <c>f</c>'s body is defined to be the result of
+      ///     replacing the free variables <c>y1</c>, ..., <c>y_m</c> in <c>t</c> with bound variables
+      ///     <c>b1</c>, ..., <c>b_m</c>.
+      ///   </item>
+      ///   <item>
+      ///     Adds a definition and axiom for <c>f</c> to <see cref="lambdaFunctions"/> and <see cref="lambdaAxioms"/>.
+      ///     Memoizes <c>f</c> as the lifted lambda for <para>lambda</para>.
+      ///   </item>
+      /// </list>
+      /// </returns>
+      private Expr LiftLambdaFreeVars(LambdaExpr lambda) {
 
         // We start by getting rid of any use of "old" inside the lambda.  This is done as follows.
         // For each variable "g" occurring inside lambda as "old(... g ...)", create a new name "og".
@@ -219,6 +278,60 @@ namespace Microsoft.Boogie {
 
         return call;
       }
+      
+      /// <summary>
+      /// Performs lambda lifting (see <see cref="LambdaHelper.ExpandLambdas"/>) by replacing with bound variables
+      /// maximally large subexpressions of a lambda that do not contain any of the lambda's bound variables.
+      /// </summary>
+      /// <param name="lambda">A lambda expression
+      ///   <code>(lambda x1: T1 ... x_n: T_n => t)</code>
+      /// where <c>t</c> contains the subexpressions <c>e1</c>, ..., <c>e_m</c>. These are maximally large
+      /// subexpressions that do not contain the lambda's bound variables.
+      /// </param>
+      /// <returns>
+      /// <list type="bullet">
+      ///   <item>
+      ///     A function application <c>f(y1, ..., y_m)</c> where <c>f</c>'s body is defined to be the result of
+      ///     replacing the expressions <c>e1</c>, ..., <c>e_m</c> in <c>t</c> with bound variables
+      ///     <c>b1</c>, ..., <c>b_m</c>.
+      ///   </item>
+      ///   <item>
+      ///     Adds a definition and axiom for <c>f</c> to <see cref="lambdaFunctions"/> and <see cref="lambdaAxioms"/>.
+      ///     Memoizes <c>f</c> as the lifted lambda for <para>lambda</para>.
+      ///   </item>
+      /// </list>
+      /// </returns>
+      // todo (MR) move old handling into MaxHolesLambdaLifter? Maybe try merging MaxHolesLambdaLifter with LambdaVisitor
+      // todo (MR) do I need to handle a more general temporal modifier (e.g. labels)?
+      private Expr LiftLambdaMaxHoles(LambdaExpr lambda) {
+        
+        // We start by getting rid of `old` expressions. Instead, we replace the free variables `x_i` that are
+        // nested inside of `old` expressions with `old(x_i)` expressions.
+        var oldFinder = new OldFinder();
+        oldFinder.Visit(lambda);
+        var oldSubst = new Dictionary<Variable, Expr>();
+        foreach (var v in oldFinder.FreeOldVars) if (v is GlobalVariable g) {
+          oldSubst.Add(g, new OldExpr(g.tok, new IdentifierExpr(g.tok, g)) {Type = g.TypedIdent.Type});
+        }
+        var lambdaBody = Substituter.ApplyReplacingOldExprs(
+          Substituter.SubstitutionFromHashtable(new Dictionary<Variable,Expr>()),
+          Substituter.SubstitutionFromHashtable(oldSubst),
+          lambda.Body);
+        var lambdaAttrs = Substituter.ApplyReplacingOldExprs(
+          Substituter.SubstitutionFromHashtable(new Dictionary<Variable, Expr>()),
+          Substituter.SubstitutionFromHashtable(oldSubst),
+          lambda.Attributes);
+        var newLambda =
+          new LambdaExpr(lambda.tok, lambda.TypeParameters, lambda.Dummies, lambdaAttrs, lambdaBody) {
+            Type = lambda.Type
+          };
+        
+        // We perform lambda lifting on the resulting lambda which now contains only `old` expressions of the form
+        // `old(x)` where `x` is a variable that is free in the lambda.
+        return new MaxHolesLambdaLifter(
+          newLambda, liftedLambdas, FreshLambdaFunctionName(), lambdaFunctions, lambdaAxioms).VisitLambdaExpr(newLambda);
+      }
+
       public override Cmd VisitCallCmd(CallCmd node) {
         var baseResult = base.VisitCallCmd(node);
         node = baseResult as CallCmd;

--- a/Source/Core/LambdaLiftingMaxHolesFiller.cs
+++ b/Source/Core/LambdaLiftingMaxHolesFiller.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using Microsoft.Boogie;
+
+namespace Core {
+
+/// <summary>
+/// Traverses an expression, replacing all holes with bound variables taken from the <see cref="_replDummies"/>
+/// queue.
+/// </summary>
+class LambdaLiftingMaxHolesFiller : Duplicator {
+        private readonly List<Absy> _holes;
+        private readonly Queue<Variable> _replDummies;
+
+        private LambdaLiftingMaxHolesFiller(List<Absy> holes, IEnumerable<Variable> replDummies) {
+          _holes = holes;
+          _replDummies = new Queue<Variable>(replDummies);
+        }
+
+        public static Expr Fill(
+          List<Absy> holes,
+          List<Variable> replDummies,
+          Expr expr
+        ) {
+          return new LambdaLiftingMaxHolesFiller(holes, replDummies).VisitExpr(expr);
+        }
+
+        private bool ShouldBeReplaced(Absy node) {
+          return _holes.Contains(node);
+        }
+        
+        private bool GetReplacementVariable(Absy node, out Variable variable) {
+          if (_replDummies.Count > 0 && ShouldBeReplaced(node)) {
+            variable = _replDummies.Dequeue();
+            return true;
+          }
+          variable = null;
+          return false;
+        }
+
+        public override Expr VisitLambdaExpr(LambdaExpr node) {
+          var attributes = node.Attributes == null ? null : VisitQKeyValue(node.Attributes);
+          var body = VisitExpr(node.Body);
+          return new LambdaExpr(node.tok, node.TypeParameters, node.Dummies, attributes, body);
+        }
+
+        public override Variable VisitVariable(Variable node) {
+          if (GetReplacementVariable(new IdentifierExpr(node.tok, node), out var variable)) return variable;
+          return base.VisitVariable(node);
+        }
+
+        public override Expr VisitExistsExpr(ExistsExpr node) {
+          if (GetReplacementVariable(node, out var variable)) return new IdentifierExpr(variable.tok, variable);
+          return base.VisitExistsExpr(node);
+        }
+
+        public override Expr VisitForallExpr(ForallExpr node) {
+          if (GetReplacementVariable(node, out var variable)) return new IdentifierExpr(variable.tok, variable);
+          return base.VisitForallExpr(node);
+        }
+
+        public override Expr VisitIdentifierExpr(IdentifierExpr node) {
+          if (GetReplacementVariable(node, out var variable)) return new IdentifierExpr(variable.tok, variable);
+          return base.VisitIdentifierExpr(node);
+        }
+
+        public override Expr VisitLetExpr(LetExpr node) {
+          if (GetReplacementVariable(node, out var variable)) return new IdentifierExpr(variable.tok, variable);
+          return base.VisitLetExpr(node);
+        }
+
+        public override Expr VisitLiteralExpr(LiteralExpr node) {
+          if (GetReplacementVariable(node, out var variable)) return new IdentifierExpr(variable.tok, variable);
+          return base.VisitLiteralExpr(node);
+        }
+
+        public override Expr VisitNAryExpr(NAryExpr node) {
+          if (GetReplacementVariable(node, out var variable)) return new IdentifierExpr(variable.tok, variable);
+          return base.VisitNAryExpr(node);
+        }
+
+        public override Expr VisitOldExpr(OldExpr node) {
+          if (GetReplacementVariable(node, out var variable)) return new IdentifierExpr(variable.tok, variable);
+          return base.VisitOldExpr(node);
+        }
+      }
+}

--- a/Source/Core/LambdaLiftingTemplate.cs
+++ b/Source/Core/LambdaLiftingTemplate.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+
+namespace Microsoft.Boogie {
+
+    /// <summary>
+    /// Templates are used in the lambda lifting algorithm based on maximally large subexpressions not containing
+    /// a lambda's bound variables (see <see cref="Core.MaxHolesLambdaLifter"/>).
+    /// After the first phase of lambda lifting has been performed, each subexpression of a lambda is mapped to
+    /// a template. A template is an expression that can have "holes" as subexpressions (holes are the maximally
+    /// large subexpressions of a lambda that are free of bound variables and that will need to be lifted out of the
+    /// lambda).
+    /// Each template comes with a list of replacement expressions that indicate what each hole should be filled with
+    /// (in other words, what is the original expression that is now replaced by a hole).
+    ///
+    /// We represent templates as follows:
+    /// <list type="bullet">
+    /// <item>
+    ///     <description>No bound variables (hole)</description>
+    ///         If a node does not have any bound variables, it is a hole.
+    ///         This is represented using <see cref="TemplateNoBoundVariables"/>.
+    ///         A hole has exactly one replacement expression.
+    /// </item>
+    /// <item>l
+    ///     <description>Contains bound variables (template with holes)</description>
+    ///         If a node contains bound variables then it can have a (possibly empty, arbitrary-sized) list
+    ///         of replacement expressions that indicate what the maximally large, bound-variable-free subexpressions
+    ///         of the template are. 
+    ///         This is represented using <see cref="TemplateWithBoundVariables"/>.
+    /// </item>
+    /// <item>
+    ///     <description>No bound variables special case: trigger or attribute</description>
+    ///         Since triggers and attributes are not considered expressions in the AST, but are instead
+    ///         represented as linked lists that contain sequences of expressions, we must allow triggers and attributes
+    ///         to contain a replacement for each expression sequence. We therefore define a special class
+    ///         <see cref="TemplateNoBoundVariablesTriggerOrKv"/> that represents holes that can have multiple
+    ///         replacements.
+    /// </item>
+    /// </list>
+    /// </summary>
+    public abstract class LambdaLiftingTemplate {
+
+        protected readonly List<Expr> llReplacements;
+
+        protected LambdaLiftingTemplate(List<Expr> llReplacements) {
+            this.llReplacements = new List<Expr>(llReplacements);
+        }
+        
+        public List<Expr> GetReplacements() {
+            return llReplacements; // todo (MR) make this readonly somewhere?
+        }
+
+        public abstract bool ContainsBoundVariables();
+    }
+
+    public class TemplateWithBoundVariables : LambdaLiftingTemplate {
+
+        public TemplateWithBoundVariables(List<Expr> llReplacements) : base(llReplacements) {}
+
+        public TemplateWithBoundVariables() : base(new List<Expr>()) { } // creating empty list so that we don't have to do null checks when concatenating lists
+
+        public override bool ContainsBoundVariables() {
+            return true;
+        }
+    }
+
+    public class TemplateNoBoundVariables : LambdaLiftingTemplate {
+
+        public TemplateNoBoundVariables(Expr llReplacement) : base(new List<Expr>() { llReplacement }) {}
+        
+        public Expr GetReplacement() {
+            Contract.Requires(llReplacements.Count == 1);
+            return llReplacements[0];
+        }
+        
+        public override bool ContainsBoundVariables() {
+            return false;
+        }
+    }
+
+    public class TemplateNoBoundVariablesTriggerOrKv : LambdaLiftingTemplate {
+
+        public TemplateNoBoundVariablesTriggerOrKv(List<Expr> llReplacements) : base(llReplacements) {}
+        
+        public override bool ContainsBoundVariables() {
+            return false;
+        }
+    }
+}

--- a/Source/Core/MaxHolesLambdaLifter.cs
+++ b/Source/Core/MaxHolesLambdaLifter.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Linq;
+using Microsoft.Boogie;
+using Type = Microsoft.Boogie.Type;
+
+namespace Core {
+using Set = GSet<object>;
+
+// todo (MR) It would be better if this class were a private class within LambdaHelper because
+//           this class relies on the lambda not having old expressions any more (only old free variables).
+//           But this makes LambdaHelper very long so I'm leaving this class in a separate file for now.
+
+// todo (MR) test more complicated repl expressions, global variables
+// todo (MR) how to define let expressions inside of lambdas? for tests
+// todo (MR) do I need to handle AsgnLhs? MapAsgnLhs?
+
+/// <summary>
+/// This visitor performs the first phase of the MaxHoles lambda lifting (see <see cref="LambdaHelper.ExpandLambdas"/>),
+/// after which it invokes the second phase in the <see cref="VisitLambdaExpr"/> method.
+/// This phase consists of generating a "template" for each subexpression of the lambda. A template is an expression
+/// that contains "holes", which will be the maximally large subexpressions that do not contain the lambda's bound
+/// variables.
+///
+/// To encode templates we store a <see cref="_templates"/> dictionary that maps each node to its template,
+/// an object of type <see cref="LambdaLiftingTemplate"/>.
+///
+/// The first phase traverses a lambda's AST bottom-up, pupulating the <see cref="_templates"/> map.
+/// At the end of the first phase, we obtain a list of replacement expressions that correspond to the holes in
+/// the lambda.
+///
+/// The second phase replaces the templates with bound variables. It is handled by the
+/// <see cref="LambdaLiftingMaxHolesFiller.Fill"/> method.
+///
+/// This class requires a lambda's `old` expressions to occur only around free variables (this
+/// transformation is performed in <c>LambdaHelper.LiftLambdaMaxHoles</c>). 
+/// </summary>
+class MaxHolesLambdaLifter : StandardVisitor {
+    private readonly List<Variable> _nestedBoundVariables = new List<Variable>();
+
+    private readonly LambdaExpr _lambda;
+    private readonly Dictionary<Expr, FunctionCall> _liftedLambdas;
+    private readonly String _freshFnName;
+    private readonly List<Function> _lambdaFunctions;
+    private readonly List<Expr> _lambdaAxioms;
+    private int _freshVarCount;
+
+    private readonly Dictionary<Absy, LambdaLiftingTemplate> _templates = new Dictionary<Absy, LambdaLiftingTemplate>();
+
+    public MaxHolesLambdaLifter(
+        LambdaExpr lambda,
+        Dictionary<Expr, FunctionCall> liftedLambdas,
+        string freshFnName,
+        List<Function> lambdaFunctions,
+        List<Expr> lambdaAxioms,
+        int freshVarCount = 0
+    ) {
+        _lambda = lambda;
+        _liftedLambdas = liftedLambdas;
+        _freshFnName = freshFnName;
+        _lambdaFunctions = lambdaFunctions;
+        _lambdaAxioms = lambdaAxioms;
+        _freshVarCount = freshVarCount;
+    }
+
+    private string FreshVarNameGen(List<string> existing) {
+        const string prefix = "l#";
+        while (true) {
+            var newName = prefix + _freshVarCount;
+            _freshVarCount++;
+            if (!existing.Contains(newName)) return newName;
+        }
+    }
+
+    private bool IsBound(Variable node) {
+        return _lambda.Dummies.Contains(node) || _nestedBoundVariables.Contains(node);
+    }
+
+    public override Expr VisitNAryExpr(NAryExpr node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        base.VisitNAryExpr(node);
+        var nodeArgs = node.Args;
+        if (nodeArgs.Any(arg => _templates[arg].ContainsBoundVariables())) {
+            var replacements = new List<Expr>();
+            foreach (Expr arg in nodeArgs) {
+                replacements.AddRange(_templates[arg].GetReplacements());
+            }
+
+            _templates[node] = new TemplateWithBoundVariables(replacements);
+        } else {
+            // todo (MR) Could we avoid the casting? Could we encode in type system that all children of hole nodes are holes?
+            var newArgs = from arg in nodeArgs select ((TemplateNoBoundVariables) _templates[arg]).GetReplacement();
+            var llReplacementExpr =
+                new NAryExpr(node.tok, node.Fun, newArgs.ToList(), node.Immutable) {
+                    TypeParameters = node.TypeParameters, Type = node.Type ?? node.ShallowType
+                };
+            _templates[node] = new TemplateNoBoundVariables(llReplacementExpr);
+        }
+
+        return node;
+    }
+
+    public override Expr VisitIdentifierExpr(IdentifierExpr node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        base.VisitIdentifierExpr(node);
+        if (IsBound(node.Decl)) {
+            _templates[node] = new TemplateWithBoundVariables();
+        } else {
+            _templates[node] = _templates[node.Decl];
+        }
+
+        return node;
+    }
+
+    public override Expr VisitLiteralExpr(LiteralExpr node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        base.VisitLiteralExpr(node);
+        _templates[node] = new TemplateNoBoundVariables(node);
+        return node;
+    }
+
+    public override Expr VisitLetExpr(LetExpr node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        base.VisitLetExpr(node);
+        var bodyTemplate = _templates[node.Body];
+        var varBodies = node.Rhss;
+        if (bodyTemplate.ContainsBoundVariables() || varBodies.Any(body => _templates[body].ContainsBoundVariables())) {
+            var replacements = new List<Expr>();
+            foreach (Expr body in varBodies) {
+                replacements.AddRange(_templates[body].GetReplacements());
+            }
+
+            replacements.AddRange(bodyTemplate.GetReplacements());
+            _templates[node] = new TemplateWithBoundVariables(replacements);
+        }
+        else {
+            var newRhss = from arg in varBodies select ((TemplateNoBoundVariables) _templates[arg]).GetReplacement();
+            LambdaLiftingTemplate template = new TemplateNoBoundVariables(
+                new LetExpr(node.tok, node.Dummies, newRhss.ToList(),
+                    node.Attributes, // todo (MR) document says attributes should be dropped?
+                    ((TemplateNoBoundVariables) _templates[node.Body])
+                    .GetReplacement()));
+            _templates[node] = template;
+            // todo (MR) explicitly set type of let expr here?
+        }
+
+        return node;
+    }
+
+    public override Expr VisitForallExpr(ForallExpr node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        _nestedBoundVariables.AddRange(node.Dummies);
+        base.VisitForallExpr(node);
+        var body = node.Body;
+        var bodyTemplate = _templates[body];
+        var trigger = node.Triggers;
+        var triggerNoBounds = trigger == null || !_templates[trigger].ContainsBoundVariables();
+        if (bodyTemplate is TemplateNoBoundVariables bt && triggerNoBounds) {
+            var newBody = bt.GetReplacement();
+            var newTrigger = ReplacementTrigger(trigger);
+            _templates[node] = new TemplateNoBoundVariables(
+                new ForallExpr(node.tok, node.TypeParameters, node.Dummies, node.Attributes, newTrigger, newBody,
+                    node.Immutable));
+            // todo (MR) explicitly set type of binder expr here?
+        } else {
+            var replacements = bodyTemplate.GetReplacements();
+            if (trigger != null) {
+                replacements.AddRange(_templates[trigger].GetReplacements());
+            }
+
+            _templates[node] = new TemplateWithBoundVariables(replacements);
+        }
+
+        return node;
+    }
+    
+    public override Expr VisitExistsExpr(ExistsExpr node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        _nestedBoundVariables.AddRange(node.Dummies);
+        base.VisitExistsExpr(node);
+        var body = node.Body;
+        var bodyTemplate = _templates[body];
+        var trigger = node.Triggers;
+        var triggerNoBounds = trigger == null || !_templates[trigger].ContainsBoundVariables();
+        if (bodyTemplate is TemplateNoBoundVariables bt && triggerNoBounds) {
+            var newBody = bt.GetReplacement();
+            var newTrigger = ReplacementTrigger(trigger);
+            _templates[node] = new TemplateNoBoundVariables(
+                new ExistsExpr(node.tok, node.TypeParameters, node.Dummies, node.Attributes, newTrigger, newBody,
+                    node.Immutable));
+            // todo (MR) explicitly set type of binder expr here?
+        } else {
+            var replacements = bodyTemplate.GetReplacements();
+            if (trigger != null) {
+                replacements.AddRange(_templates[trigger].GetReplacements());
+            }
+
+            _templates[node] = new TemplateWithBoundVariables(replacements);
+        }
+
+        return node;
+    }
+
+    private List<Expr> QKeyValueReplacements(QKeyValue node) {
+        Contract.Requires(node != null);
+        var ts = (from e in node.Params where e != null && e is Expr select _templates[e as Expr]).ToList();
+        var replacements = new List<Expr>();
+        foreach (var llt in ts) {
+            replacements.AddRange(llt.GetReplacements());
+        }
+
+        replacements.AddRange(node.Next == null ? new List<Expr>() : QKeyValueReplacements(node.Next));
+        return replacements;
+    }
+    
+    private Trigger ReplacementTrigger(Trigger trigger) {
+        if (trigger == null) return null;
+        var replacements = _templates[trigger].GetReplacements();
+        var next = trigger.Next;
+        return new Trigger(trigger.tok, trigger.Pos, replacements, next == null ? null : ReplacementTrigger(next));
+    }
+
+    public override Trigger VisitTrigger(Trigger node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        base.VisitTrigger(node);
+        var templates = (from e in node.Tr select _templates[e]).ToList();
+        var replacements = new List<Expr>();
+        foreach (var llt in templates) {
+            replacements.AddRange(llt.GetReplacements());
+        }
+
+        replacements.AddRange(node.Next == null ? new List<Expr>() : _templates[node.Next].GetReplacements());
+        var nextNoBounds = node.Next == null || !_templates[node.Next].ContainsBoundVariables();
+        if (nextNoBounds && templates.All(r => !r.ContainsBoundVariables())) {
+            _templates[node] = new TemplateNoBoundVariablesTriggerOrKv(replacements);
+        } else {
+            _templates[node] = new TemplateWithBoundVariables(replacements);
+        }
+
+        return node;
+    }
+
+    public override Expr VisitLambdaExpr(LambdaExpr node) {
+        // Phase I of the lambda lifting
+        base.VisitLambdaExpr(node);
+        if (node.Attributes != null) {
+            VisitQKeyValue(node.Attributes);
+        }
+
+        // Phase II of the lambda lifting. 
+        // todo (MR) this code should not be in a VisitLambdaExpr but in a separate function I think so that we don't confuse Phase I and Phase II.
+        
+        // todo (MR) more efficient to do in loop but I find this more clear
+        var attribReplacementExprs =
+            node.Attributes == null ? new List<Expr>() : QKeyValueReplacements(node.Attributes);
+        var llReplacementExprs = _templates[node.Body].GetReplacements();
+        var allReplacementExprs = new List<Expr>(attribReplacementExprs);
+        allReplacementExprs.AddRange(llReplacementExprs);
+        var typedIdents = (from replExpr in allReplacementExprs
+                select new TypedIdent(replExpr.tok, FreshVarNameGen(new List<string>()),
+                    replExpr.Type ?? replExpr.ShallowType)) // todo (MR) what's the difference between Type and ShallowType?
+            .ToList(); 
+        var formals = allReplacementExprs.Zip(typedIdents,
+            (replExpr, typedIdent) => (Variable) new Formal(replExpr.tok, typedIdent, true));
+        var replDummies = allReplacementExprs.Zip(typedIdents,
+            (replExpr, typedIdent) => (Variable) new BoundVariable(replExpr.tok, typedIdent)).ToList();
+        var replDummyIds = (from dummy in replDummies select (Expr) new IdentifierExpr(dummy.tok, dummy)).ToList();
+        var dummies = new List<Variable>(_lambda.Dummies);
+        dummies.AddRange(replDummies);
+
+        Set freeVars = new Set();
+        BinderExpr.ComputeBinderFreeVariables(_lambda.TypeParameters, _lambda.Dummies, _lambda.Body, _lambda.Attributes,
+            freeVars);
+        var freeTypeVars = freeVars.OfType<TypeVariable>().ToList();
+        var freeVarActuals = freeVars.OfType<Type>().ToList();
+
+        var sw = new StringWriter();
+        var wr = new TokenTextWriter(sw, true);
+        _lambda.Emit(wr);
+        string lamStr = sw.ToString();
+
+        // the resulting lifted function applied to free variables
+        FunctionCall fcall;
+        IToken tok = _lambda.tok;
+        Formal res = new Formal(tok, new TypedIdent(tok, TypedIdent.NoName, cce.NonNull(_lambda.Type)), false);
+
+        var liftedLambda = (LambdaExpr) LambdaLiftingMaxHolesFiller.Fill((from kvp in _templates where !kvp.Value.ContainsBoundVariables() select kvp.Key).ToList(), replDummies, _lambda);
+        
+        if (_liftedLambdas.TryGetValue(liftedLambda, out fcall)) {
+            if (CommandLineOptions.Clo.TraceVerify) {
+                Console.WriteLine("Old lambda: {0}", lamStr);
+            }
+        }
+        else {
+            if (CommandLineOptions.Clo.TraceVerify) {
+                Console.WriteLine("New lambda: {0}", lamStr);
+            }
+            
+            var freshTypeVars = (from tv in freeTypeVars select new TypeVariable(tv.tok, tv.Name)).ToList();
+            // this will be the lifted function that takes free variables as arguments
+            Function fn = new Function(tok, _freshFnName, freshTypeVars, formals.ToList(), res,
+                "auto-generated lambda function", liftedLambda.Attributes) {OriginalLambdaExprAsString = lamStr};
+
+            fcall = new FunctionCall(new IdentifierExpr(tok, fn.Name));
+            fcall.Func = fn;
+            _liftedLambdas[liftedLambda] = fcall; 
+
+            // the arguments to the select map (the map that will be equal to the lifted lambda)
+            List<Expr> selectArgs = new List<Expr>();
+            foreach (Variable v in _lambda.Dummies) {
+                Contract.Assert(v != null);
+                selectArgs.Add(new IdentifierExpr(v.tok, v));
+            }
+
+            NAryExpr axcall = new NAryExpr(tok, fcall, replDummyIds) {
+                Type = res.TypedIdent.Type,
+                TypeParameters = SimpleTypeParamInstantiation.From(freeTypeVars, freeVarActuals)
+            };
+            // the Boogie map, applied to selectArgs, will be equal to the lifted lambda call
+            NAryExpr select = Expr.Select(axcall, selectArgs);
+            select.Type = _lambda.Body.Type;
+            List<Type> selectTypeParamActuals = new List<Type>();
+            List<TypeVariable> forallTypeVariables = new List<TypeVariable>();
+            foreach (TypeVariable tp in _lambda.TypeParameters) {
+                Contract.Assert(tp != null);
+                selectTypeParamActuals.Add(tp);
+                forallTypeVariables.Add(tp);
+            }
+
+            forallTypeVariables.AddRange(freeTypeVars);
+            select.TypeParameters = SimpleTypeParamInstantiation.From(_lambda.TypeParameters, selectTypeParamActuals);
+
+            NAryExpr body = Expr.Eq(select, liftedLambda.Body);
+            body.Type = Type.Bool;
+            body.TypeParameters = SimpleTypeParamInstantiation.EMPTY;
+            var trig = new Trigger(select.tok, true, new List<Expr> {select});
+
+            _lambdaFunctions.Add(fn);
+            _lambdaAxioms.Add(new ForallExpr(tok, forallTypeVariables, dummies, liftedLambda.Attributes, trig, body));
+        }
+
+        NAryExpr call = new NAryExpr(tok, fcall, allReplacementExprs.ToList()) {
+            Type = res.TypedIdent.Type, TypeParameters = SimpleTypeParamInstantiation.From(freeTypeVars, freeVarActuals)
+        };
+
+        return call;
+    }
+
+    // todo (MR) will this take care of all types of variables?
+    // todo (MR) will this take care of constants?
+    // todo (MR) do I need to do something special for global variables?
+    public override Variable VisitVariable(Variable node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        base.VisitVariable(node);
+        if (IsBound(node)) {
+            _templates[node] = new TemplateWithBoundVariables();
+        } else {
+            var identifierExpr = new IdentifierExpr(node.tok, node);
+            identifierExpr.Type = node.TypedIdent.Type;
+            _templates[node] = new TemplateNoBoundVariables(identifierExpr);
+        }
+
+        return node;
+    }
+
+    public override Expr VisitOldExpr(OldExpr node) {
+        Contract.Requires(node != null);
+        if (_templates.ContainsKey(node)) return node;
+        base.VisitOldExpr(node);
+        if (_templates[node.Expr] is TemplateNoBoundVariables t) {
+            var replacement = t.GetReplacement();
+            var llReplacement = new OldExpr(replacement.tok, replacement) {Type = replacement.Type};
+            _templates[node] = new TemplateNoBoundVariables(llReplacement);
+        } else {
+            // After OldFinder pass, old expressions should only occur around free variables
+            throw new cce.UnreachableException();
+        }
+
+        return node;
+    }
+}
+}

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -84,17 +84,18 @@ public static int Parse (string s, string/*!*/ filename, out /*maybe null*/ Prog
 
   Parser parser = new Parser(scanner, errors, false);
   parser.Parse();
-  if (parser.errors.count == 0)
+  if (errors.count == 0)
+  {
+    parser.Pgm.ProcessDatatypeConstructors(errors);
+  }
+  if (errors.count == 0)
   {
     program = parser.Pgm;
-    program.ProcessDatatypeConstructors();
-    return 0;
-  }
-  else
+  } else
   {
     program = null;
-    return parser.errors.count;
   }
+  return errors.count;
 }
 
 public Parser(Scanner/*!*/ scanner, Errors/*!*/ errors, bool disambiguation)

--- a/Test/datatypes/t3.bpl
+++ b/Test/datatypes/t3.bpl
@@ -1,0 +1,7 @@
+// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+type {:datatype} Value;
+function {:constructor} Int(i: int): Value;
+
+type {:datatype} Path;
+function {:constructor} Int(i: int): Path;

--- a/Test/datatypes/t3.bpl.expect
+++ b/Test/datatypes/t3.bpl.expect
@@ -1,0 +1,2 @@
+t3.bpl(7,25): error: more than one declaration of datatype constructor name: Int
+1 parse errors detected in t3.bpl

--- a/Test/test2/LambdaExt.bpl
+++ b/Test/test2/LambdaExt.bpl
@@ -67,9 +67,6 @@ procedure Quantifiers() {
 }
 
 procedure FreeVariables() {
-  var m : [bool,bool,bool]bool;
-  var k : [bool,bool]bool;
-
   var f : [bool]bool;
   var g : [bool]bool;
 
@@ -83,6 +80,16 @@ procedure FreeVariables() {
   } else {
     assert f == g; // should fail
   }
+}
+
+procedure FreeVariables2() {
+  var k : [bool,bool]bool;
+
+  var f : [bool]bool;
+  var g : [bool]bool;
+
+  var a : bool;
+  var b : bool;
 
   f := (lambda r: bool :: k[a,b]);
   g := (lambda s: bool :: k[b,a]);
@@ -91,11 +98,21 @@ procedure FreeVariables() {
   } else {
     assert f == g; // should fail
   }
+}
+
+procedure FreeVariables3() {
+  var m : [bool,bool,bool]bool;
+
+  var f : [bool]bool;
+  var g : [bool]bool;
+
+  var a : bool;
+  var b : bool;
 
   f := (lambda r: bool :: m[a,a,b]);
   g := (lambda s: bool :: m[a,b,b]);
   if (a == b) {
-    assert f == g; // should fail because they are different lambda
+    assert f == g; // should be OK
   } else {
     assert f == g; // should fail because they are different lambda
   }

--- a/Test/test2/LambdaExt.bpl.expect
+++ b/Test/test2/LambdaExt.bpl.expect
@@ -10,47 +10,33 @@ Execution trace:
 LambdaExt.bpl(34,3): Error BP5001: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(34,3): anon0
-LambdaExt.bpl(84,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(81,5): Error BP5001: This assertion might not hold.
 Execution trace:
-    LambdaExt.bpl(79,5): anon0
-    LambdaExt.bpl(84,5): anon9_Else
-LambdaExt.bpl(92,5): Error BP5001: This assertion might not hold.
+    LambdaExt.bpl(76,5): anon0
+    LambdaExt.bpl(81,5): anon3_Else
+LambdaExt.bpl(99,5): Error BP5001: This assertion might not hold.
 Execution trace:
-    LambdaExt.bpl(79,5): anon0
-    LambdaExt.bpl(84,5): anon9_Else
-    LambdaExt.bpl(87,5): anon3
-    LambdaExt.bpl(92,5): anon10_Else
-LambdaExt.bpl(98,5): Error BP5001: This assertion might not hold.
+    LambdaExt.bpl(94,5): anon0
+    LambdaExt.bpl(99,5): anon3_Else
+LambdaExt.bpl(117,5): Error BP5001: This assertion might not hold.
 Execution trace:
-    LambdaExt.bpl(79,5): anon0
-    LambdaExt.bpl(82,5): anon9_Then
-    LambdaExt.bpl(87,5): anon3
-    LambdaExt.bpl(90,5): anon10_Then
-    LambdaExt.bpl(95,5): anon6
-    LambdaExt.bpl(98,5): anon11_Then
-LambdaExt.bpl(100,5): Error BP5001: This assertion might not hold.
+    LambdaExt.bpl(112,5): anon0
+    LambdaExt.bpl(117,5): anon3_Else
+LambdaExt.bpl(129,3): Error BP5001: This assertion might not hold.
 Execution trace:
-    LambdaExt.bpl(79,5): anon0
-    LambdaExt.bpl(84,5): anon9_Else
-    LambdaExt.bpl(87,5): anon3
-    LambdaExt.bpl(92,5): anon10_Else
-    LambdaExt.bpl(95,5): anon6
-    LambdaExt.bpl(100,5): anon11_Else
-LambdaExt.bpl(112,3): Error BP5001: This assertion might not hold.
+    LambdaExt.bpl(125,5): anon0
+LambdaExt.bpl(136,3): Error BP5001: This assertion might not hold.
 Execution trace:
-    LambdaExt.bpl(108,5): anon0
-LambdaExt.bpl(119,3): Error BP5001: This assertion might not hold.
+    LambdaExt.bpl(134,5): anon0
+LambdaExt.bpl(138,3): Error BP5001: This assertion might not hold.
 Execution trace:
-    LambdaExt.bpl(117,5): anon0
-LambdaExt.bpl(121,3): Error BP5001: This assertion might not hold.
+    LambdaExt.bpl(134,5): anon0
+LambdaExt.bpl(140,3): Error BP5001: This assertion might not hold.
 Execution trace:
-    LambdaExt.bpl(117,5): anon0
-LambdaExt.bpl(123,3): Error BP5001: This assertion might not hold.
+    LambdaExt.bpl(134,5): anon0
+LambdaExt.bpl(151,5): Error BP5001: This assertion might not hold.
 Execution trace:
-    LambdaExt.bpl(117,5): anon0
-LambdaExt.bpl(134,5): Error BP5001: This assertion might not hold.
-Execution trace:
-    LambdaExt.bpl(129,5): anon0
-    LambdaExt.bpl(134,5): anon3_Else
+    LambdaExt.bpl(146,5): anon0
+    LambdaExt.bpl(151,5): anon3_Else
 
-Boogie program verifier finished with 4 verified, 13 errors
+Boogie program verifier finished with 4 verified, 12 errors

--- a/Test/test2/LambdaLifting.bpl
+++ b/Test/test2/LambdaLifting.bpl
@@ -1,0 +1,41 @@
+// RUN: %boogie -noinfer "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure ReducingLambdaBodies() {
+	var a, b: int;
+	var f, g: [int]int;
+
+	f := (lambda x: int :: a + b);
+	g := (lambda x: int :: b + a);
+	assert f == g; // should pass
+
+	f := (lambda x: int :: x + a);
+	g := (lambda x: int :: a + x);
+	assert f == g; // should fail
+}
+
+procedure ReducingLambdaBodies2() {
+	var a, b: int;
+	var f, g: [int]int;
+	var f2, g2: [int,int]int;
+
+	f := (lambda x: int :: x + a);
+	g := (lambda x: int :: a + x);
+	assert f != g; // should fail
+}
+
+procedure ReducingLambdaBodies3() {
+	var a, b: int;
+	var f, g: [int,int]int;
+	f := (lambda x, y: int :: x + y);
+	g := (lambda x, y: int :: y + x);
+	assert f == g; // should fail
+}
+
+procedure MultibleBoundVars() {
+	var a, b: int;
+	var f, g: [int,int,bool]bool;
+	f := (lambda x: int, y: int, z: bool :: if y == (a - b)       then x + (a + b * a) > b else z == (a > b));
+	g := (lambda x: int, y: int, z: bool :: if y == (b + a - 2*b) then x + (a * b + a) > b else z == (b < a));
+	assert f == g; // should pass
+}


### PR DESCRIPTION
Currently, Boogie transforms anonymous functions into function calls that return maps. The transformation abstracts over the free variables of a lambda, replacing free variables with bound ones, and passing the original free variables as arguments to the generated lifted function. This commit generalizes this approach by abstracting over larger subexpressions of a lambda that do not contain free variables. Specifically, this lambda lifting algorithm lifts out of the lambda maximally large subexpressions that do not contain any of the lambda's bound variables.

The original lambda-lifting algorithm can be invoked using the `/freeVarLambdaLifting` option.