### PR TITLE
Using GitVersion for NetCore CLI and package.

### DIFF
--- a/Source/AIFramework/AIFramework-NetCore.csproj
+++ b/Source/AIFramework/AIFramework-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>AIFramework</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -15,6 +16,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/AIFramework/AIFramework-NetCore.csproj
+++ b/Source/AIFramework/AIFramework-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>AIFramework</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/AIFramework/AIFramework-NetCore.csproj
+++ b/Source/AIFramework/AIFramework-NetCore.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs" />
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/AbsInt/AbsInt-NetCore.csproj
+++ b/Source/AbsInt/AbsInt-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieAbsInt</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/AbsInt/AbsInt-NetCore.csproj
+++ b/Source/AbsInt/AbsInt-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieAbsInt</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -17,6 +18,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/AbsInt/AbsInt-NetCore.csproj
+++ b/Source/AbsInt/AbsInt-NetCore.csproj
@@ -16,9 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/Basetypes/Basetypes-NetCore.csproj
+++ b/Source/Basetypes/Basetypes-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieBasetypes</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -14,6 +15,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Basetypes/Basetypes-NetCore.csproj
+++ b/Source/Basetypes/Basetypes-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieBasetypes</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Basetypes/Basetypes-NetCore.csproj
+++ b/Source/Basetypes/Basetypes-NetCore.csproj
@@ -13,9 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/BoogieDriver/BoogieDriver-NetCore.csproj
+++ b/Source/BoogieDriver/BoogieDriver-NetCore.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <PackageId>Boogie</PackageId>
+    <Authors>Boogie </Authors>
+    <Description>An SMT-based program verifier.</Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryUrl>https://github.com/boogie-org/boogie</RepositoryUrl>
   </PropertyGroup>

--- a/Source/BoogieDriver/BoogieDriver-NetCore.csproj
+++ b/Source/BoogieDriver/BoogieDriver-NetCore.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>BoogieDriver</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>nupkg</PackageOutputPath>
@@ -45,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.3-beta1.61">
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/BoogieDriver/BoogieDriver-NetCore.csproj
+++ b/Source/BoogieDriver/BoogieDriver-NetCore.csproj
@@ -13,7 +13,6 @@
     <AssemblyName>BoogieDriver</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>nupkg</PackageOutputPath>

--- a/Source/BoogieDriver/BoogieDriver-NetCore.csproj
+++ b/Source/BoogieDriver/BoogieDriver-NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Boogie</PackageId>
-    <Authors>Boogie </Authors>
+    <Authors>Boogie</Authors>
     <Description>An SMT-based program verifier.</Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryUrl>https://github.com/boogie-org/boogie</RepositoryUrl>

--- a/Source/BoogieDriver/BoogieDriver-NetCore.csproj
+++ b/Source/BoogieDriver/BoogieDriver-NetCore.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PackageId>Boogie</PackageId>
-    <VersionPrefix>2.4.1</VersionPrefix>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryUrl>https://github.com/boogie-org/boogie</RepositoryUrl>
   </PropertyGroup>
@@ -36,12 +35,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs" />
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 
   <ItemGroup>
       <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.3-beta1.61">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/CodeContractsExtender/CodeContractsExtender-NetCore.csproj
+++ b/Source/CodeContractsExtender/CodeContractsExtender-NetCore.csproj
@@ -5,7 +5,15 @@
     <AssemblyName>BoogieCodeContractsExtender</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/Source/CodeContractsExtender/CodeContractsExtender-NetCore.csproj
+++ b/Source/CodeContractsExtender/CodeContractsExtender-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieCodeContractsExtender</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Concurrency/Concurrency-NetCore.csproj
+++ b/Source/Concurrency/Concurrency-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieConcurrency</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Concurrency/Concurrency-NetCore.csproj
+++ b/Source/Concurrency/Concurrency-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieConcurrency</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -18,6 +19,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Concurrency/Concurrency-NetCore.csproj
+++ b/Source/Concurrency/Concurrency-NetCore.csproj
@@ -17,9 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/Core/Core-NetCore.csproj
+++ b/Source/Core/Core-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieCore</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Core/Core-NetCore.csproj
+++ b/Source/Core/Core-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieCore</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -20,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.3-beta1.61">
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/Core/Core-NetCore.csproj
+++ b/Source/Core/Core-NetCore.csproj
@@ -16,10 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.3-beta1.61">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Doomed/Doomed-NetCore.csproj
+++ b/Source/Doomed/Doomed-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieDoomed</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -21,6 +22,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Doomed/Doomed-NetCore.csproj
+++ b/Source/Doomed/Doomed-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieDoomed</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Doomed/Doomed-NetCore.csproj
+++ b/Source/Doomed/Doomed-NetCore.csproj
@@ -20,9 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
+++ b/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieExecutionEngine</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
+++ b/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieExecutionEngine</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -29,6 +30,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
+++ b/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
@@ -28,9 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/Graph/Graph-NetCore.csproj
+++ b/Source/Graph/Graph-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieGraph</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Graph/Graph-NetCore.csproj
+++ b/Source/Graph/Graph-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieGraph</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -14,6 +15,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Graph/Graph-NetCore.csproj
+++ b/Source/Graph/Graph-NetCore.csproj
@@ -13,9 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/Houdini/Houdini-NetCore.csproj
+++ b/Source/Houdini/Houdini-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieHoudini</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -23,6 +24,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Houdini/Houdini-NetCore.csproj
+++ b/Source/Houdini/Houdini-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieHoudini</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Houdini/Houdini-NetCore.csproj
+++ b/Source/Houdini/Houdini-NetCore.csproj
@@ -22,9 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/Model/Model-NetCore.csproj
+++ b/Source/Model/Model-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieModel</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Model/Model-NetCore.csproj
+++ b/Source/Model/Model-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieModel</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -14,6 +15,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Model/Model-NetCore.csproj
+++ b/Source/Model/Model-NetCore.csproj
@@ -13,9 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/ParserHelper/ParserHelper-NetCore.csproj
+++ b/Source/ParserHelper/ParserHelper-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieParserHelper</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -14,6 +15,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/ParserHelper/ParserHelper-NetCore.csproj
+++ b/Source/ParserHelper/ParserHelper-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieParserHelper</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/ParserHelper/ParserHelper-NetCore.csproj
+++ b/Source/ParserHelper/ParserHelper-NetCore.csproj
@@ -13,9 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/Predication/Predication-NetCore.csproj
+++ b/Source/Predication/Predication-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogiePredication</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Predication/Predication-NetCore.csproj
+++ b/Source/Predication/Predication-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogiePredication</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -19,6 +20,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Predication/Predication-NetCore.csproj
+++ b/Source/Predication/Predication-NetCore.csproj
@@ -18,9 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/Provers/SMTLib/SMTLib-NetCore.csproj
+++ b/Source/Provers/SMTLib/SMTLib-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Provers.SMTLib</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/Provers/SMTLib/SMTLib-NetCore.csproj
+++ b/Source/Provers/SMTLib/SMTLib-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Provers.SMTLib</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -21,6 +22,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Provers/SMTLib/SMTLib-NetCore.csproj
+++ b/Source/Provers/SMTLib/SMTLib-NetCore.csproj
@@ -20,9 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/VCExpr/VCExpr-NetCore.csproj
+++ b/Source/VCExpr/VCExpr-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieVCExpr</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -17,6 +18,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/VCExpr/VCExpr-NetCore.csproj
+++ b/Source/VCExpr/VCExpr-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieVCExpr</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/VCExpr/VCExpr-NetCore.csproj
+++ b/Source/VCExpr/VCExpr-NetCore.csproj
@@ -16,9 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 

--- a/Source/VCGeneration/VCGeneration-NetCore.csproj
+++ b/Source/VCGeneration/VCGeneration-NetCore.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>BoogieVCGeneration</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Source/VCGeneration/VCGeneration-NetCore.csproj
+++ b/Source/VCGeneration/VCGeneration-NetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>BoogieVCGeneration</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
+    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -20,6 +21,13 @@
 
   <ItemGroup>
     <Compile Remove="**\cce.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/VCGeneration/VCGeneration-NetCore.csproj
+++ b/Source/VCGeneration/VCGeneration-NetCore.csproj
@@ -19,9 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\version.cs">
-      <Link>version.cs</Link>
-    </Compile>
     <Compile Remove="**\cce.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
**NOTE**: please do not merge this yet, this is meant to be discussed with @bkragl.

This PR leverages [GitVersion](https://gitversion.readthedocs.io) to generate version numbers for the CLI and NuGet package automatically; version numbers are generated from git history, e.g., by looking at branch names and tags.