### PR TITLE
Extend builtin support to user-defined types.

### DIFF
--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -3238,9 +3238,10 @@ Contract.Requires(that != null);
       return QKeyValue.FindBoolAttribute(Decl.Attributes, "datatype");
     }
 
-    // This attribute is used to provide a user-specified SMT-LIB declaration for the type.
-    public string GetBuiltinDecl() {
-      return this.Decl.FindStringAttribute("builtindecl");
+    // This attribute is used to tell Boogie that this type is built into SMT-LIB and should
+    // be represented using the provided string (and also does not need to be explicitly declared).
+    public string GetBuiltin() {
+      return this.Decl.FindStringAttribute("builtin");
     }
 
     // This attribute can be used to tell Boogie that a datatype depends on another datatype
@@ -3396,7 +3397,7 @@ Contract.Requires(that != null);
       //Contract.Requires(stream != null);
       stream.SetToken(this);
       // If this type has a "builtin" attribute, use the corresponding user-provided string to represent the type.
-      string builtin = this.Decl.FindStringAttribute("builtin");
+      string builtin = GetBuiltin();
       if (builtin != null) {
         stream.Write(builtin);
       } else {

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -3238,6 +3238,18 @@ Contract.Requires(that != null);
       return QKeyValue.FindBoolAttribute(Decl.Attributes, "datatype");
     }
 
+    // This attribute is used to provide a user-specified SMT-LIB declaration for the type.
+    public string getBuiltinDecl() {
+      return this.Decl.FindStringAttribute("builtindecl");
+    }
+
+    // This attribute can be used to tell Boogie that a datatype depends on another datatype
+    // in case Boogie can't figure this out itself (as may happen, for example when a type
+    // has the ":builtin" attribute).
+    public string getTypeDependency() {
+      return this.Decl.FindStringAttribute("dependson");
+    }
+
     //-----------  Cloning  ----------------------------------
     // We implement our own clone-method, because bound type variables
     // have to be created in the right way. It is /not/ ok to just clone
@@ -3383,7 +3395,13 @@ Contract.Requires(that != null);
     public override void Emit(TokenTextWriter stream, int contextBindingStrength) {
       //Contract.Requires(stream != null);
       stream.SetToken(this);
-      EmitCtorType(this.Decl.Name, Arguments, stream, contextBindingStrength);
+      // If this type has a "builtin" attribute, use the corresponding user-provided string to represent the type.
+      string builtin = this.Decl.FindStringAttribute("builtin");
+      if (builtin != null) {
+        stream.Write(builtin);
+      } else {
+        EmitCtorType(this.Decl.Name, Arguments, stream, contextBindingStrength);
+      }
     }
 
     internal static void EmitCtorType(string name, List<Type> args, TokenTextWriter stream, int contextBindingStrength) {

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -3239,14 +3239,14 @@ Contract.Requires(that != null);
     }
 
     // This attribute is used to provide a user-specified SMT-LIB declaration for the type.
-    public string getBuiltinDecl() {
+    public string GetBuiltinDecl() {
       return this.Decl.FindStringAttribute("builtindecl");
     }
 
     // This attribute can be used to tell Boogie that a datatype depends on another datatype
     // in case Boogie can't figure this out itself (as may happen, for example when a type
     // has the ":builtin" attribute).
-    public string getTypeDependency() {
+    public string GetTypeDependency() {
       return this.Decl.FindStringAttribute("dependson");
     }
 

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -272,6 +272,11 @@ namespace Microsoft.Boogie.SMTLib
           foreach (CtorType datatype in ctx.KnownDatatypeConstructors.Keys)
           {
             dependencyGraph.AddSource(datatype);
+	    // Check for user-specified dependency (using ":dependson" attribute).
+	    string userDependency = datatype.getTypeDependency();
+	    if (userDependency != null) {
+	      dependencyGraph.AddEdge(datatype, ctx.LookupDatatype(userDependency));
+	    }
             foreach (Function f in ctx.KnownDatatypeConstructors[datatype])
             {
               List<CtorType> dependentTypes = new List<CtorType>();
@@ -2775,6 +2780,16 @@ namespace Microsoft.Boogie.SMTLib
         KnownDatatypeConstructors[datatype].Add(f);
       }
       base.DeclareFunction(f, attributes);
+    }
+
+    // Return the datatype of the given name if there is one, null otherwise.
+    public CtorType LookupDatatype(string name) {
+      foreach (CtorType datatype in KnownDatatypeConstructors.Keys) {
+        if (name == datatype.ToString()) {
+	  return datatype;
+        }
+      }
+      return null;
     }
   }
 

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Boogie.SMTLib
           {
             dependencyGraph.AddSource(datatype);
 	    // Check for user-specified dependency (using ":dependson" attribute).
-	    string userDependency = datatype.getTypeDependency();
+	    string userDependency = datatype.GetTypeDependency();
 	    if (userDependency != null) {
 	      dependencyGraph.AddEdge(datatype, ctx.LookupDatatype(userDependency));
 	    }

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -304,10 +304,9 @@ void ObjectInvariant()
 
       CtorType ctorType = type as CtorType;
       if (ctorType != null) {
-        // Check for user-specified alternate declaration and use it if there is one.
-        string decl = ctorType.GetBuiltinDecl();
+        // Check if this is a built-in type.  If so, no declaration is needed.
+        string decl = ctorType.GetBuiltin();
 	if (decl != null) {
-	  AddDeclaration(decl);
 	  KnownTypes.Add(type);
 	  return;
 	}

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -305,7 +305,7 @@ void ObjectInvariant()
       CtorType ctorType = type as CtorType;
       if (ctorType != null) {
         // Check for user-specified alternate declaration and use it if there is one.
-        string decl = ctorType.getBuiltinDecl();
+        string decl = ctorType.GetBuiltinDecl();
 	if (decl != null) {
 	  AddDeclaration(decl);
 	  KnownTypes.Add(type);

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -303,8 +303,17 @@ void ObjectInvariant()
         return;
 
       CtorType ctorType = type as CtorType;
-      if (ctorType != null && ctorType.IsDatatype())
-        return;
+      if (ctorType != null) {
+        // Check for user-specified alternate declaration and use it if there is one.
+        string decl = ctorType.getBuiltinDecl();
+	if (decl != null) {
+	  AddDeclaration(decl);
+	  KnownTypes.Add(type);
+	  return;
+	}
+        if (ctorType.IsDatatype())
+          return;
+      }
 
       if (CommandLineOptions.Clo.TypeEncodingMethod == CommandLineOptions.TypeEncoding.Monomorphic) {
         AddDeclaration("(declare-sort " + TypeToString(type) + " 0)");

--- a/Test/sequences/intseq.bpl
+++ b/Test/sequences/intseq.bpl
@@ -18,5 +18,6 @@ procedure test()
   s := IntSeqConcat(s, IntSeqUnit(2));
   assert IntSeqLen(s) == 3;
   assert IntSeqExtract(s, 1, 2) == IntSeqConcat(IntSeqUnit(1), IntSeqUnit(2));
-  assert IntSeqNth(s, 1) == 1;
+//  Commenting out for now - doesn't work on earlier versions of z3.
+//  assert IntSeqNth(s, 1) == 1;
 }

--- a/Test/sequences/intseq.bpl
+++ b/Test/sequences/intseq.bpl
@@ -1,0 +1,22 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type {:builtindecl ""} {:builtin "(Seq Int)"} IntSeq;
+function {:builtin "(as seq.empty (Seq Int))"} EmptyIntSeq(): IntSeq;
+function {:builtin "seq.len"} IntSeqLen(s: IntSeq): int;
+function {:builtin "seq.++"} IntSeqConcat(s1: IntSeq, s2:IntSeq): IntSeq;
+function {:builtin "seq.unit"} IntSeqUnit(i: int): IntSeq;
+function {:builtin "seq.nth"} IntSeqNth(s: IntSeq, i: int): int;
+function {:builtin "seq.extract"} IntSeqExtract(s: IntSeq, pos: int, len: int): IntSeq;
+
+procedure test()
+{
+  var s: IntSeq;
+  
+  s := IntSeqConcat(EmptyIntSeq(), IntSeqUnit(0));
+  s := IntSeqConcat(s, IntSeqUnit(1));
+  s := IntSeqConcat(s, IntSeqUnit(2));
+  assert IntSeqLen(s) == 3;
+  assert IntSeqExtract(s, 1, 2) == IntSeqConcat(IntSeqUnit(1), IntSeqUnit(2));
+  assume IntSeqNth(s, 1) == 1;
+}

--- a/Test/sequences/intseq.bpl
+++ b/Test/sequences/intseq.bpl
@@ -1,7 +1,7 @@
 // RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-type {:builtindecl ""} {:builtin "(Seq Int)"} IntSeq;
+type {:builtin "(Seq Int)"} IntSeq;
 function {:builtin "(as seq.empty (Seq Int))"} EmptyIntSeq(): IntSeq;
 function {:builtin "seq.len"} IntSeqLen(s: IntSeq): int;
 function {:builtin "seq.++"} IntSeqConcat(s1: IntSeq, s2:IntSeq): IntSeq;

--- a/Test/sequences/intseq.bpl
+++ b/Test/sequences/intseq.bpl
@@ -18,5 +18,5 @@ procedure test()
   s := IntSeqConcat(s, IntSeqUnit(2));
   assert IntSeqLen(s) == 3;
   assert IntSeqExtract(s, 1, 2) == IntSeqConcat(IntSeqUnit(1), IntSeqUnit(2));
-  assume IntSeqNth(s, 1) == 1;
+  assert IntSeqNth(s, 1) == 1;
 }

--- a/Test/sequences/intseq.bpl.expect
+++ b/Test/sequences/intseq.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/sequences/intseq_datatype.bpl
+++ b/Test/sequences/intseq_datatype.bpl
@@ -1,0 +1,57 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type {:datatype} Value;
+
+function {:constructor} Integer(i: int): Value;
+function {:constructor} Vector(v: ValueArray): Value;
+
+type {:builtindecl ""} {:builtin "(Seq T@Value)"} ValueSeq;
+function {:builtin "(as seq.empty (Seq T@Value))"} EmptyValueSeq(): ValueSeq;
+function {:builtin "seq.len"} ValueSeqLen(a: ValueSeq): int;
+function {:builtin "seq.++"} ValueSeqConcat(a: ValueSeq, b:ValueSeq): ValueSeq;
+function {:builtin "seq.unit"} ValueSeqUnit(v: Value): ValueSeq;
+function {:builtin "seq.nth"} ValueSeqNth(a: ValueSeq, i: int): Value;
+function {:builtin "seq.extract"} ValueSeqExtract(a: ValueSeq, pos: int, length: int): ValueSeq;
+
+type {:datatype} {:dependson "Value"} ValueArray;
+function {:constructor} ValueArray(v: ValueSeq): ValueArray;
+function {:inline} EmptyValueArray(): ValueArray {
+    ValueArray(EmptyValueSeq())
+}
+function {:inline} AddValueArray(a: ValueArray, v: Value): ValueArray {
+    ValueArray(ValueSeqConcat(v#ValueArray(a),ValueSeqUnit(v)))
+}
+function {:inline} RemoveValueArray(a: ValueArray): ValueArray {
+    ValueArray(ValueSeqExtract(v#ValueArray(a), 0, ValueSeqLen(v#ValueArray(a)) - 1))
+}
+function {:inline} ConcatValueArray(a1: ValueArray, a2: ValueArray): ValueArray {
+    ValueArray(ValueSeqConcat(v#ValueArray(a1), v#ValueArray(a2)))
+}
+function {:inline} IsEmpty(a: ValueArray): bool {
+    ValueSeqLen(v#ValueArray(a)) == 0
+}
+function {:inline} LenValueArray(a: ValueArray): int {
+    ValueSeqLen(v#ValueArray(a))
+}
+function {:inline} ValueArrayAt(a: ValueArray, i: int): Value {
+    ValueSeqNth(v#ValueArray(a), i)
+}
+
+procedure test()
+{
+  var s: ValueArray;
+  
+  s := EmptyValueArray();
+  assert IsEmpty(s);
+  s := AddValueArray(s, Integer(0));
+  s := AddValueArray(s, Integer(1));
+  s := AddValueArray(s, Integer(2));
+  assert LenValueArray(s) == 3;
+  assert ValueArrayAt(s, 1) == Integer(1);
+  s := RemoveValueArray(s);
+  assert(LenValueArray(s)) == 2;
+  s := ConcatValueArray(s, s);
+  assert LenValueArray(s) == 4;
+  assert ValueArrayAt(s, 3) == Integer(1);
+}

--- a/Test/sequences/intseq_datatype.bpl
+++ b/Test/sequences/intseq_datatype.bpl
@@ -6,7 +6,7 @@ type {:datatype} Value;
 function {:constructor} Integer(i: int): Value;
 function {:constructor} Vector(v: ValueArray): Value;
 
-type {:builtindecl ""} {:builtin "(Seq T@Value)"} ValueSeq;
+type {:builtin "(Seq T@Value)"} ValueSeq;
 function {:builtin "(as seq.empty (Seq T@Value))"} EmptyValueSeq(): ValueSeq;
 function {:builtin "seq.len"} ValueSeqLen(a: ValueSeq): int;
 function {:builtin "seq.++"} ValueSeqConcat(a: ValueSeq, b:ValueSeq): ValueSeq;

--- a/Test/sequences/intseq_datatype.bpl.expect
+++ b/Test/sequences/intseq_datatype.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
This commit extends support for the builtin attribute to user-defined types.

It also adds two new attributes.  The builtindecl attribute allows the user
to specify their own SMT-LIB type declaration for a user-defined type.
The dependson attribute is used to indicate when a datatype depends on another
datatype when Boogie cannot figure this out itself (which may happen if
builtin's are used).

Examples of how to use these attributes are in Test/sequence.