### PR TITLE
[CIVL] Fix for introduction procedures.

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -221,14 +221,14 @@ namespace Microsoft.Boogie
     {
         public Procedure proc;
         public LayerRange layerRange;
-        public bool isLeaky;
 
-        public IntroductionProc(Procedure proc, LayerRange layerRange, bool isLeaking)
+        public IntroductionProc(Procedure proc, LayerRange layerRange)
         {
             this.proc = proc;
-            this.isLeaky = isLeaking;
             this.layerRange = layerRange;
         }
+
+        public bool IsLemma => proc.Modifies.Count + proc.OutParams.Count == 0;
     }
 
     /// <summary>

--- a/Test/civl/async/2pc-triggers.bpl
+++ b/Test/civl/async/2pc-triggers.bpl
@@ -221,8 +221,8 @@ modifies state;
   havoc state;
   assume xConsistent(state[xid]);
   assume state == old(state)[xid := state[xid]];
-} 
-  
+}
+
 procedure {:yields} {:layer 10} {:refines "atomic_Coordinator_TransactionReq"} Coordinator_TransactionReq () returns (xid: Xid)
 requires {:layer 8} Inv_8(state, B, votes);
 ensures  {:layer 8} Inv_8(state, B, votes);
@@ -233,7 +233,7 @@ ensures  {:layer 9,10} gConsistent(state);
   var {:linear "pair"} pairs: [Pair]bool;
   var {:layer 10} snapshot: GState;
   var i : Mid;
-  
+
   par YieldInv_8() | YieldConsistent_9() | YieldConsistent_10();
   call xid, pairs := AllocateXid();
   assert {:layer 10} NextStateTrigger(state[xid]);
@@ -269,7 +269,7 @@ modifies state;
   havoc state;
   assume xConsistentExtension(old(state)[xid], state[xid]);
   assume state == old(state)[xid := state[xid]];
-}          
+}
 
 procedure {:yields} {:layer 9} {:refines "atomic_Participant_VoteReq"} Participant_VoteReq (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
 requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid] == -1 || UndecidedOrCommitted(state[xid][mid]));
@@ -321,7 +321,7 @@ modifies state, B;
     assume xAllParticipantsInB(xid, B);
     assume xConsistentExtension(old(state)[xid], state[xid]);
     assume state == old(state)[xid := state[xid]];
-  } 
+  }
 }
 
 procedure {:yields} {:layer 8} {:refines "atomic_Coordinator_VoteYes"} Coordinator_VoteYes (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
@@ -334,13 +334,13 @@ requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid
   call YieldUndecidedOrCommitted_8(xid, mid, pair);
   assert {:layer 8} XidTrigger(xid);
   call snapshot := GhostRead();
-  call Lemma_add_to_B(pair);
-  call Lemma_all_in_B(xid);
+  call {:layer 8} Lemma_add_to_B(pair);
+  call {:layer 8} Lemma_all_in_B(xid);
   call commit := StateUpdateOnVoteYes(xid, mid, pair);
-  call Lemma_all_in_B(xid);
+  call {:layer 8} Lemma_all_in_B(xid);
   assert {:layer 8} XidTrigger(xid);
   assert {:layer 8} NextStateTrigger(state[xid]);
-  
+
   if (commit)
   {
     assert {:layer 8} xUndecidedOrCommitted(snapshot[xid]);
@@ -387,7 +387,7 @@ requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(st
   call abort := StateUpdateOnVoteNo(xid, mid);
   assert {:layer 8} XidTrigger(xid);
   assert {:layer 8} NextStateTrigger(state[xid]);
-  
+
   if (abort)
   {
     i := 1;
@@ -438,7 +438,7 @@ modifies votes, state, B;
     votes[xid] := votes[xid] + 1;
     commit := (votes[xid] == numParticipants);
     state[xid][CoordinatorMid] := (if commit then COMMITTED() else state[xid][CoordinatorMid]);
-  }               
+  }
 }
 
 procedure {:atomic} {:layer 8} atomic_StateUpdateOnVoteNo (xid: Xid, mid: Mid) returns (abort : bool)

--- a/Test/civl/async/2pc.bpl
+++ b/Test/civl/async/2pc.bpl
@@ -211,8 +211,8 @@ modifies state;
   havoc state;
   assume xConsistent(state[xid]);
   assume state == old(state)[xid := state[xid]];
-} 
-  
+}
+
 procedure {:yields} {:layer 10} {:refines "atomic_Coordinator_TransactionReq"} Coordinator_TransactionReq () returns (xid: Xid)
 requires {:layer 8} Inv_8(state, B, votes);
 ensures  {:layer 8} Inv_8(state, B, votes);
@@ -223,7 +223,7 @@ ensures  {:layer 9,10} gConsistent(state);
   var {:linear "pair"} pairs: [Pair]bool;
   var {:layer 10} snapshot: GState;
   var i : Mid;
-  
+
   par YieldInv_8() | YieldConsistent_9() | YieldConsistent_10();
   call xid, pairs := AllocateXid();
   call snapshot := GhostRead();
@@ -257,7 +257,7 @@ modifies state;
   havoc state;
   assume xConsistentExtension(old(state)[xid], state[xid]);
   assume state == old(state)[xid := state[xid]];
-}          
+}
 
 procedure {:yields} {:layer 9} {:refines "atomic_Participant_VoteReq"} Participant_VoteReq (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
 requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid] == -1 || UndecidedOrCommitted(state[xid][mid]));
@@ -309,7 +309,7 @@ modifies state, B;
     assume xAllParticipantsInB(xid, B);
     assume xConsistentExtension(old(state)[xid], state[xid]);
     assume state == old(state)[xid := state[xid]];
-  } 
+  }
 }
 
 procedure {:yields} {:layer 8} {:refines "atomic_Coordinator_VoteYes"} Coordinator_VoteYes (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
@@ -321,11 +321,11 @@ requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && (votes[xid
 
   call YieldUndecidedOrCommitted_8(xid, mid, pair);
   call snapshot := GhostRead();
-  call Lemma_add_to_B(pair);
-  call Lemma_all_in_B(xid);
+  call {:layer 8} Lemma_add_to_B(pair);
+  call {:layer 8} Lemma_all_in_B(xid);
   call commit := StateUpdateOnVoteYes(xid, mid, pair);
-  call Lemma_all_in_B(xid);
-  
+  call {:layer 8} Lemma_all_in_B(xid);
+
   if (commit)
   {
     assert {:layer 8} xUndecidedOrCommitted(snapshot[xid]);
@@ -366,7 +366,7 @@ requires {:layer 8} Inv_8(state, B, votes) && pair(xid, mid, pair) && Aborted(st
   call YieldAborted_8(xid, mid, pair);
   call snapshot := GhostRead();
   call abort := StateUpdateOnVoteNo(xid, mid);
-  
+
   if (abort)
   {
     i := 1;
@@ -413,7 +413,7 @@ modifies votes, state, B;
     votes[xid] := votes[xid] + 1;
     commit := (votes[xid] == numParticipants);
     state[xid][CoordinatorMid] := (if commit then COMMITTED() else state[xid][CoordinatorMid]);
-  }               
+  }
 }
 
 procedure {:atomic} {:layer 8} atomic_StateUpdateOnVoteNo (xid: Xid, mid: Mid) returns (abort : bool)

--- a/Test/civl/bernhard1.bpl
+++ b/Test/civl/bernhard1.bpl
@@ -1,19 +1,21 @@
 // RUN: %boogie -noinfer -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-var {:linear "x"} {:layer 0} A : [int]bool;
+var {:linear "x"} {:layer 0,1} A : [int]bool;
 
 procedure {:yields} {:layer 1} Proc ({:linear "x"} i: int)
 {
   par Yield0() | Yield1();
-  call Lemma(i);
+  call {:layer 1} Lemma(i);
   yield;
 }
 
 procedure {:yields} {:layer 0} Yield0 () { yield; }
 procedure {:yields} {:layer 1} Yield1 () { yield; }
 
-procedure Lemma (i: int);
+procedure {:layer 1} Lemma (i: int)
 requires !A[i];
+{
+}
 
 // Collectors for linear domains
 

--- a/Test/civl/bernhard1.bpl.expect
+++ b/Test/civl/bernhard1.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 5 verified, 0 errors
+Boogie program verifier finished with 6 verified, 0 errors

--- a/Test/civl/chris5.bpl
+++ b/Test/civl/chris5.bpl
@@ -1,8 +1,8 @@
 // RUN: %boogie -noinfer -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-var{:layer 1,1} g:int;
+var {:layer 1,1} g:int;
 
-procedure{:layer 1} P(x:int)
+procedure {:layer 1} P(x:int)
   requires {:layer 1} x == 0;
 {
 }
@@ -11,8 +11,8 @@ procedure{:layer 1} P(x:int)
 procedure{:yields}{:layer 1} Y(x:int)
 {
   yield;
-  
-  call P(x);
+
+  call {:layer 1} P(x);
   assert{:layer 1} x == 0;
 
   yield;

--- a/Test/civl/chris8.bpl
+++ b/Test/civl/chris8.bpl
@@ -1,14 +1,14 @@
 // RUN: %boogie -noinfer -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-var{:layer 1,1} x:int;
+var {:layer 1,1} x:int;
 
-procedure{:layer 1} P1(i:int);
-procedure P2(j:int);
+procedure {:layer 1} P1(i:int);
+procedure {:layer 1} P2(j:int);
 
 procedure{:yields}{:layer 1} A1({:layer 1}i:int)
 {
   yield;
-  call P1(i);
-  call P2(i);
+  call {:layer 1} P1(i);
+  call {:layer 1} P2(i);
   yield;
 }

--- a/Test/civl/ghost.bpl
+++ b/Test/civl/ghost.bpl
@@ -8,7 +8,7 @@ modifies x;
 
 procedure {:yields} {:layer 0} {:refines "AtomicIncr"} Incr();
 
-procedure ghost(y: int) returns (z: int)
+procedure {:layer 1} ghost(y: int) returns (z: int)
 requires y == 1;
 ensures z == 2;
 {

--- a/Test/civl/podelski/x_perm.bpl
+++ b/Test/civl/podelski/x_perm.bpl
@@ -103,13 +103,13 @@ ensures  {:layer 1} Inv(x, As, Bs);
   var {:linear "perm"} b:B;
   yield; assert {:layer 1} Inv(x, As, Bs);
   call a,b := split_ab(ab);
-  call Lemma_card_geq();
-  call Lemma_add_to_A(a);
+  call {:layer 1} Lemma_card_geq();
+  call {:layer 1} Lemma_add_to_A(a);
   call geq0_inc(a, b);
   yield;
   assert {:layer 1} Inv(x, As, Bs) && As[bToA(b)];
-  call Lemma_card_greater(b);
-  call Lemma_add_to_B(b);
+  call {:layer 1} Lemma_card_greater(b);
+  call {:layer 1} Lemma_add_to_B(b);
   call geq0_dec(b);
   yield; assert {:layer 1}{:expand} Inv(x, As, Bs);
 }


### PR DESCRIPTION
An introduction procedure introduces computation into a CIVL program.  An introduction procedure  that does not modify any global variable and has no output variables is called a lemma introduction procedure.  A call to such a lemma procedure is used to inject trusted or untrusted facts into the verification condition.

A non-lemma introduction procedures may only be called at the disappearing layer of a yielding procedure.  A lemma procedure may be called at many layers but the call command must be annotated with the layer/s at which the call is happening.

This PR should fix https://github.com/boogie-org/boogie/issues/153.