### PR TITLE
[CIVL] Move all instrumentation related to linear permissions into CIVL core

### DIFF
--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -97,8 +97,8 @@ namespace Microsoft.Boogie
             if (checkingContext.ErrorCount > 0)
                 return;
 
-            var yieldTypeChecker = new YieldTypeChecker(this);
-            yieldTypeChecker.TypeCheck();
+            var yieldSufficiencyTypeChecker = new YieldSufficiencyTypeChecker(this);
+            yieldSufficiencyTypeChecker.TypeCheck();
             if (checkingContext.ErrorCount > 0)
             {
                 return;

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -106,11 +106,6 @@ namespace Microsoft.Boogie
 
             linearTypeChecker = new LinearTypeChecker(this);
             linearTypeChecker.TypeCheck();
-            if (checkingContext.ErrorCount > 0)
-            {
-                return;
-            }
-            linearTypeChecker.Transform();
         }
 
         private void TypeCheckRefinementLayers()
@@ -129,18 +124,18 @@ namespace Microsoft.Boogie
                 }
             }
 
-            var allIndictiveSequentializationLayers = inductiveSequentializations.Select(x => x.inputAction.layerRange.upperLayerNum).ToList();
+            var allInductiveSequentializationLayers = inductiveSequentializations.Select(x => x.inputAction.layerRange.upperLayerNum).ToList();
 
-            var intersect = allRefinementLayers.Intersect(allIndictiveSequentializationLayers).ToList();
+            var intersect = allRefinementLayers.Intersect(allInductiveSequentializationLayers).ToList();
             if (intersect.Any())
                 checkingContext.Error(Token.NoToken, "The following layers mix refinement with IS: " + string.Join(",", intersect));
 
             foreach(var g in sharedVariables)
             {
                 var layerRange = GlobalVariableLayerRange(g);
-                if (allIndictiveSequentializationLayers.Contains(layerRange.lowerLayerNum))
+                if (allInductiveSequentializationLayers.Contains(layerRange.lowerLayerNum))
                     Error(g, $"Shared variable {g.Name} cannot be introduced at layer with IS");
-                if (allIndictiveSequentializationLayers.Contains(layerRange.upperLayerNum))
+                if (allInductiveSequentializationLayers.Contains(layerRange.upperLayerNum))
                     Error(g, $"Shared variable {g.Name} cannot be hidden at layer with IS");
             }
 

--- a/Source/Concurrency/CivlVCGeneration.cs
+++ b/Source/Concurrency/CivlVCGeneration.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Boogie
             program.AddTopLevelDeclarations(decls);
 
             BackwardAssignmentSubstituter.SubstituteBackwardAssignments(civlTypeChecker.procToAtomicAction.Values);
+            
+            linearTypeChecker.Transform();
             linearTypeChecker.EraseLinearAnnotations();
         }
     }

--- a/Source/Concurrency/Concurrency.csproj
+++ b/Source/Concurrency/Concurrency.csproj
@@ -54,8 +54,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GlobalSnapshotInstrumentation.cs" />
-    <Compile Include="LinearHelper.cs" />
-    <Compile Include="YieldCheckerImplementation.cs" />
+    <Compile Include="LinearPermissionInstrumentation.cs" />
+    <Compile Include="NoninterferenceChecker.cs" />
     <Compile Include="YieldingProcInstrumentation.cs" />
     <Compile Include="LinearTypeChecker.cs" />
     <Compile Include="MoverCheck.cs" />
@@ -67,7 +67,7 @@
     <Compile Include="TransitionRelationComputation.cs" />
     <Compile Include="NoninterferenceInstrumentation.cs" />
     <Compile Include="YieldingProcDuplicator.cs" />
-    <Compile Include="YieldTypeChecker.cs" />
+    <Compile Include="YieldSufficiencyTypeChecker.cs" />
     <Compile Include="CivlUtil.cs" />
     <Compile Include="CommutativityHints.cs" />
     <Compile Include="CivlCoreTypes.cs" />

--- a/Source/Concurrency/Concurrency.csproj
+++ b/Source/Concurrency/Concurrency.csproj
@@ -54,6 +54,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GlobalSnapshotInstrumentation.cs" />
+    <Compile Include="LinearHelper.cs" />
+    <Compile Include="YieldCheckerImplementation.cs" />
     <Compile Include="YieldingProcInstrumentation.cs" />
     <Compile Include="LinearTypeChecker.cs" />
     <Compile Include="MoverCheck.cs" />

--- a/Source/Concurrency/GlobalSnapshotInstrumentation.cs
+++ b/Source/Concurrency/GlobalSnapshotInstrumentation.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Boogie
         private LocalVariable OldGlobalLocal(Variable v)
         {
             return new LocalVariable(Token.NoToken,
-                new TypedIdent(Token.NoToken, $"og_global_old_{v.Name}", v.TypedIdent.Type));
+                new TypedIdent(Token.NoToken, $"civl_global_old_{v.Name}", v.TypedIdent.Type));
         }
     }
 }

--- a/Source/Concurrency/LinearHelper.cs
+++ b/Source/Concurrency/LinearHelper.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Boogie.GraphUtil;
+
+namespace Microsoft.Boogie
+{
+    public class LinearHelper
+    {
+        private CivlTypeChecker civlTypeChecker;
+        private LinearTypeChecker linearTypeChecker;
+        private int layerNum;
+        private Dictionary<Absy, Absy> absyMap;
+        private Dictionary<string, Variable> domainNameToHoleVar;
+        private Dictionary<Variable, Variable> localVarMap;
+        
+        public LinearHelper(
+            CivlTypeChecker civlTypeChecker, 
+            LinearTypeChecker linearTypeChecker, 
+            int layerNum, 
+            Dictionary<Absy, Absy> absyMap,
+            Dictionary<string, Variable> domainNameToHoleVar,
+            Dictionary<Variable, Variable> localVarMap)
+        {
+            this.civlTypeChecker = civlTypeChecker;
+            this.linearTypeChecker = linearTypeChecker;
+            this.layerNum = layerNum;
+            this.absyMap = absyMap;
+            this.domainNameToHoleVar = domainNameToHoleVar;
+            this.localVarMap = localVarMap;
+        }
+        
+        public LinearHelper(
+            CivlTypeChecker civlTypeChecker, 
+            LinearTypeChecker linearTypeChecker, 
+            int layerNum, 
+            Dictionary<Absy, Absy> absyMap)
+        {
+            this.civlTypeChecker = civlTypeChecker;
+            this.linearTypeChecker = linearTypeChecker;
+            this.layerNum = layerNum;
+            this.absyMap = absyMap;
+            this.domainNameToHoleVar = new Dictionary<string, Variable>();
+            this.localVarMap = new Dictionary<Variable, Variable>();
+        }
+        
+        public List<Cmd> DisjointnessAssumeCmds(Absy absy, bool addGlobals)
+        {
+            var availableVars = AvailableLinearLocalVars(absy).Union(addGlobals ? LinearGlobalVars() : new List<Variable>());
+            var newCmds = new List<Cmd>();
+            foreach (var expr in DisjointnessExprs(availableVars))
+            {
+                newCmds.Add(new AssumeCmd(Token.NoToken, expr));
+            }
+            return newCmds;
+        }
+
+        public Dictionary<string, Expr> PermissionExprs(Absy absy)
+        {
+            var domainNameToScope = new Dictionary<string, HashSet<Variable>>();
+            foreach (var domainName in linearTypeChecker.linearDomains.Keys)
+            {
+                domainNameToScope[domainName] = new HashSet<Variable>();
+            }
+            var availableVars = AvailableLinearLocalVars(absy).Union(LinearGlobalVars()); 
+            foreach (var v in availableVars)
+            {
+                var domainName = linearTypeChecker.FindDomainName(v);
+                domainNameToScope[domainName].Add(MapVariable(v));
+            }
+            var domainNameToExpr = new Dictionary<string, Expr>();
+            foreach (var domainName in domainNameToScope.Keys)
+            {
+                var permissionExprs = linearTypeChecker.PermissionExprForEachVariable(domainName, domainNameToScope[domainName]);
+                domainNameToExpr[domainName] = linearTypeChecker.UnionExprForPermissions(domainName, permissionExprs);
+            }
+            return domainNameToExpr;
+        }
+
+        public void AddDisjointnessAssumptions(Implementation impl, HashSet<Procedure> yieldingProcs)
+        {
+            // preconditions
+            impl.Proc.Requires.AddRange(DisjointnessFreeRequires(impl.Proc));
+            
+            // calls and parallel calls
+            foreach (var b in impl.Blocks)
+            {
+                var newCmds = new List<Cmd>();
+                foreach (var cmd in b.Cmds)
+                {
+                    newCmds.Add(cmd);
+                    if (cmd is CallCmd callCmd && yieldingProcs.Contains(callCmd.Proc))
+                    {
+                        newCmds.AddRange(DisjointnessAssumeCmds(cmd, true));
+                    }
+                    else if (cmd is ParCallCmd)
+                    {
+                        newCmds.AddRange(DisjointnessAssumeCmds(cmd, true));
+                    }
+                }
+                b.Cmds = newCmds;
+            }
+            
+            // loop headers
+            impl.PruneUnreachableBlocks();
+            impl.ComputePredecessorsForBlocks();
+            var graph = Program.GraphFromImpl(impl);
+            graph.ComputeLoops();
+            if (!graph.Reducible)
+            {
+                throw new Exception("Irreducible flow graphs are unsupported.");
+            }
+            var loopHeaders = new HashSet<Block>(graph.Headers);
+            foreach (var header in loopHeaders)
+            {
+                var newCmds = DisjointnessAssumeCmds(header,true);
+                newCmds.AddRange(header.Cmds);
+                header.Cmds = newCmds;
+            }
+        }
+        
+        private List<Requires> DisjointnessFreeRequires(Procedure proc)
+        {
+            var availableVars = AvailableLinearLocalVars(proc).Union(LinearGlobalVars());
+            var newRequires = new List<Requires>();
+            foreach (var expr in DisjointnessExprs(availableVars))
+            {
+                newRequires.Add(new Requires(true, expr));
+            }
+            return newRequires;
+        }
+
+        private List<Expr> DisjointnessExprs(IEnumerable<Variable> availableVars)
+        {
+            var domainNameToScope = new Dictionary<string, HashSet<Variable>>();
+            foreach (var domainName in linearTypeChecker.linearDomains.Keys)
+            {
+                domainNameToScope[domainName] = new HashSet<Variable>();
+            }
+            foreach (var v in availableVars)
+            {
+                var domainName = linearTypeChecker.FindDomainName(v);
+                domainNameToScope[domainName].Add(MapVariable(v));
+            }
+            var newExprs = new List<Expr>();
+            foreach (var domainName in linearTypeChecker.linearDomains.Keys)
+            {
+                var permissionExprs = 
+                    linearTypeChecker
+                    .PermissionExprForEachVariable(domainName, domainNameToScope[domainName])
+                    .Union(
+                        domainNameToHoleVar.ContainsKey(domainName)
+                        ? new List<Expr> {Expr.Ident(domainNameToHoleVar[domainName])}
+                        : new List<Expr>());
+                var expr = linearTypeChecker.DisjointnessExprForPermissions(domainName, permissionExprs);
+                if (!expr.Equals(Expr.True))
+                {
+                    newExprs.Add(expr);
+                }
+            }
+            return newExprs;
+        }
+
+        private IEnumerable<Variable> AvailableLinearLocalVars(Absy absy)
+        {
+            if (absy is Implementation impl)
+            {
+                return FilterInParams((absyMap[impl] as Implementation).InParams);
+            }
+            if (absy is Procedure proc)
+            {
+                return FilterInParams((absyMap[proc] as Procedure).InParams);
+            }
+            return linearTypeChecker.AvailableLinearVars(absyMap[absy]).Where(v =>
+                    !(v is GlobalVariable) &&
+                    layerNum >= civlTypeChecker.LocalVariableIntroLayer(v));
+        }
+
+        private IEnumerable<Variable> FilterInParams(IEnumerable<Variable> locals)
+        {
+            Predicate<LinearKind> isLinear = x => x == LinearKind.LINEAR || x == LinearKind.LINEAR_IN;
+            return locals.Where(v =>
+                isLinear(linearTypeChecker.FindLinearKind(v)) &&
+                layerNum >= civlTypeChecker.LocalVariableIntroLayer(v));
+        }
+
+        private IEnumerable<Variable> LinearGlobalVars()
+        {
+            return linearTypeChecker.program.GlobalVariables.Where(v =>
+                linearTypeChecker.FindLinearKind(v) == LinearKind.LINEAR &&
+                civlTypeChecker.GlobalVariableLayerRange(v).Contains(layerNum));
+        }
+
+        private Variable MapVariable(Variable v)
+        {
+            return localVarMap.ContainsKey(v) ? localVarMap[v] : v;
+        }
+    }
+}

--- a/Source/Concurrency/LinearPermissionInstrumentation.cs
+++ b/Source/Concurrency/LinearPermissionInstrumentation.cs
@@ -5,7 +5,7 @@ using Microsoft.Boogie.GraphUtil;
 
 namespace Microsoft.Boogie
 {
-    public class LinearHelper
+    public class LinearPermissionInstrumentation
     {
         private CivlTypeChecker civlTypeChecker;
         private LinearTypeChecker linearTypeChecker;
@@ -14,7 +14,7 @@ namespace Microsoft.Boogie
         private Dictionary<string, Variable> domainNameToHoleVar;
         private Dictionary<Variable, Variable> localVarMap;
         
-        public LinearHelper(
+        public LinearPermissionInstrumentation(
             CivlTypeChecker civlTypeChecker, 
             LinearTypeChecker linearTypeChecker, 
             int layerNum, 
@@ -30,7 +30,7 @@ namespace Microsoft.Boogie
             this.localVarMap = localVarMap;
         }
         
-        public LinearHelper(
+        public LinearPermissionInstrumentation(
             CivlTypeChecker civlTypeChecker, 
             LinearTypeChecker linearTypeChecker, 
             int layerNum, 
@@ -118,7 +118,7 @@ namespace Microsoft.Boogie
                 header.Cmds = newCmds;
             }
         }
-        
+
         private List<Requires> DisjointnessFreeRequires(Procedure proc)
         {
             var availableVars = AvailableLinearLocalVars(proc).Union(LinearGlobalVars());

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.Boogie
@@ -285,9 +286,8 @@ namespace Microsoft.Boogie
     /// The functionality is basically grouped into four parts (see #region's).
     /// 1) TypeCheck parses linear type attributes, sets up the data structures,
     ///    and performs a dataflow check on procedure implementations.
-    /// 2) Program transformation(s) to inject logical disjointness annotations.
-    /// 3) Generation of linearity-invariant checker procedures for atomic actions.
-    /// 4) Erasure procedure to remove all linearity attributes
+    /// 2) Generation of linearity-invariant checker procedures for atomic actions.
+    /// 3) Erasure procedure to remove all linearity attributes
     ///    (invoked after all other CIVL transformations).
     /// </summary>
     public class LinearTypeChecker : ReadOnlyVisitor
@@ -295,7 +295,6 @@ namespace Microsoft.Boogie
         public Program program;
         public CheckingContext checkingContext;
         public Dictionary<string, LinearDomain> linearDomains;
-        public Dictionary<string, Variable> domainNameToHoleVar;
 
         private CivlTypeChecker ctc;
 
@@ -319,7 +318,6 @@ namespace Microsoft.Boogie
             this.outParamToDomainName = new Dictionary<Variable, string>();
             this.globalVarToDomainName = new Dictionary<Variable, string>();
             this.linearDomains = new Dictionary<string, LinearDomain>();
-            this.domainNameToHoleVar = new Dictionary<string, Variable>();
             this.varToDomainName = new Dictionary<Variable, string>();
         }
 
@@ -373,14 +371,17 @@ namespace Microsoft.Boogie
         }
 
         public Formal LinearDomainInFormal(string domainName)
-        { return new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "linear_" + domainName + "_in", linearDomains[domainName].mapTypeBool), true); }
+        {
+            return new Formal(Token.NoToken, 
+                new TypedIdent(Token.NoToken, "linear_" + domainName + "_in", linearDomains[domainName].mapTypeBool), true);
+        }
 
         public LocalVariable LinearDomainAvailableLocal(string domainName)
-        { return new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "linear_" + domainName + "_available", linearDomains[domainName].mapTypeBool)); }
-
-        private GlobalVariable LinearDomainHoleGlobal(string domainName)
-        { return new GlobalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "linear_" + domainName + "_hole", linearDomains[domainName].mapTypeBool)); }
-
+        {
+            return new LocalVariable(Token.NoToken, 
+                new TypedIdent(Token.NoToken, "linear_" + domainName + "_available", linearDomains[domainName].mapTypeBool));
+        }
+        
         public void TypeCheck()
         {
             this.VisitProgram(program);
@@ -850,96 +851,9 @@ namespace Microsoft.Boogie
         }
         #endregion
 
-        #region Program Transformation
+        #region Useful public methods
         public void Transform()
         {
-            // The disjointness expressions injected below include an additional placeholder variable (a "hole")
-            // which is substituted in yield checker implementations.
-            foreach (string domainName in linearDomains.Keys)
-            {
-                GlobalVariable g = LinearDomainHoleGlobal(domainName);
-                program.AddTopLevelDeclaration(g);
-                domainNameToHoleVar[domainName] = g;
-            }
-
-            foreach (var impl in program.Implementations)
-            {
-                foreach (Block b in impl.Blocks)
-                {
-                    List<Cmd> newCmds = new List<Cmd>();
-                    for (int i = 0; i < b.Cmds.Count; i++)
-                    {
-                        Cmd cmd = b.Cmds[i];
-                        newCmds.Add(cmd);
-                        if (cmd is CallCmd || cmd is ParCallCmd || cmd is YieldCmd)
-                        {
-                            AddDisjointnessExpr(newCmds, cmd);
-                        }
-                    }
-                    b.Cmds = newCmds;
-                }
-
-                {
-                    // Loops
-                    impl.PruneUnreachableBlocks();
-                    impl.ComputePredecessorsForBlocks();
-                    GraphUtil.Graph<Block> g = Program.GraphFromImpl(impl);
-                    g.ComputeLoops();
-                    if (g.Reducible)
-                    {
-                        foreach (Block header in g.Headers)
-                        {
-                            List<Cmd> newCmds = new List<Cmd>();
-                            AddDisjointnessExpr(newCmds, header);
-                            newCmds.AddRange(header.Cmds);
-                            header.Cmds = newCmds;
-                        }
-                    }
-                }
-            }
-
-            foreach (var proc in program.Procedures)
-            {
-                Dictionary<string, HashSet<Variable>> domainNameToInputScope = new Dictionary<string, HashSet<Variable>>();
-                Dictionary<string, HashSet<Variable>> domainNameToOutputScope = new Dictionary<string, HashSet<Variable>>();
-                foreach (var domainName in linearDomains.Keys)
-                {
-                    domainNameToInputScope[domainName] = new HashSet<Variable>();
-                    domainNameToOutputScope[domainName] = new HashSet<Variable>();
-                }
-                foreach (Variable v in globalVarToDomainName.Keys)
-                {
-                    var domainName = globalVarToDomainName[v];
-                    domainNameToInputScope[domainName].Add(v);
-                    domainNameToOutputScope[domainName].Add(v);
-                }
-                foreach (Variable v in proc.InParams)
-                {
-                    var domainName = FindDomainName(v);
-                    if (domainName == null) continue;
-                    if (!this.linearDomains.ContainsKey(domainName)) continue;
-                    domainNameToInputScope[domainName].Add(v);
-                }
-                foreach (Variable v in proc.OutParams)
-                {
-                    var domainName = FindDomainName(v);
-                    if (domainName == null) continue;
-                    if (!this.linearDomains.ContainsKey(domainName)) continue;
-                    domainNameToOutputScope[domainName].Add(v);
-                }
-                // TODO: Also add linear and linear_out parameters to domainNameToOutputScope?
-                //       This should still be sound and strengthen the generated postcondition.
-                foreach (var domainName in linearDomains.Keys)
-                {
-                    Expr req = DisjointnessExpr(domainName, domainNameToInputScope[domainName]);
-                    Expr ens = DisjointnessExpr(domainName, domainNameToOutputScope[domainName]);
-                    if (!req.Equals(Expr.True))
-                        proc.Requires.Add(new Requires(true, req));
-                    if (!ens.Equals(Expr.True))
-                        proc.Ensures.Add(new Ensures(true, ens));
-                }
-            }
-
             foreach (LinearDomain domain in linearDomains.Values)
             {
                 program.AddTopLevelDeclaration(domain.mapConstBool);
@@ -955,11 +869,6 @@ namespace Microsoft.Boogie
                     program.AddTopLevelDeclaration(axiom);
                 }
             }
-
-            //int oldPrintUnstructured = CommandLineOptions.Clo.PrintUnstructured;
-            //CommandLineOptions.Clo.PrintUnstructured = 1;
-            //PrintBplFile("lsd.bpl", program, false, false);
-            //CommandLineOptions.Clo.PrintUnstructured = oldPrintUnstructured;
         }
 
         public IEnumerable<Variable> AvailableLinearVars(Absy absy)
@@ -973,30 +882,74 @@ namespace Microsoft.Boogie
                 return new HashSet<Variable>();
             }
         }
-
-        private void AddDisjointnessExpr(List<Cmd> newCmds, Absy absy)
+        
+        public IEnumerable<Expr> DisjointnessExprForEachDomain(IEnumerable<Variable> scope)
         {
             Dictionary<string, HashSet<Variable>> domainNameToScope = new Dictionary<string, HashSet<Variable>>();
             foreach (var domainName in linearDomains.Keys)
             {
                 domainNameToScope[domainName] = new HashSet<Variable>();
             }
-            foreach (Variable v in AvailableLinearVars(absy))
+            foreach (Variable v in scope)
             {
                 var domainName = FindDomainName(v);
+                if (domainName == null) continue;
                 domainNameToScope[domainName].Add(v);
             }
-            foreach (Variable v in globalVarToDomainName.Keys)
+            foreach (string domainName in domainNameToScope.Keys)
             {
-                var domainName = FindDomainName(v);
-                domainNameToScope[domainName].Add(v);
+                yield return DisjointnessExprForPermissions(
+                    domainName, 
+                    PermissionExprForEachVariable(domainName, domainNameToScope[domainName]));
             }
-            foreach (string domainName in linearDomains.Keys)
+        }
+
+        public IEnumerable<Expr> PermissionExprForEachVariable(string domainName, IEnumerable<Variable> scope)
+        {
+            var domain = linearDomains[domainName];
+            foreach (Variable v in scope)
             {
-                Expr expr = DisjointnessExpr(domainName, domainNameToHoleVar[domainName], domainNameToScope[domainName]);
-                if (!expr.Equals(Expr.True))
-                    newCmds.Add(new AssumeCmd(Token.NoToken, expr));
+                Expr expr = new NAryExpr(Token.NoToken, new FunctionCall(domain.collectors[v.TypedIdent.Type]),
+                    new List<Expr> {Expr.Ident(v)});
+                expr.Resolve(new ResolutionContext(null));
+                expr.Typecheck(new TypecheckingContext(null));
+                yield return expr;
             }
+        }
+        
+        public Expr DisjointnessExprForPermissions(string domainName, IEnumerable<Expr> permissionsExprs)
+        {
+            Expr expr = Expr.True;
+            if (permissionsExprs.Count() > 1)
+            {
+                int count = 0;
+                List<Expr> subsetExprs = new List<Expr>();
+                LinearDomain domain = linearDomains[domainName];
+                BoundVariable partition = new BoundVariable(Token.NoToken,
+                    new TypedIdent(Token.NoToken, $"partition_{domainName}", domain.mapTypeInt));
+                foreach (Expr e in permissionsExprs)
+                {
+                    subsetExprs.Add(SubsetExpr(domain, e, partition, count));
+                    count++;
+                }
+                expr = new ExistsExpr(Token.NoToken, new List<Variable> {partition},Expr.And(subsetExprs));
+            }
+            expr.Resolve(new ResolutionContext(null));
+            expr.Typecheck(new TypecheckingContext(null));
+            return expr;
+        }
+        
+        public Expr UnionExprForPermissions(string domainName, IEnumerable<Expr> permissionExprs)
+        {
+            var domain = linearDomains[domainName];
+            var expr = new NAryExpr(Token.NoToken, new FunctionCall(domain.mapConstBool), new Expr[] {Expr.False});
+            foreach (Expr e in permissionExprs)
+            {
+                expr = new NAryExpr(Token.NoToken, new FunctionCall(domain.mapOrBool), new List<Expr> {e, expr});
+            }
+            expr.Resolve(new ResolutionContext(null));
+            expr.Typecheck(new TypecheckingContext(null));
+            return expr;
         }
 
         private Expr SubsetExpr(LinearDomain domain, Expr ie, Variable partition, int partitionCount)
@@ -1006,49 +959,6 @@ namespace Microsoft.Boogie
             e = ExprHelper.FunctionCall(domain.mapImpBool, ie, e);
             e = Expr.Eq(e, ExprHelper.FunctionCall(domain.mapConstBool, Expr.True));
             return e;
-        }
-
-        private Expr DisjointnessExpr(string domainName, Variable holeVar, HashSet<Variable> scope)
-        {
-            int count = 0;
-            List<Expr> subsetExprs = new List<Expr>();
-
-            if (scope.Count == 0 || (holeVar == null && scope.Count == 1))
-            {
-                return Expr.True;
-            }
-
-            LinearDomain domain = linearDomains[domainName];
-            BoundVariable partition = new BoundVariable(
-              Token.NoToken,
-              new TypedIdent(Token.NoToken,
-                             $"partition_{domainName}",
-                             domain.mapTypeInt));
-
-            if (holeVar != null)
-            {
-                subsetExprs.Add(SubsetExpr(domain, Expr.Ident(holeVar), partition, count));
-                count++;
-            }
-
-            foreach (Variable v in scope)
-            {
-                Expr ie = ExprHelper.FunctionCall(domain.collectors[v.TypedIdent.Type], Expr.Ident(v));
-                subsetExprs.Add(SubsetExpr(domain, ie, partition, count));
-                count++;
-            }
-            var expr = new ExistsExpr(Token.NoToken,
-                                      new List<Variable> { partition },
-                                      Expr.And(subsetExprs));
-            expr.Resolve(new ResolutionContext(null));
-            expr.Typecheck(new TypecheckingContext(null));
-
-            return expr;
-        }
-
-        public Expr DisjointnessExpr(string domainName, HashSet<Variable> scope)
-        {
-            return DisjointnessExpr(domainName, null, scope);
         }
         #endregion
 

--- a/Source/Concurrency/NoninterferenceInstrumentation.cs
+++ b/Source/Concurrency/NoninterferenceInstrumentation.cs
@@ -7,9 +7,8 @@ namespace Microsoft.Boogie
     interface NoninterferenceInstrumentation
     {
         List<Variable> NewLocalVars { get; }
-        List<Cmd> CreateUpdatesToPermissionCollector(Absy absy);
         List<Cmd> CreateInitCmds(Implementation impl);
-        List<Declaration> CreateYieldCheckerProcImpl(Implementation impl, IEnumerable<List<PredicateCmd>> yields);
+        List<Cmd> CreateUpdatesToPermissionCollector(Absy absy);
         List<Cmd> CreateCallToYieldProc();
     }
     
@@ -17,19 +16,14 @@ namespace Microsoft.Boogie
     {
         public List<Variable> NewLocalVars => new List<Variable>();
         
-        public List<Cmd> CreateUpdatesToPermissionCollector(Absy absy)
-        {
-            return new List<Cmd>();
-        }
-
         public List<Cmd> CreateInitCmds(Implementation impl)
         {
             return new List<Cmd>();
         }
 
-        public List<Declaration> CreateYieldCheckerProcImpl(Implementation impl, IEnumerable<List<PredicateCmd>> yields)
+        public List<Cmd> CreateUpdatesToPermissionCollector(Absy absy)
         {
-            return new List<Declaration>();
+            return new List<Cmd>();
         }
 
         public List<Cmd> CreateCallToYieldProc()
@@ -42,67 +36,45 @@ namespace Microsoft.Boogie
     {
         private CivlTypeChecker civlTypeChecker;
         private LinearTypeChecker linearTypeChecker;
-        private int layerNum;
-        private Dictionary<Absy, Absy> absyMap;
+        private LinearHelper linearHelper;
         private Dictionary<Variable, Variable> oldGlobalMap;
-        private List<Variable> newLocalVars;
-        private Dictionary<string, Variable> domainNameToLocalVar;
         private Procedure yieldProc;
 
+        private List<Variable> newLocalVars;
+        private Dictionary<string, Variable> domainNameToHoleVar;
+        
         public SomeNoninterferenceInstrumentation(
             CivlTypeChecker civlTypeChecker,
             LinearTypeChecker linearTypeChecker,
-            int layerNum,
-            Dictionary<Absy, Absy> absyMap,
+            LinearHelper linearHelper,
             Dictionary<Variable, Variable> oldGlobalMap,
             Procedure yieldProc)
         {
             this.civlTypeChecker = civlTypeChecker;
             this.linearTypeChecker = linearTypeChecker;
-            this.layerNum = layerNum;
-            this.absyMap = absyMap;
+            this.linearHelper = linearHelper;
             this.oldGlobalMap = oldGlobalMap;
             this.yieldProc = yieldProc;
             this.newLocalVars = new List<Variable>();
-            this.domainNameToLocalVar = new Dictionary<string, Variable>();
+            this.domainNameToHoleVar = new Dictionary<string, Variable>();
+            foreach (string domainName in linearTypeChecker.linearDomains.Keys)
             {
-                foreach (string domainName in linearTypeChecker.linearDomains.Keys)
-                {
-                    Variable l = linearTypeChecker.LinearDomainAvailableLocal(domainName);
-                    domainNameToLocalVar[domainName] = l;
-                    newLocalVars.Add(l);
-                }
+                Variable l = linearTypeChecker.LinearDomainAvailableLocal(domainName);
+                domainNameToHoleVar[domainName] = l;
+                newLocalVars.Add(l);
             }
         }
 
         public List<Variable> NewLocalVars => newLocalVars;
 
-        public List<Cmd> CreateUpdatesToPermissionCollector(Absy absy)
-        {
-            Dictionary<string, Expr> domainNameToExpr = ComputeAvailableExprs(AvailableLinearVars(absy));
-            List<AssignLhs> lhss = new List<AssignLhs>();
-            List<Expr> rhss = new List<Expr>();
-            foreach (var domainName in linearTypeChecker.linearDomains.Keys)
-            {
-                lhss.Add(new SimpleAssignLhs(Token.NoToken, Expr.Ident(domainNameToLocalVar[domainName])));
-                rhss.Add(domainNameToExpr[domainName]);
-            }
-            var cmds = new List<Cmd>();
-            if (lhss.Count > 0)
-            {
-                cmds.Add(new AssignCmd(Token.NoToken, lhss, rhss));
-            }
-            return cmds;
-        }
-
         public List<Cmd> CreateInitCmds(Implementation impl)
         {
-            Dictionary<string, Expr> domainNameToExpr = ComputeAvailableExprs(impl.InParams.FindAll(x => linearTypeChecker.FindDomainName(x) != null));
+            Dictionary<string, Expr> domainNameToExpr = linearHelper.PermissionExprs(impl);
             List<AssignLhs> lhss = new List<AssignLhs>();
             List<Expr> rhss = new List<Expr>();
             foreach (string domainName in linearTypeChecker.linearDomains.Keys)
             {
-                lhss.Add(new SimpleAssignLhs(Token.NoToken, Expr.Ident(domainNameToLocalVar[domainName])));
+                lhss.Add(new SimpleAssignLhs(Token.NoToken, Expr.Ident(domainNameToHoleVar[domainName])));
                 rhss.Add(domainNameToExpr[domainName]);
             }
             var initCmds = new List<Cmd>();
@@ -113,177 +85,38 @@ namespace Microsoft.Boogie
             return initCmds;
         }
 
-        public List<Declaration> CreateYieldCheckerProcImpl(
-            Implementation impl,
-            IEnumerable<List<PredicateCmd>> yields)
+        public List<Cmd> CreateUpdatesToPermissionCollector(Absy absy)
         {
-            Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
-            List<Variable> locals = new List<Variable>();
-            List<Variable> inputs = new List<Variable>();
-
-            foreach (Variable local in impl.LocVars.Union(impl.InParams).Union(impl.OutParams))
-            {
-                var copy = CopyLocal(local);
-                locals.Add(copy);
-                map[local] = Expr.Ident(copy);
-            }
-
+            Dictionary<string, Expr> domainNameToExpr = linearHelper.PermissionExprs(absy);
+            List<AssignLhs> lhss = new List<AssignLhs>();
+            List<Expr> rhss = new List<Expr>();
             foreach (var domainName in linearTypeChecker.linearDomains.Keys)
             {
-                var inParam = linearTypeChecker.LinearDomainInFormal(domainName);
-                inputs.Add(inParam);
-                map[linearTypeChecker.domainNameToHoleVar[domainName]] = Expr.Ident(inParam);
+                lhss.Add(new SimpleAssignLhs(Token.NoToken, Expr.Ident(domainNameToHoleVar[domainName])));
+                rhss.Add(domainNameToExpr[domainName]);
             }
-
-            Dictionary<Variable, Expr> oldLocalMap = new Dictionary<Variable, Expr>();
-            Dictionary<Variable, Expr> assumeMap = new Dictionary<Variable, Expr>(map);
-            foreach (Variable g in civlTypeChecker.sharedVariables)
+            var cmds = new List<Cmd>();
+            if (lhss.Count > 0)
             {
-                var copy = OldLocalLocal(g);
-                locals.Add(copy);
-                oldLocalMap[g] = Expr.Ident(copy);
-                Formal f = OldGlobalFormal(g);
-                inputs.Add(f);
-                assumeMap[g] = Expr.Ident(f);
+                cmds.Add(new AssignCmd(Token.NoToken, lhss, rhss));
             }
-
-            Substitution assumeSubst = Substituter.SubstitutionFromHashtable(assumeMap);
-            Substitution oldSubst = Substituter.SubstitutionFromHashtable(oldLocalMap);
-            Substitution subst = Substituter.SubstitutionFromHashtable(map);
-            List<Block> yieldCheckerBlocks = new List<Block>();
-            List<String> labels = new List<String>();
-            List<Block> labelTargets = new List<Block>();
-            Block yieldCheckerBlock = new Block(Token.NoToken, "exit", new List<Cmd>(), new ReturnCmd(Token.NoToken));
-            labels.Add(yieldCheckerBlock.Label);
-            labelTargets.Add(yieldCheckerBlock);
-            yieldCheckerBlocks.Add(yieldCheckerBlock);
-            int yieldCount = 0;
-            foreach (var cs in yields)
-            {
-                List<Cmd> newCmds = new List<Cmd>();
-                foreach (var predCmd in cs)
-                {
-                    var newExpr = Substituter.ApplyReplacingOldExprs(assumeSubst, oldSubst, predCmd.Expr);
-                    newCmds.Add(new AssumeCmd(Token.NoToken, newExpr));
-                }
-
-                foreach (var predCmd in cs)
-                {
-                    if (predCmd is AssertCmd)
-                    {
-                        var newExpr = Substituter.ApplyReplacingOldExprs(subst, oldSubst, predCmd.Expr);
-                        AssertCmd assertCmd = new AssertCmd(predCmd.tok, newExpr, predCmd.Attributes);
-                        assertCmd.ErrorData = "Non-interference check failed";
-                        newCmds.Add(assertCmd);
-                    }
-
-                    /*
-                    Disjointness assumes injected by LinearTypeChecker are dropped now because the 
-                    previous loop has already substituted the old global state in these assumes.
-                    It would be unsound to have these assumes on the current global state.
-                    */
-                }
-
-                newCmds.Add(new AssumeCmd(Token.NoToken, Expr.False));
-                yieldCheckerBlock = new Block(Token.NoToken, "L" + yieldCount++, newCmds, new ReturnCmd(Token.NoToken));
-                labels.Add(yieldCheckerBlock.Label);
-                labelTargets.Add(yieldCheckerBlock);
-                yieldCheckerBlocks.Add(yieldCheckerBlock);
-            }
-
-            yieldCheckerBlocks.Insert(0,
-                new Block(Token.NoToken, "enter", new List<Cmd>(), new GotoCmd(Token.NoToken, labels, labelTargets)));
-
-            // Create the yield checker procedure
-            var yieldCheckerName = $"Impl_YieldChecker_{impl.Name}";
-            var yieldCheckerProc = new Procedure(Token.NoToken, yieldCheckerName, impl.TypeParameters, inputs,
-                new List<Variable>(), new List<Requires>(), new List<IdentifierExpr>(), new List<Ensures>());
-            CivlUtil.AddInlineAttribute(yieldCheckerProc);
-
-            // Create the yield checker implementation
-            var yieldCheckerImpl = new Implementation(Token.NoToken, yieldCheckerName, impl.TypeParameters, inputs,
-                new List<Variable>(), locals, yieldCheckerBlocks);
-            yieldCheckerImpl.Proc = yieldCheckerProc;
-            CivlUtil.AddInlineAttribute(yieldCheckerImpl);
-            return new List<Declaration>{ yieldCheckerProc, yieldCheckerImpl };
+            return cmds;
         }
-
+        
         public List<Cmd> CreateCallToYieldProc()
         {
             List<Expr> exprSeq = new List<Expr>();
             foreach (string domainName in linearTypeChecker.linearDomains.Keys)
             {
-                exprSeq.Add(Expr.Ident(domainNameToLocalVar[domainName]));
+                exprSeq.Add(Expr.Ident(domainNameToHoleVar[domainName]));
             }
-
             foreach (Variable g in civlTypeChecker.sharedVariables)
             {
                 exprSeq.Add(Expr.Ident(oldGlobalMap[g]));
             }
-
             CallCmd yieldCallCmd = new CallCmd(Token.NoToken, yieldProc.Name, exprSeq, new List<IdentifierExpr>());
             yieldCallCmd.Proc = yieldProc;
             return new List<Cmd> {yieldCallCmd};
-        }
-
-        private IEnumerable<Variable> AvailableLinearVars(Absy absy)
-        {
-            HashSet<Variable> availableVars =
-                new HashSet<Variable>(linearTypeChecker.AvailableLinearVars(absyMap[absy]));
-
-            // A bit hackish, since GlobalVariableLayerRange and LocalVariableIntroLayer return maximum layer range
-            // respectively minimum layer if called on non-global respectively non-local variable.
-            availableVars.RemoveWhere(v =>
-                !civlTypeChecker.GlobalVariableLayerRange(v).Contains(layerNum) ||
-                layerNum < civlTypeChecker.LocalVariableIntroLayer(v)
-            );
-
-            return availableVars;
-        }
-
-        private Dictionary<string, Expr> ComputeAvailableExprs(IEnumerable<Variable> availableLinearVars)
-        {
-            Dictionary<string, Expr> domainNameToExpr = new Dictionary<string, Expr>();
-            foreach (var domainName in linearTypeChecker.linearDomains.Keys)
-            {
-                var domain = linearTypeChecker.linearDomains[domainName];
-                var expr = new NAryExpr(Token.NoToken, new FunctionCall(domain.mapConstBool), new Expr[] {Expr.False});
-                expr.Resolve(new ResolutionContext(null));
-                expr.Typecheck(new TypecheckingContext(null));
-                domainNameToExpr[domainName] = expr;
-            }
-
-            foreach (Variable v in availableLinearVars)
-            {
-                var domainName = linearTypeChecker.FindDomainName(v);
-                var domain = linearTypeChecker.linearDomains[domainName];
-                Expr ie = new NAryExpr(Token.NoToken, new FunctionCall(domain.collectors[v.TypedIdent.Type]),
-                    new List<Expr> {Expr.Ident(v)});
-                var expr = new NAryExpr(Token.NoToken, new FunctionCall(domain.mapOrBool),
-                    new List<Expr> {ie, domainNameToExpr[domainName]});
-                expr.Resolve(new ResolutionContext(null));
-                expr.Typecheck(new TypecheckingContext(null));
-                domainNameToExpr[domainName] = expr;
-            }
-
-            return domainNameToExpr;
-        }
-
-        private Formal OldGlobalFormal(Variable v)
-        {
-            return new Formal(Token.NoToken,
-                new TypedIdent(Token.NoToken, $"og_global_old_{v.Name}", v.TypedIdent.Type), true);
-        }
-
-        private LocalVariable OldLocalLocal(Variable v)
-        {
-            return new LocalVariable(Token.NoToken,
-                new TypedIdent(Token.NoToken, $"og_local_old_{v.Name}", v.TypedIdent.Type));
-        }
-
-        private LocalVariable CopyLocal(Variable v)
-        {
-            return new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, v.Name, v.TypedIdent.Type));
         }
     }
 }

--- a/Source/Concurrency/NoninterferenceInstrumentation.cs
+++ b/Source/Concurrency/NoninterferenceInstrumentation.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Boogie
     {
         private CivlTypeChecker civlTypeChecker;
         private LinearTypeChecker linearTypeChecker;
-        private LinearHelper linearHelper;
+        private LinearPermissionInstrumentation linearPermissionInstrumentation;
         private Dictionary<Variable, Variable> oldGlobalMap;
         private Procedure yieldProc;
 
@@ -46,13 +46,13 @@ namespace Microsoft.Boogie
         public SomeNoninterferenceInstrumentation(
             CivlTypeChecker civlTypeChecker,
             LinearTypeChecker linearTypeChecker,
-            LinearHelper linearHelper,
+            LinearPermissionInstrumentation linearPermissionInstrumentation,
             Dictionary<Variable, Variable> oldGlobalMap,
             Procedure yieldProc)
         {
             this.civlTypeChecker = civlTypeChecker;
             this.linearTypeChecker = linearTypeChecker;
-            this.linearHelper = linearHelper;
+            this.linearPermissionInstrumentation = linearPermissionInstrumentation;
             this.oldGlobalMap = oldGlobalMap;
             this.yieldProc = yieldProc;
             this.newLocalVars = new List<Variable>();
@@ -69,7 +69,7 @@ namespace Microsoft.Boogie
 
         public List<Cmd> CreateInitCmds(Implementation impl)
         {
-            Dictionary<string, Expr> domainNameToExpr = linearHelper.PermissionExprs(impl);
+            Dictionary<string, Expr> domainNameToExpr = linearPermissionInstrumentation.PermissionExprs(impl);
             List<AssignLhs> lhss = new List<AssignLhs>();
             List<Expr> rhss = new List<Expr>();
             foreach (string domainName in linearTypeChecker.linearDomains.Keys)
@@ -87,7 +87,7 @@ namespace Microsoft.Boogie
 
         public List<Cmd> CreateUpdatesToPermissionCollector(Absy absy)
         {
-            Dictionary<string, Expr> domainNameToExpr = linearHelper.PermissionExprs(absy);
+            Dictionary<string, Expr> domainNameToExpr = linearPermissionInstrumentation.PermissionExprs(absy);
             List<AssignLhs> lhss = new List<AssignLhs>();
             List<Expr> rhss = new List<Expr>();
             foreach (var domainName in linearTypeChecker.linearDomains.Keys)

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -104,9 +104,9 @@ namespace Microsoft.Boogie
             newLocalVars = new List<Variable>();
             ActionProc actionProc = civlTypeChecker.procToYieldingProc[originalImpl.Proc] as ActionProc;
             int layerNum = actionProc.upperLayer;
-            pc = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "og_pc", Type.Bool));
+            pc = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "civl_pc", Type.Bool));
             newLocalVars.Add(pc);
-            ok = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "og_ok", Type.Bool));
+            ok = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "civl_ok", Type.Bool));
             newLocalVars.Add(ok);
 
             this.transitionRelationCache = new Dictionary<AtomicAction, Expr>();
@@ -273,7 +273,7 @@ namespace Microsoft.Boogie
         private LocalVariable Old(Variable v)
         {
             return new LocalVariable(Token.NoToken,
-                new TypedIdent(Token.NoToken, $"og_old_{v.Name}", v.TypedIdent.Type));
+                new TypedIdent(Token.NoToken, $"civl_old_{v.Name}", v.TypedIdent.Type));
         }        
     }
 }

--- a/Source/Concurrency/YieldCheckerImplementation.cs
+++ b/Source/Concurrency/YieldCheckerImplementation.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Boogie
+{
+    public static class YieldCheckerImplementation
+    {
+        public static List<Declaration> CreateYieldCheckerProcImpl(
+            CivlTypeChecker civlTypeChecker,
+            LinearTypeChecker linearTypeChecker,
+            int layerNum,
+            Dictionary<Absy, Absy> absyMap,
+            Implementation impl,
+            Dictionary<YieldCmd, List<PredicateCmd>> yields)
+        {
+            Dictionary<string, Variable> domainNameToHoleVar = new Dictionary<string, Variable>();
+            Dictionary<Variable, Variable> localVarMap = new Dictionary<Variable, Variable>();
+            Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
+            List<Variable> locals = new List<Variable>();
+            List<Variable> inputs = new List<Variable>();
+
+            foreach (var domainName in linearTypeChecker.linearDomains.Keys)
+            {
+                var inParam = linearTypeChecker.LinearDomainInFormal(domainName);
+                inputs.Add(inParam);
+                domainNameToHoleVar[domainName] = inParam;
+            }
+
+            foreach (Variable local in impl.LocVars.Union(impl.InParams).Union(impl.OutParams))
+            {
+                var copy = CopyLocal(local);
+                locals.Add(copy);
+                localVarMap[local] = copy;
+                map[local] = Expr.Ident(copy);
+            }
+
+            Dictionary<Variable, Expr> oldLocalMap = new Dictionary<Variable, Expr>();
+            Dictionary<Variable, Expr> assumeMap = new Dictionary<Variable, Expr>(map);
+            foreach (Variable g in civlTypeChecker.sharedVariables)
+            {
+                var copy = OldLocalLocal(g);
+                locals.Add(copy);
+                oldLocalMap[g] = Expr.Ident(copy);
+                Formal f = OldGlobalFormal(g);
+                inputs.Add(f);
+                assumeMap[g] = Expr.Ident(f);
+            }
+
+            var linearHelper = new LinearHelper(civlTypeChecker, linearTypeChecker, layerNum, absyMap, domainNameToHoleVar, localVarMap);
+            Substitution assumeSubst = Substituter.SubstitutionFromHashtable(assumeMap);
+            Substitution oldSubst = Substituter.SubstitutionFromHashtable(oldLocalMap);
+            Substitution subst = Substituter.SubstitutionFromHashtable(map);
+            List<Block> yieldCheckerBlocks = new List<Block>();
+            List<String> labels = new List<String>();
+            List<Block> labelTargets = new List<Block>();
+            Block yieldCheckerBlock = new Block(Token.NoToken, "exit", new List<Cmd>(), new ReturnCmd(Token.NoToken));
+            labels.Add(yieldCheckerBlock.Label);
+            labelTargets.Add(yieldCheckerBlock);
+            yieldCheckerBlocks.Add(yieldCheckerBlock);
+            int yieldCount = 0;
+            foreach (var kv in yields)
+            {
+                var yieldCmd = kv.Key;
+                var yieldPredicates = kv.Value;
+                List<Cmd> newCmds = linearHelper.DisjointnessAssumeCmds(yieldCmd,false);
+                foreach (var predCmd in yieldPredicates)
+                {
+                    var newExpr = Substituter.ApplyReplacingOldExprs(assumeSubst, oldSubst, predCmd.Expr);
+                    newCmds.Add(new AssumeCmd(Token.NoToken, newExpr));
+                }
+
+                foreach (var predCmd in yieldPredicates)
+                {
+                    if (predCmd is AssertCmd)
+                    {
+                        var newExpr = Substituter.ApplyReplacingOldExprs(subst, oldSubst, predCmd.Expr);
+                        AssertCmd assertCmd = new AssertCmd(predCmd.tok, newExpr, predCmd.Attributes);
+                        assertCmd.ErrorData = "Non-interference check failed";
+                        newCmds.Add(assertCmd);
+                    }
+                }
+
+                newCmds.Add(new AssumeCmd(Token.NoToken, Expr.False));
+                yieldCheckerBlock = new Block(Token.NoToken, "L" + yieldCount++, newCmds, new ReturnCmd(Token.NoToken));
+                labels.Add(yieldCheckerBlock.Label);
+                labelTargets.Add(yieldCheckerBlock);
+                yieldCheckerBlocks.Add(yieldCheckerBlock);
+            }
+
+            yieldCheckerBlocks.Insert(0,
+                new Block(Token.NoToken, "enter", new List<Cmd>(), new GotoCmd(Token.NoToken, labels, labelTargets)));
+
+            // Create the yield checker procedure
+            var yieldCheckerName = $"Impl_YieldChecker_{impl.Name}";
+            var yieldCheckerProc = new Procedure(Token.NoToken, yieldCheckerName, impl.TypeParameters, inputs,
+                new List<Variable>(), new List<Requires>(), new List<IdentifierExpr>(), new List<Ensures>());
+            CivlUtil.AddInlineAttribute(yieldCheckerProc);
+
+            // Create the yield checker implementation
+            var yieldCheckerImpl = new Implementation(Token.NoToken, yieldCheckerName, impl.TypeParameters, inputs,
+                new List<Variable>(), locals, yieldCheckerBlocks);
+            yieldCheckerImpl.Proc = yieldCheckerProc;
+            CivlUtil.AddInlineAttribute(yieldCheckerImpl);
+            return new List<Declaration> {yieldCheckerProc, yieldCheckerImpl};
+        }
+
+        private static LocalVariable CopyLocal(Variable v)
+        {
+            return new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, v.Name, v.TypedIdent.Type));
+        }
+
+        private static Formal OldGlobalFormal(Variable v)
+        {
+            return new Formal(Token.NoToken,
+                new TypedIdent(Token.NoToken, $"og_global_old_{v.Name}", v.TypedIdent.Type), true);
+        }
+
+        private static LocalVariable OldLocalLocal(Variable v)
+        {
+            return new LocalVariable(Token.NoToken,
+                new TypedIdent(Token.NoToken, $"og_local_old_{v.Name}", v.TypedIdent.Type));
+        }
+    }
+}

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -8,7 +8,7 @@ using System.ComponentModel;
 
 namespace Microsoft.Boogie
 {
-    public class YieldTypeChecker
+    public class YieldSufficiencyTypeChecker
     {
         // Edge labels of the automaton that abstracts the code of a procedure
         private const char Y = 'Y';  // yield
@@ -83,7 +83,7 @@ namespace Microsoft.Boogie
         public CheckingContext checkingContext;
         private Graph<MoverProc> moverProcedureCallGraph;
 
-        public YieldTypeChecker(CivlTypeChecker civlTypeChecker)
+        public YieldSufficiencyTypeChecker(CivlTypeChecker civlTypeChecker)
         {
             this.civlTypeChecker = civlTypeChecker;
             this.checkingContext = civlTypeChecker.checkingContext;
@@ -123,8 +123,8 @@ namespace Microsoft.Boogie
 
                 foreach (int layerNum in civlTypeChecker.allRefinementLayers.Where(l => l <= yieldingProc.upperLayer))
                 {
-                    PerLayerYieldTypeChecker perLayerTypeChecker = new PerLayerYieldTypeChecker(this, yieldingProc, impl, layerNum, implGraph);
-                    perLayerTypeChecker.TypeCheckLayer();
+                    PerLayerYieldSufficiencyTypeChecker perLayerSufficiencyTypeChecker = new PerLayerYieldSufficiencyTypeChecker(this, yieldingProc, impl, layerNum, implGraph);
+                    perLayerSufficiencyTypeChecker.TypeCheckLayer();
                 }
             }
 
@@ -134,9 +134,9 @@ namespace Microsoft.Boogie
             // TODO: Remove "terminates" attribute
         }
 
-        private class PerLayerYieldTypeChecker
+        private class PerLayerYieldSufficiencyTypeChecker
         {
-            YieldTypeChecker @base;
+            YieldSufficiencyTypeChecker @base;
             YieldingProc yieldingProc;
             Implementation impl;
             int currLayerNum;
@@ -146,7 +146,7 @@ namespace Microsoft.Boogie
             Absy initialState;
             HashSet<Absy> finalStates;
 
-            public PerLayerYieldTypeChecker(YieldTypeChecker @base, YieldingProc yieldingProc, Implementation impl, int currLayerNum, Graph<Block> implGraph)
+            public PerLayerYieldSufficiencyTypeChecker(YieldSufficiencyTypeChecker @base, YieldingProc yieldingProc, Implementation impl, int currLayerNum, Graph<Block> implGraph)
             {
                 this.@base = @base;
                 this.yieldingProc = yieldingProc;

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -5,7 +5,14 @@ using System.Diagnostics;
 namespace Microsoft.Boogie
 {
     public class YieldingProcDuplicator : Duplicator
-    {
+    { 
+        /* This class creates duplicate copies of yielding procedures for a particular layer
+         * rewriting calls to procedures that have been converted to atomic actions. 
+         * Async calls are also rewritten so that the resulting copies are guaranteed not to
+         * have any async calls.  The copy of yielding procedure X shares local variables of X.
+         * This sharing is exploited when instrumenting the duplicates in the class
+         * YieldProcInstrumentation.
+         */
         private CivlTypeChecker civlTypeChecker;
         private LinearTypeChecker linearTypeChecker;
         private Implementation enclosingImpl;
@@ -16,7 +23,7 @@ namespace Microsoft.Boogie
         private Dictionary<Absy, Absy> absyMap; /* Duplicate -> Original */
         private HashSet<Procedure> yieldingProcs;
         private Dictionary<string, Procedure> asyncCallPreconditionCheckers;
-
+        
         public YieldingProcDuplicator(CivlTypeChecker civlTypeChecker, LinearTypeChecker linearTypeChecker, int layerNum)
         {
             this.civlTypeChecker = civlTypeChecker;

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System;
 using System.Diagnostics;
 
 namespace Microsoft.Boogie
@@ -15,7 +14,6 @@ namespace Microsoft.Boogie
         private int layerNum;
         private Dictionary<Procedure, Procedure> procMap; /* Original -> Duplicate */
         private Dictionary<Absy, Absy> absyMap; /* Duplicate -> Original */
-        private Dictionary<Implementation, Implementation> implMap; /* Duplicate -> Original */
         private HashSet<Procedure> yieldingProcs;
         private Dictionary<string, Procedure> asyncCallPreconditionCheckers;
 
@@ -26,7 +24,6 @@ namespace Microsoft.Boogie
             this.layerNum = layerNum;
             this.procMap = new Dictionary<Procedure, Procedure>();
             this.absyMap = new Dictionary<Absy, Absy>();
-            this.implMap = new Dictionary<Implementation, Implementation>();
             this.yieldingProcs = new HashSet<Procedure>();
             this.asyncCallPreconditionCheckers = new Dictionary<string, Procedure>();
         }
@@ -80,6 +77,7 @@ namespace Microsoft.Boogie
                 }
 
                 procMap[node] = proc;
+                absyMap[proc] = node;
             }
 
             return procMap[node];
@@ -153,7 +151,7 @@ namespace Microsoft.Boogie
                     newImpl.LocVars.Add(CollectedPAs);
             }
 
-            implMap[newImpl] = impl;
+            absyMap[newImpl] = impl;
             return newImpl;
         }
 
@@ -452,13 +450,13 @@ namespace Microsoft.Boogie
         {
             var decls = new List<Declaration>();
             decls.AddRange(procMap.Values);
-            decls.AddRange(implMap.Keys);
+            var newImpls = absyMap.Keys.OfType<Implementation>();
+            decls.AddRange(newImpls);
             decls.AddRange(YieldingProcInstrumentation.TransformImplementations(
                 civlTypeChecker,
                 linearTypeChecker,
                 layerNum,
                 absyMap,
-                implMap,
                 yieldingProcs));
             return decls;
         }

--- a/Test/civl/bar.bpl.expect
+++ b/Test/civl/bar.bpl.expect
@@ -2,10 +2,10 @@ bar.bpl(28,3): Error: Non-interference check failed
 Execution trace:
     bar.bpl(7,3): anon0
     bar.bpl(14,5): inline$AtomicIncr$0$anon0
-    (0,0): inline$Impl_YieldChecker_PC_1$0$L0
+    (0,0): inline$NoninterferenceChecker_PC_1$0$L0
 bar.bpl(28,3): Error: Non-interference check failed
 Execution trace:
     bar.bpl(38,3): anon0
-    (0,0): inline$Impl_YieldChecker_PC_1$0$L0
+    (0,0): inline$NoninterferenceChecker_PC_1$0$L0
 
 Boogie program verifier finished with 8 verified, 2 errors

--- a/Test/civl/foo.bpl.expect
+++ b/Test/civl/foo.bpl.expect
@@ -2,6 +2,6 @@ foo.bpl(30,3): Error: Non-interference check failed
 Execution trace:
     foo.bpl(7,3): anon0
     foo.bpl(14,5): inline$AtomicIncr$0$anon0
-    (0,0): inline$Impl_YieldChecker_PC_1$0$L0
+    (0,0): inline$Impl_YieldChecker_PC_1$0$L1
 
 Boogie program verifier finished with 9 verified, 1 error

--- a/Test/civl/foo.bpl.expect
+++ b/Test/civl/foo.bpl.expect
@@ -2,6 +2,6 @@ foo.bpl(30,3): Error: Non-interference check failed
 Execution trace:
     foo.bpl(7,3): anon0
     foo.bpl(14,5): inline$AtomicIncr$0$anon0
-    (0,0): inline$Impl_YieldChecker_PC_1$0$L1
+    (0,0): inline$NoninterferenceChecker_PC_1$0$L1
 
 Boogie program verifier finished with 9 verified, 1 error

--- a/Test/civl/linear/list.bpl
+++ b/Test/civl/linear/list.bpl
@@ -1,5 +1,9 @@
 // RUN: %boogie -noinfer -typeEncoding:m -useArrayTheory -doModSetAnalysis "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+// XFAIL: *
+// This test depends on insertion of assumes about disjoint permissions,
+// which is automatically supported only inside yielding procedures.
+
 type X;
 function {:builtin "MapConst"} MapConstBool(bool) : [X]bool;
 function {:builtin "MapOr"} MapOr([X]bool, [X]bool) : [X]bool;

--- a/Test/civl/linear_out_bug.bpl.expect
+++ b/Test/civl/linear_out_bug.bpl.expect
@@ -3,7 +3,6 @@ linear_out_bug.bpl(10,34): Related location: Commutativity check between AddAddr
 Execution trace:
     linear_out_bug.bpl(10,34): inline$AddAddr$0$Entry
     linear_out_bug.bpl(13,14): inline$AddAddr$0$anon0
-    linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Entry
     linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0
     linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Return
 (0,0): Error BP5003: A postcondition might not hold on this return path.

--- a/Test/civl/linearity-bug-1.bpl.expect
+++ b/Test/civl/linearity-bug-1.bpl.expect
@@ -2,7 +2,6 @@
 linearity-bug-1.bpl(19,31): Related location: Commutativity check between atomic_read_n and atomic_inc_n failed
 Execution trace:
     linearity-bug-1.bpl(19,31): inline$atomic_read_n$0$Entry
-    linearity-bug-1.bpl(13,32): inline$atomic_inc_n$0$Entry
     linearity-bug-1.bpl(15,3): inline$atomic_inc_n$0$anon0
     linearity-bug-1.bpl(13,32): inline$atomic_inc_n$0$Return
 

--- a/Test/civl/linearity-bug-2.bpl
+++ b/Test/civl/linearity-bug-2.bpl
@@ -7,16 +7,6 @@ procedure {:atomic} {:layer 2} atomic_foo ({:linear "lin"} i : int)
 modifies set;
 { set[i] := true; }
 
-procedure {:yields} {:layer 1} {:refines "atomic_foo"} foo ({:linear "lin"} i : int);
-
-procedure {:yields} {:layer 2} main ({:linear "lin"} i : int)
-{
-  yield;
-  call foo(i);
-  assert {:layer 2} false;
-  yield;
-}
-
 // ###########################################################################
 // Collectors for linear domains
 

--- a/Test/civl/linearity-bug-2.bpl.expect
+++ b/Test/civl/linearity-bug-2.bpl.expect
@@ -5,4 +5,4 @@ Execution trace:
     linearity-bug-2.bpl(8,10): inline$atomic_foo$0$anon0
     linearity-bug-2.bpl(6,32): inline$atomic_foo$0$Return
 
-Boogie program verifier finished with 2 verified, 1 error
+Boogie program verifier finished with 0 verified, 1 error

--- a/Test/civl/parallel1.bpl.expect
+++ b/Test/civl/parallel1.bpl.expect
@@ -2,6 +2,6 @@ parallel1.bpl(30,3): Error: Non-interference check failed
 Execution trace:
     parallel1.bpl(7,3): anon0
     parallel1.bpl(14,5): inline$AtomicIncr$0$anon0
-    (0,0): inline$Impl_YieldChecker_PC_1$0$L0
+    (0,0): inline$Impl_YieldChecker_PC_1$0$L1
 
 Boogie program verifier finished with 7 verified, 1 error

--- a/Test/civl/parallel1.bpl.expect
+++ b/Test/civl/parallel1.bpl.expect
@@ -2,6 +2,6 @@ parallel1.bpl(30,3): Error: Non-interference check failed
 Execution trace:
     parallel1.bpl(7,3): anon0
     parallel1.bpl(14,5): inline$AtomicIncr$0$anon0
-    (0,0): inline$Impl_YieldChecker_PC_1$0$L1
+    (0,0): inline$NoninterferenceChecker_PC_1$0$L1
 
 Boogie program verifier finished with 7 verified, 1 error

--- a/Test/civl/t1.bpl.expect
+++ b/Test/civl/t1.bpl.expect
@@ -2,6 +2,6 @@ t1.bpl(80,5): Error: Non-interference check failed
 Execution trace:
     t1.bpl(99,13): anon0
     t1.bpl(99,13): anon0_1
-    (0,0): inline$Impl_YieldChecker_A_1$0$L1
+    (0,0): inline$NoninterferenceChecker_A_1$0$L1
 
 Boogie program verifier finished with 10 verified, 1 error

--- a/Test/civl/t1.bpl.expect
+++ b/Test/civl/t1.bpl.expect
@@ -2,7 +2,6 @@ t1.bpl(80,5): Error: Non-interference check failed
 Execution trace:
     t1.bpl(99,13): anon0
     t1.bpl(99,13): anon0_1
-    t1.bpl(99,13): anon0_1$1
     (0,0): inline$Impl_YieldChecker_A_1$0$L1
 
 Boogie program verifier finished with 10 verified, 1 error


### PR DESCRIPTION
This PR does the following tasks:

- It consolidates all instrumentation related to linear permissions into a new class LinearHelper which is used by the code that creates per-layer refinement checkers for each yielding procedure.  This class is aware of layers and the peculiar needs related to a "hole" for non-interference checking.  The class LinearTypeChecker, used by LinearHelper and MoverCheck, provides an API that provides primitives for applying collector function on a collection of variables and for constructing union and disjointness expressions.

-It splits out the code for generating implementation of non-interference checkers for yields into a separate class YieldCheckerImplementation.  This code used to reside in the class SomeNonInterferenceInstrumentation.  Consequently, YieldProcInstrumentation now uses both SomeNonInterferenceInstrumentation and YieldCheckerImplementation to do its job.

-It renames the concept of "YieldChecker" to "NoninterferenceChecker".  This is reflected in renaming of various files, classes, and variables.

-It renames YieldTypeChecker to YieldSufficiencyTypeChecker.