### PR TITLE
Workaround for broken build because of GitVersionTask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
   global:
     - SOLUTION=Source/Boogie-NetCore.sln
     - Z3URL=https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-ubuntu-16.04.zip
+    # Workaround for GitVersionTask bug in combination with .NET Core SDK 3.1.200
+    # (see, e.g., https://github.com/dotnet/sdk/issues/10878 and https://github.com/GitTools/GitVersion/issues/2063)
+    - MSBUILDSINGLELOADCONTEXT=1
   jobs:
     - CONFIGURATION=Debug
     - CONFIGURATION=Release


### PR DESCRIPTION
**GitVersionTask strikes again!**

With the release of .NET Core SDK 3.1.200, GitVersionTask fails the Boogie build with messages like `The "WriteVersionInfoToBuildLog" task failed unexpectedly` and `Could not load file or assembly GitVersionTask.MsBuild`.

The current workaround is to set the environment variable `MSBUILDSINGLELOADCONTEXT=1`.
The following issues should tell us when this bug is resolved:
https://github.com/dotnet/sdk/issues/10878
https://github.com/GitTools/GitVersion/issues/2063