### PR TITLE
Improvements of the .NET Core build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,20 @@
 # Nuget
-Source/packages/*
-Source/**/nupkg
+Source/packages/
+
+# Binaries
+bin/
+obj/
+Binaries/**/*.dll
+Binaries/**/*.mdb
+Binaries/**/*.exe
+Binaries/**/*.pdb
+Binaries/**/*.config
+Binaries/**/*.vshost.exe.manifest
 
 # Tests
 Source/UnitTests/TestResult.xml
-Source/UnitTests/*/bin
-Source/UnitTests/*/obj
 Test/**/Output
 TestResult.xml
-
-# Binaries
-Source/*/bin
-Source/*/obj
-Source/Provers/*/bin
-Source/Provers/*/obj
-Binaries/*.dll
-Binaries/*.mdb
-Binaries/*.exe
-Binaries/*.pdb
-Binaries/*.config
-Binaries/*.vshost.exe.manifest
 
 # Coco/R
 Scanner.cs.old
@@ -30,9 +25,7 @@ Parser.cs.old
 
 # Visual Studio files
 Source/_ReSharper.Boogie
-Source/Provers/*/*.user
-Source/*/*.user
-Source/*.user
+Source/**/*.user
 Source/*.suo
 Source/*.cache
 Source/.vs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,37 @@
 # vim: set sw=2 ts=2 softtabstop=2 expandtab:
 language: csharp
-dist: trusty
+dist: bionic
 sudo: true
-solution: "Source/Boogie.sln"
+dotnet: 3.1
+mono: none
 env:
   global:
+    - SOLUTION=Source/Boogie-NetCore.sln
     - Z3URL=https://github.com/Z3Prover/z3/releases/download/z3-4.8.4/z3-4.8.4.d6df51951f4c-x64-ubuntu-14.04.zip
   matrix:
-    - BOOGIE_CONFIG=Debug
-    - BOOGIE_CONFIG=Release
+    - CONFIGURATION=Debug
+    - CONFIGURATION=Release
 install:
   # Download a Z3 release
   - wget ${Z3URL}
   - unzip z3*.zip
-  # NuGet is a little flakey in legacy TravisCI, use travis_retry command to retry the command if it fails
-  - travis_retry nuget restore ${TRAVIS_SOLUTION}
-  - travis_retry nuget install -Version 3.10.0 NUnit.Console -OutputDirectory Source/packages/
+  - export PATH="$(find $PWD/z3* -name bin -type d):$PATH"
   # Install needed python tools
   - sudo pip install lit OutputCheck pyyaml
 script:
-  - msbuild /p:Configuration=${BOOGIE_CONFIG} ${TRAVIS_SOLUTION}
-  # Run unit tests
-  - python Source/UnitTests/run-unittests.py ${BOOGIE_CONFIG}
-  # Run driver tests
-  - ln -s $(find $PWD/z3* -name z3 -type f) Binaries/z3.exe
-  - lit -v Test/
+  - dotnet build -c ${CONFIGURATION} ${SOLUTION}
+  - dotnet test --no-build -c ${CONFIGURATION} ${SOLUTION}
+  - lit -v -D dotnet -D configuration=${CONFIGURATION} Test
+deploy:
+  skip_cleanup: true
+  on:
+    branch: master
+    tags: true
+    condition: ${CONFIGURATION}=Release
+  - provider: script
+    script :
+      - dotnet nuget push Source/BoogieDriver/bin/${CONFIGURATION}/Boogie*.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json
+  - provider: releases
+    api_key: TODO
+    file_glob: true
+    file: Source/BoogieDriver/bin/${CONFIGURATION}/Boogie*.nupkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: bionic
 sudo: true
 dotnet: 3.1
 mono: none
+git:
+  depth: false
 env:
   global:
     - SOLUTION=Source/Boogie-NetCore.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ deploy:
       tags: true
       condition: ${CONFIGURATION}=Release
   - provider: releases
-    api_key: TODO
+    api_key:
+      secure: ZjKhOiIpC6R+Xfp1iJX/1a2DD1o+tYhUefZDqRjUfM4rDZqzvOBvY7mA/1BcqNs4gXJIk3p11Kud72cPSSS8iW2EVlRm2UlfdVOf2wmGys/TILvHNDWUoVFSxhVgxbzMVULp6fIrqDypaZ0PAYZVg2loLkVI5AZ/P35ZRVaa9oE=
     file_glob: true
     file: Source/BoogieDriver/bin/${CONFIGURATION}/Boogie*.nupkg
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,20 @@ script:
   - dotnet test --no-build -c ${CONFIGURATION} ${SOLUTION}
   - lit -v -D dotnet -D configuration=${CONFIGURATION} Test
 deploy:
-  skip_cleanup: true
-  on:
-    branch: master
-    tags: true
-    condition: ${CONFIGURATION}=Release
   - provider: script
-    script :
+    script:
       - dotnet nuget push Source/BoogieDriver/bin/${CONFIGURATION}/Boogie*.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json
+    skip_cleanup: true
+    on:
+      branch: master
+      tags: true
+      condition: ${CONFIGURATION}=Release
   - provider: releases
     api_key: TODO
     file_glob: true
     file: Source/BoogieDriver/bin/${CONFIGURATION}/Boogie*.nupkg
+    skip_cleanup: true
+    on:
+      branch: master
+      tags: true
+      condition: ${CONFIGURATION}=Release

--- a/README.md
+++ b/README.md
@@ -55,78 +55,74 @@ You can also report issues on our [issue tracker](https://github.com/boogie-org/
 
 ## Building
 
-### Requirements
+The preferred way to build (and run) Boogie today is using .NET Core.
+Historically, Boogie can also be built using the classic .NET Framework (on
+Windows) and Mono (on Linux/OSX), but this might not be supported in the future.
 
-- [NuGet](https://www.nuget.org/)
-- [Z3](https://github.com/Z3Prover/z3) 4.8.4 (earlier versions may also work, but the test suite assumes 4.8.4 to produce the expected output) or [CVC4](http://cvc4.cs.nyu.edu/web/) **FIXME_VERSION** (note
-  CVC4 support is experimental)
+To run Boogie, a supported SMT solver has to be available (see below).
 
-#### Windows specific
-
-- Visual Studio >= 2012
-
-#### Linux/OSX specific
-
-- Mono
-
-### Windows
-
-1. Open ``Source\Boogie.sln`` in Visual Studio
-2. Right click the ``Boogie`` solution in the Solution Explorer and click ``Enable NuGet Package Restore``.
-   You will probably get a prompt asking to confirm this. Choose ``Yes``.
-3. Click ``BUILD > Build Solution``.
-
-### Linux/OSX
-
-You first need to fetch the NuGet packages that Boogie depends on. If you're doing this on the command line run
+### .NET Core
 
 ```
-$ cd /path/to/repository
-$ wget https://nuget.org/nuget.exe
-$ mono ./nuget.exe restore Source/Boogie.sln
+$ dotnet build Source/Boogie-NetCore.sln
 ```
 
-Note if you're using MonoDevelop it has a NuGet plug-in which you can use to "restore" the packages needed by Boogie.
+**TODO**: Describe how to install and run.
 
-Note if you see an error message like the following
+### Windows (requires Visual Studio)
+
+1. Open ``Source\Boogie.sln`` in Visual Studio.
+2. Right click the ``Boogie`` solution in the Solution Explorer and click ``Restore NuGet Packages``.
+3. Click ``Build > Build Solution``.
+
+The compiled Boogie binary is `Binaries\Boogie.exe`.
+
+### Linux/OSX (requires Mono)
+
+Either open ``Source\Boogie.sln`` in MonoDevelop and perform the same steps as
+described for Visual Studio above, of compile on the command line as follows.
+
+Fetch the NuGet packages that Boogie depends on:
 
 ```
-WARNING: Error: SendFailure (Error writing headers)
-Unable to find version '2.6.3' of package 'NUnit.Runners'.
+$ nuget restore Source/Boogie.sln
 ```
 
-then you need to initialise Mono's certificate store by running
-
-```
-$ mozroots --import --sync
-```
-
-then you can build by running
+Build Boogie:
 
 ```
 $ msbuild Source/Boogie.sln
 ```
 
-Finally make sure there is a symlink to Z3 in the Binaries directory
-(replace with ``cvc4`` if using CVC4 instead).
+The compiled Boogie binary is `Binaries/Boogie.exe`, which can be executed with
+`mono` or using the wrapper script `Binaries/boogie`.
 
-```
-$ ln -s /usr/bin/z3 Binaries/z3.exe
-```
+## Backend SMT Solver
 
-## Running
+The default SMT solver for Boogie is [Z3](https://github.com/Z3Prover/z3).
+Support for [CVC4](https://cvc4.github.io/) and
+[Yices2](https://yices.csl.sri.com/) is experimental.
 
-On a Windows system call the Boogie binary:
+### Z3
 
-```
-$ Binaries\Boogie.exe
-```
+The current test suite assumes version 4.8.4, but earlier and never versions may
+also work.
 
-On a non-Windows system use the wrapper script:
+Option 1: Make sure a Z3 executable called `z3` or `z3.exe` is in your `PATH`
+environment variable.
 
-```
-$ Binaries/boogie
-```
+Option 2: Call Boogie with `/z3exe:<path>`.
+
+### CVC4 (experimental)
+
+Call Boogie with `/proverOpt:SOLVER=CVC4 /cvc4exe:<path>`.
+
+### Yices2 (experimental)
+
+Call Boogie with `/proverOpt:SOLVER=Yices2 /yices2exe:<path> /useArrayTheory`.
+
+Works for unquantified fragments, e.g. arrays + arithmetic + bitvectors. Does
+not work for quantifiers, generalized arrays, datatypes.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Support for [CVC4](https://cvc4.github.io/) and
 
 ### Z3
 
-The current test suite assumes version 4.8.4, but earlier and never versions may
+The current test suite assumes version 4.8.4, but earlier and newer versions may
 also work.
 
 Option 1: Make sure a Z3 executable called `z3` or `z3.exe` is in your `PATH`

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ many aspects of the Boogie IVL but is slightly out of date.
 We have a public [mailing list](https://mailman.ic.ac.uk/mailman/listinfo/boogie-dev) for users of Boogie.
 You can also report issues on our [issue tracker](https://github.com/boogie-org/boogie/issues)
 
+## Installation
+
+Boogie releases are packaged as a .NET Core global tool available at
+[nuget.org](https://www.nuget.org/packages/Boogie). To install Boogie simply
+run:
+
+```
+$ dotnet tool install --global boogie
+```
+
+To run Boogie, a supported SMT solver has to be available (see below).
+
 ## Building
 
 The preferred way to build (and run) Boogie today is using .NET Core.
@@ -67,7 +79,10 @@ To run Boogie, a supported SMT solver has to be available (see below).
 $ dotnet build Source/Boogie-NetCore.sln
 ```
 
-**TODO**: Describe how to install and run.
+The compiled Boogie binary is
+`Source/BoogieDriver/bin/${CONFIGURATION}/${FRAMEWORK}/BoogieDriver`. Also, a
+NuGet package is placed in `Source/BoogieDriver/bin/Debug/` which can be used
+for a local installation.
 
 ### Windows (requires Visual Studio)
 

--- a/Source/BoogieDriver/BoogieDriver-NetCore.csproj
+++ b/Source/BoogieDriver/BoogieDriver-NetCore.csproj
@@ -13,7 +13,6 @@
     <AssemblyName>BoogieDriver</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageOutputPath>nupkg</PackageOutputPath>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>boogie</ToolCommandName>
   </PropertyGroup>

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -190,11 +190,8 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    public static System.TimeSpan TotalUserTime = System.TimeSpan.Zero;
-
     public void Close()
     {
-      TotalUserTime += prover.UserProcessorTime;
       TerminateProver();
       DisposeProver();
     }

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -72,25 +72,31 @@ def quotePath(path):
 
 ### Add Boogie specific substitutions
 
-# Find Boogie.exe
+# Find Boogie executable and runtime
 up = os.path.dirname
-repositoryRoot = up(
-                     up( os.path.abspath(__file__) )
-                   )
+repositoryRoot = up(up(os.path.abspath(__file__)))
 lit_config.note('Repository root is {}'.format(repositoryRoot))
 
-binaryDir = os.path.join( repositoryRoot, 'Binaries')
-boogieExecutable = os.path.join( binaryDir, 'Boogie.exe')
+configuration = lit_config.params.get('configuration', 'Debug')
+framework = lit_config.params.get('framework', 'netcoreapp3.1')
 
+runtime = ''
+
+if 'dotnet' in lit_config.params:
+    boogieBinary = 'Source/BoogieDriver/bin/{}/{}/BoogieDriver'.format(configuration, framework)
+else:
+    boogieBinary = 'Binaries/Boogie.exe'
+    if os.name == 'posix':
+        runtime = 'mono'
+
+boogieExecutable = quotePath(os.path.join(repositoryRoot, boogieBinary))
+        
 if not os.path.exists(boogieExecutable):
-    lit_config.fatal('Could not find Boogie.exe at {}'.format(boogieExecutable))
+    lit_config.fatal('Could not find Boogie executable at {}'.format(boogieExecutable))
+if runtime and lit.util.which(runtime) == None:
+    lit_config.fatal('Cannot find {}. Make sure it is in your PATH'.format(runtime))
 
-boogieExecutable = quotePath(boogieExecutable)
-
-if os.name == 'posix':
-    boogieExecutable = 'mono ' + boogieExecutable
-    if lit.util.which('mono') == None:
-        lit_config.fatal('Cannot find mono. Make sure it is your PATH')
+boogieExecutable = runtime + ' ' + boogieExecutable
 
 # Expected output does not contain logo
 boogieExecutable += ' -nologo'
@@ -99,32 +105,14 @@ boogieExecutable += ' -nologo'
 boogieExecutable += ' -useBaseNameForFileName'
 
 # Allow user to provide extra arguments to Boogie
-boogieParams = lit_config.params.get('boogie_params','')
+boogieParams = lit_config.params.get('boogie_params', '')
 if len(boogieParams) > 0:
     boogieExecutable = boogieExecutable + ' ' + boogieParams
 
 # Inform user what executable is being used
 lit_config.note('Using Boogie: {}'.format(boogieExecutable))
 
-config.substitutions.append( ('%boogie', boogieExecutable) )
-
-# Sanity check: Check solver executable is available
-# FIXME: Should this check be removed entirely?
-if os.name != 'nt':
-    solvers = ['z3.exe','cvc4.exe']
-    solverFound = False
-    for solver in solvers:
-        if os.path.exists( os.path.join(binaryDir, solver)):
-            solverFound = True
-
-    if not solverFound:
-        lit_config.fatal('Could not find solver in "{binaryDir}". Tried looking for {solvers}'.format(
-                           binaryDir=binaryDir,
-                           solvers=solvers
-                           )
-                        )
-else:
-    lit_config.warning('Skipping solver sanity check on Windows')
+config.substitutions.append(('%boogie', boogieExecutable))
 
 # Add diff tool substitution
 if os.name == 'posix':
@@ -134,17 +122,17 @@ if os.name == 'posix':
     diffExecutable = lit.util.which('diff')
 else:
     # use driver around Python's difflib
-    pydiff = quotePath( os.path.join(config.test_source_root, 'pydiff.py') )
+    pydiff = quotePath(os.path.join(config.test_source_root, 'pydiff.py'))
     diffExecutable = sys.executable + ' ' + pydiff
 
 diffExecutable += ' --unified=3 --strip-trailing-cr --ignore-all-space'
 lit_config.note("Using diff tool: {}".format(diffExecutable))
 
-config.substitutions.append( ('%diff', diffExecutable ))
+config.substitutions.append(('%diff', diffExecutable))
 
 # Detect the OutputCheck tool
 outputCheckPath = lit.util.which('OutputCheck')
 if outputCheckPath == None:
     lit_config.fatal('The OutputCheck tool is not in your PATH. Please install it.')
 
-config.substitutions.append( ('%OutputCheck', outputCheckPath + ' --dump-file-to-check') )
+config.substitutions.append(('%OutputCheck', outputCheckPath + ' --dump-file-to-check'))

--- a/Test/test15/CaptureState.bpl.expect
+++ b/Test/test15/CaptureState.bpl.expect
@@ -5,12 +5,12 @@ Execution trace:
     CaptureState.bpl(19,5): anon4_Then
     CaptureState.bpl(27,5): anon3
 *** MODEL
-$mv_state_const -> 4
 %lbl%@1 -> false
 %lbl%+0 -> true
 %lbl%+3 -> true
 %lbl%+4 -> true
 %lbl%+5 -> true
+$mv_state_const -> 4
 F -> T@FieldName!val!0
 Heap -> |T@[Ref,FieldName]Int!val!0|
 m -> **m


### PR DESCRIPTION
**Edit:** This PR evolved quite a bit from its original version. Points 1 and 3 below do not apply anymore, and point 5 was added.

This PR makes the following (in my opinion) improvements:

~1. The build output of the BoogieDriver project is set to the `Binaries` directory, as for the old build. Thus the compiled executable is written to `Binaries/Boogie.dll`. The option `AppendTargetFrameworkToOutputPath` is set to `false` because otherwise the location would depend on the target framework (e.g., `Binaries/netcoreapp2.2/Boogie.dll`). Also, the created NuGet package is placed into `Binaries/nupkg/`.~
2. The lit test tool can now be called with `-D dotnet` to run the regression tests with the .NET Core build.
~3. A wrapper script `Binaries/boogie-dotnet` is added. This makes it more convenient to call on the command line or to configure the Emacs Flycheck mode for Boogie.~
4. The build instructions in `README.md` are cleaned up and emphasize that .NET Core is from now on the preferred way to build/run Boogie. I think this was the consensus from previous discussions. Also, more details for the three supported SMT solvers are given.
5. **Added**: The Travis CI build is switched from Mono to .NET Core and configured to automatically deploy tagged releases.

@michael-emmi, please let me know if you agree with the above changes, or if anything should be updated.