### PR TITLE
Restore TotalUserTime field removed by 714d5a0.

### DIFF
--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -190,8 +190,21 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
+
+    // NOTE: this field is used by Corral.
+    // https://github.com/boogie-org/corral/blob/master/source/Driver.cs
+    public static System.TimeSpan TotalUserTime = System.TimeSpan.Zero;
+
     public void Close()
     {
+      try {
+        TotalUserTime += prover.UserProcessorTime;
+      } catch (Exception e) {
+        if (options.Verbosity >= 1) {
+          Console.Error.WriteLine("Warning: prover time not incremented due to {0}", e.GetType());
+        }
+      }
+
       TerminateProver();
       DisposeProver();
     }
@@ -394,4 +407,3 @@ namespace Microsoft.Boogie.SMTLib
     #endregion
   }
 }
-


### PR DESCRIPTION
The `TotalUserTime` field was removed from `Microsoft.Boogie.SMTLib.SMTLibProcess` by 714d5a0 because it was causing a crash. However, other projects, [e.g., Corral](https://github.com/boogie-org/corral/blob/master/source/Driver.cs#L444), were using this field, so that commit blocks them from updating Boogie.

This commit solves the original issue, by not invoking the getter for `UserProcessorTime` if the given process has already exited.