### PR TITLE
Remove rewrite

### DIFF
--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -399,14 +399,6 @@ namespace Microsoft.Boogie.VCExprAST {
           BinaryOperator oper = (BinaryOperator)node.Fun;
           if (oper.Op == BinaryOperator.Opcode.Imp)
               flipContextForArg0 = true;
-          else if (oper.Op == BinaryOperator.Opcode.Iff) {
-              Expr one = new NAryExpr(node.tok, new BinaryOperator(node.tok, BinaryOperator.Opcode.Imp), new List<Expr> { node.Args[0], node.Args[1] });
-              Expr two = new NAryExpr(node.tok, new BinaryOperator(node.tok, BinaryOperator.Opcode.Imp), new List<Expr> { node.Args[1], node.Args[0] });
-              NAryExpr cmpd = new NAryExpr(node.tok, new BinaryOperator(node.tok, BinaryOperator.Opcode.And), new List<Expr> { one, two });
-              TypecheckingContext tc = new TypecheckingContext(null);
-              cmpd.Typecheck(tc);
-              return TranslateNAryExpr(cmpd);
-          }
       }
 
       int n = node.Args.Count;

--- a/Test/livevars/bla1.bpl.expect
+++ b/Test/livevars/bla1.bpl.expect
@@ -51,17 +51,14 @@ Execution trace:
     bla1.bpl(1741,3): anon7#1
     bla1.bpl(1798,3): inline$storm_IoCancelIrp$0$anon12_Then#1
     bla1.bpl(1803,3): inline$storm_IoCancelIrp$0$anon2#1
-    bla1.bpl(1814,3): inline$storm_IoCancelIrp$0$anon14_Else#1
-    bla1.bpl(1822,3): inline$storm_IoCancelIrp$0$anon15_Then#1
+    bla1.bpl(1827,3): inline$storm_IoCancelIrp$0$anon14_Then#1
     bla1.bpl(1832,3): inline$storm_IoCancelIrp$0$anon5#1
-    bla1.bpl(1840,3): inline$storm_IoCancelIrp$0$anon16_Else#1
-    bla1.bpl(1848,3): inline$storm_IoCancelIrp$0$anon17_Then#1
+    bla1.bpl(1853,3): inline$storm_IoCancelIrp$0$anon16_Then#1
     bla1.bpl(1858,3): inline$storm_IoCancelIrp$0$anon8#1
     bla1.bpl(1869,3): inline$storm_IoCancelIrp$0$anon18_Then#1
     bla1.bpl(1874,3): inline$storm_IoCancelIrp$0$anon10#1
     bla1.bpl(1934,3): inline$storm_IoAcquireCancelSpinLock$0$label_11_true#1
-    bla1.bpl(1949,3): inline$storm_IoAcquireCancelSpinLock$0$anon6_Else#1
-    bla1.bpl(1957,3): inline$storm_IoAcquireCancelSpinLock$0$anon7_Then#1
+    bla1.bpl(1962,3): inline$storm_IoAcquireCancelSpinLock$0$anon6_Then#1
     bla1.bpl(1967,3): inline$storm_IoAcquireCancelSpinLock$0$anon3#1
     bla1.bpl(1978,3): inline$storm_IoAcquireCancelSpinLock$0$anon8_Then#1
     bla1.bpl(1983,3): inline$storm_IoAcquireCancelSpinLock$0$anon5#1

--- a/Test/livevars/stack_overflow.bpl.expect
+++ b/Test/livevars/stack_overflow.bpl.expect
@@ -23,69 +23,70 @@ Execution trace:
     stack_overflow.bpl(1756,3): inline$IoGetCurrentIrpStackLocation$1$label_3_false#1
     stack_overflow.bpl(1796,3): inline$storm_thread_dispatch$0$anon4_Else#1
     stack_overflow.bpl(1879,3): inline$BDLPnP$0$anon54_Else#1
-    stack_overflow.bpl(1893,3): inline$BDLPnP$0$label_16_true#1
+    stack_overflow.bpl(1889,3): inline$BDLPnP$0$label_16_false#1
     stack_overflow.bpl(1937,3): inline$BDLPnP$0$anon55_Else#1
     stack_overflow.bpl(1947,3): inline$BDLPnP$0$label_26_false#1
     stack_overflow.bpl(1995,3): inline$BDLPnP$0$anon56_Else#1
-    stack_overflow.bpl(2005,3): inline$BDLPnP$0$label_36_false#1
+    stack_overflow.bpl(2009,3): inline$BDLPnP$0$label_36_true#1
     stack_overflow.bpl(2035,3): inline$IoGetCurrentIrpStackLocation$2$label_3_false#1
     stack_overflow.bpl(2075,3): inline$BDLPnP$0$anon57_Else#1
     stack_overflow.bpl(2102,3): inline$BDLPnP$0$label_44_true#1
     stack_overflow.bpl(2111,3): inline$BDLPnP$0$label_47#1
     stack_overflow.bpl(2115,3): inline$BDLPnP$0$anon58_Else#1
     stack_overflow.bpl(2129,3): inline$BDLPnP$0$label_51_false#1
-    stack_overflow.bpl(11320,3): inline$BDLPnP$0$label_52_case_7#1
-    stack_overflow.bpl(11369,3): inline$BDLPnPCancelStop$0$anon22_Else#1
-    stack_overflow.bpl(11379,3): inline$BDLPnPCancelStop$0$label_8_false#1
-    stack_overflow.bpl(11427,3): inline$BDLPnPCancelStop$0$anon23_Else#1
-    stack_overflow.bpl(11441,3): inline$BDLPnPCancelStop$0$label_18_true#1
-    stack_overflow.bpl(11485,3): inline$BDLPnPCancelStop$0$anon24_Else#1
-    stack_overflow.bpl(11495,3): inline$BDLPnPCancelStop$0$label_28_false#1
-    stack_overflow.bpl(11506,3): inline$BDLPnPCancelStop$0$label_29#1
-    stack_overflow.bpl(11559,3): inline$IoGetCurrentIrpStackLocation$112$label_3_false#1
-    stack_overflow.bpl(11599,3): inline$IoCopyCurrentIrpStackLocationToNext$5$anon4_Else#1
-    stack_overflow.bpl(11623,3): inline$IoGetNextIrpStackLocation$11$label_3_false#1
-    stack_overflow.bpl(11659,3): inline$IoCopyCurrentIrpStackLocationToNext$5$anon5_Else#1
-    stack_overflow.bpl(11693,3): inline$BDLCallLowerLevelDriverAndWait$5$anon16_Else#1
-    stack_overflow.bpl(11727,3): inline$BDLCallLowerLevelDriverAndWait$5$anon17_Else#1
-    stack_overflow.bpl(11755,3): inline$storm_IoSetCompletionRoutine$5$label_7_false#1
-    stack_overflow.bpl(11808,3): inline$IoGetNextIrpStackLocation$12$label_3_false#1
-    stack_overflow.bpl(11844,3): inline$storm_IoSetCompletionRoutine$5$anon5_Else#1
-    stack_overflow.bpl(11860,3): inline$storm_IoSetCompletionRoutine$5$label_1#1
-    stack_overflow.bpl(11877,3): inline$BDLCallLowerLevelDriverAndWait$5$anon18_Else#1
-    stack_overflow.bpl(11898,3): inline$IoGetCurrentIrpStackLocation$113$label_3_false#1
-    stack_overflow.bpl(11938,3): inline$BDLCallLowerLevelDriverAndWait$5$anon19_Else#1
-    stack_overflow.bpl(11948,3): inline$BDLCallLowerLevelDriverAndWait$5$label_18_false#1
-    stack_overflow.bpl(11980,3): inline$storm_IoCallDriver$11$label_9_false#1
-    stack_overflow.bpl(12033,3): inline$IoSetNextIrpStackLocation$12$label_3_false#1
-    stack_overflow.bpl(12056,3): inline$IoSetNextIrpStackLocation$12$label_5#1
-    stack_overflow.bpl(12078,3): inline$storm_IoCallDriver$11$anon11_Else#1
-    stack_overflow.bpl(12118,3): inline$IoGetCurrentIrpStackLocation$114$label_3_true#1
-    stack_overflow.bpl(12139,3): inline$storm_IoCallDriver$11$anon13_Else#1
-    stack_overflow.bpl(14506,3): inline$storm_IoCallDriver$11$label_27_case_1#1
-    stack_overflow.bpl(14576,3): inline$IoGetCurrentIrpStackLocation$119$label_3_true#1
-    stack_overflow.bpl(14597,3): inline$CallCompletionRoutine$23$anon10_Else#1
-    stack_overflow.bpl(14654,3): inline$IoGetCurrentIrpStackLocation$120$label_3_true#1
-    stack_overflow.bpl(14675,3): inline$CallCompletionRoutine$23$anon11_Else#1
-    stack_overflow.bpl(14688,3): inline$CallCompletionRoutine$23$label_18_false#1
-    stack_overflow.bpl(16816,3): inline$CallCompletionRoutine$23$label_1#1
-    stack_overflow.bpl(16837,3): inline$storm_IoCallDriver$11$anon15_Else#1
-    stack_overflow.bpl(16865,3): inline$storm_IoCallDriver$11$label_36#1
-    stack_overflow.bpl(16869,3): inline$storm_IoCallDriver$11$label_1#1
-    stack_overflow.bpl(16891,3): inline$BDLCallLowerLevelDriverAndWait$5$anon20_Else#1
-    stack_overflow.bpl(21910,3): inline$BDLCallLowerLevelDriverAndWait$5$label_29_false#1
-    stack_overflow.bpl(22068,3): inline$BDLCallLowerLevelDriverAndWait$5$label_30#1
-    stack_overflow.bpl(22111,3): inline$BDLPnPCancelStop$0$anon25_Else#1
-    stack_overflow.bpl(22125,3): inline$BDLPnPCancelStop$0$label_34_false#1
-    stack_overflow.bpl(22154,3): inline$BDLPnPCancelStop$0$anon26_Else#1
-    stack_overflow.bpl(22354,3): inline$BDLPnPCancelStop$0$anon30_Else#1
-    stack_overflow.bpl(22364,3): inline$BDLPnPCancelStop$0$label_66_false#1
-    stack_overflow.bpl(22412,3): inline$BDLPnPCancelStop$0$anon31_Else#1
-    stack_overflow.bpl(22426,3): inline$BDLPnPCancelStop$0$label_76_true#1
-    stack_overflow.bpl(22470,3): inline$BDLPnPCancelStop$0$anon32_Else#1
-    stack_overflow.bpl(22480,3): inline$BDLPnPCancelStop$0$label_86_false#1
-    stack_overflow.bpl(22491,3): inline$BDLPnPCancelStop$0$label_87#1
-    stack_overflow.bpl(22545,3): inline$BDLPnP$0$anon73_Else#1
+    stack_overflow.bpl(66448,3): inline$BDLPnP$0$label_52_case_2#1
+    stack_overflow.bpl(66497,3): inline$BDLPnPQueryRemove$0$anon22_Else#1
+    stack_overflow.bpl(66507,3): inline$BDLPnPQueryRemove$0$label_8_false#1
+    stack_overflow.bpl(66555,3): inline$BDLPnPQueryRemove$0$anon23_Else#1
+    stack_overflow.bpl(66569,3): inline$BDLPnPQueryRemove$0$label_18_true#1
+    stack_overflow.bpl(66613,3): inline$BDLPnPQueryRemove$0$anon24_Else#1
+    stack_overflow.bpl(66627,3): inline$BDLPnPQueryRemove$0$label_28_true#1
+    stack_overflow.bpl(66634,3): inline$BDLPnPQueryRemove$0$label_29#1
+    stack_overflow.bpl(66638,3): inline$BDLPnPQueryRemove$0$anon25_Else#1
+    stack_overflow.bpl(66648,3): inline$BDLPnPQueryRemove$0$label_33_false#1
+    stack_overflow.bpl(66706,3): inline$IoGetCurrentIrpStackLocation$23$label_3_false#1
+    stack_overflow.bpl(66746,3): inline$IoCopyCurrentIrpStackLocationToNext$1$anon4_Else#1
+    stack_overflow.bpl(66770,3): inline$IoGetNextIrpStackLocation$3$label_3_false#1
+    stack_overflow.bpl(66806,3): inline$IoCopyCurrentIrpStackLocationToNext$1$anon5_Else#1
+    stack_overflow.bpl(66840,3): inline$BDLCallLowerLevelDriverAndWait$1$anon16_Else#1
+    stack_overflow.bpl(66874,3): inline$BDLCallLowerLevelDriverAndWait$1$anon17_Else#1
+    stack_overflow.bpl(66902,3): inline$storm_IoSetCompletionRoutine$1$label_7_false#1
+    stack_overflow.bpl(66955,3): inline$IoGetNextIrpStackLocation$4$label_3_false#1
+    stack_overflow.bpl(66991,3): inline$storm_IoSetCompletionRoutine$1$anon5_Else#1
+    stack_overflow.bpl(67007,3): inline$storm_IoSetCompletionRoutine$1$label_1#1
+    stack_overflow.bpl(67024,3): inline$BDLCallLowerLevelDriverAndWait$1$anon18_Else#1
+    stack_overflow.bpl(67045,3): inline$IoGetCurrentIrpStackLocation$24$label_3_false#1
+    stack_overflow.bpl(67085,3): inline$BDLCallLowerLevelDriverAndWait$1$anon19_Else#1
+    stack_overflow.bpl(67095,3): inline$BDLCallLowerLevelDriverAndWait$1$label_18_false#1
+    stack_overflow.bpl(67127,3): inline$storm_IoCallDriver$2$label_9_false#1
+    stack_overflow.bpl(67180,3): inline$IoSetNextIrpStackLocation$3$label_3_false#1
+    stack_overflow.bpl(67203,3): inline$IoSetNextIrpStackLocation$3$label_5#1
+    stack_overflow.bpl(67225,3): inline$storm_IoCallDriver$2$anon11_Else#1
+    stack_overflow.bpl(67265,3): inline$IoGetCurrentIrpStackLocation$25$label_3_true#1
+    stack_overflow.bpl(67286,3): inline$storm_IoCallDriver$2$anon13_Else#1
+    stack_overflow.bpl(69653,3): inline$storm_IoCallDriver$2$label_27_case_1#1
+    stack_overflow.bpl(69723,3): inline$IoGetCurrentIrpStackLocation$30$label_3_true#1
+    stack_overflow.bpl(69744,3): inline$CallCompletionRoutine$5$anon10_Else#1
+    stack_overflow.bpl(69801,3): inline$IoGetCurrentIrpStackLocation$31$label_3_true#1
+    stack_overflow.bpl(69822,3): inline$CallCompletionRoutine$5$anon11_Else#1
+    stack_overflow.bpl(69835,3): inline$CallCompletionRoutine$5$label_18_false#1
+    stack_overflow.bpl(71963,3): inline$CallCompletionRoutine$5$label_1#1
+    stack_overflow.bpl(71984,3): inline$storm_IoCallDriver$2$anon15_Else#1
+    stack_overflow.bpl(72012,3): inline$storm_IoCallDriver$2$label_36#1
+    stack_overflow.bpl(72016,3): inline$storm_IoCallDriver$2$label_1#1
+    stack_overflow.bpl(72038,3): inline$BDLCallLowerLevelDriverAndWait$1$anon20_Else#1
+    stack_overflow.bpl(77057,3): inline$BDLCallLowerLevelDriverAndWait$1$label_29_false#1
+    stack_overflow.bpl(77215,3): inline$BDLCallLowerLevelDriverAndWait$1$label_30#1
+    stack_overflow.bpl(77258,3): inline$BDLPnPQueryRemove$0$anon26_Else#1
+    stack_overflow.bpl(77272,3): inline$BDLPnPQueryRemove$0$label_65_false#1
+    stack_overflow.bpl(77490,3): inline$BDLPnPQueryRemove$0$anon27_Else#1
+    stack_overflow.bpl(77504,3): inline$BDLPnPQueryRemove$0$label_41_true#1
+    stack_overflow.bpl(77548,3): inline$BDLPnPQueryRemove$0$anon28_Else#1
+    stack_overflow.bpl(77562,3): inline$BDLPnPQueryRemove$0$label_51_true#1
+    stack_overflow.bpl(77606,3): inline$BDLPnPQueryRemove$0$anon29_Else#1
+    stack_overflow.bpl(77620,3): inline$BDLPnPQueryRemove$0$label_61_true#1
+    stack_overflow.bpl(77627,3): inline$BDLPnPQueryRemove$0$label_62#1
+    stack_overflow.bpl(77669,3): inline$BDLPnP$0$anon68_Else#1
     stack_overflow.bpl(94595,3): inline$BDLPnP$0$label_139_true#1
     stack_overflow.bpl(94624,3): inline$storm_IoCompleteRequest$57$label_6_true#1
     stack_overflow.bpl(94632,3): inline$storm_IoCompleteRequest$57$anon3_Else#1


### PR DESCRIPTION
Remove rewrite of Boolean equality to two implications.  This is no longer necessary in SMT-LIB.  It adds complexity and removes structure.  Also, this rewrite makes it difficult to recognize function definitions which we may want to do in some analyses.