### PR TITLE
Fix lit for mac

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -84,6 +84,9 @@ runtime = ''
 
 if 'dotnet' in lit_config.params:
     boogieBinary = 'Source/BoogieDriver/bin/{}/{}/BoogieDriver'.format(configuration, framework)
+    if platform.system() == 'Darwin':
+        runtime = 'dotnet'
+        boogieBinary += '.dll'
 else:
     boogieBinary = 'Binaries/Boogie.exe'
     if os.name == 'posix':

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -83,10 +83,8 @@ framework = lit_config.params.get('framework', 'netcoreapp3.1')
 runtime = ''
 
 if 'dotnet' in lit_config.params:
-    boogieBinary = 'Source/BoogieDriver/bin/{}/{}/BoogieDriver'.format(configuration, framework)
-    if platform.system() == 'Darwin':
-        runtime = 'dotnet'
-        boogieBinary += '.dll'
+    boogieBinary = 'Source/BoogieDriver/bin/{}/{}/BoogieDriver.dll'.format(configuration, framework)
+    runtime = 'dotnet'
 else:
     boogieBinary = 'Binaries/Boogie.exe'
     if os.name == 'posix':


### PR DESCRIPTION
When running the test framework "lit" on a mac, it needs to be run as an argument of "dotnet" and the name has a ".dll" suffix.  This fixes the configuration to automatically do the right thing when running
lit -D dotnet