### PR TITLE
Pass over Rustan's PR#140 comments. Added lambda-lifting tests.

### DIFF
--- a/Source/Core/AbsyQuant.cs
+++ b/Source/Core/AbsyQuant.cs
@@ -575,7 +575,6 @@ namespace Microsoft.Boogie {
       }
     }
 
-    // todo (MR) this was implemented to throw an error; is this bad?
     public override int GetHashCode() {
       int hash = 17;
       hash = hash * 23 + tr.GetHashCode();

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1919,9 +1919,8 @@ namespace Microsoft.Boogie {
   /freeVarLambdaLifting : Boogie's lambda lifting transforms the bodies of lambda
                          expressions into templates with holes. By default, holes
                          are maximally large subexpressions that do not contain
-                         bound variables (see Section 8 of Boogie 3 paper).
-                         This option performs a form of lambda lifting
-                         in which holes are the lambda's free variables. 
+                         bound variables. This option performs a form of lambda
+                         lifting in which holes are the lambda's free variables. 
 
   /overlookTypeErrors : skip any implementation with resolution or type
                         checking errors

--- a/Source/Core/LambdaHelper.cs
+++ b/Source/Core/LambdaHelper.cs
@@ -84,7 +84,6 @@ namespace Microsoft.Boogie {
     }
 
     private class LambdaVisitor : StandardVisitor {
-      // todo (MR) why are we not using this map as a cache for lifted lambdas? why are we recomputing them?
       private readonly Dictionary<Expr, FunctionCall> liftedLambdas = 
         new Dictionary<Expr, FunctionCall>(new AlphaEquality());
 
@@ -118,7 +117,7 @@ namespace Microsoft.Boogie {
       /// free variables with bound ones.
       /// </summary>
       /// <param name="lambda">A lambda expression
-      ///   <code>(lambda x1: T1 ... x_n: T_n => t)</code>
+      ///   <code>(lambda x1: T1 ... x_n: T_n :: t)</code>
       /// where <c>t</c> contains the free variables <c>y1</c>, ..., <c>y_m</c>.
       /// </param>
       /// <returns>
@@ -284,7 +283,7 @@ namespace Microsoft.Boogie {
       /// maximally large subexpressions of a lambda that do not contain any of the lambda's bound variables.
       /// </summary>
       /// <param name="lambda">A lambda expression
-      ///   <code>(lambda x1: T1 ... x_n: T_n => t)</code>
+      ///   <code>(lambda x1: T1 ... x_n: T_n :: t)</code>
       /// where <c>t</c> contains the subexpressions <c>e1</c>, ..., <c>e_m</c>. These are maximally large
       /// subexpressions that do not contain the lambda's bound variables.
       /// </param>
@@ -301,8 +300,6 @@ namespace Microsoft.Boogie {
       ///   </item>
       /// </list>
       /// </returns>
-      // todo (MR) move old handling into MaxHolesLambdaLifter? Maybe try merging MaxHolesLambdaLifter with LambdaVisitor
-      // todo (MR) do I need to handle a more general temporal modifier (e.g. labels)?
       private Expr LiftLambdaMaxHoles(LambdaExpr lambda) {
         
         // We start by getting rid of `old` expressions. Instead, we replace the free variables `x_i` that are

--- a/Source/Core/LambdaLiftingMaxHolesFiller.cs
+++ b/Source/Core/LambdaLiftingMaxHolesFiller.cs
@@ -7,7 +7,7 @@ namespace Core {
 /// Traverses an expression, replacing all holes with bound variables taken from the <see cref="_replDummies"/>
 /// queue.
 /// </summary>
-class LambdaLiftingMaxHolesFiller : Duplicator {
+class LambdaLiftingMaxHolesFiller : StandardVisitor {
         private readonly List<Absy> _holes;
         private readonly Queue<Variable> _replDummies;
 

--- a/Source/Core/LambdaLiftingTemplate.cs
+++ b/Source/Core/LambdaLiftingTemplate.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Boogie {
         }
         
         public List<Expr> GetReplacements() {
-            return llReplacements; // todo (MR) make this readonly somewhere?
+            return llReplacements;
         }
 
         public abstract bool ContainsBoundVariables();

--- a/Test/test2/LambdaLifting.bpl
+++ b/Test/test2/LambdaLifting.bpl
@@ -1,0 +1,52 @@
+// RUN: %boogie -noinfer "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure ReducingLambdaBodies() {
+	var a, b: int;
+	var f, g: [int]int;
+
+	f := (lambda x: int :: a + b);
+	g := (lambda x: int :: b + a);
+	assert f == g; // should pass
+
+	f := (lambda x: int :: x + a);
+	g := (lambda x: int :: a + x);
+	assert f == g; // should fail
+}
+
+procedure ReducingLambdaBodies2() {
+	var a, b: int;
+	var f, g: [int]int;
+	var f2, g2: [int,int]int;
+
+	f := (lambda x: int :: x + a);
+	g := (lambda x: int :: a + x);
+	assert f != g; // should fail
+}
+
+procedure ReducingLambdaBodies3() {
+	var a, b: int;
+	var f, g: [int,int]int;
+	f := (lambda x, y: int :: x + y);
+	g := (lambda x, y: int :: y + x);
+	assert f == g; // should fail
+}
+
+procedure MultibleBoundVars() {
+	var a, b: int;
+	var f, g: [int,int,bool]bool;
+	f := (lambda x: int, y: int, z: bool :: if y == (a - b)       then x + (a + b * a) > b else z == (a > b));
+	g := (lambda x: int, y: int, z: bool :: if y == (b + a - 2*b) then x + (a * b + a) > b else z == (b < a));
+	assert f == g; // should pass
+}
+
+function g(int,int) : int;
+
+procedure Triggers'(w: int, w': int) {
+	var a,b : [int]bool;
+	a := (lambda x:int :: (forall u:int :: { g(u,w) } x == g(u,w)));
+	b := (lambda y:int :: (forall v:int :: { g(v,w') } y == g(v,w')));
+	assert w == w' ==> a == b;
+	b := (lambda y:int :: (forall v:int :: y == g(v,w')));
+	assert w == w' ==> a == b; // should fail because triggers are different
+}

--- a/Test/test2/LambdaLifting.bpl.expect
+++ b/Test/test2/LambdaLifting.bpl.expect
@@ -1,0 +1,14 @@
+LambdaLifting.bpl(14,2): Error BP5001: This assertion might not hold.
+Execution trace:
+    LambdaLifting.bpl(8,4): anon0
+LambdaLifting.bpl(24,2): Error BP5001: This assertion might not hold.
+Execution trace:
+    LambdaLifting.bpl(22,4): anon0
+LambdaLifting.bpl(32,2): Error BP5001: This assertion might not hold.
+Execution trace:
+    LambdaLifting.bpl(30,4): anon0
+LambdaLifting.bpl(51,2): Error BP5001: This assertion might not hold.
+Execution trace:
+    LambdaLifting.bpl(47,4): anon0
+
+Boogie program verifier finished with 1 verified, 4 errors


### PR DESCRIPTION
This PR adds tests for the lambda-lifting algorithm based on maximally large bound-variable-free subexpressions and applies Rustan's suggestions to the draft pull request [#140](https://github.com/boogie-org/boogie/pull/140).