### PR TITLE
Refactor monomorphic

### DIFF
--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1274,10 +1274,6 @@ namespace Microsoft.Boogie {
               case "arguments":
                 TypeEncodingMethod = TypeEncoding.Arguments;
                 break;
-              case "m":
-              case "monomorphic":
-                TypeEncodingMethod = TypeEncoding.Monomorphic;
-                break;
               default:
                 ps.Error("Invalid argument \"{0}\" to option {1}", args[ps.i], ps.s);
                 break;
@@ -1524,10 +1520,6 @@ namespace Microsoft.Boogie {
 
       if (ProverHelpRequested) {
         Console.WriteLine(TheProverFactory.BlankProverOptions().Help);
-      }
-
-      if (UseArrayTheory) {
-        TypeEncodingMethod = TypeEncoding.Monomorphic;
       }
 
       if (inferLeastForUnsat != null) {
@@ -1891,13 +1883,14 @@ namespace Microsoft.Boogie {
   /causalImplies
                 Translate Boogie's A ==> B into prover's A ==> A && B.
   /typeEncoding:<m>
-                how to encode types when sending VC to theorem prover
+                Encoding of types when generating VC of a polymorphic program:
                    p = predicates (default)
                    a = arguments
-                   m = monomorphic
+                Boogie automatically detects monomorphic programs and enables
+                monomorphic VC generation, thereby overriding the above option.
   /useArrayTheory
-                use the SMT theory of arrays (as opposed to axioms). Currently
-                implies /typeEncoding:m.
+                Use the SMT theory of arrays (as opposed to axioms). Supported
+                only for monomorphic programs.
   /reflectAdd   In the VC, generate an auxiliary symbol, elsewhere defined
                 to be +, instead of +.
 

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -731,8 +731,6 @@ namespace Microsoft.Boogie {
     };
     public TypeEncoding TypeEncodingMethod = TypeEncoding.Predicates;
 
-    public bool Monomorphize = false;
-
     public bool ReflectAdd = false;
 
     public int LiveVariableAnalysis = 1;
@@ -1476,7 +1474,6 @@ namespace Microsoft.Boogie {
               ps.CheckBooleanFlag("dbgRefuted", ref DebugRefuted) ||
               ps.CheckBooleanFlag("causalImplies", ref CausalImplies) ||
               ps.CheckBooleanFlag("reflectAdd", ref ReflectAdd) ||
-              ps.CheckBooleanFlag("monomorphize", ref Monomorphize) ||
               ps.CheckBooleanFlag("useArrayTheory", ref UseArrayTheory) ||
               ps.CheckBooleanFlag("weakArrayTheory", ref WeakArrayTheory) ||
               ps.CheckBooleanFlag("doModSetAnalysis", ref DoModSetAnalysis) ||
@@ -1535,7 +1532,7 @@ namespace Microsoft.Boogie {
       }
 
       if (UseArrayTheory) {
-        Monomorphize = true;
+        TypeEncodingMethod = TypeEncoding.Monomorphic;
       }
 
       if (inferLeastForUnsat != null) {
@@ -1903,10 +1900,9 @@ namespace Microsoft.Boogie {
                    p = predicates (default)
                    a = arguments
                    m = monomorphic
-  /monomorphize
-                Do not abstract map types in the encoding (this is an
-                experimental feature that will not do the right thing if
-                the program uses polymorphism)
+  /useArrayTheory
+                use the SMT theory of arrays (as opposed to axioms). Currently
+                implies /typeEncoding:m.
   /reflectAdd   In the VC, generate an auxiliary symbol, elsewhere defined
                 to be +, instead of +.
 
@@ -2023,11 +2019,6 @@ namespace Microsoft.Boogie {
   /platform:<ptype>,<location>
                 ptype = v11,v2,cli1
                 location = platform libraries directory
-
-  Z3 specific options:
-  /useArrayTheory
-                use Z3's native theory (as opposed to axioms).  Currently
-                implies /monomorphize.
 ");
     }
   }

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -566,11 +566,6 @@ namespace Microsoft.Boogie {
     public bool TraceDiagnosticsOnTimeout = false;
     public int TimeLimitPerAssertionInPercent = 10;
     public bool SIBoolControlVC = false;
-    public bool MonomorphicArrays {
-      get {
-        return UseArrayTheory || TypeEncodingMethod == TypeEncoding.Monomorphic;
-      }
-    }
     public bool ExpandLambdas = true; // not useful from command line, only to be set to false programatically
     public bool DoModSetAnalysis = false;
     public bool UseAbstractInterpretation = false;

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -736,6 +736,11 @@ namespace Microsoft.Boogie
       {
           CommandLineOptions.Clo.TypeEncodingMethod = CommandLineOptions.TypeEncoding.Monomorphic;
       }
+      else if (CommandLineOptions.Clo.UseArrayTheory)
+      {
+        Console.WriteLine("Option /useArrayTheory only supported for monomorphic programs and polymorphism is detected in {0}", GetFileNameForConsole(bplFileName));
+        return PipelineOutcome.FatalError;
+      }
 
       CollectModSets(program);
 

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Boogie.SMTLib
     void ObjectInvariant()
     {
       Contract.Invariant(ctx != null);
-      Contract.Invariant(AxBuilder != null);
       Contract.Invariant(Namer != null);
       Contract.Invariant(DeclCollector != null);
       Contract.Invariant(cce.NonNullElements(Axioms));
@@ -2770,7 +2769,7 @@ namespace Microsoft.Boogie.SMTLib
 
     public override string Lookup(VCExprVar var)
     {
-      VCExprVar v = parent.AxBuilder.TryTyped2Untyped(var);
+      VCExprVar v = parent.AxBuilder?.TryTyped2Untyped(var);
       if (v != null) {
         var = v;
       }

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -282,7 +282,7 @@ void ObjectInvariant()
       Contract.Requires(type != null);
       if (KnownTypes.Contains(type)) return;
 
-      if (type.IsMap && CommandLineOptions.Clo.MonomorphicArrays) {
+      if (type.IsMap && CommandLineOptions.Clo.TypeEncodingMethod == CommandLineOptions.TypeEncoding.Monomorphic) {
         KnownTypes.Add(type);
         MapType mapType = type.AsMap;
         Contract.Assert(mapType != null);
@@ -352,7 +352,7 @@ void ObjectInvariant()
         string decl = "(declare-fun " + name + " (" + node.MapConcat(n => TypeToString(n.Type), " ") + ") " + TypeToString(node.Type) + ")";
         AddDeclaration(decl);
 
-        if (CommandLineOptions.Clo.MonomorphicArrays) {
+        if (CommandLineOptions.Clo.TypeEncodingMethod == CommandLineOptions.TypeEncoding.Monomorphic) {
           var sel = SimplifyLikeExprLineariser.SelectOpName(node);
           sel = Namer.GetQuotedName(sel, sel);
           

--- a/Source/VCExpr/TypeErasure.cs
+++ b/Source/VCExpr/TypeErasure.cs
@@ -685,7 +685,7 @@ namespace Microsoft.Boogie.TypeErasure {
     [Pure]
     public override bool UnchangedType(Type type) {
       //Contract.Requires(type != null);
-      return type.IsInt || type.IsReal || type.IsBool || type.IsBv || type.IsFloat || type.IsRMode || type.IsString || type.IsRegEx || (type.IsMap && CommandLineOptions.Clo.MonomorphicArrays);
+      return type.IsInt || type.IsReal || type.IsBool || type.IsBv || type.IsFloat || type.IsRMode || type.IsString || type.IsRegEx;
     }
 
     public VCExpr Cast(VCExpr expr, Type toType) {

--- a/Source/VCExpr/TypeErasure.cs
+++ b/Source/VCExpr/TypeErasure.cs
@@ -934,9 +934,6 @@ namespace Microsoft.Boogie.TypeErasure {
       Contract.Requires(rawType != null);
       Contract.Ensures(Contract.Result<Type>() != null);
 
-      if (CommandLineOptions.Clo.Monomorphize && AxBuilder.UnchangedType(rawType))
-        return rawType;
-
       if (rawType.FreeVariables.All(var => !boundTypeParams.Contains(var))) {
         // Bingo!
         // if the type does not contain any bound variables, we can simply

--- a/Source/VCExpr/TypeErasureArguments.cs
+++ b/Source/VCExpr/TypeErasureArguments.cs
@@ -204,24 +204,14 @@ Contract.Ensures(Contract.ValueAtReturn(out store) != null);
       // Fill in the index types
       foreach (Type/*!*/ type in abstractedType.Arguments) {
         Contract.Assert(type != null);
-        if (CommandLineOptions.Clo.Monomorphize && AxBuilder.UnchangedType(type)) {
-          selectTypes[i] = type;
-          storeTypes[i] = type;
-        } else {
-          selectTypes[i] = AxBuilder.U;
-          storeTypes[i] = AxBuilder.U;
-        }
+        selectTypes[i] = AxBuilder.U;
+        storeTypes[i] = AxBuilder.U;
         i++;
       }
       // Fill in the output type for select function which also happens 
       // to be the type of the last argument to the store function
-      if (CommandLineOptions.Clo.Monomorphize && AxBuilder.UnchangedType(abstractedType.Result)) {
-        selectTypes[i] = abstractedType.Result;
-        storeTypes[i] = abstractedType.Result;
-      } else {
-        selectTypes[i] = AxBuilder.U;
-        storeTypes[i] = AxBuilder.U;
-      }
+      selectTypes[i] = AxBuilder.U;
+      storeTypes[i] = AxBuilder.U;
       i++;
       // Fill in the map type which is the output of the store function
       if (CommandLineOptions.Clo.MonomorphicArrays)

--- a/Source/VCExpr/TypeErasureArguments.cs
+++ b/Source/VCExpr/TypeErasureArguments.cs
@@ -193,13 +193,8 @@ Contract.Ensures(Contract.ValueAtReturn(out store) != null);
         storeTypes[i] = AxBuilder.T;
       }
       // Fill in the map type
-      if (CommandLineOptions.Clo.MonomorphicArrays) {
-        selectTypes[i] = abstractedType;
-        storeTypes[i] = abstractedType;
-      } else {
-        selectTypes[i] = AxBuilder.U;
-        storeTypes[i] = AxBuilder.U;
-      }
+      selectTypes[i] = AxBuilder.U;
+      storeTypes[i] = AxBuilder.U;
       i++;
       // Fill in the index types
       foreach (Type/*!*/ type in abstractedType.Arguments) {
@@ -214,10 +209,7 @@ Contract.Ensures(Contract.ValueAtReturn(out store) != null);
       storeTypes[i] = AxBuilder.U;
       i++;
       // Fill in the map type which is the output of the store function
-      if (CommandLineOptions.Clo.MonomorphicArrays)
-        storeTypes[i] = abstractedType;
-      else
-        storeTypes[i] = AxBuilder.U;
+      storeTypes[i] = AxBuilder.U;
       Contract.Assert(cce.NonNullElements<Type>(selectTypes));
       Contract.Assert(cce.NonNullElements<Type>(storeTypes));
 

--- a/Source/VCExpr/TypeErasurePremisses.cs
+++ b/Source/VCExpr/TypeErasurePremisses.cs
@@ -643,10 +643,7 @@ namespace Microsoft.Boogie.TypeErasure
         mapTypeParams.Add(var);
       }
 
-      if (CommandLineOptions.Clo.MonomorphicArrays)
-        mapTypeSynonym = abstractedType;
-      else
-        mapTypeSynonym = new CtorType(Token.NoToken, synonymDecl, mapTypeParams);
+      mapTypeSynonym = new CtorType(Token.NoToken, synonymDecl, mapTypeParams);
 
       originalIndexTypes.Add(mapTypeSynonym);
       originalIndexTypes.AddRange(abstractedType.Arguments.ToList());

--- a/Source/VCExpr/TypeErasurePremisses.cs
+++ b/Source/VCExpr/TypeErasurePremisses.cs
@@ -680,16 +680,10 @@ namespace Microsoft.Boogie.TypeErasure
         ioTypes[i] = AxBuilder.T;
       foreach (Type/*!*/ type in originalInTypes) {
         Contract.Assert(type != null);
-        if (CommandLineOptions.Clo.Monomorphize && AxBuilder.UnchangedType(type))
-          ioTypes[i] = type;
-        else
-          ioTypes[i] = AxBuilder.U;
+        ioTypes[i] = AxBuilder.U;
         i++;
       }
-      if (CommandLineOptions.Clo.Monomorphize && AxBuilder.UnchangedType(originalResult))
-        ioTypes[i] = originalResult;
-      else
-        ioTypes[i] = AxBuilder.U;
+      ioTypes[i] = AxBuilder.U;
 
       Function/*!*/ res = HelperFuns.BoogieFunction(name, ioTypes);
       Contract.Assert(res != null);

--- a/Test/civl/DeviceCache.bpl
+++ b/Test/civl/DeviceCache.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 function {:builtin "MapConst"} mapconstbool(bool): [X]bool;

--- a/Test/civl/FlanaganQadeer.bpl
+++ b/Test/civl/FlanaganQadeer.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 const nil: X;

--- a/Test/civl/GC.bpl
+++ b/Test/civl/GC.bpl
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //
 
-// RUN: %boogie -useArrayTheory -typeEncoding:m "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type X = int;

--- a/Test/civl/Program1.bpl
+++ b/Test/civl/Program1.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,1} x:int;
 

--- a/Test/civl/Program2.bpl
+++ b/Test/civl/Program2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,1} x:int;
 

--- a/Test/civl/Program3.bpl
+++ b/Test/civl/Program3.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,1} x:int;
 

--- a/Test/civl/Program4.bpl
+++ b/Test/civl/Program4.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,1} x:int;
 

--- a/Test/civl/StoreBuffer.bpl
+++ b/Test/civl/StoreBuffer.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} MapConstBool(bool) : [int]bool;
 

--- a/Test/civl/akash.bpl
+++ b/Test/civl/akash.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} mapconstbool(bool) : [int]bool;
 

--- a/Test/civl/alloc-tid.bpl
+++ b/Test/civl/alloc-tid.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,2} a:[int]int;
 var {:layer 0,1} count: int;

--- a/Test/civl/array-insert.bpl
+++ b/Test/civl/array-insert.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Insertion into a sorted array

--- a/Test/civl/async/2agree_1.bpl
+++ b/Test/civl/async/2agree_1.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,3} val_a : int;

--- a/Test/civl/async/2agree_2.bpl
+++ b/Test/civl/async/2agree_2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,3} val_a : int;

--- a/Test/civl/async/2agree_3.bpl
+++ b/Test/civl/async/2agree_3.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,3} val_a : int;

--- a/Test/civl/async/2pc-triggers.bpl
+++ b/Test/civl/async/2pc-triggers.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // ###########################################################################

--- a/Test/civl/async/2pc.bpl
+++ b/Test/civl/async/2pc.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // ###########################################################################

--- a/Test/civl/async/inc-dec-2.bpl
+++ b/Test/civl/async/inc-dec-2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const N : int;

--- a/Test/civl/async/inc-dec.bpl
+++ b/Test/civl/async/inc-dec.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const N : int;

--- a/Test/civl/async/inc-server.bpl
+++ b/Test/civl/async/inc-server.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // ###########################################################################

--- a/Test/civl/async/inc-server_mover.bpl
+++ b/Test/civl/async/inc-server_mover.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // ###########################################################################

--- a/Test/civl/async/leader.bpl
+++ b/Test/civl/async/leader.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const N : int;

--- a/Test/civl/async/lock-service-impl.bpl
+++ b/Test/civl/async/lock-service-impl.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 // XFAIL: *
 

--- a/Test/civl/async/lock-service.bpl
+++ b/Test/civl/async/lock-service.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 // XFAIL: *
 

--- a/Test/civl/async/pending-async-test.bpl
+++ b/Test/civl/async/pending-async-test.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 // XFAIL: *
 

--- a/Test/civl/async/rec-inc.bpl
+++ b/Test/civl/async/rec-inc.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // ###########################################################################

--- a/Test/civl/async/simple-tds.bpl
+++ b/Test/civl/async/simple-tds.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 function {:builtin "MapConst"} MapConstBool(bool): [int]bool;

--- a/Test/civl/async/tds.bpl
+++ b/Test/civl/async/tds.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 function {:builtin "MapConst"} MapConstBool(bool): [int]bool;

--- a/Test/civl/async/tds2.bpl
+++ b/Test/civl/async/tds2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 function {:builtin "MapConst"} MapConstBool(bool): [int]bool;

--- a/Test/civl/chris.bpl
+++ b/Test/civl/chris.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var{:layer 1,3} x:int;
 

--- a/Test/civl/chris2.bpl
+++ b/Test/civl/chris2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var{:layer 20,40} x:int;
 

--- a/Test/civl/chris3.bpl
+++ b/Test/civl/chris3.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 procedure{:atomic}{:layer 95} skip() { }

--- a/Test/civl/chris4.bpl
+++ b/Test/civl/chris4.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 procedure{:yields}{:layer 94} Test()
 {

--- a/Test/civl/civl-paper.bpl
+++ b/Test/civl/civl-paper.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 const nil: X;

--- a/Test/civl/cyclic-concur.bpl
+++ b/Test/civl/cyclic-concur.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,2} x : int;
 

--- a/Test/civl/funky.bpl
+++ b/Test/civl/funky.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 const nil: X;

--- a/Test/civl/ghost.bpl
+++ b/Test/civl/ghost.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,2} x: int;
 

--- a/Test/civl/hide-params-pa-2.bpl
+++ b/Test/civl/hide-params-pa-2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type {:pending_async}{:datatype} PA;

--- a/Test/civl/hide-params-pa.bpl
+++ b/Test/civl/hide-params-pa.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type {:pending_async}{:datatype} PA;

--- a/Test/civl/inc-dec.bpl
+++ b/Test/civl/inc-dec.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // ###########################################################################

--- a/Test/civl/inductive-sequentialization/2PC.bpl
+++ b/Test/civl/inductive-sequentialization/2PC.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // A type for vote messages of participants

--- a/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl
+++ b/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const n:int;

--- a/Test/civl/inductive-sequentialization/ChangRoberts.bpl
+++ b/Test/civl/inductive-sequentialization/ChangRoberts.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const n:int;

--- a/Test/civl/inductive-sequentialization/ChangRoberts_pendingAsyncs.bpl
+++ b/Test/civl/inductive-sequentialization/ChangRoberts_pendingAsyncs.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const n:int;

--- a/Test/civl/inductive-sequentialization/NBuyer.bpl
+++ b/Test/civl/inductive-sequentialization/NBuyer.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const n:int;      // Number of buyers

--- a/Test/civl/inductive-sequentialization/NoChoice.bpl
+++ b/Test/civl/inductive-sequentialization/NoChoice.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,2} x:int;

--- a/Test/civl/inductive-sequentialization/PingPong.bpl
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,3} ping_channel:[int]int; // Incoming channel of Ping

--- a/Test/civl/inductive-sequentialization/ProducerConsumer.bpl
+++ b/Test/civl/inductive-sequentialization/ProducerConsumer.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,3} C:[int]int; // FIFO channel

--- a/Test/civl/inductive-sequentialization/paxos/is.sh
+++ b/Test/civl/inductive-sequentialization/paxos/is.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# RUN: %boogie -typeEncoding:m -useArrayTheory Paxos.bpl PaxosSeqAxioms.bpl PaxosActions.bpl PaxosAbstractions.bpl PaxosSeq.bpl > "%t"
+# RUN: %boogie -useArrayTheory Paxos.bpl PaxosSeqAxioms.bpl PaxosActions.bpl PaxosAbstractions.bpl PaxosSeq.bpl > "%t"
 # RUN: %diff "%s.expect" "%t"
 
-boogie -nologo -typeEncoding:m -useArrayTheory $@ Paxos.bpl PaxosSeqAxioms.bpl PaxosActions.bpl PaxosAbstractions.bpl PaxosSeq.bpl
+boogie -nologo -useArrayTheory $@ Paxos.bpl PaxosSeqAxioms.bpl PaxosActions.bpl PaxosAbstractions.bpl PaxosSeq.bpl

--- a/Test/civl/inductive-sequentialization/paxos/ref.sh
+++ b/Test/civl/inductive-sequentialization/paxos/ref.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# RUN: %boogie -typeEncoding:m -useArrayTheory Paxos.bpl PaxosActions.bpl PaxosImpl.bpl > "%t"
+# RUN: %boogie -useArrayTheory Paxos.bpl PaxosActions.bpl PaxosImpl.bpl > "%t"
 # RUN: %diff "%s.expect" "%t"
 
-boogie -nologo -typeEncoding:m -useArrayTheory $@ Paxos.bpl PaxosActions.bpl PaxosImpl.bpl
+boogie -nologo -useArrayTheory $@ Paxos.bpl PaxosActions.bpl PaxosImpl.bpl

--- a/Test/civl/intro.bpl
+++ b/Test/civl/intro.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 1,2} y:int;

--- a/Test/civl/lamport.bpl
+++ b/Test/civl/lamport.bpl
@@ -10,7 +10,7 @@
 // Both lines are assumed to be atomic. This algorithm has the property that
 // once all processes have finished, at least one y[j] == 1.
 
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Number of processes in the algorithm. There needs to be at least one.

--- a/Test/civl/lamport_prophecy.bpl
+++ b/Test/civl/lamport_prophecy.bpl
@@ -10,7 +10,7 @@
 // algorithm has the property that once all processes have finished, at
 // least one y[j] == 1.
 
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 // XFAIL: *
 

--- a/Test/civl/lease.bpl
+++ b/Test/civl/lease.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // datatype lockMsg = transfer(epoch:int) | locked(epoch:int)

--- a/Test/civl/left-mover.bpl
+++ b/Test/civl/left-mover.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,2} x : int;

--- a/Test/civl/linear-set.bpl
+++ b/Test/civl/linear-set.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 function {:builtin "MapConst"} MapConstInt(int) : [X]int;

--- a/Test/civl/linear-set2.bpl
+++ b/Test/civl/linear-set2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 function {:builtin "MapConst"} MapConstInt(int) : [X]int;

--- a/Test/civl/linear/allocator.bpl
+++ b/Test/civl/linear/allocator.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory -doModSetAnalysis "%s" > "%t"
+// RUN: %boogie -useArrayTheory -doModSetAnalysis "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} MapConstBool(bool) : [int]bool;
 function {:inline} {:linear "tid"} TidCollector(x: int) : [int]bool

--- a/Test/civl/linear/async-bug.bpl
+++ b/Test/civl/linear/async-bug.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory -doModSetAnalysis "%s" > "%t"
+// RUN: %boogie -useArrayTheory -doModSetAnalysis "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 const GcTid:int;
 

--- a/Test/civl/linear/bug.bpl
+++ b/Test/civl/linear/bug.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory -doModSetAnalysis "%s" > "%t"
+// RUN: %boogie -useArrayTheory -doModSetAnalysis "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} MapConstBool(bool) : [int]bool;
 function {:inline} {:linear ""} LinearIntDistinctness(x:int) : [int]bool { MapConstBool(false)[x := true] }

--- a/Test/civl/linear/f1.bpl
+++ b/Test/civl/linear/f1.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory -doModSetAnalysis "%s" > "%t"
+// RUN: %boogie -useArrayTheory -doModSetAnalysis "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} mapconstbool(bool) : [int]bool;
 const {:existential true} b0: bool;

--- a/Test/civl/linear/f2.bpl
+++ b/Test/civl/linear/f2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory -doModSetAnalysis "%s" > "%t"
+// RUN: %boogie -useArrayTheory -doModSetAnalysis "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} mapconstbool(bool) : [int]bool;
 function {:builtin "MapOr"} mapunion([int]bool, [int]bool) : [int]bool;

--- a/Test/civl/linear/f3.bpl
+++ b/Test/civl/linear/f3.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory -doModSetAnalysis "%s" > "%t"
+// RUN: %boogie -useArrayTheory -doModSetAnalysis "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} MapConstBool(bool) : [int]bool;
 function {:inline} {:linear "tid"} TidCollector(x: int) : [int]bool

--- a/Test/civl/linear/list.bpl
+++ b/Test/civl/linear/list.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory -doModSetAnalysis "%s" > "%t"
+// RUN: %boogie -useArrayTheory -doModSetAnalysis "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 // XFAIL: *
 // This test depends on insertion of assumes about disjoint permissions,

--- a/Test/civl/linear/typecheck.bpl
+++ b/Test/civl/linear/typecheck.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory  "%s" > "%t"
+// RUN: %boogie -useArrayTheory  "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 

--- a/Test/civl/linear_out_bug.bpl
+++ b/Test/civl/linear_out_bug.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,2} {:linear "addr"} Addrs:[int]bool;

--- a/Test/civl/linearity-bug-1.bpl
+++ b/Test/civl/linearity-bug-1.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -useArrayTheory -typeEncoding:m "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,1} n : int;

--- a/Test/civl/linearity-bug-2.bpl
+++ b/Test/civl/linearity-bug-2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:linear "lin"} {:layer 1,2} set : [int]bool;

--- a/Test/civl/lipton.bpl
+++ b/Test/civl/lipton.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // The semaphor operations P and V used in [Lipton 1975]

--- a/Test/civl/lock-introduced.bpl
+++ b/Test/civl/lock-introduced.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type X;

--- a/Test/civl/lock.bpl
+++ b/Test/civl/lock.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,2} b: bool;
 

--- a/Test/civl/lock2.bpl
+++ b/Test/civl/lock2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,2} b: int;
 

--- a/Test/civl/multiset.bpl
+++ b/Test/civl/multiset.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 

--- a/Test/civl/new1.bpl
+++ b/Test/civl/new1.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} mapconstbool(x:bool): [int]bool;
 

--- a/Test/civl/par-incr.bpl
+++ b/Test/civl/par-incr.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,3} x: int;

--- a/Test/civl/par-intro-bug.bpl
+++ b/Test/civl/par-intro-bug.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0} x : int;

--- a/Test/civl/parallel2.bpl
+++ b/Test/civl/parallel2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,1} a:[int]int;
 

--- a/Test/civl/parallel4.bpl
+++ b/Test/civl/parallel4.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,1} a:int;
 

--- a/Test/civl/parallel5.bpl
+++ b/Test/civl/parallel5.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,1} a:[int]int;
 

--- a/Test/civl/pending-async-1.bpl
+++ b/Test/civl/pending-async-1.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type {:pending_async}{:datatype} PA;

--- a/Test/civl/pending-async-2.bpl
+++ b/Test/civl/pending-async-2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const n:int;

--- a/Test/civl/perm.bpl
+++ b/Test/civl/perm.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,1} x: int;
 function {:builtin "MapConst"} ch_mapconstbool(x: bool) : [int]bool;

--- a/Test/civl/podelski/t-s.bpl
+++ b/Test/civl/podelski/t-s.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,1} s:int;

--- a/Test/civl/podelski/x.bpl
+++ b/Test/civl/podelski/x.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,1} x:int;

--- a/Test/civl/podelski/x_perm.bpl
+++ b/Test/civl/podelski/x_perm.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Permission types

--- a/Test/civl/seqlock.bpl
+++ b/Test/civl/seqlock.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type Tid;

--- a/Test/civl/signature-mismatch.bpl
+++ b/Test/civl/signature-mismatch.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 var {:layer 0,1} x:int;

--- a/Test/civl/t1.bpl
+++ b/Test/civl/t1.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function {:builtin "MapConst"} mapconstbool(bool) : [int]bool;
 

--- a/Test/civl/termination.bpl
+++ b/Test/civl/termination.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 procedure {:atomic} {:layer 1} AtomicX() { }
 

--- a/Test/civl/termination2.bpl
+++ b/Test/civl/termination2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 procedure {:atomic} {:layer 1} AtomicX() { }
 

--- a/Test/civl/ticket.bpl
+++ b/Test/civl/ticket.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 function RightOpen (n: int) : [int]bool;

--- a/Test/civl/treiber-stack.bpl
+++ b/Test/civl/treiber-stack.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 const null: int;

--- a/Test/civl/unprotected-read.bpl
+++ b/Test/civl/unprotected-read.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Write (although lock-protected) is a non-mover, becaues of the unprotected

--- a/Test/civl/write-barrier.bpl
+++ b/Test/civl/write-barrier.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type Tid;

--- a/Test/civl/wsq.bpl
+++ b/Test/civl/wsq.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type Tid;
 const nil: Tid;

--- a/Test/civl/zeldovich.bpl
+++ b/Test/civl/zeldovich.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type Tid;

--- a/Test/datatypes/ex.bpl
+++ b/Test/datatypes/ex.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type{:datatype} finite_map;
 function{:constructor} finite_map(dom:[int]bool, map:[int]int):finite_map;

--- a/Test/datatypes/t1.bpl
+++ b/Test/datatypes/t1.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type TT;
 type {:datatype} Tree;

--- a/Test/datatypes/t2.bpl
+++ b/Test/datatypes/t2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type TT;
 type {:datatype} Tree;

--- a/Test/datatypes/t3.bpl
+++ b/Test/datatypes/t3.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type {:datatype} Value;
 function {:constructor} Int(i: int): Value;

--- a/Test/generalizedarray/Maps.bpl
+++ b/Test/generalizedarray/Maps.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -useArrayTheory "%s" > "%t"
+// RUN: %boogie -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type X;
 

--- a/Test/havoc0/KbdCreateClassObject.bpl
+++ b/Test/havoc0/KbdCreateClassObject.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -monomorphize "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff success.expect "%t"
 type byte, name;
 function OneByteToInt(byte) returns (int);

--- a/Test/havoc0/KeyboardClassFindMorePorts.bpl
+++ b/Test/havoc0/KeyboardClassFindMorePorts.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -monomorphize "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff success.expect "%t"
 type byte, name;
 function OneByteToInt(byte) returns (int);

--- a/Test/havoc0/KeyboardClassUnload.bpl
+++ b/Test/havoc0/KeyboardClassUnload.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -monomorphize "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff success.expect "%t"
 type byte, name;
 function OneByteToInt(byte) returns (int);

--- a/Test/havoc0/MouCreateClassObject.bpl
+++ b/Test/havoc0/MouCreateClassObject.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -monomorphize "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff success.expect "%t"
 type byte, name;
 function OneByteToInt(byte) returns (int);

--- a/Test/havoc0/MouseClassFindMorePorts.bpl
+++ b/Test/havoc0/MouseClassFindMorePorts.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -monomorphize "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff success.expect "%t"
 type byte, name;
 function OneByteToInt(byte) returns (int);

--- a/Test/havoc0/MouseClassUnload.bpl
+++ b/Test/havoc0/MouseClassUnload.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -monomorphize "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff success.expect "%t"
 type byte, name;
 function OneByteToInt(byte) returns (int);

--- a/Test/prover/EQ_v2.Eval__v4.Eval_out.bpl
+++ b/Test/prover/EQ_v2.Eval__v4.Eval_out.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var v4.Mem: [name][int]int;
 

--- a/Test/prover/usedot.bpl
+++ b/Test/prover/usedot.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m -proverLog:"%t.smt2" "%s"
+// RUN: %boogie -proverLog:"%t.smt2" "%s"
 // RUN: %OutputCheck "%s" --file-to-check="%t.smt2"
 procedure foo() {
   // . is an illegal starting character in SMT-LIBv2

--- a/Test/prover/z3mutl.bpl
+++ b/Test/prover/z3mutl.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 var x:int;
 

--- a/Test/test2/Arrays.bpl
+++ b/Test/test2/Arrays.bpl
@@ -1,6 +1,6 @@
 // RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 // --------------------  1-dimensional arrays  --------------------
 

--- a/Test/test2/Lambda.bpl
+++ b/Test/test2/Lambda.bpl
@@ -1,6 +1,6 @@
 // RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 procedure foo()
 {

--- a/Test/test2/TypeEncodingM.bpl
+++ b/Test/test2/TypeEncodingM.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -typeEncoding:m "%s" > "%t"
+// RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 type TT;
 

--- a/Test/z3api/runtest.bat
+++ b/Test/z3api/runtest.bat
@@ -6,7 +6,7 @@ set BGEXE=..\..\Binaries\Boogie.exe
 for %%f in (boog0.bpl boog1.bpl boog2.bpl boog3.bpl boog4.bpl boog5.bpl boog6.bpl boog7.bpl boog8.bpl boog9.bpl boog10.bpl boog11.bpl boog12.bpl boog13.bpl boog14.bpl boog15.bpl boog16.bpl boog17.bpl boog18.bpl boog19.bpl boog20.bpl boog21.bpl boog22.bpl boog23.bpl boog24.bpl boog25.bpl boog28.bpl boog29.bpl boog30.bpl boog31.bpl boog34.bpl boog35.bpl) do (
   echo.
   echo -------------------- %%f --------------------
-  %BGEXE% %* /nologo /typeEncoding:m /prover:z3api %%f
+  %BGEXE% %* /nologo /prover:z3api %%f
 )
 
 for %%f in (bar1.bpl bar2.bpl bar3.bpl bar4.bpl bar6.bpl) do (


### PR DESCRIPTION
This pull request:
- Disables AxiomBuilder for monomorphic encoding
- Removes Monomorphize and MonomorphicArrays flags. This means that array theory cannot be enabled on polymorphic programs, but that part did not work anyways and nobody was relying on it (to the best of my knowledge)
- Removed /typeEncoding:m from command line options. Boogie was already inferring whether a program is monomorphic automatically, and so we do not need a command like option for that.
- Boogie now reports an error if /useArrayTheory is used with a polymorphic program.