### PR TITLE
Passing produce-models to CVC4

### DIFF
--- a/Source/Provers/SMTLib/SMTLibProverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibProverOptions.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Boogie.SMTLib
           SolverArguments.Add("-smt2 -in");
           break;
         case SolverKind.CVC4:
-          SolverArguments.Add("--lang=smt --no-strict-parsing --no-condense-function-values --incremental");
+          SolverArguments.Add("--lang=smt --no-strict-parsing --no-condense-function-values --incremental --produce-models");
           if (Logic == null) Logic = "ALL_SUPPORTED";
           break;
         case SolverKind.YICES2:


### PR DESCRIPTION
Otherwise, CVC4 does not produce a model, which leads to a crash
in Boogie when it tries to generate an error trace.