### PR TITLE
Bug fix in yield type checking of calls to introduction procedures

### DIFF
--- a/Source/Concurrency/CivlRefinement.cs
+++ b/Source/Concurrency/CivlRefinement.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Boogie
         {
             Procedure originalProc = originalCallCmd.Proc;
 
-            if (civlTypeChecker.procToInstrumentationProc.ContainsKey(originalProc))
+            if (civlTypeChecker.procToIntroductionProc.ContainsKey(originalProc))
             {
                 if (!civlTypeChecker.CallExists(originalCallCmd, enclosingYieldingProc.upperLayer, layerNum))
                     return;

--- a/Test/civl/intro.bpl
+++ b/Test/civl/intro.bpl
@@ -46,12 +46,14 @@ procedure {:yields} {:layer 0} {:refines "atomic_read_x"} read_x () returns ({:l
 {
   yield;
   call v := intro_read_x();
+  yield;
 }
 
 procedure {:yields} {:layer 0} {:refines "atomic_write_x"} write_x (x':int)
 {
   yield;
   call intro_write_x(x');
+  yield;
 }
 
 procedure {:layer 0} intro_read_x () returns (v:int)

--- a/Test/civl/par-intro-bug.bpl
+++ b/Test/civl/par-intro-bug.bpl
@@ -1,0 +1,24 @@
+// RUN: %boogie -noinfer -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0} x : int;
+
+procedure {:layer 0} set_x(v: int)
+ensures {:layer 0} x == v;	 
+modifies x;
+{
+  x := v;
+}	
+
+procedure {:yields} {:layer 0} yield_set_x(v: int)
+ensures {:layer 0} x == v;	
+{
+  yield;
+	call set_x(v);
+}
+
+procedure {:yields} {:layer 0} main()
+{
+  par yield_set_x(4) | yield_set_x(3);
+	assert {:layer 0} false;
+}	

--- a/Test/civl/par-intro-bug.bpl.expect
+++ b/Test/civl/par-intro-bug.bpl.expect
@@ -1,0 +1,2 @@
+par-intro-bug.bpl(13,31): Error: Implementation yield_set_x fails bracket check at layer 0. All code that accesses global variables must be bracketed by yields.
+1 type checking errors detected in par-intro-bug.bpl

--- a/Test/civl/termination.bpl.expect
+++ b/Test/civl/termination.bpl.expect
@@ -1,2 +1,2 @@
-termination.bpl(9,31): Error: Implementation main fails simulation check C at layer 1. Transactions must be separated by a yield.
+termination.bpl(9,31): Error: Implementation main fails atomicity check at layer 1. Transactions must be separated by yields.
 1 type checking errors detected in termination.bpl

--- a/Test/civl/wsq.bpl
+++ b/Test/civl/wsq.bpl
@@ -100,11 +100,9 @@ ensures {:layer 3} {:expand} emptyInv(put_in_cs, take_in_cs, items,status,T);
   var {:layer 3} oldT:int;
   var {:layer 3} oldStatusT:bool;
   
-  call oldH, oldT := GhostRead();
   yield;
   assert {:layer 3} {:expand} queueInv(steal_in_cs,put_in_cs,take_in_cs,items, status, H, T-1) && tid == ptTid && !take_in_cs && !put_in_cs;
   assert {:layer 3} {:expand} {:expand} ideasInv(put_in_cs,items, status, H, T, take_in_cs, steal_in_cs, h_ss, t_ss);
-  assert {:layer 3} oldH <= H && oldT == T;
   assert {:layer 3} {:expand} emptyInv(put_in_cs, take_in_cs, items,status,T);
 
   call t := readT_put(tid);
@@ -161,11 +159,9 @@ ensures {:layer 3} ideasInv(put_in_cs,items, status, H, T, take_in_cs, steal_in_
   var {:layer 3} oldH:int;
   var {:layer 3} oldT:int;
 
-  call oldH, oldT := GhostRead();
   yield;
   assert {:layer 3} queueInv(steal_in_cs,put_in_cs,take_in_cs,items, status, H, T-1) && tid == ptTid && !take_in_cs && !put_in_cs;
   assert {:layer 3} ideasInv(put_in_cs,items, status, H, T, take_in_cs, steal_in_cs, h_ss, t_ss);
-  assert {:layer 3} oldH <= H && oldT == T;
   
   while(true)
   invariant {:layer 3} queueInv(steal_in_cs,put_in_cs,take_in_cs,items, status, H, T-1) && tid == ptTid && !take_in_cs && !put_in_cs;
@@ -321,12 +317,10 @@ ensures {:layer 3} ideasInv(put_in_cs,items, status, H, T, take_in_cs, steal_in_
   var {:layer 3} oldH:int;
   var {:layer 3} oldT:int;
 
-  call oldH, oldT := GhostRead();
   yield;
   assert {:layer 3} stealerTid(tid);
   assert {:layer 3} queueInv(steal_in_cs,put_in_cs,take_in_cs,items, status, H, T-1);
   assert {:layer 3} ideasInv(put_in_cs,items, status, H, T, take_in_cs, steal_in_cs, h_ss, t_ss);
-  assert {:layer 3} oldH <= H;
   assert {:layer 3} !steal_in_cs[tid];
 
   while(true)


### PR DESCRIPTION
This PR does the following:
- fixes bug in yield type checking when introduction procedures are used;  bug fix required unifying ASpec and BSpec automata into a single automaton that checks yield bracketing.
- renames instrumentation to introduction to match the terminology we have settled on.