### PR TITLE
Central configuration and conditioning of GitVersionTask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ script:
   - dotnet build -c ${CONFIGURATION} ${SOLUTION}
   - dotnet test --no-build -c ${CONFIGURATION} ${SOLUTION}
   - lit -v -D dotnet -D configuration=${CONFIGURATION} Test
+  # Do not deploy if GitVersionTask could not be used to extract the correct version number
+  - test ! -e Source/BoogieDriver/bin/${CONFIGURATION}/Boogie.1.0.0.nupkg
 deploy:
   - provider: script
     script: dotnet nuget push Source/BoogieDriver/bin/${CONFIGURATION}/Boogie*.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json

--- a/Source/AbsInt/AbsInt-NetCore.csproj
+++ b/Source/AbsInt/AbsInt-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieAbsInt</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/AbsInt/AbsInt-NetCore.csproj
+++ b/Source/AbsInt/AbsInt-NetCore.csproj
@@ -13,11 +13,4 @@
     <ProjectReference Include="..\ParserHelper\ParserHelper-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Basetypes/Basetypes-NetCore.csproj
+++ b/Source/Basetypes/Basetypes-NetCore.csproj
@@ -10,11 +10,4 @@
     <ProjectReference Include="..\CodeContractsExtender\CodeContractsExtender-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Basetypes/Basetypes-NetCore.csproj
+++ b/Source/Basetypes/Basetypes-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieBasetypes</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/BoogieDriver/BoogieDriver-NetCore.csproj
+++ b/Source/BoogieDriver/BoogieDriver-NetCore.csproj
@@ -36,11 +36,4 @@
       <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/BoogieDriver/BoogieDriver-NetCore.csproj
+++ b/Source/BoogieDriver/BoogieDriver-NetCore.csproj
@@ -11,7 +11,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>BoogieDriver</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>boogie</ToolCommandName>

--- a/Source/CodeContractsExtender/CodeContractsExtender-NetCore.csproj
+++ b/Source/CodeContractsExtender/CodeContractsExtender-NetCore.csproj
@@ -6,11 +6,4 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/CodeContractsExtender/CodeContractsExtender-NetCore.csproj
+++ b/Source/CodeContractsExtender/CodeContractsExtender-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieCodeContractsExtender</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Source/Concurrency/Concurrency-NetCore.csproj
+++ b/Source/Concurrency/Concurrency-NetCore.csproj
@@ -14,11 +14,4 @@
     <ProjectReference Include="..\ParserHelper\ParserHelper-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Concurrency/Concurrency-NetCore.csproj
+++ b/Source/Concurrency/Concurrency-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieConcurrency</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Core/Core-NetCore.csproj
+++ b/Source/Core/Core-NetCore.csproj
@@ -14,11 +14,4 @@
     <ProjectReference Include="..\ParserHelper\ParserHelper-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Core/Core-NetCore.csproj
+++ b/Source/Core/Core-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieCore</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>COREFX_SUBSET</DefineConstants>
   </PropertyGroup>
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,8 +1,16 @@
 <Project>
+
+  <!-- Configure target framework for .NET Core build -->
+  <PropertyGroup Condition="$(MSBuildProjectName.Contains('-NetCore'))">
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Configure GitVersionTask -->
   <ItemGroup Condition="$(MSBuildProjectName.Contains('-NetCore')) AND Exists('$(MSBuildThisFileDirectory)\..\.git') AND $(BOOGIE_NO_GITVERSION) != 1">
     <PackageReference Include="GitVersionTask" Version="5.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  
 </Project>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup Condition="$(MSBuildProjectName.Contains('-NetCore')) AND Exists('$(MSBuildThisFileDirectory)\..\.git') AND $(BOOGIE_NO_GITVERSION) != 1">
+    <PackageReference Include="GitVersionTask" Version="5.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
+++ b/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieExecutionEngine</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
+++ b/Source/ExecutionEngine/ExecutionEngine-NetCore.csproj
@@ -24,11 +24,4 @@
     <ProjectReference Include="..\VCGeneration\VCGeneration-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Graph/Graph-NetCore.csproj
+++ b/Source/Graph/Graph-NetCore.csproj
@@ -10,11 +10,4 @@
     <ProjectReference Include="..\CodeContractsExtender\CodeContractsExtender-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Graph/Graph-NetCore.csproj
+++ b/Source/Graph/Graph-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieGraph</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Houdini/Houdini-NetCore.csproj
+++ b/Source/Houdini/Houdini-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieHoudini</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Houdini/Houdini-NetCore.csproj
+++ b/Source/Houdini/Houdini-NetCore.csproj
@@ -19,11 +19,4 @@
     <ProjectReference Include="..\VCGeneration\VCGeneration-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Model/Model-NetCore.csproj
+++ b/Source/Model/Model-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieModel</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Model/Model-NetCore.csproj
+++ b/Source/Model/Model-NetCore.csproj
@@ -10,11 +10,4 @@
     <ProjectReference Include="..\CodeContractsExtender\CodeContractsExtender-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/ParserHelper/ParserHelper-NetCore.csproj
+++ b/Source/ParserHelper/ParserHelper-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieParserHelper</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/ParserHelper/ParserHelper-NetCore.csproj
+++ b/Source/ParserHelper/ParserHelper-NetCore.csproj
@@ -10,11 +10,4 @@
     <ProjectReference Include="..\CodeContractsExtender\CodeContractsExtender-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Predication/Predication-NetCore.csproj
+++ b/Source/Predication/Predication-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogiePredication</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Predication/Predication-NetCore.csproj
+++ b/Source/Predication/Predication-NetCore.csproj
@@ -15,11 +15,4 @@
     <ProjectReference Include="..\VCGeneration\VCGeneration-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Provers/SMTLib/SMTLib-NetCore.csproj
+++ b/Source/Provers/SMTLib/SMTLib-NetCore.csproj
@@ -17,11 +17,4 @@
     <ProjectReference Include="..\..\VCGeneration\VCGeneration-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/Provers/SMTLib/SMTLib-NetCore.csproj
+++ b/Source/Provers/SMTLib/SMTLib-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>Provers.SMTLib</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/UnitTests/BasetypesTests/BasetypesTests-NetCore.csproj
+++ b/Source/UnitTests/BasetypesTests/BasetypesTests-NetCore.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/UnitTests/CoreTests/CoreTests-NetCore.csproj
+++ b/Source/UnitTests/CoreTests/CoreTests-NetCore.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/UnitTests/TestUtil/TestUtil-NetCore.csproj
+++ b/Source/UnitTests/TestUtil/TestUtil-NetCore.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/VCExpr/VCExpr-NetCore.csproj
+++ b/Source/VCExpr/VCExpr-NetCore.csproj
@@ -13,11 +13,4 @@
     <ProjectReference Include="..\ParserHelper\ParserHelper-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Source/VCExpr/VCExpr-NetCore.csproj
+++ b/Source/VCExpr/VCExpr-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieVCExpr</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/VCGeneration/VCGeneration-NetCore.csproj
+++ b/Source/VCGeneration/VCGeneration-NetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>BoogieVCGeneration</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/VCGeneration/VCGeneration-NetCore.csproj
+++ b/Source/VCGeneration/VCGeneration-NetCore.csproj
@@ -16,11 +16,4 @@
     <ProjectReference Include="..\VCExpr\VCExpr-NetCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This PR fixes the problem that GitVersionTask fails a build that is executed outside of a Git clone (i.e., without the Git history available in the `.git` directory). If we do not find the `.git` directory, GitVersionTask is not loaded and all assemblies get the default version number `1.0.0`.

Since GitVersionTask seems to slow down the build process a bit, it can be manually disabled by setting the environment variable `BOOGIE_NO_GITVERSION=1`.

Finally, GitVersionTask and the .NET Core target framework are now configured globally in `Directory.Build.props`.

Thanks @michael-emmi for the suggestion of using MSBuild conditions!