### PR TITLE
Inductive sequentialization

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -110,7 +110,9 @@ namespace Microsoft.Boogie
             return modifiedVars;
         }
 
-        public bool HasAssumeCmd { get { return impl.Blocks.Any(b => b.Cmds.Any(c => c is AssumeCmd)); } }
+        public bool HasAssumeCmd => impl.Blocks.Any(b => b.Cmds.Any(c => c is AssumeCmd));
+
+        public bool HasPendingAsyncs => pendingAsyncs != null;
 
         public bool TriviallyCommutesWith(AtomicAction other)
         {

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Boogie
         public Implementation impl;
         public MoverType moverType;
         public LayerRange layerRange;
-        public DatatypeConstructor pendingAsyncCtor;
 
         public List<AssertCmd> gate;
 
@@ -60,6 +59,9 @@ namespace Microsoft.Boogie
         public HashSet<Variable> gateUsedGlobalVars;
         public HashSet<Variable> actionUsedGlobalVars;
         public HashSet<Variable> modifiedGlobalVars;
+
+        public DatatypeConstructor pendingAsyncCtor;
+        public HashSet<AtomicAction> pendingAsyncs;
 
         public AtomicAction(Procedure proc, Implementation impl, MoverType moverType, LayerRange layerRange)
         {

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Boogie
 
         public DatatypeConstructor pendingAsyncCtor;
         public HashSet<AtomicAction> pendingAsyncs;
+        public bool hasChoice; // only relevant for invariant actions
 
         public Dictionary<Variable, Function> triggerFunctions;
 

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Boogie
         {
             return other.lowerLayerNum <= lowerLayerNum && upperLayerNum <= other.upperLayerNum;
         }
+
+        internal bool OverlapsWith(LayerRange other)
+        {
+            return lowerLayerNum <= other.upperLayerNum && other.lowerLayerNum <= upperLayerNum;
+        }
     }
 
     public class AtomicAction

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Boogie
         public Implementation impl;
         public MoverType moverType;
         public LayerRange layerRange;
+        public AtomicAction refinedAction;
 
         public List<AssertCmd> gate;
 
@@ -168,6 +169,19 @@ namespace Microsoft.Boogie
             : base(proc, refinedAction.moverType, upperLayer)
         {
             this.refinedAction = refinedAction;
+        }
+
+        public AtomicAction RefinedActionAtLayer(int layer)
+        {
+            if (layer <= upperLayer) return null;
+            var action = refinedAction;
+            while (action != null)
+            {
+                if (layer <= action.layerRange.upperLayerNum)
+                    return action;
+                action = action.refinedAction;
+            }
+            return null;
         }
     }
 

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -876,6 +876,10 @@ namespace Microsoft.Boogie
             return procToIsAbstraction.Values.FirstOrDefault(a => a.proc.Name == name);
         }
 
+        public IEnumerable<AtomicAction> AllActions =>
+            procToAtomicAction.Union(procToIsInvariant).Union(procToIsAbstraction)
+            .Select(x => x.Value);
+
         public void Error(Absy node, string message)
         {
             checkingContext.Error(node, message);
@@ -1347,12 +1351,7 @@ namespace Microsoft.Boogie
             {
                 var attributeEraser = new AttributeEraser();
                 attributeEraser.VisitProgram(ctc.program);
-                var allActions =
-                    ctc.procToAtomicAction
-                    .Union(ctc.procToIsInvariant)
-                    .Union(ctc.procToIsAbstraction)
-                    .Select(x => x.Value);
-                foreach (var action in allActions)
+                foreach (var action in ctc.AllActions)
                 {
                     attributeEraser.VisitAtomicAction(action);
                 }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -585,6 +585,8 @@ namespace Microsoft.Boogie
                     else
                     {
                         action.pendingAsyncCtor = ctor;
+                        if (action.proc.HasAttribute(CivlAttributes.IS))
+                            Error(ctor, "Actions transformed by IS cannot be pending asyncs");
                         // TODO: check that action and ctor have the same inputs
                     }
                 }
@@ -1141,9 +1143,12 @@ namespace Microsoft.Boogie
                         }
                         else
                         {
-                            if (call.IsAsync && call.HasAttribute(CivlAttributes.SYNC))
+                            if (call.IsAsync)
                             {
-                                Require(calleeActionProc.refinedAction.IsLeftMover, call, "Synchronized call must be a left mover");
+                                if (call.HasAttribute(CivlAttributes.SYNC))
+                                    Require(calleeActionProc.refinedAction.IsLeftMover, call, "Synchronized call must be a left mover");
+                                else
+                                    Require(highestRefinedAction.pendingAsyncCtor != null, call, "No pending-async constructor available for this call");
                             }
                             if (!(callerProc is ActionProc))
                             {

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -264,8 +264,9 @@ namespace Microsoft.Boogie
                     }
                     if (kv.Key == CivlAttributes.ELIM)
                     {
-                        if (kv.Params.Count >= 1 && kv.Params.Count <= 2 && kv.Params[0] is string actionName)
+                        if (kv.Params.Count >= 1 && kv.Params.Count <= 2 && kv.Params.All(p => p is string))
                         {
+                            string actionName = (string)kv.Params[0];
                             AtomicAction elimAction = FindAtomicAction(actionName);
                             AtomicAction absAction = null;
                             if (elimAction == null)
@@ -278,9 +279,12 @@ namespace Microsoft.Boogie
                                     Error(kv, $"No pending async constructor for atomic action {actionName}");
                                 if (!elimAction.layerRange.Contains(layer)) 
                                     Error(kv, $"Elim action does not exist at layer {layer}");
+                                if (kv.Params.Count == 1 && !elimAction.IsLeftMover)
+                                    Error(kv, "Elim action must be a left mover");
                             }
-                            if (kv.Params.Count == 2 && kv.Params[1] is string abstractionName)
+                            if (kv.Params.Count == 2)
                             {
+                                string abstractionName = (string)kv.Params[1];
                                 absAction = FindIsAbstraction(abstractionName);
                                 if (absAction == null)
                                     Error(kv, "Could not find abstraction action");

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1181,7 +1181,7 @@ namespace Microsoft.Boogie
                         // (1) the call is a non-synchronized asynchronous call (i.e., results in a pending async), and
                         // (2) the caller is an action procedure (that can summarize the pending async).
                         Require(callerProc is ActionProc && call.IsAsync && !call.HasAttribute(CivlAttributes.SYNC),
-                            call, "");
+                            call, "Call to an action procedure on the same layer must be asynchronous (and turn into a pending async)");
                         Require(calleeActionProc.refinedAction.pendingAsyncCtor != null, call, "No pending-async constructor available for this call");
                     }
                     else

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -670,7 +670,8 @@ namespace Microsoft.Boogie
                             var pendingAsync = FindAtomicAction(actionName);
                             if (pendingAsync != null)
                             {
-                                // TODO: check layers
+                                if (!action.layerRange.Subset(pendingAsync.layerRange))
+                                    Error(kv, $"Pending async {actionName} is not available on all layers of {action.proc.Name}");
                                 if (pendingAsync.pendingAsyncCtor != null)
                                     pendingAsyncs.Add(pendingAsync);
                                 else

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -279,19 +279,23 @@ namespace Microsoft.Boogie
                                     Error(kv, $"No pending async constructor for atomic action {actionName}");
                                 if (!elimAction.layerRange.Contains(layer)) 
                                     Error(kv, $"Elim action does not exist at layer {layer}");
-                                if (kv.Params.Count == 1 && !elimAction.IsLeftMover)
-                                    Error(kv, "Elim action must be a left mover");
                             }
                             if (kv.Params.Count == 2)
                             {
                                 string abstractionName = (string)kv.Params[1];
-                                absAction = FindIsAbstraction(abstractionName);
+                                absAction = FindAtomicAction(abstractionName);
+                                if (absAction == null)
+                                    absAction = FindIsAbstraction(abstractionName);
                                 if (absAction == null)
                                     Error(kv, "Could not find abstraction action");
                                 else if (!absAction.layerRange.Contains(layer))
                                     Error(kv, "Abstraction action does not exist at layer {layer}");
                             }
-                            if (elimAction != null)
+                            else
+                            {
+                                absAction = elimAction;
+                            }
+                            if (elimAction != null && absAction != null)
                                 elim[elimAction] = absAction;
                         }
                         else

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1134,8 +1134,8 @@ namespace Microsoft.Boogie
                 {
                     if (callerProc.upperLayer > calleeProc.upperLayer)
                     {
-                        var calledAction = calleeActionProc.RefinedActionAtLayer(callerProc.upperLayer);
-                        if (calledAction == null)
+                        var highestRefinedAction = calleeActionProc.RefinedActionAtLayer(callerProc.upperLayer);
+                        if (highestRefinedAction == null)
                         {
                             ctc.Error(call, $"Called action is not available at layer {callerProc.upperLayer}");
                         }
@@ -1143,11 +1143,11 @@ namespace Microsoft.Boogie
                         {
                             if (call.IsAsync && call.HasAttribute(CivlAttributes.SYNC))
                             {
-                                Require(calledAction.IsLeftMover, call, "Synchronized call must be a left mover");
+                                Require(calleeActionProc.refinedAction.IsLeftMover, call, "Synchronized call must be a left mover");
                             }
                             if (!(callerProc is ActionProc))
                             {
-                                Require(!calledAction.HasPendingAsyncs && (!call.IsAsync || call.HasAttribute(CivlAttributes.SYNC)),
+                                Require(!highestRefinedAction.HasPendingAsyncs && (!call.IsAsync || call.HasAttribute(CivlAttributes.SYNC)),
                                     call, "Only action procedures can summarize pending asyncs");
                             }
                         }

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -33,6 +33,40 @@ namespace Microsoft.Boogie
         }
     }
 
+    public static class CmdHelper
+    {
+        public static ReturnCmd ReturnCmd => new ReturnCmd(Token.NoToken);
+
+        public static CallCmd CallCmd(Procedure callee, List<Expr> ins, List<IdentifierExpr> outs)
+        {
+            return new CallCmd(Token.NoToken, callee.Name, ins, outs)
+            { Proc = callee };
+        }
+
+        public static AssumeCmd AssumeCmd(Expr expr)
+        {
+            return new AssumeCmd(Token.NoToken, expr);
+        }
+    }
+
+    public static class VarHelper
+    {
+        public static LocalVariable LocalVariable(string name, Type type)
+        {
+            return new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, name, type));
+        }
+
+        public static BoundVariable BoundVariable(string name, Type type)
+        {
+            return new BoundVariable(Token.NoToken, new TypedIdent(Token.NoToken, name, type));
+        }
+
+        public static Formal Formal(string name, Type type, bool incoming)
+        {
+            return new Formal(Token.NoToken, new TypedIdent(Token.NoToken, name, type), incoming);
+        }
+    }
+
     public static class LinqExtensions
     {
         public static IEnumerable<IEnumerable<T>> CartesianProduct<T>(this IEnumerable<IEnumerable<T>> sequences)

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -115,6 +115,40 @@ namespace Microsoft.Boogie
         {
             return Substituter.Apply(FromVariableMap(map), cmd);
         }
+
+        public static IEnumerable<Expr> Apply(Substitution subst, IEnumerable<Expr> exprs)
+        {
+            return exprs.Select(x => Substituter.Apply(subst, x));
+        }
+
+        public static IEnumerable<Expr> Apply(Dictionary<Variable, Expr> map, IEnumerable<Expr> exprs)
+        {
+            var subst = Substituter.SubstitutionFromHashtable(map);
+            return Apply(subst, exprs);
+        }
+
+        public static IEnumerable<Expr> Apply(Dictionary<Variable, Variable> map, IEnumerable<Expr> exprs)
+        {
+            var subst = FromVariableMap(map);
+            return Apply(subst, exprs);
+        }
+
+        public static IEnumerable<Cmd> Apply(Substitution subst, IEnumerable<Cmd> cmds)
+        {
+            return cmds.Select(x => Substituter.Apply(subst, x));
+        }
+
+        public static IEnumerable<Cmd> Apply(Dictionary<Variable, Expr> map, IEnumerable<Cmd> cmds)
+        {
+            var subst = Substituter.SubstitutionFromHashtable(map);
+            return Apply(subst, cmds);
+        }
+
+        public static IEnumerable<Cmd> Apply(Dictionary<Variable, Variable> map, IEnumerable<Cmd> cmds)
+        {
+            var subst = FromVariableMap(map);
+            return Apply(subst, cmds);
+        }
     }
 
     public static class LinqExtensions

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -69,6 +69,12 @@ namespace Microsoft.Boogie
         {
             return new AssumeCmd(Token.NoToken, expr);
         }
+
+        public static AssignCmd AssignCmd(Variable v, Expr x)
+        {
+            var lhs = new SimpleAssignLhs(Token.NoToken, Expr.Ident(v));
+            return new AssignCmd(Token.NoToken, new List<AssignLhs> { lhs }, new List<Expr> { x });
+        }
     }
 
     public static class VarHelper

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -11,6 +11,18 @@ namespace Microsoft.Boogie
         {
             decl.AddAttribute("inline", Expr.Literal(1));
         }
+
+        public static void ResolveAndTypecheck(Absy absy)
+        {
+            absy.Resolve(new ResolutionContext(null));
+            absy.Typecheck(new TypecheckingContext(null));
+        }
+
+        public static void ResolveAndTypecheck(IEnumerable<Absy> absys)
+        {
+            foreach (var absy in absys)
+                ResolveAndTypecheck(absy);
+        }
     }
 
     // Handy syntactic suggar missing in Expr

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -95,6 +95,26 @@ namespace Microsoft.Boogie
         {
             return Substituter.SubstitutionFromHashtable(map.ToDictionary(kv => kv.Key, kv => (Expr)Expr.Ident(kv.Value)));
         }
+
+        public static Expr Apply(Dictionary<Variable, Expr> map, Expr expr)
+        {
+            return Substituter.Apply(Substituter.SubstitutionFromHashtable(map), expr);
+        }
+
+        public static Expr Apply(Dictionary<Variable, Variable> map, Expr expr)
+        {
+            return Substituter.Apply(FromVariableMap(map), expr);
+        }
+
+        public static Cmd Apply(Dictionary<Variable, Expr> map, Cmd cmd)
+        {
+            return Substituter.Apply(Substituter.SubstitutionFromHashtable(map), cmd);
+        }
+
+        public static Cmd Apply(Dictionary<Variable, Variable> map, Cmd cmd)
+        {
+            return Substituter.Apply(FromVariableMap(map), cmd);
+        }
     }
 
     public static class LinqExtensions

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -43,6 +43,16 @@ namespace Microsoft.Boogie
         {
             return new OldExpr(Token.NoToken, expr);
         }
+
+        public static void FlattenAnd(Expr x, List<Expr> xs)
+        {
+            if (x is NAryExpr naryExpr && naryExpr.Fun.FunctionName == "&&")
+            {
+                FlattenAnd(naryExpr.Args[0], xs);
+                FlattenAnd(naryExpr.Args[1], xs);
+            }
+            else { xs.Add(x); }
+        }
     }
 
     public static class CmdHelper
@@ -79,6 +89,14 @@ namespace Microsoft.Boogie
         }
     }
 
+    public static class SubstitutionHelper
+    {
+        public static Substitution FromVariableMap(Dictionary<Variable, Variable> map)
+        {
+            return Substituter.SubstitutionFromHashtable(map.ToDictionary(kv => kv.Key, kv => (Expr)Expr.Ident(kv.Value)));
+        }
+    }
+
     public static class LinqExtensions
     {
         public static IEnumerable<IEnumerable<T>> CartesianProduct<T>(this IEnumerable<IEnumerable<T>> sequences)
@@ -90,6 +108,11 @@ namespace Microsoft.Boogie
                 from acc in accumulator
                 from item in sequence
                 select acc.Concat(new[] { item }));
+        }
+
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<TKey> keys, Func<TKey, TValue> f)
+        {
+            return keys.ToDictionary(k => k, k => f(k));
         }
     }
 }

--- a/Source/Concurrency/CivlVCGeneration.cs
+++ b/Source/Concurrency/CivlVCGeneration.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Boogie
             LinearTypeChecker.AddCheckers(linearTypeChecker, civlTypeChecker, decls);
 
             InductiveSequentializationChecker.AddChecks(civlTypeChecker);
+            PendingAsyncChecker.AddCheckers(civlTypeChecker);
 
             // Remove original declarations and add new checkers generated above
             program.RemoveTopLevelDeclarations(x => originalDecls.Contains(x));

--- a/Source/Concurrency/CivlVCGeneration.cs
+++ b/Source/Concurrency/CivlVCGeneration.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Boogie
             // Linear type checks
             LinearTypeChecker.AddCheckers(linearTypeChecker, civlTypeChecker, decls);
 
+            InductiveSequentializationChecker.AddChecks(civlTypeChecker);
+
             // Remove original declarations and add new checkers generated above
             program.RemoveTopLevelDeclarations(x => originalDecls.Contains(x));
             program.AddTopLevelDeclarations(decls);

--- a/Source/Concurrency/CivlVCGeneration.cs
+++ b/Source/Concurrency/CivlVCGeneration.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Boogie
             program.RemoveTopLevelDeclarations(x => originalDecls.Contains(x));
             program.AddTopLevelDeclarations(decls);
 
-            civlTypeChecker.SubstituteBackwardAssignments();
+            BackwardAssignmentSubstituter.SubstituteBackwardAssignments(civlTypeChecker.procToAtomicAction.Values);
         }
     }
 }

--- a/Source/Concurrency/CivlVCGeneration.cs
+++ b/Source/Concurrency/CivlVCGeneration.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Boogie
             InductiveSequentializationChecker.AddChecks(civlTypeChecker);
             PendingAsyncChecker.AddCheckers(civlTypeChecker);
 
+            foreach(AtomicAction action in civlTypeChecker.procToAtomicAction.Values.Union(civlTypeChecker.procToIsAbstraction.Values))
+            {
+                action.AddTriggerAssumes(program);
+            }
+
             // Remove original declarations and add new checkers generated above
             program.RemoveTopLevelDeclarations(x => originalDecls.Contains(x));
             program.AddTopLevelDeclarations(decls);

--- a/Source/Concurrency/CivlVCGeneration.cs
+++ b/Source/Concurrency/CivlVCGeneration.cs
@@ -32,12 +32,6 @@ namespace Microsoft.Boogie
             program.AddTopLevelDeclarations(decls);
 
             civlTypeChecker.SubstituteBackwardAssignments();
-
-            foreach (AtomicAction atomicAction in civlTypeChecker.procToAtomicAction.Values)
-            {
-                program.RemoveTopLevelDeclaration(atomicAction.proc);
-                program.RemoveTopLevelDeclaration(atomicAction.impl);
-            }
         }
     }
 }

--- a/Source/Concurrency/Concurrency.csproj
+++ b/Source/Concurrency/Concurrency.csproj
@@ -91,6 +91,7 @@
     <Compile Include="CivlUtil.cs" />
     <Compile Include="Witnesses.cs" />
     <Compile Include="CivlCoreTypes.cs" />
+    <Compile Include="InductiveSequentialization.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Source/Concurrency/Concurrency.csproj
+++ b/Source/Concurrency/Concurrency.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Witnesses.cs" />
     <Compile Include="CivlCoreTypes.cs" />
     <Compile Include="InductiveSequentialization.cs" />
+    <Compile Include="PendingAsyncChecker.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Source/Concurrency/Concurrency.csproj
+++ b/Source/Concurrency/Concurrency.csproj
@@ -90,6 +90,7 @@
     <Compile Include="YieldTypeChecker.cs" />
     <Compile Include="CivlUtil.cs" />
     <Compile Include="Witnesses.cs" />
+    <Compile Include="CivlCoreTypes.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Boogie
 
         private Type PendingAsyncType => PendingAsyncMultisetType.Arguments[0];
 
-        private bool HasChoice => invariantAction.impl.OutParams.Count > inputAction.impl.OutParams.Count;
+        private bool HasChoice => invariantAction.hasChoice;
 
         private IdentifierExpr PAs => Expr.Ident(HasChoice ? invariantAction.impl.OutParams[invariantAction.impl.OutParams.Count - 2] : invariantAction.impl.OutParams.Last());
 

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -1,0 +1,367 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Boogie
+{
+    public class InductiveSequentialization
+    {
+        public AtomicAction inputAction;
+        public AtomicAction outputAction;
+        public AtomicAction invariantAction;
+        public Dictionary<AtomicAction, AtomicAction> elim;
+
+        private List<IdentifierExpr> modifies;
+        private IdentifierExpr choice;
+        private IdentifierExpr newPAs;
+        private string checkName;
+
+        public InductiveSequentialization(AtomicAction inputAction, AtomicAction outputAction,
+            AtomicAction invariantAction, Dictionary<AtomicAction, AtomicAction> elim)
+        {
+            this.inputAction = inputAction;
+            this.outputAction = outputAction;
+            this.invariantAction = invariantAction;
+            this.elim = elim;
+
+            this.modifies = new List<AtomicAction> { invariantAction, outputAction, inputAction }
+                .Union(elim.Values.Where(a => a != null))
+                .SelectMany(a => a.proc.Modifies).Distinct().ToList();
+
+            newPAs = Expr.Ident(VarHelper.LocalVariable("newPAs", PendingAsyncMultisetType));
+            if (HasChoice)
+            {
+                choice = Expr.Ident(invariantAction.impl.OutParams.Last());
+            }
+            else
+            {
+                choice = Expr.Ident(VarHelper.LocalVariable("choice", PendingAsyncType));
+            }
+        }
+
+        public Tuple<Procedure, Implementation> GenerateBaseCaseChecker()
+        {
+            this.checkName = "base";
+            var requires = invariantAction.gate.Select(g => new Requires(false, g.Expr)).ToList();
+            var ensures = new List<Ensures> { GetEnsures(GetInvariantTransitionRelation()) };
+
+            var subst = GetSubstitution(inputAction, invariantAction);
+            List<Cmd> cmds = GetGateAsserts(inputAction, subst).ToList<Cmd>();
+            cmds.Add(GetCallCmd(inputAction));
+            var blocks = new List<Block> { new Block(Token.NoToken, "init", cmds, CmdHelper.ReturnCmd) };
+
+            return GetCheckerTuple(requires, ensures, new List<Variable>(), blocks);
+        }
+
+
+
+        public Tuple<Procedure, Implementation> GenerateConclusionChecker()
+        {
+            this.checkName = "conclusion";
+            var subst = GetSubstitution(outputAction, invariantAction);
+            var requires = outputAction.gate.Select(g => new Requires(false, Substituter.Apply(subst, g.Expr))).ToList();
+            var ensures = new List<Ensures> {
+                GetEnsures(Substituter.Apply(subst, GetTransitionRelation(outputAction)))
+            };
+            if (!OutputHasPendingAsyncs)
+                ensures.Add(new Ensures(false, NoPendingAsyncs));
+
+            List<Cmd> cmds = GetGateAsserts(invariantAction, null).ToList<Cmd>();
+            cmds.Add(GetCallCmd(invariantAction));
+            cmds.Add(new AssumeCmd(Token.NoToken, PendingAsyncsEliminatedExpr));
+            var blocks = new List<Block> { new Block(Token.NoToken, "init", cmds, CmdHelper.ReturnCmd) };
+
+            return GetCheckerTuple(requires, ensures, new List<Variable>(), blocks);
+        }
+
+        public Tuple<Procedure, Implementation> GenerateStepChecker(Function pendingAsyncAdd)
+        {
+            this.checkName = "step";
+            var requires = invariantAction.gate.Select(g => new Requires(false, g.Expr)).ToList();
+            var ensures = new List<Ensures> { GetEnsures(GetInvariantTransitionRelation()) };
+            var locals = new List<Variable>();
+            if (elim.Keys.Any(a => a.pendingAsyncs != null))
+            {
+                locals.Add(newPAs.Decl);
+            }
+
+            List<Block> blocks = new List<Block>();
+            foreach (var pendingAsync in elim.Keys)
+            {
+                AtomicAction abs = elim[pendingAsync];
+                if (abs == null)
+                    abs = pendingAsync;
+
+                Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
+                List<Expr> inputExprs = new List<Expr>();
+                for (int i = 0; i < abs.impl.InParams.Count; i++)
+                {
+                    var pendingAsyncParam = ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.selectors[i], choice);
+                    map[abs.impl.InParams[i]] = pendingAsyncParam;
+                    inputExprs.Add(pendingAsyncParam);
+                }
+                var subst = Substituter.SubstitutionFromHashtable(map);
+                List<IdentifierExpr> outputVars = new List<IdentifierExpr>();
+                if (pendingAsync.pendingAsyncs != null)
+                {
+                    outputVars.Add(newPAs);
+                }
+
+                List<Cmd> cmds = new List<Cmd>();
+                cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.membership, choice)));
+                cmds.AddRange(GetGateAsserts(abs, subst));
+                cmds.Add(CmdHelper.CallCmd(abs.proc, inputExprs, outputVars));
+                if (pendingAsync.pendingAsyncs != null)
+                {
+                    cmds.Add(AddNewPAs(pendingAsyncAdd));
+                }
+                var block = new Block(Token.NoToken, pendingAsync.proc.Name, cmds, CmdHelper.ReturnCmd);
+                blocks.Add(block);
+            }
+
+            {
+                List<Cmd> cmds = new List<Cmd>();
+                cmds.Add(GetCallCmd(invariantAction));
+                if (HasChoice)
+                {
+                    cmds.Add(new AssumeCmd(Token.NoToken, ValidChoiceExpr));
+                    cmds.Add(
+                        new AssertCmd(Token.NoToken, ElimPendingAsyncExpr(choice))
+                        { ErrorData = $"Failed to validate choice in IS of {inputAction.proc.Name}" }
+                    );
+                }
+                else
+                {
+                    locals.Add(choice.Decl);
+                    cmds.Add(new AssumeCmd(Token.NoToken, ElimPendingAsyncExpr(choice)));
+                }
+                cmds.Add(RemoveChoice);
+                var initBlock = new Block(Token.NoToken, "init", cmds, new GotoCmd(Token.NoToken, blocks.ToList()));
+                blocks.Insert(0, initBlock);
+            }
+
+            return GetCheckerTuple(requires, ensures, locals, blocks);
+        }
+
+        private CallCmd GetCallCmd(AtomicAction callee)
+        {
+            return CmdHelper.CallCmd(
+                callee.proc,
+                invariantAction.impl.InParams.Select(Expr.Ident).ToList<Expr>(),
+                invariantAction.impl.OutParams.GetRange(0, callee.impl.OutParams.Count).Select(Expr.Ident).ToList()
+            );
+        }
+
+        private Ensures GetEnsures(Expr expr)
+        {
+            // expr.Resolve(new ResolutionContext(null) { StateMode = ResolutionContext.State.Two });
+            expr.Typecheck(new TypecheckingContext(null)); // TODO: why here?
+            return new Ensures(false, expr)
+            { ErrorData = $"IS {checkName} of {inputAction.proc.Name} failed" };
+        }
+
+        public static IEnumerable<AssertCmd> GetGateAsserts(AtomicAction action, Substitution subst, string msg)
+        {
+            foreach (var gate in action.gate)
+            {
+                AssertCmd cmd;
+                if (subst != null)
+                    cmd = (AssertCmd)Substituter.Apply(subst, gate);
+                else
+                    cmd = new AssertCmd(gate.tok, gate.Expr);
+                cmd.ErrorData = msg;
+                yield return cmd;
+            }
+        }
+
+        private IEnumerable<AssertCmd> GetGateAsserts(AtomicAction action, Substitution subst)
+        {
+            return GetGateAsserts(action, subst,
+                 $"Gate of {action.proc.Name} fails in IS {checkName} of {inputAction.proc.Name}");
+        }
+
+        private Tuple<Procedure, Implementation> GetCheckerTuple
+        (List<Requires> requires, List<Ensures> ensures, List<Variable> locals, List<Block> blocks)
+        {
+            var proc = new Procedure(Token.NoToken, $"IS_{checkName}_{inputAction.proc.Name}", new List<TypeVariable>(),
+                invariantAction.impl.InParams, invariantAction.impl.OutParams, requires, modifies, ensures);
+            var impl = new Implementation(Token.NoToken, proc.Name, new List<TypeVariable>(),
+                proc.InParams, proc.OutParams, locals, blocks)
+            { Proc = proc };
+            return new Tuple<Procedure, Implementation>(proc, impl);
+        }
+
+        private MapType PendingAsyncMultisetType => inputAction.impl.OutParams.Last().TypedIdent.Type as MapType;
+
+        private Type PendingAsyncType => PendingAsyncMultisetType.Arguments[0];
+
+        private bool HasChoice => invariantAction.impl.OutParams.Count > inputAction.impl.OutParams.Count;
+
+        private bool OutputHasPendingAsyncs => outputAction.pendingAsyncs != null;
+
+        private IdentifierExpr PAs => Expr.Ident(HasChoice ? invariantAction.impl.OutParams[invariantAction.impl.OutParams.Count - 2] : invariantAction.impl.OutParams.Last());
+
+        private Expr NoPendingAsyncs
+        {
+            get
+            {
+                var paBound = VarHelper.BoundVariable("pa", PendingAsyncType);
+                var pa = Expr.Ident(paBound);
+                var expr = Expr.Eq(Expr.Select(PAs, pa), Expr.Literal(0));
+                var forallExpr = new ForallExpr(Token.NoToken, new List<Variable> { paBound }, expr);
+                forallExpr.Typecheck(new TypecheckingContext(null));  // TODO: why here?
+                return forallExpr;
+            }
+        }
+
+        private Expr PendingAsyncsEliminatedExpr
+        {
+            get
+            {
+                var paBound = VarHelper.BoundVariable("pa", PendingAsyncType);
+                var pa = Expr.Ident(paBound);
+                var expr = Expr.Imp(
+                    Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0)),
+                    Expr.And(elim.Keys.Select(a => Expr.Not(ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa)))));
+                return new ForallExpr(Token.NoToken, new List<Variable> { paBound }, expr);
+            }
+        }
+
+        private Expr ValidChoiceExpr
+        {
+            get
+            {
+                var paBound = VarHelper.BoundVariable("pa", PendingAsyncType);
+                var pa = Expr.Ident(paBound);
+                return new ExistsExpr(Token.NoToken, new List<Variable> { paBound }, ElimPendingAsyncExpr(pa));
+            }
+        }
+
+        private Expr ElimPendingAsyncExpr(IdentifierExpr pa)
+        {
+            return Expr.And(
+                Expr.Or(elim.Keys.Select(a => ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa))),
+                Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0))
+            );
+        }
+
+        private AssignCmd RemoveChoice
+        {
+            get
+            {
+                var rhs = Expr.Sub(Expr.Select(PAs, choice), Expr.Literal(1));
+                return AssignCmd.MapAssign(Token.NoToken, PAs, new List<Expr> { choice }, rhs);
+            }
+        }
+
+        private AssignCmd AddNewPAs(Function pendingAsyncAdd)
+        {
+            return AssignCmd.SimpleAssign(Token.NoToken,
+                PAs,
+                ExprHelper.FunctionCall(pendingAsyncAdd, PAs, newPAs));
+        }
+
+
+        public static Substitution GetSubstitution(AtomicAction from, AtomicAction to)
+        {
+            Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
+            for (int i = 0; i < from.impl.InParams.Count; i++)
+            {
+                map[from.impl.InParams[i]] = Expr.Ident(to.impl.InParams[i]);
+            }
+            for (int i = 0; i < Math.Min(from.impl.OutParams.Count, to.impl.OutParams.Count); i++)
+            {
+                map[from.impl.OutParams[i]] = Expr.Ident(to.impl.OutParams[i]);
+            }
+            return Substituter.SubstitutionFromHashtable(map);
+        }
+
+        public static Expr GetTransitionRelation(AtomicAction action)
+        {
+            return TransitionRelationComputation.Refinement(action,
+                new HashSet<Variable>(action.gateUsedGlobalVars.Union(action.actionUsedGlobalVars)));
+        }
+
+        private Expr GetInvariantTransitionRelation()
+        {
+            var tr = GetTransitionRelation(invariantAction);
+            if (HasChoice)
+            {
+                return new ChoiceEraser(invariantAction.impl.OutParams.Last()).VisitExpr(tr);
+            }
+            return tr;
+        }
+
+        // TODO: Check that choice only occurs as one side of a positive equality.
+        private class ChoiceEraser : Duplicator
+        {
+            private Variable choice;
+
+            public ChoiceEraser(Variable choice)
+            {
+                this.choice = choice;
+            }
+            public override Expr VisitExpr(Expr node)
+            {
+                if (node is NAryExpr nary &&
+                    nary.Fun is BinaryOperator op &&
+                    op.Op == BinaryOperator.Opcode.Eq &&
+                    VariableCollector.Collect(node).Contains(choice))
+                {
+                    return Expr.True;
+                }
+                return base.VisitExpr(node);
+            }
+        }
+    }
+
+    public static class InductiveSequentializationChecker
+    {
+        public static void AddChecks(CivlTypeChecker ctc)
+        {
+            foreach (var x in ctc.inductiveSequentializations)
+            {
+                var t = x.GenerateBaseCaseChecker();
+                ctc.program.AddTopLevelDeclaration(t.Item1);
+                ctc.program.AddTopLevelDeclaration(t.Item2);
+                t = x.GenerateConclusionChecker();
+                ctc.program.AddTopLevelDeclaration(t.Item1);
+                ctc.program.AddTopLevelDeclaration(t.Item2);
+                t = x.GenerateStepChecker(ctc.pendingAsyncAdd);
+                ctc.program.AddTopLevelDeclaration(t.Item1);
+                ctc.program.AddTopLevelDeclaration(t.Item2);
+            }
+
+            var absChecks = ctc.inductiveSequentializations.SelectMany(x => x.elim.Where(kv => kv.Value != null)).Distinct();
+            foreach (var absCheck in absChecks)
+            {
+                var action = absCheck.Key;
+                var abs = absCheck.Value;
+
+                var requires = abs.gate.Select(g => new Requires(false, g.Expr)).ToList();
+                var tr = InductiveSequentialization.GetTransitionRelation(abs);
+                var ensures = new List<Ensures> { new Ensures(false, tr)
+                    {ErrorData = $"Abstraction {abs.proc.Name} does not summarize {action.proc.Name}" } };
+
+                var subst = InductiveSequentialization.GetSubstitution(action, abs);
+                List<Cmd> cmds = InductiveSequentialization.GetGateAsserts(action, subst,
+                    $"Abstraction {abs.proc.Name} fails gate of {action.proc.Name}").ToList<Cmd>();
+                cmds.Add(
+                    CmdHelper.CallCmd(
+                        action.proc,
+                        abs.impl.InParams.Select(Expr.Ident).ToList<Expr>(),
+                        abs.impl.OutParams.Select(Expr.Ident).ToList()
+                ));
+                var blocks = new List<Block> { new Block(Token.NoToken, "init", cmds, CmdHelper.ReturnCmd) };
+
+                var proc = new Procedure(Token.NoToken, $"AbstractionCheck_{action.proc.Name}_{abs.proc.Name}", new List<TypeVariable>(),
+                    abs.impl.InParams, abs.impl.OutParams, requires, abs.modifiedGlobalVars.Select(Expr.Ident).ToList(), ensures);
+                var impl = new Implementation(Token.NoToken, proc.Name, new List<TypeVariable>(),
+                    proc.InParams, proc.OutParams, new List<Variable>(), blocks)
+                { Proc = proc };
+                ctc.program.AddTopLevelDeclaration(proc);
+                ctc.program.AddTopLevelDeclaration(impl);
+            }
+        }
+    }
+}

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -53,8 +53,6 @@ namespace Microsoft.Boogie
             return GetCheckerTuple(requires, ensures, new List<Variable>(), blocks);
         }
 
-
-
         public Tuple<Procedure, Implementation> GenerateConclusionChecker()
         {
             this.checkName = "conclusion";
@@ -63,7 +61,7 @@ namespace Microsoft.Boogie
             var ensures = new List<Ensures> {
                 GetEnsures(Substituter.Apply(subst, GetTransitionRelation(outputAction)))
             };
-            if (!OutputHasPendingAsyncs)
+            if (!outputAction.HasPendingAsyncs)
                 ensures.Add(new Ensures(false, NoPendingAsyncs));
 
             List<Cmd> cmds = GetGateAsserts(invariantAction, null).ToList<Cmd>();
@@ -80,7 +78,7 @@ namespace Microsoft.Boogie
             var requires = invariantAction.gate.Select(g => new Requires(false, g.Expr)).ToList();
             var ensures = new List<Ensures> { GetEnsures(GetInvariantTransitionRelation()) };
             var locals = new List<Variable>();
-            if (elim.Keys.Any(a => a.pendingAsyncs != null))
+            if (elim.Keys.Any(a => a.HasPendingAsyncs))
             {
                 locals.Add(newPAs.Decl);
             }
@@ -102,7 +100,7 @@ namespace Microsoft.Boogie
                 }
                 var subst = Substituter.SubstitutionFromHashtable(map);
                 List<IdentifierExpr> outputVars = new List<IdentifierExpr>();
-                if (pendingAsync.pendingAsyncs != null)
+                if (pendingAsync.HasPendingAsyncs)
                 {
                     outputVars.Add(newPAs);
                 }
@@ -111,7 +109,7 @@ namespace Microsoft.Boogie
                 cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.membership, choice)));
                 cmds.AddRange(GetGateAsserts(abs, subst));
                 cmds.Add(CmdHelper.CallCmd(abs.proc, inputExprs, outputVars));
-                if (pendingAsync.pendingAsyncs != null)
+                if (pendingAsync.HasPendingAsyncs)
                 {
                     cmds.Add(AddNewPAs(pendingAsyncAdd));
                 }
@@ -196,8 +194,6 @@ namespace Microsoft.Boogie
         private Type PendingAsyncType => PendingAsyncMultisetType.Arguments[0];
 
         private bool HasChoice => invariantAction.impl.OutParams.Count > inputAction.impl.OutParams.Count;
-
-        private bool OutputHasPendingAsyncs => outputAction.pendingAsyncs != null;
 
         private IdentifierExpr PAs => Expr.Ident(HasChoice ? invariantAction.impl.OutParams[invariantAction.impl.OutParams.Count - 2] : invariantAction.impl.OutParams.Last());
 

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -1055,9 +1055,6 @@ namespace Microsoft.Boogie
         #region Linearity Invariant Checker
         public static void AddCheckers(LinearTypeChecker linearTypeChecker, CivlTypeChecker civlTypeChecker, List<Declaration> decls)
         {
-            if (civlTypeChecker.procToAtomicAction.Count == 0)
-                return;
-
             foreach (var action in civlTypeChecker.procToAtomicAction.Values)
             {
                 AddChecker(action, linearTypeChecker, decls);
@@ -1177,13 +1174,13 @@ namespace Microsoft.Boogie
         {
             public override Variable VisitVariable(Variable node)
             {
-                CivlAttributes.RemoveLinearAttribute(node);
+                CivlAttributes.RemoveLinearAttributes(node);
                 return base.VisitVariable(node);
             }
 
             public override Function VisitFunction(Function node)
             {
-                CivlAttributes.RemoveLinearAttribute(node);
+                CivlAttributes.RemoveLinearAttributes(node);
                 return base.VisitFunction(node);
             }
         }

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -456,8 +456,6 @@ namespace Microsoft.Boogie
         {
             if (ctc.procToAtomicAction.ContainsKey(node.Proc))
                 return node;
-            if (ctc.procToAtomicAction.Values.SelectMany(a => a.layerToActionCopy.Values).Select(a => a.impl).Contains(node))
-                return node;
 
             node.PruneUnreachableBlocks();
             node.ComputePredecessorsForBlocks();
@@ -1060,14 +1058,13 @@ namespace Microsoft.Boogie
             if (civlTypeChecker.procToAtomicAction.Count == 0)
                 return;
 
-            foreach (var action in civlTypeChecker.procToAtomicAction.Values
-                .SelectMany(a => a.layerToActionCopy.Values))
+            foreach (var action in civlTypeChecker.procToAtomicAction.Values)
             {
                 AddChecker(action, linearTypeChecker, decls);
             }
         }
 
-        private static void AddChecker(AtomicActionCopy action, LinearTypeChecker linearTypeChecker, List<Declaration> decls)
+        private static void AddChecker(AtomicAction action, LinearTypeChecker linearTypeChecker, List<Declaration> decls)
         {
             // Note: The implementation should be used as the variables in the
             //       gate are bound to implementation and not to the procedure.

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Boogie
                     }
                 }
             }
-            foreach (AtomicAction atomicAction in civlTypeChecker.procToAtomicAction.Values.Where(a => a.IsLeftMover))
+            foreach (AtomicAction atomicAction in civlTypeChecker.AllActions.Where(a => a.IsLeftMover))
             {
                 moverChecking.CreateNonBlockingChecker(atomicAction);
             }

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -38,9 +38,10 @@ namespace Microsoft.Boogie
             foreach (int layer in Enumerable.Range(min, max))
             {
                 var pool = civlTypeChecker.procToAtomicAction.Values.Where(a => a.layerRange.Contains(layer));
+                var absPool = civlTypeChecker.procToIsAbstraction.Values.Where(a => a.layerRange.Contains(layer));
 
                 var moverChecks =
-                    from first in pool
+                    from first in pool.Union(absPool)
                     from second in pool
                     where first.moverType != MoverType.Atomic
                     select new { First = first, Second = second };

--- a/Source/Concurrency/PendingAsyncChecker.cs
+++ b/Source/Concurrency/PendingAsyncChecker.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Boogie
+{
+    public static class PendingAsyncChecker
+    {
+        public static void AddCheckers(CivlTypeChecker ctc)
+        {
+            foreach (var action in ctc.AllActions.Where(a => a.HasPendingAsyncs))
+            {
+                var requires = action.gate.Select(g => new Requires(false, g.Expr)).ToList();
+                var cmds = new List<Cmd>
+                {
+                    CmdHelper.CallCmd(
+                        action.proc,
+                        action.impl.InParams.Select(Expr.Ident).ToList<Expr>(),
+                        action.impl.OutParams.Select(Expr.Ident).ToList())
+                };
+                var blocks = new List<Block>() { new Block(Token.NoToken, "init", cmds, CmdHelper.ReturnCmd) };
+
+                var PAs = Expr.Ident(action.impl.OutParams.Last(p => p.TypedIdent.Type.Equals(ctc.pendingAsyncMultisetType)));
+                var paBound = VarHelper.BoundVariable("pa", ctc.pendingAsyncType);
+                var pa = Expr.Ident(paBound);
+
+                var nonnegativeExpr =
+                    new ForallExpr(Token.NoToken, new List<Variable> { paBound },
+                        Expr.Ge(Expr.Select(PAs, pa), Expr.Literal(0)));
+                var correctTypeExpr = new ForallExpr(Token.NoToken, new List<Variable> { paBound },
+                    Expr.Imp(
+                        Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0)),
+                        Expr.Or(action.pendingAsyncs.Select(a => ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa)))));
+                var ensures = new List<Ensures> {
+                    new Ensures(false, nonnegativeExpr) { ErrorData = $"Action {action.proc.Name} might create negative pending asyncs" },
+                    new Ensures(false, correctTypeExpr) { ErrorData = $"Action {action.proc.Name} might create undeclared pending asyncs" },
+                };
+
+                CivlUtil.ResolveAndTypecheck(ensures);
+
+                var proc = new Procedure(Token.NoToken, $"PendingAsyncChecker_{action.proc.Name}", new List<TypeVariable>(),
+                    action.impl.InParams, action.impl.OutParams,
+                    requires, action.proc.Modifies, ensures);
+                var impl = new Implementation(Token.NoToken, proc.Name, proc.TypeParameters,
+                    proc.InParams, proc.OutParams, new List<Variable>(), blocks)
+                    { Proc = proc };
+
+                ctc.program.AddTopLevelDeclaration(proc);
+                ctc.program.AddTopLevelDeclaration(impl);
+            }
+        }
+    }
+}

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Boogie
                 allOutParams = new HashSet<Variable>(first.OutParams);
                 allLocVars = new HashSet<Variable>(first.LocVars);
                 frameIntermediateCopy = new Dictionary<Variable, Variable>();
-                if (IsJoint())
+                if (IsJoint)
                 {
                     allInParams.UnionWith(second.InParams);
                     allOutParams.UnionWith(second.OutParams);
@@ -202,7 +202,7 @@ namespace Microsoft.Boogie
                 SetupVarCopies();
                 IntroduceIntermediateVars();
                 EliminateIntermediateVariables();
-                if (IsJoint())
+                if (IsJoint)
                 {
                     EliminateWithIntermediateState();
                 }
@@ -211,7 +211,7 @@ namespace Microsoft.Boogie
 
             private void EliminateWithIntermediateState()
             {
-                Debug.Assert(IsJoint());
+                Debug.Assert(IsJoint);
 
                 var remainingIntermediateFrame = frameIntermediateCopy.Values.Except(varToExpr.Keys);
                 while (TryElimination(remainingIntermediateFrame)) { }
@@ -221,38 +221,19 @@ namespace Microsoft.Boogie
                 // TODO: Generate warning for variables without any witness functions
             }
 
-            private bool IsJoint()
-            {
-                return second != null;
-            }
+            private bool IsJoint => second != null;
 
-            private IEnumerable<Variable> UsedVariables
-            {
-                get
-                {
-                    return allInParams.
-                        Union(allOutParams).
-                        Union(allLocVars).
-                        Union(frame).Distinct();
-                }
-            }
+            private IEnumerable<Variable> UsedVariables =>
+                allInParams.
+                    Union(allOutParams).
+                    Union(allLocVars).
+                    Union(frame).Distinct();
 
-            private IEnumerable<Variable> FrameWithWitnesses
-            {
-                get {
-                    return frame.Intersect(
-                        transitionRelationComputer.globalVarToWitnesses.Keys);
-                }
-            }
+            private IEnumerable<Variable> FrameWithWitnesses =>
+                frame.Intersect(transitionRelationComputer.globalVarToWitnesses.Keys);
 
-            private IEnumerable<Variable> IntermediateFrameWithWitnesses
-            {
-                get
-                {
-                    return FrameWithWitnesses.
-                        Select(v => frameIntermediateCopy[v]);
-                }
-            }
+            private IEnumerable<Variable> IntermediateFrameWithWitnesses =>
+                FrameWithWitnesses.Select(v => frameIntermediateCopy[v]);
 
             private void SetupVarCopies()
             {
@@ -288,7 +269,7 @@ namespace Microsoft.Boogie
                 newCmds = new List<Cmd>();
                 for (int k = 0; k < cmds.Count; k++)
                 {
-                    if (IsJoint() && k == transitionRelationComputer.transferIndex)
+                    if (IsJoint && k == transitionRelationComputer.transferIndex)
                     {
                         PopulateIntermediateFrameCopy();
                         oldSub = Substituter.SubstitutionFromHashtable(GetPreStateVars().
@@ -346,7 +327,7 @@ namespace Microsoft.Boogie
                     }
                 }
                 // TODO: Add note on this
-                if (!IsJoint() || cmds.Count == transitionRelationComputer.transferIndex)
+                if (!IsJoint || cmds.Count == transitionRelationComputer.transferIndex)
                     PopulateIntermediateFrameCopy();
             }
 
@@ -470,7 +451,7 @@ namespace Microsoft.Boogie
                 AddBoundVariablesForRemainingVars();
                 ReplacePreOrPostStateVars();
                 TransitionRelationExpr = Expr.And(pathExprs);
-                if (IsJoint())
+                if (IsJoint)
                 {
                     ComputeWitnessedTransitionRelationExprs();
                     if (witnessedTransitionRelations.Count > 0)

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -594,4 +594,55 @@ namespace Microsoft.Boogie
             }
         }
     }
+
+    public static class BackwardAssignmentSubstituter
+    {
+        public static void SubstituteBackwardAssignments(IEnumerable<AtomicAction> actions)
+        {
+            foreach (var action in actions)
+            {
+                SubstituteBackwardAssignments(action);
+            }
+        }
+
+        private static void SubstituteBackwardAssignments(AtomicAction action)
+        {
+            foreach (Block block in action.impl.Blocks)
+            {
+                List<Cmd> cmds = new List<Cmd>();
+                foreach (Cmd cmd in block.cmds)
+                {
+                    if (cmd is AssignCmd _assignCmd &&
+                        QKeyValue.FindBoolAttribute(_assignCmd.Attributes, CivlAttributes.BACKWARD))
+                    {
+                        AssignCmd assignCmd = _assignCmd.AsSimpleAssignCmd;
+                        var lhss = assignCmd.Lhss;
+                        var rhss = assignCmd.Rhss;
+                        var rhssVars = rhss.SelectMany(x => VariableCollector.Collect(x));
+                        var lhssVars = lhss.SelectMany(x => VariableCollector.Collect(x));
+                        if (rhssVars.Intersect(lhssVars).Any())
+                        {
+                            // TODO
+                            throw new NotImplementedException("Substitution of backward assignment where lhs appears on rhs");
+                        }
+                        else
+                        {
+                            List<Expr> assumeExprs = new List<Expr>();
+                            for (int k = 0; k < lhss.Count; k++)
+                            {
+                                assumeExprs.Add(Expr.Eq(lhss[k].AsExpr, rhss[k]));
+                            }
+                            cmds.Add(new AssumeCmd(Token.NoToken, Expr.And(assumeExprs)));
+                            cmds.Add(new HavocCmd(Token.NoToken, lhss.Select(x => x.DeepAssignedIdentifier).ToList()));
+                        }
+                    }
+                    else
+                    {
+                        cmds.Add(cmd);
+                    }
+                }
+                block.cmds = cmds;
+            }
+        }
+    }
 }

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Boogie
             {
                 return new AssignCmd(cmd.tok,
                     assignCmd.Lhss,
-                    assignCmd.Rhss.Select(x => Substituter.Apply(sub, x)).ToList(),
+                    SubstitutionHelper.Apply(sub, assignCmd.Rhss).ToList(),
                     assignCmd.Attributes);
             }
             return Substituter.Apply(sub, cmd);
@@ -468,8 +468,7 @@ namespace Microsoft.Boogie
         {
             var remainingVars = NotEliminatedVars.Except(IntermediateFrameWithWitnesses);
             existsVarMap = remainingVars.ToDictionary(v => (Variable)VarHelper.BoundVariable(v.Name, v.TypedIdent.Type));
-            var varSubst = SubstitutionHelper.FromVariableMap(existsVarMap);
-            pathExprs = pathExprs.Select(x => Substituter.Apply(varSubst, x)).ToList();
+            pathExprs = SubstitutionHelper.Apply(existsVarMap, pathExprs).ToList();
         }
 
         private void ReplacePreOrPostStateVars()
@@ -495,8 +494,7 @@ namespace Microsoft.Boogie
                 frameCopiesSub = frameCopiesSub.Union(postStateSub).ToDictionary(k => k.Key, v => v.Value);
             }
 
-            var finalSub = Substituter.SubstitutionFromHashtable(frameCopiesSub);
-            pathExprs = pathExprs.Select(x => Substituter.Apply(finalSub, x)).ToList();
+            pathExprs = SubstitutionHelper.Apply(frameCopiesSub, pathExprs).ToList();
         }
 
         private void ComputeWitnessedTransitionRelationExprs()
@@ -518,9 +516,8 @@ namespace Microsoft.Boogie
                             witnessFunction.function, witnessFunction.args.ToArray()
                         );
                 }
-                var subst = Substituter.SubstitutionFromHashtable(witnessSubst);
                 witnessedTransitionRelations.Add(
-                    Substituter.Apply(subst, TransitionRelationExpr));
+                    SubstitutionHelper.Apply(witnessSubst, TransitionRelationExpr));
             }
         }
 

--- a/Source/Concurrency/Witnesses.cs
+++ b/Source/Concurrency/Witnesses.cs
@@ -7,54 +7,36 @@ namespace Microsoft.Boogie
 {
     public class WitnessFunction
     {
-        public enum InputArgumentKind
-        {
-            PRE_STATE,
-            POST_STATE,
-            FIRST_ARG,
-            SECOND_ARG
-        }
-
-        public struct InputArgument
-        {
-            public readonly InputArgumentKind Kind;
-            public readonly string Name;
-
-            public InputArgument(InputArgumentKind kind, string name)
-            {
-                this.Kind = kind;
-                this.Name = name;
-            }
-        }
-
         public readonly Function function;
-        public readonly GlobalVariable globalVar;
+        public readonly Variable witnessedVariable;
         public readonly AtomicAction firstAction;
         public readonly AtomicAction secondAction;
-        public readonly List<int> layers;
-        public List<InputArgument> InputArgs { get; private set; }
+        public List<Expr> args;
 
-        public WitnessFunction(Function function, GlobalVariable globalVar,
-            AtomicAction firstAction, AtomicAction secondAction, List<int> layers)
+        public WitnessFunction(Function function, Variable witnessedVariable,
+            AtomicAction firstAction, AtomicAction secondAction, List<Expr> args)
         {
             this.function = function;
-            this.globalVar = globalVar;
+            this.witnessedVariable = witnessedVariable;
             this.firstAction = firstAction;
             this.secondAction = secondAction;
-            this.layers = layers;
-            this.InputArgs = new List<InputArgument>();
-        }
-
-        internal void AddInputMap(InputArgumentKind argumentKind, string name)
-        {
-            InputArgs.Add(new InputArgument(argumentKind, name));
+            this.args = args;
         }
     }
 
-    class WitnessFunctionVisitor : ReadOnlyVisitor
+    class WitnessFunctionVisitor
     {
+        private const string FirstProcInputPrefix = "first_";
+        private const string SecondProcInputPrefix = "second_";
+        private const string PostStateSuffix = "'";
+
         private readonly CivlTypeChecker ctc;
         internal List<WitnessFunction> allWitnessFunctions;
+
+        private Variable witnessedVariable;
+        private AtomicAction firstAction;
+        private AtomicAction secondAction;
+        private List<Expr> args;
 
         public WitnessFunctionVisitor(CivlTypeChecker ctc)
         {
@@ -62,294 +44,113 @@ namespace Microsoft.Boogie
             allWitnessFunctions = new List<WitnessFunction>();
         }
 
-        public override Function VisitFunction(Function node)
+        public void VisitFunctions()
         {
-            for (QKeyValue kv = node.Attributes; kv != null; kv = kv.Next)
+            foreach (var f in ctc.program.Functions)
+            {
+                VisitFunction(f);
+            }
+        }
+
+        private void VisitFunction(Function function)
+        {
+            Debug.Assert(function.OutParams.Count == 1);
+            for (QKeyValue kv = function.Attributes; kv != null; kv = kv.Next)
             {
                 if (kv.Key != CivlAttributes.WITNESS)
                     continue;
-                if (kv.Params.Count == 1 && kv.Params[0] is string witnessAttribute)
+                if (kv.Params.Count == 3 &&
+                    kv.Params[0] is string witnessedVariableName &&
+                    kv.Params[1] is string firstActionName &&
+                    kv.Params[2] is string secondActionName)
                 {
-                    int parserErrorCount = WitnessAttributeParser.Parse(ctc, node, witnessAttribute,
-                        out WitnessFunction witnessFunction);
-                    if (parserErrorCount == 0 &&
-                        WitnessFunctionChecker.Check(node, ctc, witnessFunction) == 0)
+                    witnessedVariable = ctc.sharedVariables.Find(v => v.Name == witnessedVariableName);
+                    if (witnessedVariable == null)
                     {
-                        allWitnessFunctions.Add(witnessFunction);
+                        ctc.Error(kv, $"Could not find shared variable {witnessedVariableName}");
                     }
+                    else if (!function.OutParams[0].TypedIdent.Type.Equals(witnessedVariable.TypedIdent.Type))
+                    {
+                        ctc.Error(function, "Result type does not match witnessed variable");
+                    }
+                    firstAction = ctc.FindAtomicAction(firstActionName);
+                    secondAction = ctc.FindAtomicAction(secondActionName);
+                    if (firstAction == null)
+                    {
+                        ctc.Error(kv, $"Could not find atomic action {firstActionName}");
+                    }
+                    if (secondAction == null)
+                    {
+                        ctc.Error(kv, $"Could not find atomic action {firstActionName}");
+                    }
+                    if (firstAction != null && secondAction != null)
+                    {
+                        CheckInParams(function.InParams);
+                    }
+                    allWitnessFunctions.Add(new WitnessFunction(function, witnessedVariable,
+                        firstAction, secondAction, args));
                 }
                 else
                 {
-                    ctc.Error(node, "Witness attribute has to be a string.");
+                    ctc.Error(kv, "Witness attribute expects three string parameters");
                 }
-            }
-            return base.VisitFunction(node);
-        }
-
-        private class WitnessFunctionChecker
-        {
-            // TODO: Move these to a better place
-            private const string FirstProcInputPrefix = "first_";
-            private const string SecondProcInputPrefix = "second_";
-            private const string PostStateSuffix = "'";
-            private readonly Function node;
-            private readonly CivlTypeChecker ctc;
-            private readonly WitnessFunction witnessFunction;
-
-            private int errorCount;
-
-            private WitnessFunctionChecker(Function node, CivlTypeChecker ctc, WitnessFunction witnessFunction)
-            {
-                this.node = node;
-                this.ctc = ctc;
-                this.witnessFunction = witnessFunction;
-                this.errorCount = 0;
-                Check();
-            }
-
-            internal static int Check(Function node, CivlTypeChecker ctc, WitnessFunction witnessFunction)
-            {
-                var checker = new WitnessFunctionChecker(node, ctc, witnessFunction);
-                return checker.errorCount;
-            }
-
-            private void Check()
-            {
-                CheckOutputVariable();
-                CheckAtomicActionsLayers();
-                CheckArguments();
-            }
-
-            private void CheckAtomicActionsLayers()
-            {
-                AtomicAction[] actions = { witnessFunction.firstAction, witnessFunction.secondAction };
-                foreach (var action in actions)
-                {
-                    CheckLayerExistence(action.layerRange, action.proc.Name);
-                }
-            }
-
-            private void CheckLayerExistence(LayerRange layerRange, string nodeName)
-            {
-                foreach (int layer in witnessFunction.layers)
-                {
-                    if (!layerRange.Contains(layer))
-                    {
-                        Error(string.Format("{0} does not exist at layer {1}", nodeName, layer));
-                    }
-                }
-            }
-
-            private void CheckOutputVariable()
-            {
-                if (node.OutParams.Count != 1)
-                {
-                    Error("Witness functions must have only one output");
-                    return;
-                }
-                var v = witnessFunction.globalVar;
-                CheckGlobalArg(v.TypedIdent.Type, v.Name);
-            }
-
-            private void CheckArguments()
-            {
-                for (int k = 0; k < node.InParams.Count; k++)
-                {
-                    var arg = node.InParams[k];
-                    string name = node.InParams[k].Name;
-                    Type type = arg.TypedIdent.Type;
-                    WitnessFunction.InputArgumentKind argumentKind;
-                    if (name.StartsWith(FirstProcInputPrefix, StringComparison.Ordinal))
-                    {
-                        name = name.Substring(FirstProcInputPrefix.Length);
-                        argumentKind = WitnessFunction.InputArgumentKind.FIRST_ARG;
-                        CheckArg(witnessFunction.firstAction, type, name);
-                    }
-                    else if (name.StartsWith(SecondProcInputPrefix, StringComparison.Ordinal))
-                    {
-                        name = name.Substring(SecondProcInputPrefix.Length);
-                        argumentKind = WitnessFunction.InputArgumentKind.SECOND_ARG;
-                        CheckArg(witnessFunction.secondAction, type, name);
-                    }
-                    else
-                    {
-                        if (name.EndsWith(PostStateSuffix, StringComparison.Ordinal))
-                        {
-                            name = name.Substring(0, name.Length - 1);
-                            argumentKind = WitnessFunction.InputArgumentKind.POST_STATE;
-                        }
-                        else
-                        {
-                            argumentKind = WitnessFunction.InputArgumentKind.PRE_STATE;
-                        }
-                        CheckGlobalArg(type, name);
-                    }
-                    witnessFunction.AddInputMap(argumentKind, name);
-                }
-            }
-
-            private void CheckGlobalArg(Type type, string name)
-            {
-                GlobalVariable globalVar = ctc.sharedVariables.Find(v => v.Name == name);
-                if (globalVar is null)
-                {
-                    Error("No matching global variable named " + name);
-                    return;
-                }
-
-                var gType = globalVar.TypedIdent.Type;
-                if (!type.Equals(gType))
-                {
-                    Error(string.Format(
-                        "Type mismatch for variable {0}. Expected {1} found {2}",
-                        name, gType, type));
-                }
-                CheckLayerExistence(ctc.GlobalVariableLayerRange(globalVar), globalVar.Name);
-            }
-
-            private void CheckArg(AtomicAction action, Type type, string name)
-            {
-                var proc = action.proc;
-                var v = proc.InParams.Union(proc.OutParams).
-                    FirstOrDefault(i => i.Name == name && i.TypedIdent.Type.Equals(type));
-                if (v is null)
-                {
-                    Error(string.Format("No parameter {0}:{1} found in {2}",
-                        name, type, action.proc.Name));
-                }
-            }
-
-            private void Error(string msg)
-            {
-                ctc.Error(node, msg);
-                errorCount++;
             }
         }
 
-        private class WitnessAttributeParser
+        private void CheckInParams(List<Variable> inParams)
         {
-            private readonly CivlTypeChecker ctc;
-            private readonly Function node;
-            private readonly string[] parts;
-
-            internal GlobalVariable globalVar;
-            internal AtomicAction firstAction;
-            internal AtomicAction secondAction;
-            internal List<int> layers;
-
-            private int parseIndex;
-            private string ld;
-
-            private int errorCount;
-
-            private WitnessAttributeParser(CivlTypeChecker ctc, Function node, string witnessAttr)
+            args = new List<Expr>();
+            foreach (var param in inParams)
             {
-                this.ctc = ctc;
-                this.node = node;
-
-                char[] separators = { ' ', '\t' };
-                parts = witnessAttr.Split(separators,
-                    StringSplitOptions.RemoveEmptyEntries);
-
-                this.parseIndex = 0;
-                this.errorCount = 0;
-                Parse();
-            }
-
-            internal static int Parse(CivlTypeChecker ctc, Function node, string witnessAttr,
-                out WitnessFunction witnessFunction)
-            {
-                var parser = new WitnessAttributeParser(ctc, node, witnessAttr);
-                witnessFunction = new WitnessFunction(node, parser.globalVar,
-                    parser.firstAction, parser.secondAction, parser.layers);
-                return parser.errorCount;
-            }
-
-            private void Parse()
-            {
-                ParseGlobalVar();
-                ParseProc(out firstAction);
-                ParseProc(out secondAction);
-                ParseLayers();
-                Debug.Assert(!TryNext());
-            }
-
-            private bool TryNext(string msg = null)
-            {
-                if (parseIndex >= parts.Length)
+                Expr arg = null;
+                if (param.Name.StartsWith(FirstProcInputPrefix, StringComparison.Ordinal))
                 {
-                    if (msg != null) { Error(msg); }
-                    ld = null;
-                    return false;
+                    arg = CheckLocal(param, firstAction.firstImpl, FirstProcInputPrefix);
                 }
-                ld = parts[parseIndex++];
-                return true;
-            }
-
-            private void ParseLayers()
-            {
-                layers = new List<int>();
-                if (TryNext("Expected layer number"))
+                else if (param.Name.StartsWith(SecondProcInputPrefix, StringComparison.Ordinal))
                 {
-                    do
-                    {
-                        AddLayer();
-                    } while (TryNext());
-                }
-            }
-
-            private void AddLayer()
-            {
-                if (int.TryParse(ld, out int layerNum))
-                {
-                    layers.Add(layerNum);
+                    arg = CheckLocal(param, secondAction.secondImpl, SecondProcInputPrefix);
                 }
                 else
                 {
-                    Error(string.Format("Expected integer layer number but received {0}", ld));
+                    arg = CheckGlobal(param);
                 }
+                args.Add(arg);
             }
+        }
 
-            private void ParseProc(out AtomicAction action)
+        private Expr CheckLocal(Variable param, Implementation impl, string prefix)
+        {
+            var var = FindVariable(param.Name, param.TypedIdent.Type,
+                impl.InParams.Union(impl.OutParams));
+            if (var != null)
+                return Expr.Ident(var);
+            var name = param.Name.Remove(0, prefix.Length);
+            ctc.Error(param, $"Action {impl.Name} does not have parameter {name}:{param.TypedIdent.Type}");
+            return null;
+        }
+
+        private Expr CheckGlobal(Variable param)
+        {
+            bool postState = param.Name.EndsWith(PostStateSuffix, StringComparison.Ordinal);
+            var name = param.Name;
+            if (postState)
+                name = name.Substring(0, name.Length - 1);
+            var var = FindVariable(name, param.TypedIdent.Type, ctc.sharedVariables);
+            if (var != null)
             {
-                TryNext("Expected procedure name.");
-                Procedure proc = ctc.program.FindProcedure(ld);
-                if (proc is null)
-                {
-                    Error("No procedure found with name of " + ld);
-                    action = null;
-                }
+                if (!postState)
+                    return ExprHelper.Old(Expr.Ident(var));
                 else
-                {
-                    if (!ctc.procToAtomicAction.ContainsKey(proc))
-                    {
-                        ctc.checkingContext.Warning(node,
-                            string.Format(
-                                "Procedure {0} does not have a mover type, witness function is ignored.",
-                                proc.Name));
-                        // TODO: Add notes on this
-                        errorCount++;
-                        action = null;
-                    }
-                    else { action = ctc.procToAtomicAction[proc]; }
-                }
+                    return Expr.Ident(var);
             }
+            ctc.Error(param, $"No shared variable {name}:{param.TypedIdent.Type}");
+            return null;
+        }
 
-            private void ParseGlobalVar()
-            {
-                TryNext("Expected global variable name");
-                globalVar = ctc.sharedVariables.Find(v => v.Name == ld);
-                if (globalVar is null)
-                {
-                    Error("No global variable found with name of " + ld);
-                }
-            }
-
-            private void Error(string msg)
-            {
-                ctc.Error(node, msg);
-                errorCount++;
-            }
+        private Variable FindVariable(string name, Type type, IEnumerable<Variable> vars)
+        {
+            return vars.FirstOrDefault(i => i.Name == name && i.TypedIdent.Type.Equals(type));
         }
     }
 }

--- a/Source/Concurrency/YieldTypeChecker.cs
+++ b/Source/Concurrency/YieldTypeChecker.cs
@@ -333,19 +333,16 @@ namespace Microsoft.Boogie
                 YieldingProc callee = @base.civlTypeChecker.procToYieldingProc[callCmd.Proc];
                 if (callCmd.IsAsync)
                 {
-                    if ((currLayerNum < yieldingProc.upperLayer && currLayerNum > callee.upperLayer) ||
-                        (currLayerNum == yieldingProc.upperLayer && callee.upperLayer < yieldingProc.upperLayer))
-                    {
+                    if (callee is ActionProc && !callCmd.HasAttribute(CivlAttributes.SYNC))
+                        return L;
+                    if (callee.upperLayer < currLayerNum || (callee.upperLayer == currLayerNum && callee is MoverProc))
                         return MoverTypeToLabel(callee.moverType);
-                    }
                     return L;
                 }
                 else
                 {
                     if (callee.upperLayer < currLayerNum || (callee.upperLayer == currLayerNum && callee is MoverProc))
-                    {
                         return MoverTypeToLabel(callee.moverType);
-                    }
                     return Y;
                 }
             }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Boogie
         private CivlTypeChecker civlTypeChecker;
         private LinearTypeChecker linearTypeChecker;
         private Dictionary<Procedure, Procedure> procToSkipProcDummy;
+        private Implementation enclosingImpl;
         private YieldingProc enclosingYieldingProc;
 
         private int layerNum;
@@ -44,7 +45,7 @@ namespace Microsoft.Boogie
                     if (yieldingProc is ActionProc actionProc)
                     {
                         // yielding procedure already transformed to atomic action
-                        return actionProc.refinedAction.proc;
+                        return actionProc.RefinedActionAtLayer(layerNum).proc;
                     }
                     else if (yieldingProc is SkipProc)
                     {
@@ -114,17 +115,40 @@ namespace Microsoft.Boogie
             return ensures;
         }
 
+        private bool IsRefinementLayer => layerNum == enclosingYieldingProc.upperLayer;
+
         public override Implementation VisitImplementation(Implementation impl)
         {
             if (!civlTypeChecker.procToYieldingProc.ContainsKey(impl.Proc))
                 return impl;
 
+            enclosingImpl = impl;
             enclosingYieldingProc = civlTypeChecker.procToYieldingProc[impl.Proc];
             if (layerNum > enclosingYieldingProc.upperLayer)
                 return impl;
 
+            returnedPAs = null;
+
             Implementation newImpl = base.VisitImplementation(impl);
             newImpl.Name = newImpl.Proc.Name;
+
+            if (returnedPAs != null)
+                newImpl.LocVars.Add(returnedPAs);
+            if (enclosingYieldingProc is ActionProc && SummaryHasPendingAsyncParam && IsRefinementLayer)
+            {
+                // TODO: This was copied from InductiveSequentialization property NoPendingAsyncs.
+                // Unify pending async stuff in something like PendingAsyncInstrumentation?
+                var paBound = VarHelper.BoundVariable("pa", civlTypeChecker.pendingAsyncType);
+                var pa = Expr.Ident(paBound);
+                var expr = Expr.Eq(Expr.Select(Expr.Ident(CollectedPAs), pa), Expr.Literal(0));
+                var forallExpr = new ForallExpr(Token.NoToken, new List<Variable> { paBound }, expr);
+                forallExpr.Typecheck(new TypecheckingContext(null));  // TODO: why here?
+                newImpl.Blocks.First().Cmds.Insert(0, CmdHelper.AssumeCmd(forallExpr));
+
+                if (!impl.LocVars.Contains(CollectedPAs))
+                    newImpl.LocVars.Add(CollectedPAs);
+            }
+
             implMap[newImpl] = impl;
             return newImpl;
         }
@@ -155,27 +179,6 @@ namespace Microsoft.Boogie
         {
             CallCmd newCall = (CallCmd) base.VisitCallCmd(call);
             newCall.Proc = VisitProcedure(newCall.Proc);
-
-            if (newCall.IsAsync)
-            {
-                Debug.Assert(civlTypeChecker.procToYieldingProc.ContainsKey(call.Proc));
-                YieldingProc yieldingProc = civlTypeChecker.procToYieldingProc[call.Proc];
-                Debug.Assert(yieldingProc.IsLeftMover);
-                if (yieldingProc.upperLayer < layerNum ||
-                    (yieldingProc is MoverProc && yieldingProc.upperLayer == layerNum))
-                {
-                    newCall.IsAsync = false;
-                }
-
-                if (enclosingYieldingProc.upperLayer == layerNum && yieldingProc.upperLayer > layerNum)
-                {
-                    ActionProc actionProc = (ActionProc) yieldingProc;
-                    // TODO: IS
-                    // newCall.Proc = actionProc.addPendingAsyncProc;
-                    newCall.IsAsync = false;
-                }
-            }
-
             newCall.callee = newCall.Proc.Name;
             absyMap[newCall] = call;
             return newCall;
@@ -188,40 +191,154 @@ namespace Microsoft.Boogie
             return parCallCmd;
         }
 
+        private List<Cmd> newCmdSeq;
+
         public override List<Cmd> VisitCmdSeq(List<Cmd> cmdSeq)
         {
-            List<Cmd> visitedCmdSeq = base.VisitCmdSeq(cmdSeq);
-            List<Cmd> newCmdSeq = new List<Cmd>();
-            for (int i = 0; i < visitedCmdSeq.Count; i++)
+            newCmdSeq = new List<Cmd>();
+            foreach(var cmd in cmdSeq)
             {
-                Cmd originalCmd = cmdSeq[i];
-                Cmd visitedCmd = visitedCmdSeq[i];
+                Cmd newCmd = (Cmd)Visit(cmd);
 
-                if (originalCmd is CallCmd)
+                if (newCmd is CallCmd)
                 {
-                    ProcessCallCmd((CallCmd) originalCmd, (CallCmd) visitedCmd, newCmdSeq);
+                    ProcessCallCmd((CallCmd) cmd, (CallCmd)newCmd);
                 }
-                else if (originalCmd is ParCallCmd)
+                else if (newCmd is ParCallCmd)
                 {
-                    ProcessParCallCmd((ParCallCmd) originalCmd, (ParCallCmd) visitedCmd, newCmdSeq);
+                    ProcessParCallCmd((ParCallCmd) cmd, (ParCallCmd) newCmd);
                 }
-                else
+                else if (!(newCmd is PredicateCmd predicateCmd && predicateCmd.Expr.Equals(Expr.True)))
                 {
-                    newCmdSeq.Add(visitedCmd);
+                    newCmdSeq.Add(newCmd);
                 }
             }
 
-            newCmdSeq.RemoveAll(cmd => (cmd is AssertCmd assertCmd && assertCmd.Expr.Equals(Expr.True)) ||
-                                       (cmd is AssumeCmd assumeCmd && assumeCmd.Expr.Equals(Expr.True)));
             return newCmdSeq;
+        }
+
+        private bool SummaryHasPendingAsyncParam => ((ActionProc)enclosingYieldingProc).refinedAction.HasPendingAsyncs;
+
+        private Variable returnedPAs;
+        private Variable ReturnedPAs
+        {
+            get
+            {
+                if (returnedPAs == null)
+                    returnedPAs = VarHelper.LocalVariable("returnedPAs", civlTypeChecker.pendingAsyncMultisetType);
+                return ReturnedPAs;
+            }
+        }
+
+        private Variable CollectedPAs
+        {
+            get
+            {
+                if (!civlTypeChecker.implToPendingAsyncCollector.TryGetValue(enclosingImpl, out var collectedPAs))
+                {
+                    collectedPAs = VarHelper.LocalVariable("collectedPAs", civlTypeChecker.pendingAsyncMultisetType);
+                    civlTypeChecker.implToPendingAsyncCollector[enclosingImpl] = collectedPAs;
+                }
+                return collectedPAs;
+            }
+        }
+
+        private void ProcessCallCmd(CallCmd call, CallCmd newCall)
+        {
+            if (civlTypeChecker.procToIntroductionProc.ContainsKey(call.Proc))
+            {
+                if (!civlTypeChecker.CallExists(call, enclosingYieldingProc.upperLayer, layerNum))
+                    return;
+            }
+            else
+            {
+                YieldingProc yieldingProc = civlTypeChecker.procToYieldingProc[call.Proc];
+                if (newCall.IsAsync)
+                {
+                    if (((yieldingProc is SkipProc || call.HasAttribute(CivlAttributes.SYNC)) && yieldingProc.upperLayer < layerNum) ||
+                        (yieldingProc is MoverProc && yieldingProc.upperLayer == layerNum))
+                    {
+                        newCall.IsAsync = false;
+                    }
+
+                    if (yieldingProc is ActionProc actionProc && !call.HasAttribute(CivlAttributes.SYNC) && yieldingProc.upperLayer <= layerNum)
+                    {
+                        if (layerNum != enclosingYieldingProc.upperLayer) return;
+                        if (SummaryHasPendingAsyncParam)
+                        {
+                            AtomicAction paAction;
+                            if (actionProc.upperLayer == enclosingYieldingProc.upperLayer)
+                                paAction = actionProc.refinedAction;
+                            else
+                                paAction = actionProc.RefinedActionAtLayer(layerNum);
+
+                            var pa = ExprHelper.FunctionCall(paAction.pendingAsyncCtor, newCall.Ins.ToArray());
+                            var inc = Expr.Add(Expr.Select(Expr.Ident(CollectedPAs), pa), Expr.Literal(1));
+                            var add = CmdHelper.AssignCmd(CollectedPAs, Expr.Store(Expr.Ident(CollectedPAs), pa, inc));
+                            newCmdSeq.Add(add);
+                        }
+                        else
+                        {
+                            newCmdSeq.Add(new AssertCmd(call.tok, Expr.False) { ErrorData = "This pending async is not summarized" });
+                        }
+                        return;
+                    }
+                }
+
+                InjectGate(yieldingProc, newCall);
+            }
+
+            newCmdSeq.Add(newCall);
+            if (call.Outs.Count < newCall.Outs.Count)
+            {
+                newCall.Outs.Add(Expr.Ident(ReturnedPAs));
+                if (IsRefinementLayer)
+                {
+                    if (SummaryHasPendingAsyncParam)
+                    {
+                        var collectedUnionReturned = ExprHelper.FunctionCall(civlTypeChecker.pendingAsyncAdd, Expr.Ident(CollectedPAs), Expr.Ident(ReturnedPAs));
+                        newCmdSeq.Add(CmdHelper.AssignCmd(CollectedPAs, collectedUnionReturned));
+                    }
+                    else
+                    {
+                        // TODO: As above, this was copied from InductiveSequentialization property NoPendingAsyncs.
+                        // Unify pending async stuff in something like PendingAsyncInstrumentation?
+                        var paBound = VarHelper.BoundVariable("pa", civlTypeChecker.pendingAsyncType);
+                        var pa = Expr.Ident(paBound);
+                        var expr = Expr.Eq(Expr.Select(Expr.Ident(ReturnedPAs), pa), Expr.Literal(0));
+                        var forallExpr = new ForallExpr(Token.NoToken, new List<Variable> { paBound }, expr);
+                        forallExpr.Typecheck(new TypecheckingContext(null));  // TODO: why here?
+                        newCmdSeq.Add(new AssertCmd(call.tok, forallExpr) { ErrorData = "Pending asyncs created by this call are not summarized" });
+                    }
+                }
+            }
+        }
+
+        private void ProcessParCallCmd(ParCallCmd parCall, ParCallCmd newParCall)
+        {
+            int maxCalleeLayerNum = parCall.CallCmds.Select(c => civlTypeChecker.procToYieldingProc[c.Proc].upperLayer).Max();
+
+            if (layerNum > maxCalleeLayerNum)
+            {
+                foreach (var pair in parCall.CallCmds.Zip(newParCall.CallCmds))
+                {
+                    ProcessCallCmd(pair.Item1, pair.Item2);
+                    absyMap[pair.Item2] = parCall;
+                }
+            }
+            else
+            {
+                newCmdSeq.Add(newParCall);
+            }
         }
 
         // We only have to check the gate of a called atomic action (via an assert) at the creation layer of the caller.
         // In all layers below we just establish invariants which do not require the gates to be checked and we can inject is as an assume.
-        private void InjectGate(ActionProc calledActionProc, CallCmd callCmd, List<Cmd> newCmds)
+        private void InjectGate(YieldingProc yieldingProc, CallCmd callCmd)
         {
+            if (!(yieldingProc is ActionProc calledActionProc)) return;
             if (calledActionProc.upperLayer >= layerNum) return;
-            AtomicAction atomicAction = calledActionProc.refinedAction;
+            AtomicAction atomicAction = calledActionProc.RefinedActionAtLayer(layerNum);
             if (atomicAction.gate.Count == 0) return;
 
             Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
@@ -235,58 +352,16 @@ namespace Microsoft.Boogie
 
             // Important: Do not remove CommentCmd!
             // It separates the injected gate from yield assertions in CollectAndDesugarYields.
-            newCmds.Add(new CommentCmd("<<< injected gate"));
+            newCmdSeq.Add(new CommentCmd("<<< injected gate"));
             foreach (AssertCmd assertCmd in atomicAction.gate)
             {
-                if (layerNum == enclosingYieldingProc.upperLayer)
-                    newCmds.Add((AssertCmd) Substituter.Apply(subst, assertCmd));
+                if (IsRefinementLayer)
+                    newCmdSeq.Add((AssertCmd)Substituter.Apply(subst, assertCmd));
                 else
-                    newCmds.Add(new AssumeCmd(assertCmd.tok, Substituter.Apply(subst, assertCmd.Expr)));
+                    newCmdSeq.Add(new AssumeCmd(assertCmd.tok, Substituter.Apply(subst, assertCmd.Expr)));
             }
 
-            newCmds.Add(new CommentCmd("injected gate >>>"));
-        }
-
-        private void ProcessCallCmd(CallCmd originalCallCmd, CallCmd callCmd, List<Cmd> newCmds)
-        {
-            Procedure originalProc = originalCallCmd.Proc;
-
-            if (civlTypeChecker.procToIntroductionProc.ContainsKey(originalProc))
-            {
-                if (!civlTypeChecker.CallExists(originalCallCmd, enclosingYieldingProc.upperLayer, layerNum))
-                    return;
-            }
-            else if (civlTypeChecker.procToYieldingProc[originalProc] is ActionProc actionProc)
-            {
-                Debug.Assert(layerNum <= enclosingYieldingProc.upperLayer);
-                InjectGate(actionProc, callCmd, newCmds);
-            }
-
-            newCmds.Add(callCmd);
-        }
-
-        private void ProcessParCallCmd(ParCallCmd originalParCallCmd, ParCallCmd parCallCmd, List<Cmd> newCmds)
-        {
-            int maxCalleeLayerNum = 0;
-            foreach (CallCmd iter in originalParCallCmd.CallCmds)
-            {
-                int calleeLayerNum = civlTypeChecker.procToYieldingProc[iter.Proc].upperLayer;
-                if (calleeLayerNum > maxCalleeLayerNum)
-                    maxCalleeLayerNum = calleeLayerNum;
-            }
-
-            if (layerNum > maxCalleeLayerNum)
-            {
-                for (int i = 0; i < parCallCmd.CallCmds.Count; i++)
-                {
-                    ProcessCallCmd(originalParCallCmd.CallCmds[i], parCallCmd.CallCmds[i], newCmds);
-                    absyMap[parCallCmd.CallCmds[i]] = originalParCallCmd;
-                }
-            }
-            else
-            {
-                newCmds.Add(parCallCmd);
-            }
+            newCmdSeq.Add(new CommentCmd("injected gate >>>"));
         }
 
         public List<Declaration> Collect()

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -45,7 +45,12 @@ namespace Microsoft.Boogie
                     if (yieldingProc is ActionProc actionProc)
                     {
                         // yielding procedure already transformed to atomic action
-                        return actionProc.RefinedActionAtLayer(layerNum).proc;
+                        var refinedAction = actionProc.RefinedActionAtLayer(layerNum);
+                        if (refinedAction == null)
+                            // TODO: This can only happen because YieldingProcChecker.AddCheckers calls
+                            // VisitProcedure on every layer. Do this "call redirection" somewhere else?
+                            return node;
+                        return refinedAction.proc;
                     }
                     else if (yieldingProc is SkipProc)
                     {

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -150,16 +150,16 @@ namespace Microsoft.Boogie
 
             // initialize globalSnapshotInstrumentation
             globalSnapshotInstrumentation = new GlobalSnapshotInstrumentation(civlTypeChecker);
-            
+
             // initialize refinementInstrumentation
-            Procedure originalProc = implMap[impl].Proc;
-            YieldingProc yieldingProc = civlTypeChecker.procToYieldingProc[originalProc];
+            Implementation originalImpl = implMap[impl];
+            YieldingProc yieldingProc = civlTypeChecker.procToYieldingProc[originalImpl.Proc];
             if (yieldingProc.upperLayer == this.layerNum)
             {
                 refinementInstrumentation = new SomeRefinementInstrumentation(
                     civlTypeChecker, 
                     impl, 
-                    originalProc,
+                    originalImpl,
                     globalSnapshotInstrumentation.OldGlobalMap, 
                     yieldingLoopHeaders);
             }

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Boogie
         public const string WITNESS = "witness";
 
         public const string PENDING_ASYNC = "pending_async";
+        public const string SYNC = "sync";
 
         public const string IS = "IS";
         public const string IS_INVARIANT = "IS_invariant";

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Boogie
 
         private static string[] CIVL_ATTRIBUTES =
             {LAYER, YIELDS, ATOMIC, LEFT, RIGHT, BOTH, REFINES, WITNESS,
-             PENDING_ASYNC, IS_INVARIANT, IS_ABSTRACTION, ELIM, CHOICE };
+             PENDING_ASYNC, IS, IS_INVARIANT, IS_ABSTRACTION, ELIM, CHOICE };
 
         private static string[] LINEAR_ATTRIBUTES =
             {LINEAR, LINEAR_IN, LINEAR_OUT };

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -26,10 +26,16 @@ namespace Microsoft.Boogie
         public const string LINEAR_IN = "linear_in";
         public const string LINEAR_OUT = "linear_out";
 
-        public const string PURE = "pure";
-
         public const string BACKWARD = "backward";
         public const string WITNESS = "witness";
+
+        public const string PENDING_ASYNC = "pending_async";
+
+        public static bool HasAttribute(this ICarriesAttributes obj, string attribute)
+        { return QKeyValue.FindBoolAttribute(obj.Attributes, attribute); }
+
+        public static bool IsYield(this Declaration decl) { return decl.HasAttribute(CivlAttributes.YIELDS); }
+        public static bool HasPendingAsync(this Declaration decl) { return decl.HasAttribute(CivlAttributes.PENDING_ASYNC); }
 
         public static bool RemoveAttribute(ICarriesAttributes obj, Func<QKeyValue, bool> cond)
         {

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -31,13 +31,23 @@ namespace Microsoft.Boogie
 
         public const string PENDING_ASYNC = "pending_async";
 
+        public const string IS = "IS";
+        public const string IS_INVARIANT = "IS_invariant";
+        public const string IS_ABSTRACTION = "IS_abstraction";
+        public const string ELIM = "elim";
+        public const string CHOICE = "choice";
+
+        private static string[] CIVL_ATTRIBUTES =
+            {LAYER, YIELDS, ATOMIC, LEFT, RIGHT, BOTH, REFINES, WITNESS,
+             PENDING_ASYNC, IS_INVARIANT, IS_ABSTRACTION, ELIM, CHOICE };
+
+        private static string[] LINEAR_ATTRIBUTES =
+            {LINEAR, LINEAR_IN, LINEAR_OUT };
+
         public static bool HasAttribute(this ICarriesAttributes obj, string attribute)
         { return QKeyValue.FindBoolAttribute(obj.Attributes, attribute); }
 
-        public static bool IsYield(this Declaration decl) { return decl.HasAttribute(CivlAttributes.YIELDS); }
-        public static bool HasPendingAsync(this Declaration decl) { return decl.HasAttribute(CivlAttributes.PENDING_ASYNC); }
-
-        public static bool RemoveAttribute(ICarriesAttributes obj, Func<QKeyValue, bool> cond)
+        public static bool RemoveAttributes(ICarriesAttributes obj, Func<QKeyValue, bool> cond)
         {
             QKeyValue curr = obj.Attributes;
             bool removed = false;
@@ -63,58 +73,19 @@ namespace Microsoft.Boogie
             return removed;
         }
 
-        public static void RemoveYieldsAttribute(ICarriesAttributes obj)
+        public static void RemoveAttributes(ICarriesAttributes obj, ICollection<string> keys)
         {
-            RemoveAttribute(obj, kv => kv.Key == YIELDS);
+            RemoveAttributes(obj, kv => keys.Contains(kv.Key));
         }
 
-        public static void RemoveMoverAttribute(ICarriesAttributes obj)
+        public static void RemoveCivlAttributes(ICarriesAttributes obj)
         {
-            RemoveAttribute(obj,
-                kv => kv.Key == ATOMIC || kv.Key == LEFT || kv.Key == RIGHT || kv.Key == BOTH);
+            RemoveAttributes(obj, CIVL_ATTRIBUTES);
         }
 
-        public static void RemoveLayerAttribute(ICarriesAttributes obj)
+        public static void RemoveLinearAttributes(ICarriesAttributes obj)
         {
-            RemoveAttribute(obj, kv => kv.Key == LAYER);
-        }
-
-        public static void RemoveLinearAttribute(ICarriesAttributes obj)
-        {
-            RemoveAttribute(obj,
-                kv => kv.Key == LINEAR || kv.Key == LINEAR_IN || kv.Key == LINEAR_OUT);
-        }
-
-        public static void RemoveRefinesAttribute(ICarriesAttributes obj)
-        {
-            RemoveAttribute(obj, kv => kv.Key == REFINES);
-        }
-
-        public static void RemoveWitnessAttribute(ICarriesAttributes obj)
-        {
-            RemoveAttribute(obj, kv => kv.Key == WITNESS);
-        }
-
-        public static void DesugarYieldAssert(Program program)
-        {
-            foreach (var proc in program.Procedures)
-            {
-                if (RemoveAttribute(proc, kv => kv.Key == YIELD_ASSERT))
-                {
-                    proc.AddAttribute(YIELDS);
-                    foreach (var requires in proc.Requires)
-                    {
-                        var ensures = new Ensures(false, requires.Condition);
-                        ensures.Attributes = requires.Attributes;
-                        proc.Ensures.Add(ensures);
-                    }
-                }
-            }
-
-            foreach (var impl in program.Implementations)
-            {
-                RemoveAttribute(impl, kv => kv.Key == YIELD_ASSERT);
-            }
+            RemoveAttributes(obj, LINEAR_ATTRIBUTES);
         }
     }
 }

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -492,8 +492,6 @@ namespace Microsoft.Boogie
           PrintBplFile(CommandLineOptions.Clo.PrintFile, program, false, true, CommandLineOptions.Clo.PrettyPrint);
         }
 
-        CivlAttributes.DesugarYieldAssert(program);
-
         LinearTypeChecker linearTypeChecker;
         CivlTypeChecker civlTypeChecker;
         PipelineOutcome oc = ResolveAndTypecheck(program, fileNames[fileNames.Count - 1], out linearTypeChecker, out civlTypeChecker);

--- a/Test/civl/alloc-tid.bpl
+++ b/Test/civl/alloc-tid.bpl
@@ -81,7 +81,7 @@ ensures  {:layer 1} AllocInv(count, unallocated);
   assert {:layer 1} AllocInv(count, unallocated);
 }
 
-procedure {:atomic} {:layer 2,2} {:refines "AtomicWrite"} AtomicWrite({:linear "tid"} tid: int, i: int, val: int)
+procedure {:atomic} {:layer 2,2} AtomicWrite({:linear "tid"} tid: int, i: int, val: int)
 modifies a;
 {
   a[tid] := val;

--- a/Test/civl/async/2pc-triggers.bpl
+++ b/Test/civl/async/2pc-triggers.bpl
@@ -130,36 +130,44 @@ function {:inline} VotesEqCoordinatorState (votes: [Xid]int, state: GState, xid:
 // ###########################################################################
 // Yield assertions
 
-procedure {:yield_assert} {:layer 8} YieldInv_8 ()
+procedure {:yields} {:layer 8} YieldInv_8 ()
        requires {:layer 8} Inv_8(state, B, votes);
+       ensures  {:layer 8} Inv_8(state, B, votes);
 { yield; assert {:layer 8} Inv_8(state, B, votes); }
 
-procedure {:yield_assert} {:layer 8} YieldPairs_8 (xid: Xid, {:linear "pair"} pairs: [Pair]bool)
+procedure {:yields} {:layer 8} YieldPairs_8 (xid: Xid, {:linear "pair"} pairs: [Pair]bool)
        requires {:layer 8} Inv_8(state, B, votes) && (votes[xid] == -1 || (forall p: Pair :: pairs[p] ==> pair(xid, mid#Pair(p), p) && UndecidedOrCommitted(state[xid][mid#Pair(p)])));
+       ensures  {:layer 8} Inv_8(state, B, votes) && (votes[xid] == -1 || (forall p: Pair :: pairs[p] ==> pair(xid, mid#Pair(p), p) && UndecidedOrCommitted(state[xid][mid#Pair(p)])));
 { yield; assert {:layer 8} Inv_8(state, B, votes) && (votes[xid] == -1 || (forall p: Pair :: pairs[p] ==> pair(xid, mid#Pair(p), p) && UndecidedOrCommitted(state[xid][mid#Pair(p)]))); }
 
-procedure {:yield_assert} {:layer 8} YieldUndecidedOrCommitted_8 (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
+procedure {:yields} {:layer 8} YieldUndecidedOrCommitted_8 (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
        requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid] == -1 || UndecidedOrCommitted(state[xid][mid]));
+       ensures  {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid] == -1 || UndecidedOrCommitted(state[xid][mid]));
 { yield; assert {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid] == -1 || UndecidedOrCommitted(state[xid][mid])); }
 
-procedure {:yield_assert} {:layer 8} YieldAborted_8 (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
+procedure {:yields} {:layer 8} YieldAborted_8 (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
        requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(state[xid][mid]);
+       ensures  {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(state[xid][mid]);
 { yield; assert {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(state[xid][mid]); }
 
-procedure {:yield_assert} {:layer 9} YieldInv_9 (xid: Xid)
+procedure {:yields} {:layer 9} YieldInv_9 (xid: Xid)
        requires {:layer 9} Inv_9(state, B, xid);
+       ensures  {:layer 9} Inv_9(state, B, xid);
 { yield; assert {:layer 9} Inv_9(state, B, xid); }
 
-procedure {:yield_assert} {:layer 9} YieldConsistent_9 ()
+procedure {:yields} {:layer 9} YieldConsistent_9 ()
        requires {:layer 9} gConsistent(state);
+       ensures  {:layer 9} gConsistent(state);
 { yield; assert {:layer 9} gConsistent(state); }
 
-procedure {:yield_assert} {:layer 10} YieldConsistent_10 ()
+procedure {:yields} {:layer 10} YieldConsistent_10 ()
        requires {:layer 10} gConsistent(state);
+       ensures  {:layer 10} gConsistent(state);
 { yield; assert {:layer 10} gConsistent(state); }
 
-procedure {:yield_assert} {:layer 11} YieldConsistent_11 ()
+procedure {:yields} {:layer 11} YieldConsistent_11 ()
        requires {:layer 11} gConsistent(state);
+       ensures  {:layer 11} gConsistent(state);
 { yield; assert {:layer 11} gConsistent(state); }
 
 // ###########################################################################

--- a/Test/civl/async/2pc-triggers.bpl
+++ b/Test/civl/async/2pc-triggers.bpl
@@ -165,13 +165,13 @@ procedure {:yield_assert} {:layer 11} YieldConsistent_11 ()
 // ###########################################################################
 
 function
-{:witness "state atomic_Coordinator_VoteNo atomic_Coordinator_VoteNo 9"}
-{:witness "state atomic_Coordinator_VoteYes atomic_Coordinator_VoteNo 9"}
-{:witness "state atomic_Coordinator_VoteNo atomic_Coordinator_VoteYes 9"}
-{:witness "state atomic_Coordinator_VoteYes atomic_Coordinator_VoteYes 9"}
-{:witness "state atomic_SetParticipantAborted atomic_Coordinator_VoteYes 9"}
-{:witness "state atomic_SetParticipantAborted atomic_Coordinator_VoteNo 9"}
-{:witness "state atomic_Participant_VoteReq atomic_Participant_VoteReq 10"}
+{:witness "state","atomic_Coordinator_VoteNo","atomic_Coordinator_VoteNo"}
+{:witness "state","atomic_Coordinator_VoteYes","atomic_Coordinator_VoteNo"}
+{:witness "state","atomic_Coordinator_VoteNo","atomic_Coordinator_VoteYes"}
+{:witness "state","atomic_Coordinator_VoteYes","atomic_Coordinator_VoteYes"}
+{:witness "state","atomic_SetParticipantAborted","atomic_Coordinator_VoteYes"}
+{:witness "state","atomic_SetParticipantAborted","atomic_Coordinator_VoteNo"}
+{:witness "state","atomic_Participant_VoteReq","atomic_Participant_VoteReq"}
 witness (state:GState, state':GState, second_xid:Xid) : GState
 {
    state[second_xid := state'[second_xid]]

--- a/Test/civl/async/2pc-triggers.bpl
+++ b/Test/civl/async/2pc-triggers.bpl
@@ -250,7 +250,7 @@ ensures  {:layer 9,10} gConsistent(state);
   invariant {:layer 8,10} 1 <= i && i <= numParticipants + 1;
   {
     call pairs, pair := TransferPair(xid, i, pairs);
-    async call Participant_VoteReq(xid, i, pair);
+    async call {:sync} Participant_VoteReq(xid, i, pair);
     i := i + 1;
     par YieldPairs_8(xid, pairs) | YieldInv_9(xid);
     assert {:layer 10} NextStateTrigger(state[xid]);
@@ -278,10 +278,10 @@ requires {:layer 9} Inv_9(state, B, xid);
   par YieldUndecidedOrCommitted_8(xid, mid, pair) | YieldInv_9(xid);
 
   if (*) {
-    async call Coordinator_VoteYes(xid, mid, pair);
+    async call {:sync} Coordinator_VoteYes(xid, mid, pair);
   } else {
     call SetParticipantAborted(xid, mid, pair);
-    async call Coordinator_VoteNo(xid, mid, pair);
+    async call {:sync} Coordinator_VoteNo(xid, mid, pair);
   }
 
   yield;
@@ -352,7 +352,7 @@ requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid
     invariant {:layer 8} Inv_8(state, B, votes);
     invariant {:layer 8} ExistsMonotoneExtension(snapshot, state, xid);
     {
-      async call Participant_Commit(xid, i);
+      async call {:sync} Participant_Commit(xid, i);
       i := i + 1;
       assert {:layer 8} XidTrigger(xid);
       assert {:layer 8} NextStateTrigger(state[xid]);
@@ -399,7 +399,7 @@ requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(st
     invariant {:layer 8} Inv_8(state, B, votes);
     invariant {:layer 8} ExistsMonotoneExtension(snapshot, state, xid);
     {
-      async call Participant_Abort(xid, i);
+      async call {:sync} Participant_Abort(xid, i);
       i := i + 1;
       assert {:layer 8} XidTrigger(xid);
       assert {:layer 8} NextStateTrigger(state[xid]);

--- a/Test/civl/async/2pc-triggers.bpl.expect
+++ b/Test/civl/async/2pc-triggers.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 111 verified, 0 errors
+Boogie program verifier finished with 106 verified, 0 errors

--- a/Test/civl/async/2pc.bpl
+++ b/Test/civl/async/2pc.bpl
@@ -120,36 +120,44 @@ function {:inline} VotesEqCoordinatorState (votes: [Xid]int, state: GState, xid:
 // ###########################################################################
 // Yield assertions
 
-procedure {:yield_assert} {:layer 8} YieldInv_8 ()
+procedure {:yields} {:layer 8} YieldInv_8 ()
        requires {:layer 8} Inv_8(state, B, votes);
+       ensures  {:layer 8} Inv_8(state, B, votes);
 { yield; assert {:layer 8} Inv_8(state, B, votes); }
 
-procedure {:yield_assert} {:layer 8} YieldPairs_8 (xid: Xid, {:linear "pair"} pairs: [Pair]bool)
+procedure {:yields} {:layer 8} YieldPairs_8 (xid: Xid, {:linear "pair"} pairs: [Pair]bool)
        requires {:layer 8} Inv_8(state, B, votes) && (votes[xid] == -1 || (forall p: Pair :: pairs[p] ==> pair(xid, mid#Pair(p), p) && UndecidedOrCommitted(state[xid][mid#Pair(p)])));
+       ensures  {:layer 8} Inv_8(state, B, votes) && (votes[xid] == -1 || (forall p: Pair :: pairs[p] ==> pair(xid, mid#Pair(p), p) && UndecidedOrCommitted(state[xid][mid#Pair(p)])));
 { yield; assert {:layer 8} Inv_8(state, B, votes) && (votes[xid] == -1 || (forall p: Pair :: pairs[p] ==> pair(xid, mid#Pair(p), p) && UndecidedOrCommitted(state[xid][mid#Pair(p)]))); }
 
-procedure {:yield_assert} {:layer 8} YieldUndecidedOrCommitted_8 (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
+procedure {:yields} {:layer 8} YieldUndecidedOrCommitted_8 (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
        requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid] == -1 || UndecidedOrCommitted(state[xid][mid]));
+       ensures  {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid] == -1 || UndecidedOrCommitted(state[xid][mid]));
 { yield; assert {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid] == -1 || UndecidedOrCommitted(state[xid][mid])); }
 
-procedure {:yield_assert} {:layer 8} YieldAborted_8 (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
+procedure {:yields} {:layer 8} YieldAborted_8 (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
        requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(state[xid][mid]);
+       ensures  {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(state[xid][mid]);
 { yield; assert {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(state[xid][mid]); }
 
-procedure {:yield_assert} {:layer 9} YieldInv_9 (xid: Xid)
+procedure {:yields} {:layer 9} YieldInv_9 (xid: Xid)
        requires {:layer 9} Inv_9(state, B, xid);
+       ensures  {:layer 9} Inv_9(state, B, xid);
 { yield; assert {:layer 9} Inv_9(state, B, xid); }
 
-procedure {:yield_assert} {:layer 9} YieldConsistent_9 ()
+procedure {:yields} {:layer 9} YieldConsistent_9 ()
        requires {:layer 9} gConsistent(state);
+       ensures  {:layer 9} gConsistent(state);
 { yield; assert {:layer 9} gConsistent(state); }
 
-procedure {:yield_assert} {:layer 10} YieldConsistent_10 ()
+procedure {:yields} {:layer 10} YieldConsistent_10 ()
        requires {:layer 10} gConsistent(state);
+       ensures  {:layer 10} gConsistent(state);
 { yield; assert {:layer 10} gConsistent(state); }
 
-procedure {:yield_assert} {:layer 11} YieldConsistent_11 ()
+procedure {:yields} {:layer 11} YieldConsistent_11 ()
        requires {:layer 11} gConsistent(state);
+       ensures  {:layer 11} gConsistent(state);
 { yield; assert {:layer 11} gConsistent(state); }
 
 // ###########################################################################

--- a/Test/civl/async/2pc.bpl
+++ b/Test/civl/async/2pc.bpl
@@ -239,7 +239,7 @@ ensures  {:layer 9,10} gConsistent(state);
   invariant {:layer 8,10} 1 <= i && i <= numParticipants + 1;
   {
     call pairs, pair := TransferPair(xid, i, pairs);
-    async call Participant_VoteReq(xid, i, pair);
+    async call {:sync} Participant_VoteReq(xid, i, pair);
     i := i + 1;
     par YieldPairs_8(xid, pairs) | YieldInv_9(xid);
   }
@@ -266,10 +266,10 @@ requires {:layer 9} Inv_9(state, B, xid);
   par YieldUndecidedOrCommitted_8(xid, mid, pair) | YieldInv_9(xid);
 
   if (*) {
-    async call Coordinator_VoteYes(xid, mid, pair);
+    async call {:sync} Coordinator_VoteYes(xid, mid, pair);
   } else {
     call SetParticipantAborted(xid, mid, pair);
-    async call Coordinator_VoteNo(xid, mid, pair);
+    async call {:sync} Coordinator_VoteNo(xid, mid, pair);
   }
 
   yield;
@@ -337,7 +337,7 @@ requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid
     invariant {:layer 8} Inv_8(state, B, votes);
     invariant {:layer 8} ExistsMonotoneExtension(snapshot, state, xid);
     {
-      async call Participant_Commit(xid, i);
+      async call {:sync} Participant_Commit(xid, i);
       i := i + 1;
     }
   }
@@ -378,7 +378,7 @@ requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(st
     invariant {:layer 8} Inv_8(state, B, votes);
     invariant {:layer 8} ExistsMonotoneExtension(snapshot, state, xid);
     {
-      async call Participant_Abort(xid, i);
+      async call {:sync} Participant_Abort(xid, i);
       i := i + 1;
     }
   }

--- a/Test/civl/async/2pc.bpl
+++ b/Test/civl/async/2pc.bpl
@@ -155,13 +155,13 @@ procedure {:yield_assert} {:layer 11} YieldConsistent_11 ()
 // ###########################################################################
 
 function
-{:witness "state atomic_Coordinator_VoteNo atomic_Coordinator_VoteNo 9"}
-{:witness "state atomic_Coordinator_VoteYes atomic_Coordinator_VoteNo 9"}
-{:witness "state atomic_Coordinator_VoteNo atomic_Coordinator_VoteYes 9"}
-{:witness "state atomic_Coordinator_VoteYes atomic_Coordinator_VoteYes 9"}
-{:witness "state atomic_SetParticipantAborted atomic_Coordinator_VoteYes 9"}
-{:witness "state atomic_SetParticipantAborted atomic_Coordinator_VoteNo 9"}
-{:witness "state atomic_Participant_VoteReq atomic_Participant_VoteReq 10"}
+{:witness "state","atomic_Coordinator_VoteNo","atomic_Coordinator_VoteNo"}
+{:witness "state","atomic_Coordinator_VoteYes","atomic_Coordinator_VoteNo"}
+{:witness "state","atomic_Coordinator_VoteNo","atomic_Coordinator_VoteYes"}
+{:witness "state","atomic_Coordinator_VoteYes","atomic_Coordinator_VoteYes"}
+{:witness "state","atomic_SetParticipantAborted","atomic_Coordinator_VoteYes"}
+{:witness "state","atomic_SetParticipantAborted","atomic_Coordinator_VoteNo"}
+{:witness "state","atomic_Participant_VoteReq","atomic_Participant_VoteReq"}
 witness (state:GState, state':GState, second_xid:Xid) : GState
 {
    state[second_xid := state'[second_xid]]

--- a/Test/civl/async/2pc.bpl.expect
+++ b/Test/civl/async/2pc.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 111 verified, 0 errors
+Boogie program verifier finished with 106 verified, 0 errors

--- a/Test/civl/async/async1.bpl
+++ b/Test/civl/async/async1.bpl
@@ -11,6 +11,6 @@ procedure {:yields} {:layer 0} {:refines "AtomicIncr"} Incr();
 procedure {:yields} {:layer 1} {:refines "AtomicIncr"} AsyncIncr()
 {
   yield;
-  async call Incr();
+  async call {:sync} Incr();
   yield;
 }

--- a/Test/civl/async/async2.bpl
+++ b/Test/civl/async/async2.bpl
@@ -16,21 +16,21 @@ procedure {:yields} {:layer 0} {:refines "AtomicDecr"} Decr();
 procedure {:yields} {:layer 1} {:refines "AtomicIncr"} AsyncIncr()
 {
   yield;
-  async call Incr();
+  async call {:sync} Incr();
   yield;
 }
 
 procedure {:yields} {:layer 1} {:refines "AtomicDecr"} AsyncDecr()
 {
   yield;
-  async call Decr();
+  async call {:sync} Decr();
   yield;
 }
 
 procedure {:yields} {:layer 1} AsyncIncrDecr()
 {
   yield;
-  async call Incr();
-  async call Decr();
+  async call {:sync} Incr();
+  async call {:sync} Decr();
   yield;
 }

--- a/Test/civl/async/async2.bpl.expect
+++ b/Test/civl/async/async2.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 10 verified, 0 errors
+Boogie program verifier finished with 8 verified, 0 errors

--- a/Test/civl/async/inc-dec-2.bpl
+++ b/Test/civl/async/inc-dec-2.bpl
@@ -25,8 +25,8 @@ procedure {:yields} {:layer 1} {:refines "skip"} Main ()
   invariant {:layer 1} x == old(x);
   invariant {:layer 1} {:terminates} true;    
   {
-    async call inc();
-    async call dec();
+    async call {:sync} inc();
+    async call {:sync} dec();
     i := i + 1;
     yield; assert {:layer 1} x == old(x);
   }

--- a/Test/civl/async/inc-dec.bpl
+++ b/Test/civl/async/inc-dec.bpl
@@ -15,8 +15,8 @@ var {:layer 0,1} x : int;
 procedure {:yields} {:layer 1} main ()
 {
   yield;
-  async call inc_by_N();
-  async call dec_by_N();
+  async call {:sync} inc_by_N();
+  async call {:sync} dec_by_N();
   yield;
 }
 
@@ -34,7 +34,7 @@ ensures {:layer 1} x == old(x) + N;
   invariant {:layer 1} {:terminates} true;    
   {
     i := i + 1;
-    async call inc();
+    async call {:sync} inc();
     call dummy();
   }
 
@@ -55,7 +55,7 @@ ensures {:layer 1} x == old(x) - N;
   invariant {:layer 1} {:terminates} true;
   {
     i := i + 1;
-    async call dec();
+    async call {:sync} dec();
     call dummy();
   }
 

--- a/Test/civl/async/inc-server.bpl
+++ b/Test/civl/async/inc-server.bpl
@@ -25,7 +25,7 @@ procedure {:yields}{:layer 11} main ({:linear_in "lin"} p : int)
 requires {:layer 9} perm(p) && x == y;
 {
   yield; assert {:layer 9} perm(p) && x == y;
-  async call Server_Inc(p);
+  async call {:sync} Server_Inc(p);
   yield;
 }
 
@@ -40,7 +40,7 @@ procedure {:yields}{:layer 10}{:refines "inc_x_high_atomic"} Server_Inc ({:linea
 requires {:layer 9} perm(p) && x == y;
 {
   yield; assert {:layer 9} perm(p) && x == y;
-  async call AsyncInc(p);
+  async call {:sync} AsyncInc(p);
   yield;
 }
 
@@ -49,7 +49,7 @@ requires {:layer 9} perm(p) && x == y;
 {
   yield; assert {:layer 9} perm(p) && x == y;
   call inc_x_perm(p);
-  async call Client_IncDone(p);
+  async call {:sync} Client_IncDone(p);
   yield;
 }
 

--- a/Test/civl/async/inc-server.bpl.expect
+++ b/Test/civl/async/inc-server.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 20 verified, 0 errors
+Boogie program verifier finished with 19 verified, 0 errors

--- a/Test/civl/async/inc-server_mover.bpl
+++ b/Test/civl/async/inc-server_mover.bpl
@@ -49,7 +49,7 @@ modifies x;
 {
   call Yield_8();
   call inc_x_perm(p);
-  async call Client_IncDone(p);
+  async call {:sync} Client_IncDone(p);
   call Yield_8();
 }
 

--- a/Test/civl/async/leader.bpl
+++ b/Test/civl/async/leader.bpl
@@ -77,7 +77,7 @@ requires {:layer 1} col_dom == (lambda i:int :: (lambda j:int :: false));
   invariant {:layer 1} s > N ==> all_decided(init_val, dec_dom, dec_val);
   {
     call perms',perms'' := split_perms_sender(s, perms');
-    async call P(s, perms'');
+    async call {:sync} P(s, perms'');
     s := s + 1;
   }
   yield; assert {:layer 1} all_decided(init_val, dec_dom, dec_val);
@@ -105,7 +105,7 @@ modifies col_dom, col_val, dec_dom, dec_val;
   invariant {:layer 1} s == N ==> all_decided'(r, init_val, dec_dom, dec_val);
   {
     call perms',p := split_perms_receiver(s,r,perms');
-    async call Q(r, s, v, p);
+    async call {:sync} Q(r, s, v, p);
     r := r + 1;
   }
   call dummy();

--- a/Test/civl/async/lock-service-impl.bpl
+++ b/Test/civl/async/lock-service-impl.bpl
@@ -1,5 +1,6 @@
 // RUN: %boogie -noinfer -typeEncoding:m -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+// XFAIL: *
 
 type Tid = int;
 

--- a/Test/civl/async/lock-service.bpl
+++ b/Test/civl/async/lock-service.bpl
@@ -1,5 +1,6 @@
 // RUN: %boogie -noinfer -typeEncoding:m -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+// XFAIL: *
 
 type Tid = int;
 

--- a/Test/civl/async/pending-async-test.bpl
+++ b/Test/civl/async/pending-async-test.bpl
@@ -1,5 +1,6 @@
 // RUN: %boogie -noinfer -typeEncoding:m -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+// XFAIL: *
 
 var {:layer 0,3} x:int;  
 

--- a/Test/civl/async/rec-inc.bpl.expect
+++ b/Test/civl/async/rec-inc.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 6 verified, 0 errors
+Boogie program verifier finished with 5 verified, 0 errors

--- a/Test/civl/async/simple-tds.bpl
+++ b/Test/civl/async/simple-tds.bpl
@@ -27,7 +27,7 @@ procedure {:atomic} {:layer 1,3} AtomicR0({:linear "tid"} tid: int)
 modifies x;
 { assert tid == r; assume x == 2; x := 3; }
 
-procedure {:yields} {:layer 1} {:refines "AtomicP1"} P1({:linear_in "tid"} tid: int) { yield; async call P0(tid); yield; }
+procedure {:yields} {:layer 1} {:refines "AtomicP1"} P1({:linear_in "tid"} tid: int) { yield; async call {:sync} P0(tid); yield; }
 procedure {:atomic} {:layer 2,3} AtomicP1({:linear_in "tid"} tid: int)
 modifies x;
 { assert tid == p; assert x == 0; x := 1; }
@@ -45,7 +45,7 @@ modifies x;
 procedure {:yields} {:layer 3} {:refines "AtomicMain3"} Main3({:linear_in "tid"} tidp: int, {:linear_in "tid"} tidq: int) {
     yield;
     call P1(tidp);
-    async call Q1(tidq);
+    async call {:sync} Q1(tidq);
     yield;
 }
 procedure {:atomic} {:layer 4} AtomicMain3({:linear_in "tid"} tidp: int, {:linear_in "tid"} tidq: int)
@@ -55,7 +55,7 @@ modifies x;
 procedure {:yields} {:layer 4} {:refines "AtomicMain4"} Main4({:linear_in "tid"} tidp: int, {:linear_in "tid"} tidq: int, {:linear_in "tid"} tidr: int) {
     yield;
     call Main3(tidp, tidq);
-    async call R3(tidr);
+    async call {:sync} R3(tidr);
     yield;
 }
 procedure {:atomic} {:layer 5} AtomicMain4({:linear_in "tid"} tidp: int, {:linear_in "tid"} tidq: int, {:linear_in "tid"} tidr: int)

--- a/Test/civl/async/simple-tds.bpl.expect
+++ b/Test/civl/async/simple-tds.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 51 verified, 0 errors
+Boogie program verifier finished with 40 verified, 0 errors

--- a/Test/civl/async/tds.bpl
+++ b/Test/civl/async/tds.bpl
@@ -94,7 +94,7 @@ procedure {:yields} {:layer 3} {:refines "atomic_server"} server3({:linear "tid"
     invariant {:layer 3} status == (lambda j: int :: if (0 <= j && j < i) then CREATED else snapshot[j]);
     {
         call tid, tids' := Alloc(i, tids');
-        async call server2(tid);
+        async call {:sync} server2(tid);
         i := i + 1;
     }
     yield;

--- a/Test/civl/bar.bpl.expect
+++ b/Test/civl/bar.bpl.expect
@@ -2,7 +2,7 @@ bar.bpl(28,3): Error: Non-interference check failed
 Execution trace:
     bar.bpl(7,3): anon0
     bar.bpl(7,3): anon0_1
-    bar.bpl(14,5): inline$AtomicIncr_1$0$anon0
+    bar.bpl(14,5): inline$AtomicIncr$0$anon0
     (0,0): YieldChecker
     (0,0): inline$Impl_YieldChecker_PC_1$0$L0
 bar.bpl(28,3): Error: Non-interference check failed

--- a/Test/civl/chris2.bpl.expect
+++ b/Test/civl/chris2.bpl.expect
@@ -5,17 +5,17 @@ Execution trace:
     chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
-Execution trace:
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Entry
-    chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
 chris2.bpl(23,3): Related location: Gate of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
     chris2.bpl(11,32): inline$atomic_p_gt1$0$Entry
     chris2.bpl(13,5): inline$atomic_p_gt1$0$anon0
     chris2.bpl(11,32): inline$atomic_p_gt1$0$Return
+(0,0): Error BP5003: A postcondition might not hold on this return path.
+chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
+Execution trace:
+    chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Entry
+    chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
+    chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
 chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:

--- a/Test/civl/chris2.bpl.expect
+++ b/Test/civl/chris2.bpl.expect
@@ -1,50 +1,26 @@
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(23,3): Related location: Gate of atomic_p_gt2_21 not preserved by atomic_p_gt1_lower_21
+chris2.bpl(23,3): Related location: Gate of atomic_p_gt2 not preserved by atomic_p_gt1_lower
 Execution trace:
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower_21$0$Entry
-    chris2.bpl(7,5): inline$atomic_p_gt1_lower_21$0$anon0
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower_21$0$Return
+    chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Entry
+    chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
+    chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2_21 not preserved by atomic_p_gt1_lower_21
+chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
 Execution trace:
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower_21$0$Entry
-    chris2.bpl(7,5): inline$atomic_p_gt1_lower_21$0$anon0
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower_21$0$Return
+    chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Entry
+    chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
+    chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(23,3): Related location: Gate of atomic_p_gt2_25 not preserved by atomic_p_gt1_lower_25
+chris2.bpl(23,3): Related location: Gate of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower_25$0$Entry
-    chris2.bpl(7,5): inline$atomic_p_gt1_lower_25$0$anon0
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower_25$0$Return
+    chris2.bpl(11,32): inline$atomic_p_gt1$0$Entry
+    chris2.bpl(13,5): inline$atomic_p_gt1$0$anon0
+    chris2.bpl(11,32): inline$atomic_p_gt1$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2_25 not preserved by atomic_p_gt1_lower_25
+chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower_25$0$Entry
-    chris2.bpl(7,5): inline$atomic_p_gt1_lower_25$0$anon0
-    chris2.bpl(5,32): inline$atomic_p_gt1_lower_25$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(23,3): Related location: Gate of atomic_p_gt2_26 not preserved by atomic_p_gt1_26
-Execution trace:
-    chris2.bpl(11,32): inline$atomic_p_gt1_26$0$Entry
-    chris2.bpl(13,5): inline$atomic_p_gt1_26$0$anon0
-    chris2.bpl(11,32): inline$atomic_p_gt1_26$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2_26 not preserved by atomic_p_gt1_26
-Execution trace:
-    chris2.bpl(11,32): inline$atomic_p_gt1_26$0$Entry
-    chris2.bpl(13,5): inline$atomic_p_gt1_26$0$anon0
-    chris2.bpl(11,32): inline$atomic_p_gt1_26$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(23,3): Related location: Gate of atomic_p_gt2_40 not preserved by atomic_p_gt1_40
-Execution trace:
-    chris2.bpl(11,32): inline$atomic_p_gt1_40$0$Entry
-    chris2.bpl(13,5): inline$atomic_p_gt1_40$0$anon0
-    chris2.bpl(11,32): inline$atomic_p_gt1_40$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(22,32): Related location: Gate failure of atomic_p_gt2_40 not preserved by atomic_p_gt1_40
-Execution trace:
-    chris2.bpl(11,32): inline$atomic_p_gt1_40$0$Entry
-    chris2.bpl(13,5): inline$atomic_p_gt1_40$0$anon0
-    chris2.bpl(11,32): inline$atomic_p_gt1_40$0$Return
+    chris2.bpl(11,32): inline$atomic_p_gt1$0$Entry
+    chris2.bpl(13,5): inline$atomic_p_gt1$0$anon0
+    chris2.bpl(11,32): inline$atomic_p_gt1$0$Return
 
-Boogie program verifier finished with 2 verified, 8 errors
+Boogie program verifier finished with 2 verified, 4 errors

--- a/Test/civl/civl-paper.bpl.expect
+++ b/Test/civl/civl-paper.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 61 verified, 0 errors
+Boogie program verifier finished with 55 verified, 0 errors

--- a/Test/civl/foo.bpl.expect
+++ b/Test/civl/foo.bpl.expect
@@ -2,7 +2,7 @@ foo.bpl(30,3): Error: Non-interference check failed
 Execution trace:
     foo.bpl(7,3): anon0
     foo.bpl(7,3): anon0_1
-    foo.bpl(14,5): inline$AtomicIncr_1$0$anon0
+    foo.bpl(14,5): inline$AtomicIncr$0$anon0
     (0,0): YieldChecker
     (0,0): inline$Impl_YieldChecker_PC_1$0$L0
 

--- a/Test/civl/funky.bpl.expect
+++ b/Test/civl/funky.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 146 verified, 0 errors
+Boogie program verifier finished with 91 verified, 0 errors

--- a/Test/civl/inc-dec.bpl
+++ b/Test/civl/inc-dec.bpl
@@ -33,7 +33,7 @@ ensures {:layer 1} x == old(x) + N;
   invariant {:layer 1} {:terminates} true;    
   {
     i := i + 1;
-    async call inc();
+    async call {:sync} inc();
     call dummy();
   }
 
@@ -55,7 +55,7 @@ ensures {:layer 1} x == old(x) - N;
   invariant {:layer 1} {:terminates} true;
   {
     i := i + 1;
-    async call dec();
+    async call {:sync} dec();
     call dummy();
   }
 

--- a/Test/civl/left-mover.bpl.expect
+++ b/Test/civl/left-mover.bpl.expect
@@ -1,16 +1,16 @@
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-left-mover.bpl(11,32): Related location: Gate failure of ass_eq_1_1 not preserved by inc_1
+left-mover.bpl(11,32): Related location: Gate failure of ass_eq_1 not preserved by inc
 Execution trace:
-    left-mover.bpl(6,30): inline$inc_1$0$Entry
-    left-mover.bpl(8,5): inline$inc_1$0$anon0
-    left-mover.bpl(6,30): inline$inc_1$0$Return
+    left-mover.bpl(6,30): inline$inc$0$Entry
+    left-mover.bpl(8,5): inline$inc$0$anon0
+    left-mover.bpl(6,30): inline$inc$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-left-mover.bpl(19,32): Related location: Commutativity check between init_1 and inc_1 failed
+left-mover.bpl(19,32): Related location: Commutativity check between init and inc failed
 Execution trace:
-    left-mover.bpl(19,32): inline$init_1$0$Entry
-    left-mover.bpl(8,5): inline$inc_1$0$anon0
-    left-mover.bpl(6,30): inline$inc_1$0$Return
-left-mover.bpl(26,30): Error: Non-blocking check for block_2 failed
+    left-mover.bpl(19,32): inline$init$0$Entry
+    left-mover.bpl(8,5): inline$inc$0$anon0
+    left-mover.bpl(6,30): inline$inc$0$Return
+left-mover.bpl(26,30): Error: Non-blocking check for block failed
 Execution trace:
     left-mover.bpl(26,30): L
 

--- a/Test/civl/linear_out_bug.bpl.expect
+++ b/Test/civl/linear_out_bug.bpl.expect
@@ -1,10 +1,4 @@
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-linear_out_bug.bpl(20,5): Related location: Gate of RemoveAddr_1 not preserved by RemoveAddr_1
-Execution trace:
-    linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Entry
-    linear_out_bug.bpl(20,5): inline$RemoveAddr_1$0$anon0
-    linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
 linear_out_bug.bpl(10,34): Related location: Commutativity check between AddAddr and RemoveAddr_2 failed
 Execution trace:
     linear_out_bug.bpl(10,34): inline$AddAddr$0$Entry
@@ -12,6 +6,12 @@ Execution trace:
     linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Entry
     linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0
     linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Return
+(0,0): Error BP5003: A postcondition might not hold on this return path.
+linear_out_bug.bpl(20,5): Related location: Gate of RemoveAddr_1 not preserved by RemoveAddr_1
+Execution trace:
+    linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Entry
+    linear_out_bug.bpl(20,5): inline$RemoveAddr_1$0$anon0
+    linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
 linear_out_bug.bpl(25,30): Related location: Linearity invariant for domain addr is not preserved by RemoveAddr_2.
 Execution trace:

--- a/Test/civl/linear_out_bug.bpl.expect
+++ b/Test/civl/linear_out_bug.bpl.expect
@@ -1,22 +1,22 @@
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-linear_out_bug.bpl(20,5): Related location: Gate of RemoveAddr_1_1 not preserved by RemoveAddr_1_1
+linear_out_bug.bpl(20,5): Related location: Gate of RemoveAddr_1 not preserved by RemoveAddr_1
 Execution trace:
-    linear_out_bug.bpl(17,30): inline$RemoveAddr_1_1$0$Entry
-    linear_out_bug.bpl(20,5): inline$RemoveAddr_1_1$0$anon0
-    linear_out_bug.bpl(17,30): inline$RemoveAddr_1_1$0$Return
+    linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Entry
+    linear_out_bug.bpl(20,5): inline$RemoveAddr_1$0$anon0
+    linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-linear_out_bug.bpl(10,34): Related location: Commutativity check between AddAddr_2 and RemoveAddr_2_2 failed
+linear_out_bug.bpl(10,34): Related location: Commutativity check between AddAddr and RemoveAddr_2 failed
 Execution trace:
-    linear_out_bug.bpl(10,34): inline$AddAddr_2$0$Entry
-    linear_out_bug.bpl(13,14): inline$AddAddr_2$0$anon0
-    linear_out_bug.bpl(25,30): inline$RemoveAddr_2_2$0$Entry
-    linear_out_bug.bpl(28,14): inline$RemoveAddr_2_2$0$anon0
-    linear_out_bug.bpl(25,30): inline$RemoveAddr_2_2$0$Return
+    linear_out_bug.bpl(10,34): inline$AddAddr$0$Entry
+    linear_out_bug.bpl(13,14): inline$AddAddr$0$anon0
+    linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Entry
+    linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0
+    linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-linear_out_bug.bpl(25,30): Related location: Linearity invariant for domain addr is not preserved by RemoveAddr_2_2.
+linear_out_bug.bpl(25,30): Related location: Linearity invariant for domain addr is not preserved by RemoveAddr_2.
 Execution trace:
-    linear_out_bug.bpl(25,30): inline$RemoveAddr_2_2$0$Entry
-    linear_out_bug.bpl(28,14): inline$RemoveAddr_2_2$0$anon0
-    linear_out_bug.bpl(25,30): inline$RemoveAddr_2_2$0$Return
+    linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Entry
+    linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0
+    linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Return
 
-Boogie program verifier finished with 8 verified, 3 errors
+Boogie program verifier finished with 7 verified, 3 errors

--- a/Test/civl/linearity-bug-1.bpl.expect
+++ b/Test/civl/linearity-bug-1.bpl.expect
@@ -1,9 +1,9 @@
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-linearity-bug-1.bpl(19,31): Related location: Commutativity check between atomic_read_n_1 and atomic_inc_n_1 failed
+linearity-bug-1.bpl(19,31): Related location: Commutativity check between atomic_read_n and atomic_inc_n failed
 Execution trace:
-    linearity-bug-1.bpl(19,31): inline$atomic_read_n_1$0$Entry
-    linearity-bug-1.bpl(13,32): inline$atomic_inc_n_1$0$Entry
-    linearity-bug-1.bpl(15,3): inline$atomic_inc_n_1$0$anon0
-    linearity-bug-1.bpl(13,32): inline$atomic_inc_n_1$0$Return
+    linearity-bug-1.bpl(19,31): inline$atomic_read_n$0$Entry
+    linearity-bug-1.bpl(13,32): inline$atomic_inc_n$0$Entry
+    linearity-bug-1.bpl(15,3): inline$atomic_inc_n$0$anon0
+    linearity-bug-1.bpl(13,32): inline$atomic_inc_n$0$Return
 
 Boogie program verifier finished with 1 verified, 1 error

--- a/Test/civl/linearity-bug-2.bpl.expect
+++ b/Test/civl/linearity-bug-2.bpl.expect
@@ -1,8 +1,8 @@
 (0,0): Error BP5003: A postcondition might not hold on this return path.
-linearity-bug-2.bpl(6,32): Related location: Linearity invariant for domain lin is not preserved by atomic_foo_2.
+linearity-bug-2.bpl(6,32): Related location: Linearity invariant for domain lin is not preserved by atomic_foo.
 Execution trace:
-    linearity-bug-2.bpl(6,32): inline$atomic_foo_2$0$Entry
-    linearity-bug-2.bpl(8,10): inline$atomic_foo_2$0$anon0
-    linearity-bug-2.bpl(6,32): inline$atomic_foo_2$0$Return
+    linearity-bug-2.bpl(6,32): inline$atomic_foo$0$Entry
+    linearity-bug-2.bpl(8,10): inline$atomic_foo$0$anon0
+    linearity-bug-2.bpl(6,32): inline$atomic_foo$0$Return
 
 Boogie program verifier finished with 2 verified, 1 error

--- a/Test/civl/multiset.bpl.expect
+++ b/Test/civl/multiset.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 132 verified, 0 errors
+Boogie program verifier finished with 96 verified, 0 errors

--- a/Test/civl/ogcounter2.bpl.expect
+++ b/Test/civl/ogcounter2.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 39 verified, 0 errors
+Boogie program verifier finished with 35 verified, 0 errors

--- a/Test/civl/parallel1.bpl.expect
+++ b/Test/civl/parallel1.bpl.expect
@@ -2,7 +2,7 @@ parallel1.bpl(30,3): Error: Non-interference check failed
 Execution trace:
     parallel1.bpl(7,3): anon0
     parallel1.bpl(7,3): anon0_1
-    parallel1.bpl(14,5): inline$AtomicIncr_1$0$anon0
+    parallel1.bpl(14,5): inline$AtomicIncr$0$anon0
     (0,0): YieldChecker
     (0,0): inline$Impl_YieldChecker_PC_1$0$L0
 

--- a/Test/civl/refinement.bpl.expect
+++ b/Test/civl/refinement.bpl.expect
@@ -2,23 +2,23 @@
 Execution trace:
     refinement.bpl(8,3): anon0
     refinement.bpl(8,3): anon0_2
-    refinement.bpl(43,5): inline$INCR_1$1$anon0
+    refinement.bpl(43,5): inline$INCR$1$anon0
     refinement.bpl(8,3): anon0_1
-    refinement.bpl(43,5): inline$INCR_1$0$anon0
+    refinement.bpl(43,5): inline$INCR$0$anon0
     (0,0): YieldChecker
 (0,0): Error: Transition invariant violated in initial state
 Execution trace:
     refinement.bpl(17,3): anon0
     refinement.bpl(17,3): anon0_2
-    refinement.bpl(50,5): inline$DECR_1$0$anon0
+    refinement.bpl(50,5): inline$DECR$0$anon0
     (0,0): YieldChecker
 (0,0): Error: Transition invariant violated in final state
 Execution trace:
     refinement.bpl(17,3): anon0
     refinement.bpl(17,3): anon0_2
-    refinement.bpl(50,5): inline$DECR_1$0$anon0
+    refinement.bpl(50,5): inline$DECR$0$anon0
     refinement.bpl(17,3): anon0_1
-    refinement.bpl(43,5): inline$INCR_1$0$anon0
+    refinement.bpl(43,5): inline$INCR$0$anon0
     (0,0): YieldChecker
 
-Boogie program verifier finished with 8 verified, 3 errors
+Boogie program verifier finished with 6 verified, 3 errors

--- a/Test/civl/seqlock.bpl.expect
+++ b/Test/civl/seqlock.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 57 verified, 0 errors
+Boogie program verifier finished with 49 verified, 0 errors

--- a/Test/civl/signature-mismatch.bpl.expect
+++ b/Test/civl/signature-mismatch.bpl.expect
@@ -1,4 +1,4 @@
-signature-mismatch.bpl(19,61): Error: mismatched type of in-parameter in refinement procedure write_x_1: y' (named x' in atomic action)
-signature-mismatch.bpl(27,61): Error: mismatched number of in-parameters in refinement procedure: write_x_2
-signature-mismatch.bpl(36,61): Error: mismatched linearity type of in-parameter in refinement procedure write_x_3: x'
+signature-mismatch.bpl(19,61): Error: mismatched type of in-parameter in atomic_write_x_1: y' (named x' in atomic_write_x_1)
+signature-mismatch.bpl(27,61): Error: mismatched number of in-parameters in atomic_write_x_2
+signature-mismatch.bpl(36,61): Error: mismatched linearity type of in-parameter in atomic_write_x_3: x'
 3 type checking errors detected in signature-mismatch.bpl

--- a/Test/civl/ticket.bpl.expect
+++ b/Test/civl/ticket.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 36 verified, 0 errors
+Boogie program verifier finished with 33 verified, 0 errors

--- a/Test/civl/verified-ft.bpl
+++ b/Test/civl/verified-ft.bpl
@@ -1197,30 +1197,18 @@ function {:inline false} f(i: int): bool {  true  }
 
 
 function
-{:witness "shadow.VC AtomicVC.Inc AtomicVC.Copy 11"}
-{:witness "shadow.VC AtomicVC.Inc AtomicVC.Join 11"}
-{:witness "shadow.VC AtomicVCSetElem AtomicVC.Copy 11"}
-{:witness "shadow.VC AtomicVCSetElem AtomicVC.Join 11"}
-{:witness "shadow.VC AtomicVCSetElemShared AtomicVC.Copy 11"}
-{:witness "shadow.VC AtomicVCSetElemShared AtomicVC.Join 11"}
-{:witness "shadow.VC AtomicVCInit AtomicVC.Copy 11"}
-{:witness "shadow.VC AtomicVCInit AtomicVC.Join 11"}
-{:witness "shadow.VC AtomicVC.Copy AtomicVC.Copy 11"}
-{:witness "shadow.VC AtomicVC.Copy AtomicVC.Join 11"}
-{:witness "shadow.VC AtomicVC.Join AtomicVC.Copy 11"}
-{:witness "shadow.VC AtomicVC.Join AtomicVC.Join 11"}
-{:witness "shadow.VC AtomicVC.Inc AtomicVC.Copy 20"}
-{:witness "shadow.VC AtomicVC.Inc AtomicVC.Join 20"}
-{:witness "shadow.VC AtomicVCSetElem AtomicVC.Copy 20"}
-{:witness "shadow.VC AtomicVCSetElem AtomicVC.Join 20"}
-{:witness "shadow.VC AtomicVCSetElemShared AtomicVC.Copy 20"}
-{:witness "shadow.VC AtomicVCSetElemShared AtomicVC.Join 20"}
-{:witness "shadow.VC AtomicVCInit AtomicVC.Copy 20"}
-{:witness "shadow.VC AtomicVCInit AtomicVC.Join 20"}
-{:witness "shadow.VC AtomicVC.Copy AtomicVC.Copy 20"}
-{:witness "shadow.VC AtomicVC.Copy AtomicVC.Join 20"}
-{:witness "shadow.VC AtomicVC.Join AtomicVC.Copy 20"}
-{:witness "shadow.VC AtomicVC.Join AtomicVC.Join 20"}
+{:witness "shadow.VC","AtomicVC.Inc","AtomicVC.Copy"}
+{:witness "shadow.VC","AtomicVC.Inc","AtomicVC.Join"}
+{:witness "shadow.VC","AtomicVCSetElem","AtomicVC.Copy"}
+{:witness "shadow.VC","AtomicVCSetElem","AtomicVC.Join"}
+{:witness "shadow.VC","AtomicVCSetElemShared","AtomicVC.Copy"}
+{:witness "shadow.VC","AtomicVCSetElemShared","AtomicVC.Join"}
+{:witness "shadow.VC","AtomicVCInit","AtomicVC.Copy"}
+{:witness "shadow.VC","AtomicVCInit","AtomicVC.Join"}
+{:witness "shadow.VC","AtomicVC.Copy","AtomicVC.Copy"}
+{:witness "shadow.VC","AtomicVC.Copy","AtomicVC.Join"}
+{:witness "shadow.VC","AtomicVC.Join","AtomicVC.Copy"}
+{:witness "shadow.VC","AtomicVC.Join","AtomicVC.Join"}
 witness (shadow.VC:[Shadowable]VC, shadow.VC':[Shadowable]VC, second_v1:Shadowable) : [Shadowable]VC
 {
    shadow.VC[second_v1 := shadow.VC'[second_v1]]

--- a/Test/civl/verified-ft.bpl.expect
+++ b/Test/civl/verified-ft.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 1012 verified, 0 errors
+Boogie program verifier finished with 355 verified, 0 errors

--- a/Test/civl/write-barrier.bpl.expect
+++ b/Test/civl/write-barrier.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 27 verified, 0 errors
+Boogie program verifier finished with 26 verified, 0 errors

--- a/Test/civl/wsq.bpl.expect
+++ b/Test/civl/wsq.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 41 verified, 0 errors
+Boogie program verifier finished with 25 verified, 0 errors


### PR DESCRIPTION
This PR implements the inductive sequentialization (IS) proof rule in CIVL. The main new features are:

- A mechanism to represent and summarize unboundedly many asynchronous calls as pending asyncs.
- An integration of the IS proof rule to eliminate unboundedly many pending asyncs from atomic actions.

Besides the new implementation of IS, most changes are in the CIVL type checker (to support and check all new annotations) and in the treatment of async calls in the yield checker and in the refinement instrumentation.

Since atomic actions can now only change explicitly (by aplying IS) we do not have to internally generate per-layer versions of atomic actions anymore.

Refactoring work that is also part of this PR:
- Extraction of all core CIVL datatypes to a separate file CivlCoreTypes.cs.
- Refactoring and cleanup work in transition relation computation and witnesses.