### PR TITLE
[CIVL] Do atomic-action typechecking for IS invariants and IS abstractions

### DIFF
--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -258,11 +258,7 @@ namespace Microsoft.Boogie
         private void TypeCheckActionImpls()
         {
             ActionVisitor actionVisitor = new ActionVisitor(this);
-            foreach (var action in procToAtomicAction.Values)
-            {
-                actionVisitor.VisitAction(action);
-            }
-            foreach (var action in procToIntroductionAction.Values)
+            foreach (var action in Enumerable.Concat<Action>(AllAtomicActions, procToIntroductionAction.Values))
             {
                 actionVisitor.VisitAction(action);
             }
@@ -985,7 +981,7 @@ namespace Microsoft.Boogie
             return FindIsAbstraction(name);
         }
 
-        public IEnumerable<AtomicAction> AllActions =>
+        public IEnumerable<AtomicAction> AllAtomicActions =>
             procToAtomicAction.Union(procToIsInvariant).Union(procToIsAbstraction)
             .Select(x => x.Value);
 
@@ -1574,7 +1570,7 @@ namespace Microsoft.Boogie
             {
                 var attributeEraser = new AttributeEraser();
                 attributeEraser.VisitProgram(civlTypeChecker.program);
-                foreach (var action in civlTypeChecker.AllActions)
+                foreach (var action in civlTypeChecker.AllAtomicActions)
                 {
                     attributeEraser.VisitAtomicAction(action);
                 }

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Boogie
             }
 
             // Here we include IS abstractions
-            foreach (var atomicAction in civlTypeChecker.AllActions.Where(a => a.IsLeftMover))
+            foreach (var atomicAction in civlTypeChecker.AllAtomicActions.Where(a => a.IsLeftMover))
             {
                 moverChecking.CreateNonBlockingChecker(atomicAction);
             }

--- a/Source/Concurrency/PendingAsyncChecker.cs
+++ b/Source/Concurrency/PendingAsyncChecker.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Boogie
     {
         public static void AddCheckers(CivlTypeChecker ctc)
         {
-            foreach (var action in ctc.AllActions.Where(a => a.HasPendingAsyncs))
+            foreach (var action in ctc.AllAtomicActions.Where(a => a.HasPendingAsyncs))
             {
                 var requires = action.gate.Select(g => new Requires(false, g.Expr)).ToList();
                 var cmds = new List<Cmd>

--- a/Test/civl/action-no-call.bpl
+++ b/Test/civl/action-no-call.bpl
@@ -1,0 +1,25 @@
+// RUN: %boogie -useArrayTheory "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure {:atomic}{:layer 2} foo () {}
+
+type {:pending_async}{:datatype} PA;
+
+procedure {:atomic}{:layer 2} atomic ()
+{
+  call foo();
+}
+
+procedure {:intro}{:layer 2} intro ()
+{
+  call foo();
+}
+
+procedure {:IS_invariant}{:layer 2} IS_invariant () returns ({:pending_async} PAs:[PA]int)
+{
+  call foo();
+}
+procedure {:IS_abstraction}{:layer 2} IS_abstraction ()
+{
+  call foo();
+}

--- a/Test/civl/action-no-call.bpl.expect
+++ b/Test/civl/action-no-call.bpl.expect
@@ -1,0 +1,5 @@
+action-no-call.bpl(10,2): Error: Call command not allowed inside an atomic action
+action-no-call.bpl(20,2): Error: Call command not allowed inside an atomic action
+action-no-call.bpl(24,2): Error: Call command not allowed inside an atomic action
+action-no-call.bpl(15,2): Error: Call command not allowed inside an atomic action
+4 type checking errors detected in action-no-call.bpl


### PR DESCRIPTION
Invoking the type checker for these kinds of atomic actions was missing.