### PR TITLE
[CIVL] Improve inductive sequentialization proof for Paxos

### DIFF
--- a/Test/civl/inductive-sequentialization/2PC.bpl.expect
+++ b/Test/civl/inductive-sequentialization/2PC.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 64 verified, 0 errors
+Boogie program verifier finished with 66 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl.expect
+++ b/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 25 verified, 0 errors
+Boogie program verifier finished with 27 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/ChangRoberts.bpl.expect
+++ b/Test/civl/inductive-sequentialization/ChangRoberts.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 35 verified, 0 errors
+Boogie program verifier finished with 37 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/ChangRoberts_pendingAsyncs.bpl.expect
+++ b/Test/civl/inductive-sequentialization/ChangRoberts_pendingAsyncs.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 40 verified, 0 errors
+Boogie program verifier finished with 42 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/NBuyer.bpl.expect
+++ b/Test/civl/inductive-sequentialization/NBuyer.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 120 verified, 0 errors
+Boogie program verifier finished with 123 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/NoChoice.bpl.expect
+++ b/Test/civl/inductive-sequentialization/NoChoice.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 7 verified, 0 errors
+Boogie program verifier finished with 8 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/PingPong.bpl.expect
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 40 verified, 0 errors
+Boogie program verifier finished with 42 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/ProducerConsumer.bpl.expect
+++ b/Test/civl/inductive-sequentialization/ProducerConsumer.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 23 verified, 0 errors
+Boogie program verifier finished with 25 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/paxos/Paxos.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/Paxos.bpl
@@ -78,7 +78,7 @@ function {:inline} SingletonNode(node: Node): NodeSet { NoNodes()[node := true] 
 function Cardinality(q: NodeSet): int;
 axiom Cardinality(NoNodes()) == 0;
 
-function {:inline} IsQuorum(ns: NodeSet): bool {
+function IsQuorum(ns: NodeSet): bool {
   2 * Cardinality(ns) > numNodes &&
   (forall n: Node :: ns[n] ==> Node(n))
 }

--- a/Test/civl/inductive-sequentialization/paxos/is.sh.expect
+++ b/Test/civl/inductive-sequentialization/paxos/is.sh.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 108 verified, 0 errors
+Boogie program verifier finished with 113 verified, 0 errors


### PR DESCRIPTION
The Inductive Sequentialization proof for Paxos is flaky.  This PR attempts to make it more robust by adding patterns on a quantifier and removing inline attribute on a function being used in a trigger.