### PR TITLE
Add implementations of GetHashCode to classes that override Equals

### DIFF
--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -2249,7 +2249,9 @@ namespace Microsoft.Boogie {
       }
     }
 
-
+    public override int GetHashCode() {
+      return Type.GetHashCode();
+    }
 
     public
       string/*!*/ FunctionName {

--- a/Source/Core/AbsyQuant.cs
+++ b/Source/Core/AbsyQuant.cs
@@ -889,6 +889,10 @@ namespace Microsoft.Boogie {
           (!CompareAttributesAndTriggers || object.Equals(Triggers, other.Triggers));
       }
     }
+
+    public override int GetHashCode() {
+      return base.GetHashCode();
+    }
   }
 
 

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -995,6 +995,11 @@ namespace Microsoft.Boogie {
       return this.T.GetHashCode();
     }
 
+    [Pure]
+    public override int GetHashCode() {
+      return this.T.GetHashCode();
+    }
+
     //-----------  Resolution  ----------------------------------
 
     public override Type ResolveType(ResolutionContext rc) {
@@ -3288,6 +3293,11 @@ Contract.Requires(that != null);
         res = res * 3 + t.GetHashCode(boundVariables);
       }
       return res;
+    }
+
+    [Pure]
+    public override int GetHashCode() {
+      return base.GetHashCode();
     }
 
     //-----------  Linearisation  ----------------------------------


### PR DESCRIPTION
The following classes are affected:
* TypeCoercion
* QuantifierExpr
* BasicType
* CtorType