### PR TITLE
Adding checksum lambda attribute to lambda lifting to fix Dafny tests

### DIFF
--- a/Source/Core/LambdaLiftingMaxHolesFiller.cs
+++ b/Source/Core/LambdaLiftingMaxHolesFiller.cs
@@ -9,19 +9,19 @@ namespace Core {
 /// </summary>
 class LambdaLiftingMaxHolesFiller : StandardVisitor {
         private readonly List<Absy> _holes;
+        private readonly QKeyValue _lambdaAttrs;
         private readonly Queue<Variable> _replDummies;
 
-        private LambdaLiftingMaxHolesFiller(List<Absy> holes, IEnumerable<Variable> replDummies) {
+        private LambdaLiftingMaxHolesFiller(List<Absy> holes, IEnumerable<Variable> replDummies, QKeyValue lambdaAttrs) {
           _holes = holes;
+          _lambdaAttrs = lambdaAttrs;
           _replDummies = new Queue<Variable>(replDummies);
         }
 
-        public static Expr Fill(
-          List<Absy> holes,
+        public static Expr Fill(List<Absy> holes,
           List<Variable> replDummies,
-          Expr expr
-        ) {
-          return new LambdaLiftingMaxHolesFiller(holes, replDummies).VisitExpr(expr);
+          Expr expr, QKeyValue lambdaAttrs) {
+          return new LambdaLiftingMaxHolesFiller(holes, replDummies, lambdaAttrs).VisitExpr(expr);
         }
 
         private bool ShouldBeReplaced(Absy node) {
@@ -38,7 +38,7 @@ class LambdaLiftingMaxHolesFiller : StandardVisitor {
         }
 
         public override Expr VisitLambdaExpr(LambdaExpr node) {
-          var attributes = node.Attributes == null ? null : VisitQKeyValue(node.Attributes);
+          var attributes =_lambdaAttrs == null ? null : VisitQKeyValue(_lambdaAttrs);
           var body = VisitExpr(node.Body);
           return new LambdaExpr(node.tok, node.TypeParameters, node.Dummies, attributes, body);
         }


### PR DESCRIPTION
The new lambda-lifting broke the following tests in the Dafny suite:
```
    Dafny :: dafny0/snapshots/Snapshots8.run.dfy
    Dafny :: server/git-issue223.transcript
    Dafny :: server/simple-session.transcript
```
This PR fixes the tests which occurred because the new lambda lifting did not handle a `checksum` lambda.