### PR TITLE
Implemented processing of CVC4 warnings

### DIFF
--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -1242,6 +1242,11 @@ namespace Microsoft.Boogie.SMTLib
 
     protected void HandleProverError(string s)
     {
+      // Trying to match prover warnings of the form:
+      // - for Z3: WARNING: warning_message
+      // - for CVC4: query.smt2:222.24: warning: warning_message
+      // All other lines are considered to be errors.
+
       s = s.Replace("\r", "");
       const string ProverWarning = "WARNING: ";
       string errors = "";

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -1244,17 +1244,32 @@ namespace Microsoft.Boogie.SMTLib
     {
       s = s.Replace("\r", "");
       lock (proverWarnings) {
-        while (s.StartsWith("WARNING: ")) {
-          var idx = s.IndexOf('\n');
-          var warn = s;
-          if (idx > 0) {
-            warn = s.Substring(0, idx);
-            s = s.Substring(idx + 1);
-          } else {
-            s = "";
+        if (options.Solver == SolverKind.Z3) {
+          while (s.StartsWith("WARNING: ")) {
+            var idx = s.IndexOf('\n');
+            var warn = s;
+            if (idx > 0) {
+              warn = s.Substring(0, idx);
+              s = s.Substring(idx + 1);
+            } else {
+              s = "";
+            }
+            warn = warn.Substring(9);
+            proverWarnings.Add(warn);
           }
-          warn = warn.Substring(9);
-          proverWarnings.Add(warn);
+        } else if (options.Solver == SolverKind.CVC4) {
+          while (s.Contains("warning: ")) {
+            var idx = s.IndexOf('\n');
+            var warn = s;
+            if (idx > 0) {
+              warn = s.Substring(0, idx);
+              s = s.Substring(idx + 1);
+            } else {
+              s = "";
+            }
+            warn = warn.Substring(warn.IndexOf("warning: ") + 9);
+            proverWarnings.Add(warn);
+          }
         }
       }
 


### PR DESCRIPTION
We were missing code for processing of CVC4 warnings. Hence, they would end up being treated as errors since Boogie did not recognize then as warnings (since their formatting is different than Z3 warnings).