### PR TITLE
Add option /noProc:<p> to exclude procedures matching pattern <p> from checking

### DIFF
--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -764,6 +764,9 @@ namespace Microsoft.Boogie {
       }
     }
 
+    // Note that procsToCheck stores all patterns <p> supplied with /proc:<p>
+    // (and similarly procsToIgnore for /noProc:<p>). Thus, if procsToCheck
+    // is empty it means that all procedures should be checked.
     private List<string/*!*/> procsToCheck = new List<string/*!*/>();
     private List<string/*!*/> procsToIgnore = new List<string/*!*/>();
 

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -764,18 +764,13 @@ namespace Microsoft.Boogie {
       }
     }
 
-    public IEnumerable<string/*!*/> ProcsToCheck {
-      get {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<string/*!*/>>(), true));
-        return this.procsToCheck != null ? this.procsToCheck.AsEnumerable() : null;
-      }
-    }
-
-    private List<string/*!*/> procsToCheck = null;  // null means "no restriction"
+    private List<string/*!*/> procsToCheck = new List<string/*!*/>();
+    private List<string/*!*/> procsToIgnore = new List<string/*!*/>();
 
     [ContractInvariantMethod]
     void ObjectInvariant5() {
       Contract.Invariant(cce.NonNullElements(this.procsToCheck, true));
+      Contract.Invariant(cce.NonNullElements(this.procsToIgnore, true));
       Contract.Invariant(Ai != null);
     }
 
@@ -849,11 +844,14 @@ namespace Microsoft.Boogie {
           return true;
 
         case "proc":
-          if (this.procsToCheck == null) {
-            this.procsToCheck = new List<string/*!*/>();
-          }
           if (ps.ConfirmArgumentCount(1)) {
             this.procsToCheck.Add(cce.NonNull(args[ps.i]));
+          }
+          return true;
+
+        case "noProc":
+          if (ps.ConfirmArgumentCount(1)) {
+            this.procsToIgnore.Add(cce.NonNull(args[ps.i]));
           }
           return true;
 
@@ -1580,11 +1578,8 @@ namespace Microsoft.Boogie {
 
     public bool UserWantsToCheckRoutine(string methodFullname) {
       Contract.Requires(methodFullname != null);
-      if (ProcsToCheck == null) {
-        // no preference
-        return true;
-      }
-      return ProcsToCheck.Any(s => Regex.IsMatch(methodFullname, "^" + Regex.Escape(s).Replace(@"\*", ".*") + "$"));
+      Func<string, bool> match = s => Regex.IsMatch(methodFullname, "^" + Regex.Escape(s).Replace(@"\*", ".*") + "$");
+      return (procsToCheck.Count == 0 || procsToCheck.Any(match)) && !procsToIgnore.Any(match);
     }
 
     public virtual StringCollection ParseNamedArgumentList(string argList) {
@@ -1749,13 +1744,11 @@ namespace Microsoft.Boogie {
 
   /proc:<p>      : Only check procedures matched by pattern <p>. This option
                    may be specified multiple times to match multiple patterns.
-                   The pattern <p> matches the whole procedure name (i.e.
-                   pattern ""foo"" will only match a procedure called foo and
-                   not fooBar). The pattern <p> may contain * wildcards which
-                   match any character zero or more times. For example the
-                   pattern ""ab*d"" would match abd, abcd and abccd but not
-                   Aabd nor abdD. The pattern ""*ab*d*"" would match abd,
-                   abcd, abccd, Abd and abdD.
+                   The pattern <p> matches the whole procedure name and may
+                   contain * wildcards which match any character zero or more
+                   times.
+  /noProc:<p>    : Do not check procedures matched by pattern <p>. Exclusions
+                   with /noProc are applied after inclusions with /proc.
   /noResolve     : parse only
   /noTypecheck   : parse and resolve only
 

--- a/Test/commandline/noProc.bpl
+++ b/Test/commandline/noProc.bpl
@@ -1,0 +1,26 @@
+// RUN: %boogie -noProc:b* "%s" > "%t1"
+// RUN: %boogie -proc:a* -noProc:ab "%s" > "%t2"
+// RUN: %boogie -noProc:ba -proc:aa -proc:ab -proc:ba "%s" > "%t3"
+// RUN: %diff "%s.1.expect" "%t1"
+// RUN: %diff "%s.2.expect" "%t2"
+// RUN: %diff "%s.3.expect" "%t3"
+
+procedure aa ()
+{
+  assert false;
+}
+
+procedure ab ()
+{
+  assert false;
+}
+
+procedure ba ()
+{
+  assert false;
+}
+
+procedure bb ()
+{
+  assert false;
+}

--- a/Test/commandline/noProc.bpl.1.expect
+++ b/Test/commandline/noProc.bpl.1.expect
@@ -1,0 +1,8 @@
+noProc.bpl(10,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    noProc.bpl(10,3): anon0
+noProc.bpl(15,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    noProc.bpl(15,3): anon0
+
+Boogie program verifier finished with 0 verified, 2 errors

--- a/Test/commandline/noProc.bpl.2.expect
+++ b/Test/commandline/noProc.bpl.2.expect
@@ -1,0 +1,5 @@
+noProc.bpl(10,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    noProc.bpl(10,3): anon0
+
+Boogie program verifier finished with 0 verified, 1 error

--- a/Test/commandline/noProc.bpl.3.expect
+++ b/Test/commandline/noProc.bpl.3.expect
@@ -1,0 +1,8 @@
+noProc.bpl(10,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    noProc.bpl(10,3): anon0
+noProc.bpl(15,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    noProc.bpl(15,3): anon0
+
+Boogie program verifier finished with 0 verified, 2 errors


### PR DESCRIPTION
`/noProc` is a counterpart to the already existing option `/proc`. The idea is that we first consider the set of *included* procedures (either all procedures if no `/proc` argument is given, or otherwise all procedures matching any of the given `/proc` arguments), and then remove from it all procedures matching any of the given `/noProc` arguments.