### PR TITLE
Fix test config for Boogie paths that contain spaces

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -90,14 +90,14 @@ else:
     if os.name == 'posix':
         runtime = 'mono'
 
-boogieExecutable = quotePath(os.path.join(repositoryRoot, boogieBinary))
+boogieExecutable = os.path.join(repositoryRoot, boogieBinary)
         
 if not os.path.exists(boogieExecutable):
     lit_config.fatal('Could not find Boogie executable at {}'.format(boogieExecutable))
 if runtime and lit.util.which(runtime) == None:
     lit_config.fatal('Cannot find {}. Make sure it is in your PATH'.format(runtime))
 
-boogieExecutable = runtime + ' ' + boogieExecutable
+boogieExecutable = runtime + ' ' + quotePath(boogieExecutable)
 
 # Expected output does not contain logo
 boogieExecutable += ' -nologo'


### PR DESCRIPTION
The driver tests currently don't work with paths that contain spaces (at least on our Windows machine) because the test framework complains that it ``Could not find Boogie executable at ...``. 

The problem is that if the path of the Boogie executable contains spaces, it is put in quotes by the ``quotePath`` function _before_ it is checked if the file exists. This check does not seem to expect the path to be in quotes and fails (even though the file exists), which leads to the error message.

The fix is to add the quotes after the the check if the file exists. If there are no spaces in the path, this fix does not change the behavior in any way.