### PR TITLE
[CIVL] Refactoring verified-ft and GC to use yield invariants properly

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -280,7 +280,6 @@ namespace Microsoft.Boogie
                     return action;
                 action = action.refinedAction;
             }
-            Debug.Assert(false);
             return null;
         }
     }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1337,15 +1337,15 @@ namespace Microsoft.Boogie
         class YieldInvariantCallVisitor : ReadOnlyVisitor
         {
             private CivlTypeChecker civlTypeChecker;
-            private bool allowOld;
-            private bool insideOld;
+            private bool allowOldExpr;
+            private int insideOldExpr;
             private bool ok;
 
-            public YieldInvariantCallVisitor(CivlTypeChecker civlTypeChecker, bool allowOld)
+            public YieldInvariantCallVisitor(CivlTypeChecker civlTypeChecker, bool allowOldExpr)
             {
                 this.civlTypeChecker = civlTypeChecker;
-                this.allowOld = allowOld;
-                this.insideOld = false;
+                this.allowOldExpr = allowOldExpr;
+                this.insideOldExpr = 0;
                 this.ok = true;
             }
 
@@ -1357,22 +1357,21 @@ namespace Microsoft.Boogie
 
             public override Expr VisitOldExpr(OldExpr node)
             {
-                if (!allowOld)
+                if (!allowOldExpr)
                 {
                     ok = false;
                     civlTypeChecker.Error(node,"Old expression not allowed only in this context");
                     return node;
                 }
-                var saved = insideOld;
-                insideOld = true;
+                insideOldExpr++;
                 base.VisitOldExpr(node);
-                insideOld = saved;
+                insideOldExpr--;
                 return node;
             }
 
             public override Expr VisitIdentifierExpr(IdentifierExpr node)
             {
-                if (node.Decl is GlobalVariable && allowOld && !insideOld)
+                if (node.Decl is GlobalVariable && allowOldExpr && insideOldExpr == 0)
                 {
                     ok = false;
                     civlTypeChecker.Error(node, "Global variable cannot be accessed in this context");

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1414,7 +1414,10 @@ namespace Microsoft.Boogie
                 Debug.Assert(yieldingProc == null);
                 yieldingProc = civlTypeChecker.procToYieldingProc[node.Proc];
                 var ret = base.VisitImplementation(node);
-                CheckMoverProcModifiesClause(node);
+                if (civlTypeChecker.checkingContext.ErrorCount == 0)
+                {
+                    CheckMoverProcModifiesClause(node);
+                }
                 yieldingProc = null;
                 return ret;
             }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1363,9 +1363,10 @@ namespace Microsoft.Boogie
                     civlTypeChecker.Error(node,"Old expression not allowed only in this context");
                     return node;
                 }
+                var saved = insideOld;
                 insideOld = true;
                 base.VisitOldExpr(node);
-                insideOld = false;
+                insideOld = saved;
                 return node;
             }
 

--- a/Source/Concurrency/CivlVCGeneration.cs
+++ b/Source/Concurrency/CivlVCGeneration.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Boogie
 
             // Commutativity checks
             List<Declaration> decls = new List<Declaration>();
-            if (!CommandLineOptions.Clo.TrustAtomicityTypes)
+            if (!CommandLineOptions.Clo.TrustMoverTypes)
             {
                 MoverCheck.AddCheckers(linearTypeChecker, civlTypeChecker, decls);
             }

--- a/Source/Concurrency/NoninterferenceChecker.cs
+++ b/Source/Concurrency/NoninterferenceChecker.cs
@@ -46,14 +46,14 @@ namespace Microsoft.Boogie
             }
 
             var linearPermissionInstrumentation = new LinearPermissionInstrumentation(civlTypeChecker, linearTypeChecker, layerNum, absyMap, domainNameToHoleVar, localVarMap);
-            List<Tuple<List<Cmd>, List<PredicateCmd>>> yieldInfo = null;
+            List<YieldInfo> yieldInfos = null;
             if (decl is Implementation impl)
             {
-                yieldInfo = CollectYields(civlTypeChecker, absyMap, layerNum, impl).Select(kv => new Tuple<List<Cmd>, List<PredicateCmd>>(linearPermissionInstrumentation.DisjointnessAssumeCmds(kv.Key, false), kv.Value)).ToList();
+                yieldInfos = CollectYields(civlTypeChecker, absyMap, layerNum, impl).Select(kv => new YieldInfo(linearPermissionInstrumentation.DisjointnessAssumeCmds(kv.Key, false), kv.Value)).ToList();
             }
             else if (decl is Procedure proc)
             {
-                yieldInfo = new List<Tuple<List<Cmd>, List<PredicateCmd>>>();
+                yieldInfos = new List<YieldInfo>();
                 if (civlTypeChecker.procToYieldInvariant.ContainsKey(proc))
                 {
                     if (proc.Requires.Count > 0)
@@ -63,7 +63,7 @@ namespace Microsoft.Boogie
                             requires.Free
                                 ? (PredicateCmd) new AssumeCmd(requires.tok, requires.Condition)
                                 : (PredicateCmd) new AssertCmd(requires.tok, requires.Condition)).ToList();
-                        yieldInfo.Add(new Tuple<List<Cmd>, List<PredicateCmd>>(disjointnessCmds, yieldPredicates));
+                        yieldInfos.Add(new YieldInfo(disjointnessCmds, yieldPredicates));
                     }
                 }
                 else
@@ -76,8 +76,7 @@ namespace Microsoft.Boogie
                             requires.Free
                                 ? (PredicateCmd) new AssumeCmd(requires.tok, requires.Condition)
                                 : (PredicateCmd) new AssertCmd(requires.tok, requires.Condition)).ToList();
-                        yieldInfo.Add(
-                            new Tuple<List<Cmd>, List<PredicateCmd>>(entryDisjointnessCmds, entryYieldPredicates));
+                        yieldInfos.Add(new YieldInfo(entryDisjointnessCmds, entryYieldPredicates));
                     }
                     if (proc.Ensures.Count > 0)
                     {
@@ -87,8 +86,7 @@ namespace Microsoft.Boogie
                             ensures.Free
                                 ? (PredicateCmd) new AssumeCmd(ensures.tok, ensures.Condition)
                                 : (PredicateCmd) new AssertCmd(ensures.tok, ensures.Condition)).ToList();
-                        yieldInfo.Add(
-                            new Tuple<List<Cmd>, List<PredicateCmd>>(exitDisjointnessCmds, exitYieldPredicates));
+                        yieldInfos.Add(new YieldInfo(exitDisjointnessCmds, exitYieldPredicates));
                     }
                 }
             }
@@ -97,8 +95,8 @@ namespace Microsoft.Boogie
                 Debug.Assert(false);
             }
 
-            var filteredYieldInfo = yieldInfo.Where(info => info.Item2.Any(predCmd => new GlobalAccessChecker().AccessesGlobal(predCmd.Expr)));
-            if (filteredYieldInfo.Count() == 0)
+            var filteredYieldInfos = yieldInfos.Where(info => info.invariantCmds.Any(predCmd => new GlobalAccessChecker().AccessesGlobal(predCmd.Expr)));
+            if (filteredYieldInfos.Count() == 0)
             {
                 return new List<Declaration>();
             }
@@ -114,18 +112,15 @@ namespace Microsoft.Boogie
             labelTargets.Add(noninterferenceCheckerBlock);
             noninterferenceCheckerBlocks.Add(noninterferenceCheckerBlock);
             int yieldCount = 0;
-            foreach (var kv in filteredYieldInfo)
+            foreach (var kv in filteredYieldInfos)
             {
-                var disjointnessCmds = kv.Item1;
-                var yieldPredicates = kv.Item2;
-                var newCmds = new List<Cmd>(disjointnessCmds);
-                foreach (var predCmd in yieldPredicates)
+                var newCmds = new List<Cmd>(kv.disjointnessCmds);
+                foreach (var predCmd in kv.invariantCmds)
                 {
                     var newExpr = Substituter.ApplyReplacingOldExprs(assumeSubst, oldSubst, predCmd.Expr);
                     newCmds.Add(new AssumeCmd(Token.NoToken, newExpr));
                 }
-
-                foreach (var predCmd in yieldPredicates)
+                foreach (var predCmd in kv.invariantCmds)
                 {
                     if (predCmd is AssertCmd)
                     {
@@ -135,7 +130,6 @@ namespace Microsoft.Boogie
                         newCmds.Add(assertCmd);
                     }
                 }
-
                 newCmds.Add(new AssumeCmd(Token.NoToken, Expr.False));
                 noninterferenceCheckerBlock = new Block(Token.NoToken, "L" + yieldCount++, newCmds, new ReturnCmd(Token.NoToken));
                 labels.Add(noninterferenceCheckerBlock.Label);
@@ -219,16 +213,28 @@ namespace Microsoft.Boogie
                 new TypedIdent(Token.NoToken, $"civl_local_old_{v.Name}", v.TypedIdent.Type));
         }
     }
+
+    class YieldInfo
+    {
+        public List<Cmd> disjointnessCmds;
+        public List<PredicateCmd> invariantCmds;
+
+        public YieldInfo(List<Cmd> disjointnessCmds, List<PredicateCmd> invariantCmds)
+        {
+            this.disjointnessCmds = disjointnessCmds;
+            this.invariantCmds = invariantCmds;
+        }
+    }
     
     class GlobalAccessChecker : ReadOnlyVisitor
     {
         private bool accessesGlobal;
-        private bool insideOld;
+        private int insideOldExpr;
         
         public GlobalAccessChecker()
         {
             this.accessesGlobal = false;
-            this.insideOld = false;
+            this.insideOldExpr = 0;
         }
 
         public bool AccessesGlobal(Expr expr)
@@ -239,16 +245,15 @@ namespace Microsoft.Boogie
 
         public override Expr VisitOldExpr(OldExpr node)
         {
-            var saved = insideOld;
-            insideOld = true;
+            insideOldExpr++;
             base.VisitOldExpr(node);
-            insideOld = saved;
+            insideOldExpr--;
             return node;
         }
 
         public override Expr VisitIdentifierExpr(IdentifierExpr node)
         {
-            if (node.Decl is GlobalVariable && !insideOld)
+            if (node.Decl is GlobalVariable && insideOldExpr == 0)
             {
                 accessesGlobal = true;
             }

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Boogie
 
         private void AddNoninterferenceCheckers()
         {
-            if (CommandLineOptions.Clo.TrustNonInterference) return;
+            if (CommandLineOptions.Clo.TrustNoninterference) return;
             foreach (var proc in civlTypeChecker.procToYieldInvariant.Keys)
             {
                 var yieldInvariant = civlTypeChecker.procToYieldInvariant[proc];
@@ -330,7 +330,7 @@ namespace Microsoft.Boogie
             }
 
             // initialize noninterferenceInstrumentation
-            if (CommandLineOptions.Clo.TrustNonInterference)
+            if (CommandLineOptions.Clo.TrustNoninterference)
             {
                 noninterferenceInstrumentation = new NoneNoninterferenceInstrumentation();
             }
@@ -435,6 +435,7 @@ namespace Microsoft.Boogie
                 SplitCmds(header.Cmds, out firstCmds, out secondCmds);
                 List<Cmd> newCmds = new List<Cmd>();
                 newCmds.AddRange(firstCmds);
+                newCmds.AddRange(refinementInstrumentation.CreateAssumeCmds());
                 newCmds.AddRange(InlineYieldLoopInvariants(civlTypeChecker.yieldingLoops[(Block) absyMap[header]].yieldInvariants));
                 newCmds.AddRange(YieldingLoopDummyAssignment());
                 newCmds.AddRange(globalSnapshotInstrumentation.CreateUpdatesToOldGlobalVars());
@@ -531,8 +532,8 @@ namespace Microsoft.Boogie
             if (civlTypeChecker.GlobalVariables.Count() > 0)
             {
                 newCmds.Add(new HavocCmd(Token.NoToken, civlTypeChecker.GlobalVariables.Select(v => Expr.Ident(v)).ToList()));
-                newCmds.AddRange(refinementInstrumentation.CreateAssumeCmds());
             }
+            newCmds.AddRange(refinementInstrumentation.CreateAssumeCmds());
             newCmds.AddRange(globalSnapshotInstrumentation.CreateUpdatesToOldGlobalVars());
             newCmds.AddRange(refinementInstrumentation.CreateUpdatesToOldOutputVars());
             newCmds.AddRange(block.Cmds);
@@ -647,8 +648,8 @@ namespace Microsoft.Boogie
             if (civlTypeChecker.GlobalVariables.Count() > 0)
             {
                 newCmds.Add(new HavocCmd(Token.NoToken, civlTypeChecker.GlobalVariables.Select(v => Expr.Ident(v)).ToList()));
-                newCmds.AddRange(refinementInstrumentation.CreateAssumeCmds());
             }
+            newCmds.AddRange(refinementInstrumentation.CreateAssumeCmds());
             newCmds.AddRange(linearPermissionInstrumentation.DisjointnessAssumeCmds(yieldCmd, true));
             newCmds.AddRange(globalSnapshotInstrumentation.CreateUpdatesToOldGlobalVars());
             newCmds.AddRange(refinementInstrumentation.CreateUpdatesToOldOutputVars());
@@ -721,11 +722,7 @@ namespace Microsoft.Boogie
             CallCmd checkerCallCmd = new CallCmd(parCallCmd.tok, proc.Name, ins, outs, parCallCmd.Attributes);
             checkerCallCmd.Proc = proc;
             newCmds.Add(checkerCallCmd);
-            
-            if (civlTypeChecker.GlobalVariables.Count() > 0)
-            {
-                newCmds.AddRange(refinementInstrumentation.CreateAssumeCmds());
-            }
+            newCmds.AddRange(refinementInstrumentation.CreateAssumeCmds());
             newCmds.AddRange(globalSnapshotInstrumentation.CreateUpdatesToOldGlobalVars());
             newCmds.AddRange(refinementInstrumentation.CreateUpdatesToOldOutputVars());
             newCmds.AddRange(noninterferenceInstrumentation.CreateUpdatesToPermissionCollector(parCallCmd));

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -558,8 +558,8 @@ namespace Microsoft.Boogie {
     public bool UseAbstractInterpretation = false;
 
     public string CivlDesugaredFile = null;
-    public bool TrustAtomicityTypes = false;
-    public bool TrustNonInterference = false;
+    public bool TrustMoverTypes = false;
+    public bool TrustNoninterference = false;
     public int TrustLayersUpto = -1;
     public int TrustLayersDownto = int.MaxValue;
 
@@ -1451,8 +1451,8 @@ namespace Microsoft.Boogie {
               ps.CheckBooleanFlag("nonUniformUnfolding", ref NonUniformUnfolding) ||
               ps.CheckBooleanFlag("deterministicExtractLoops", ref DeterministicExtractLoops) ||
               ps.CheckBooleanFlag("verifySeparately", ref VerifySeparately) ||
-              ps.CheckBooleanFlag("trustAtomicityTypes", ref TrustAtomicityTypes) ||
-              ps.CheckBooleanFlag("trustNonInterference", ref TrustNonInterference) ||
+              ps.CheckBooleanFlag("trustMoverTypes", ref TrustMoverTypes) ||
+              ps.CheckBooleanFlag("trustNoninterference", ref TrustNoninterference) ||
               ps.CheckBooleanFlag("useBaseNameForFileName", ref UseBaseNameForFileName) ||
               ps.CheckBooleanFlag("freeVarLambdaLifting", ref FreeVarLambdaLifting) ||
               ps.CheckBooleanFlag("warnNotEliminatedVars", ref WarnNotEliminatedVars)
@@ -1777,9 +1777,9 @@ namespace Microsoft.Boogie {
 
   ---- CIVL options ----------------------------------------------------------
 
-  /trustAtomicityTypes
-                do not verify atomic action declarations
-  /trustNonInterference
+  /trustMoverTypes
+                do not verify mover type annotations on atomic action declarations
+  /trustNoninterference
                 do not perform noninterference checks
   /trustLayersUpto:<n>
                 do not verify layers <n> and below

--- a/Test/civl/GC.bpl
+++ b/Test/civl/GC.bpl
@@ -1233,7 +1233,7 @@ ensures {:layer 98} collectorPhase == old(collectorPhase);
 }
 
 //////////////////////////////////////////////////////////////////////////////
-// Phase 96
+// Layer 96
 //////////////////////////////////////////////////////////////////////////////
 
 procedure {:atomic} {:layer 97,100} AtomicSET_RemoveFromSet({:linear "tid"} tid:Tid, scannedLocal:int)
@@ -1480,10 +1480,10 @@ procedure {:yields} {:layer 96} {:refines "AtomicCollectorRootScanBarrierWait"} 
 procedure {:atomic} {:layer 97,99} AtomicMutatorRootScanBarrierEnter({:linear_in "tid"} tid: Tid) returns({:linear "tid"} tid_left: Tid)
 modifies rootScanBarrier, mutatorsInRootScanBarrier;
 {
-                        assert mutatorTidWhole(tid);
-                        rootScanBarrier := rootScanBarrier - 1;
-                        mutatorsInRootScanBarrier[i#Tid(tid)] := true;
-                        tid_left := Tid(i#Tid(tid), true, false);
+    assert mutatorTidWhole(tid);
+    rootScanBarrier := rootScanBarrier - 1;
+    mutatorsInRootScanBarrier[i#Tid(tid)] := true;
+    tid_left := Tid(i#Tid(tid), true, false);
 }
 
 procedure {:yields} {:layer 96} {:refines "AtomicMutatorRootScanBarrierEnter"} MutatorRootScanBarrierEnter({:linear_in "tid"} tid: Tid) returns({:linear "tid"} tid_left: Tid)
@@ -1502,11 +1502,11 @@ ensures {:layer 95,96} i#Tid(tid_left) == i#Tid(tid) && left#Tid(tid_left);
 procedure {:atomic} {:layer 97,99} AtomicMutatorRootScanBarrierWait({:linear_in "tid"} tid_left: Tid) returns({:linear "tid"} tid: Tid)
 modifies rootScanBarrier, mutatorsInRootScanBarrier;
 {
-                        assert mutatorTidLeft(tid_left) && mutatorsInRootScanBarrier[i#Tid(tid_left)];
-                        assume !rootScanOn;
-                        rootScanBarrier := rootScanBarrier + 1;
-                        mutatorsInRootScanBarrier[i#Tid(tid_left)] := false;
-                        tid := Tid(i#Tid(tid_left), true, true);
+    assert mutatorTidLeft(tid_left) && mutatorsInRootScanBarrier[i#Tid(tid_left)];
+    assume !rootScanOn;
+    rootScanBarrier := rootScanBarrier + 1;
+    mutatorsInRootScanBarrier[i#Tid(tid_left)] := false;
+    tid := Tid(i#Tid(tid_left), true, true);
 }
 
 procedure {:yields} {:layer 96} {:refines "AtomicMutatorRootScanBarrierWait"} MutatorRootScanBarrierWait({:linear_in "tid"} tid_left: Tid) returns({:linear "tid"} tid: Tid)
@@ -1618,7 +1618,7 @@ procedure {:yields} {:layer 96} {:refines "AtomicClearToAbsWhite"} ClearToAbsWhi
 }
 
 //////////////////////////////////////////////////////////////////////////////
-// Phase 95
+// Layer 95
 //////////////////////////////////////////////////////////////////////////////
 
 procedure {:atomic} {:layer 96} AtomicLockedClearToAbsWhite({:linear "tid"} tid:Tid)

--- a/Test/civl/GC.bpl
+++ b/Test/civl/GC.bpl
@@ -136,26 +136,26 @@ function tidOwns(tid:Tid, x:idx):bool { owner(x) == i#Tid(tid) }
 
 function {:inline} Iso(root:[idx]int, rootAbs:[idx]obj, mem:[int][fld]int, memAbs:[obj][fld]obj, Color:[int]int, toAbs:[int]obj, allocSet:[obj]bool) returns (bool)
 {
-  (forall x: int :: memAddr(x) <==> memAddrAbs(toAbs[x])) &&
-  (forall x: int, y: int :: toAbs[x] == toAbs[y] ==> x == y || (memAddr(x) && toAbs[x] == nil) || (memAddr(y) && toAbs[y] == nil)) &&
-  (forall x: idx :: rootAddr(x) ==> toAbs[root[x]] == rootAbs[x]) &&
-  (forall x: int, f: fld :: memAddr(x) && toAbs[x] != nil && fieldAddr(f) ==> toAbs[mem[x][f]] == memAbs[toAbs[x]][f]) &&
-  (forall x: int :: memAddr(x) && toAbs[x] != nil ==> allocSet[toAbs[x]]) &&
-  (forall x: idx :: rootAddr(x) && memAddr(root[x]) ==> toAbs[root[x]] != nil) &&
-  (forall x: int, f: fld :: memAddr(x) && toAbs[x] != nil && fieldAddr(f) && memAddr(mem[x][f]) ==> toAbs[mem[x][f]] != nil) &&
-  (forall x: int, f: fld :: memAddr(x) && Unalloc(Color[x]) ==> toAbs[x] == nil)
+    (forall x: int :: memAddr(x) <==> memAddrAbs(toAbs[x])) &&
+    (forall x: int, y: int :: toAbs[x] == toAbs[y] ==> x == y || (memAddr(x) && toAbs[x] == nil) || (memAddr(y) && toAbs[y] == nil)) &&
+    (forall x: idx :: rootAddr(x) ==> toAbs[root[x]] == rootAbs[x]) &&
+    (forall x: int, f: fld :: memAddr(x) && toAbs[x] != nil && fieldAddr(f) ==> toAbs[mem[x][f]] == memAbs[toAbs[x]][f]) &&
+    (forall x: int :: memAddr(x) && toAbs[x] != nil ==> allocSet[toAbs[x]]) &&
+    (forall x: idx :: rootAddr(x) && memAddr(root[x]) ==> toAbs[root[x]] != nil) &&
+    (forall x: int, f: fld :: memAddr(x) && toAbs[x] != nil && fieldAddr(f) && memAddr(mem[x][f]) ==> toAbs[mem[x][f]] != nil) &&
+    (forall x: int, f: fld :: memAddr(x) && Unalloc(Color[x]) ==> toAbs[x] == nil)
 }
 
 function {:inline false} MST(i:int) returns (bool) { true }
 
 function {:inline} MsWellFormed(MarkStack:[int]int, MarkStackPtr:int, Color:[int]int, nodePeeked:int) returns (bool)
 {
-  (forall i:int :: {MST(i)} MST(i) ==> (0 <= i && i < MarkStackPtr) ==> (memAddr(MarkStack[i]) && Gray(Color[MarkStack[i]]))) &&
-  (nodePeeked != 0 ==> memAddr(nodePeeked) && Gray(Color[nodePeeked])) &&
-  (forall i:int :: (memAddr(i) && Gray(Color[i])) ==>  (exists j:int :: {MST(j)} MST(j) && 0 <= j && j < MarkStackPtr && MarkStack[j] == i) || nodePeeked == i) &&
-  (forall i:int :: {MST(i)} MST(i) ==> (0 <= i && i < MarkStackPtr) ==> (forall j:int :: {MST(j)} MST(j) ==> (0 <= j && j < MarkStackPtr && i != j) ==> MarkStack[i] != MarkStack[j])) &&
-  (forall i:int :: {MST(i)} MST(i) ==> (0 <= i && i < MarkStackPtr) ==> MarkStack[i] != nodePeeked) &&
-  (0 <= MarkStackPtr)
+    (forall i:int :: {MST(i)} MST(i) ==> (0 <= i && i < MarkStackPtr) ==> (memAddr(MarkStack[i]) && Gray(Color[MarkStack[i]]))) &&
+    (nodePeeked != 0 ==> memAddr(nodePeeked) && Gray(Color[nodePeeked])) &&
+    (forall i:int :: (memAddr(i) && Gray(Color[i])) ==>  (exists j:int :: {MST(j)} MST(j) && 0 <= j && j < MarkStackPtr && MarkStack[j] == i) || nodePeeked == i) &&
+    (forall i:int :: {MST(i)} MST(i) ==> (0 <= i && i < MarkStackPtr) ==> (forall j:int :: {MST(j)} MST(j) ==> (0 <= j && j < MarkStackPtr && i != j) ==> MarkStack[i] != MarkStack[j])) &&
+    (forall i:int :: {MST(i)} MST(i) ==> (0 <= i && i < MarkStackPtr) ==> MarkStack[i] != nodePeeked) &&
+    (0 <= MarkStackPtr)
 }
 
 function {:inline} PhaseConsistent(collectorPhase: int, mutatorPhase: [int]int) returns (bool)
@@ -165,25 +165,25 @@ function {:inline} PhaseConsistent(collectorPhase: int, mutatorPhase: [int]int) 
 
 function {:inline} MarkInv(root:[idx]int, rootAbs:[idx]obj, mem:[int][fld]int, memAbs:[obj][fld]obj, Color:[int]int, toAbs:[int]obj, allocSet:[obj]bool) returns (bool)
 {
-  Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet) &&
-  (forall x: int :: memAddr(x) ==> (toAbs[x] == nil <==> Unalloc(Color[x]))) &&
-  (forall x: int, f: fld :: memAddr(x) && Black(Color[x]) && fieldAddr(f) && memAddr(mem[x][f]) ==> Gray(Color[mem[x][f]]) || Black(Color[mem[x][f]]))
+    Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet) &&
+    (forall x: int :: memAddr(x) ==> (toAbs[x] == nil <==> Unalloc(Color[x]))) &&
+    (forall x: int, f: fld :: memAddr(x) && Black(Color[x]) && fieldAddr(f) && memAddr(mem[x][f]) ==> Gray(Color[mem[x][f]]) || Black(Color[mem[x][f]]))
 }
 
 function {:inline} SweepInv(root:[idx]int, rootAbs:[idx]obj, mem:[int][fld]int, memAbs:[obj][fld]obj, Color:[int]int, toAbs:[int]obj, allocSet:[obj]bool) returns (bool)
 {
-  Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet) &&
-  (forall x: int :: memAddr(x) ==> (toAbs[x] == nil <==> Unalloc(Color[x]))) &&
-  (forall x: int :: memAddr(x) ==> !Gray(Color[x])) &&
-  (forall x: int, f: fld :: memAddr(x) && Black(Color[x]) && fieldAddr(f) && memAddr(mem[x][f]) ==> Black(Color[mem[x][f]]))
+    Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet) &&
+    (forall x: int :: memAddr(x) ==> (toAbs[x] == nil <==> Unalloc(Color[x]))) &&
+    (forall x: int :: memAddr(x) ==> !Gray(Color[x])) &&
+    (forall x: int, f: fld :: memAddr(x) && Black(Color[x]) && fieldAddr(f) && memAddr(mem[x][f]) ==> Black(Color[mem[x][f]]))
 }
 
 function {:inline} SweepInvInit(root:[idx]int, rootAbs:[idx]obj, mem:[int][fld]int, memAbs:[obj][fld]obj, Color:[int]int, toAbs:[int]obj, allocSet:[obj]bool) returns (bool)
 {
-  Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet) &&
-  (forall x: int :: memAddr(x) ==> (toAbs[x] != nil <==> Black(Color[x]))) &&
-  (forall x: int :: memAddr(x) ==> !Gray(Color[x])) &&
-  (forall x: int, f: fld :: memAddr(x) && Black(Color[x]) && fieldAddr(f) && memAddr(mem[x][f]) ==> Black(Color[mem[x][f]]))
+    Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet) &&
+    (forall x: int :: memAddr(x) ==> (toAbs[x] != nil <==> Black(Color[x]))) &&
+    (forall x: int :: memAddr(x) ==> !Gray(Color[x])) &&
+    (forall x: int, f: fld :: memAddr(x) && Black(Color[x]) && fieldAddr(f) && memAddr(mem[x][f]) ==> Black(Color[mem[x][f]]))
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -487,28 +487,28 @@ procedure {:yields} {:layer 100}
 Sweep({:linear "tid"} tid:Tid)
 requires {:layer 98,99,100} tid == GcTid;
 {
-  var localSweepPtr: int;
-  var {:layer 100} snapColor: [int]int;
+    var localSweepPtr: int;
+    var {:layer 100} snapColor: [int]int;
 
-  localSweepPtr := memLo;
-  call ClearToAbsWhite(tid);
-  par YieldSweepBegin(tid, true, Color) | Yield_MsWellFormed(tid, 0) | Yield_RootScanBarrierInv() | Yield_Iso();
+    localSweepPtr := memLo;
+    call ClearToAbsWhite(tid);
+    par YieldSweepBegin(tid, true, Color) | Yield_MsWellFormed(tid, 0) | Yield_RootScanBarrierInv() | Yield_Iso();
 
-  call snapColor := GhostReadColor100();
-  while (localSweepPtr < memHi)
-  invariant {:layer 95,96}{:yields} true;
-  invariant {:terminates} {:layer 97,98,99,100} true;
-  invariant {:layer 98} MsWellFormed(MarkStack, MarkStackPtr, Color, 0);
-  invariant {:layer 100} Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet);
-  invariant {:layer 100} SweepPhase(collectorPhase) && PhaseConsistent(collectorPhase, mutatorPhase);
-  invariant {:layer 100} localSweepPtr == sweepPtr && memLo <= sweepPtr && sweepPtr <= memHi;
-  invariant {:layer 100} (forall i: int :: rootAddr(i) && memAddr(root[i]) ==> Black(snapColor[root[i]]));
-  invariant {:layer 100} SweepInvInit(root, rootAbs, mem, memAbs, snapColor, toAbs, allocSet);
-  invariant {:layer 100} (forall i:int:: memAddr(i) ==> if sweepPtr <= i then Color[i] == snapColor[i] else if Black(snapColor[i]) then White(Color[i]) else Unalloc(Color[i]));
-  {
-    call SweepNext(tid);
-    localSweepPtr := localSweepPtr + 1;
-  }
+    call snapColor := GhostReadColor100();
+    while (localSweepPtr < memHi)
+    invariant {:layer 95,96}{:yields} true;
+    invariant {:terminates} {:layer 97,98,99,100} true;
+    invariant {:layer 98} MsWellFormed(MarkStack, MarkStackPtr, Color, 0);
+    invariant {:layer 100} Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet);
+    invariant {:layer 100} SweepPhase(collectorPhase) && PhaseConsistent(collectorPhase, mutatorPhase);
+    invariant {:layer 100} localSweepPtr == sweepPtr && memLo <= sweepPtr && sweepPtr <= memHi;
+    invariant {:layer 100} (forall i: int :: rootAddr(i) && memAddr(root[i]) ==> Black(snapColor[root[i]]));
+    invariant {:layer 100} SweepInvInit(root, rootAbs, mem, memAbs, snapColor, toAbs, allocSet);
+    invariant {:layer 100} (forall i:int:: memAddr(i) ==> if sweepPtr <= i then Color[i] == snapColor[i] else if Black(snapColor[i]) then White(Color[i]) else Unalloc(Color[i]));
+    {
+        call SweepNext(tid);
+        localSweepPtr := localSweepPtr + 1;
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -683,17 +683,17 @@ procedure {:yields} {:layer 99} {:refines "AtomicEqRaw"} EqRaw({:linear "tid"} t
 procedure {:atomic} {:layer 100} AtomicAllocRaw({:linear "tid"} tid:Tid, y:idx) returns (ptr: int, absPtr: obj)
 modifies allocSet, rootAbs, root, toAbs, memAbs, Color, mem;
 {
-     assert mutatorTidWhole(tid) && rootAddr(y) && tidOwns(tid, y);
-     assert (forall x: int, f: fld :: memAddr(x) && Unalloc(Color[x]) ==> toAbs[x] == nil);
-     assume(memAddr(ptr) && Unalloc(Color[ptr]));
-     assume(memAddrAbs(absPtr) && !allocSet[absPtr] && absPtr != nil);
-     allocSet[absPtr] := true;
-     rootAbs[y] := absPtr;
-     root[y] := ptr;
-     toAbs[ptr] := absPtr;
-     memAbs[absPtr] := (lambda z: int :: if (fieldAddr(z)) then absPtr else memAbs[absPtr][z]);
-     Color[ptr] := if sweepPtr <= ptr then BLACK() else WHITE();
-     mem[ptr] := (lambda z: int :: if (fieldAddr(z)) then ptr else mem[ptr][z]);
+    assert mutatorTidWhole(tid) && rootAddr(y) && tidOwns(tid, y);
+    assert (forall x: int, f: fld :: memAddr(x) && Unalloc(Color[x]) ==> toAbs[x] == nil);
+    assume(memAddr(ptr) && Unalloc(Color[ptr]));
+    assume(memAddrAbs(absPtr) && !allocSet[absPtr] && absPtr != nil);
+    allocSet[absPtr] := true;
+    rootAbs[y] := absPtr;
+    root[y] := ptr;
+    toAbs[ptr] := absPtr;
+    memAbs[absPtr] := (lambda z: int :: if (fieldAddr(z)) then absPtr else memAbs[absPtr][z]);
+    Color[ptr] := if sweepPtr <= ptr then BLACK() else WHITE();
+    mem[ptr] := (lambda z: int :: if (fieldAddr(z)) then ptr else mem[ptr][z]);
 }
 
 procedure {:yields} {:layer 99} {:refines "AtomicAllocRaw"} AllocRaw({:linear "tid"} tid:Tid, y:idx) returns (ptr: int, absPtr: obj)
@@ -1212,15 +1212,15 @@ modifies collectorPhase;
 {
     assert tid == GcTid;
     if (IdlePhase(collectorPhase)) {
-       collectorPhase := MARK();
-       nextPhase := MARK();
+        collectorPhase := MARK();
+        nextPhase := MARK();
     } else if (MarkPhase(collectorPhase)) {
-       collectorPhase := SWEEP();
-       nextPhase := SWEEP();
+        collectorPhase := SWEEP();
+        nextPhase := SWEEP();
     } else {
-       //assume (SweepPhase(collectorPhase));
-       collectorPhase := IDLE();
-       nextPhase := IDLE();
+        //assume (SweepPhase(collectorPhase));
+        collectorPhase := IDLE();
+        nextPhase := IDLE();
     }
 }
 
@@ -1827,8 +1827,8 @@ procedure {:yields} {:layer 95} {:refines "AtomicSetColor3"} SetColor3({:linear 
 procedure {:both} {:layer 96,99} AtomicInitToAbs({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 modifies toAbs;
 {
-  assert gcAndMutatorTids(tid, mutatorTids);
-  toAbs := (lambda i:int :: if memAddr(i) then nil else Int(i));
+    assert gcAndMutatorTids(tid, mutatorTids);
+    toAbs := (lambda i:int :: if memAddr(i) then nil else Int(i));
 }
 
 procedure {:yields} {:layer 95} {:refines "AtomicInitToAbs"} InitToAbs({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
@@ -2009,12 +2009,12 @@ procedure {:yields} {:layer 0} {:refines "AtomicPrimitiveSetColor"} PrimitiveSet
 procedure {:atomic} {:layer 1,95} AtomicPrimitiveLockCAS(next: int) returns (status: bool)
 modifies lock;
 {
-  assert next != 0;
-  if (*) {
-    assume lock == 0; lock := next; status := true;
-  } else {
-    status := false;
-  }
+    assert next != 0;
+    if (*) {
+        assume lock == 0; lock := next; status := true;
+    } else {
+        status := false;
+    }
 }
 procedure {:yields} {:layer 0} {:refines "AtomicPrimitiveLockCAS"} PrimitiveLockCAS(next: int) returns (status: bool);
 

--- a/Test/civl/GC.bpl.expect
+++ b/Test/civl/GC.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 1304 verified, 0 errors
+Boogie program verifier finished with 730 verified, 0 errors

--- a/Test/civl/lit.local.cfg
+++ b/Test/civl/lit.local.cfg
@@ -1,1 +1,1 @@
-config.excludes = ['GC.bpl', 'reserve.bpl']
+config.excludes = ['reserve.bpl']

--- a/Test/civl/t1.bpl.expect
+++ b/Test/civl/t1.bpl.expect
@@ -2,6 +2,6 @@ t1.bpl(75,5): Error: Non-interference check failed
 Execution trace:
     t1.bpl(94,13): anon0
     t1.bpl(94,13): anon0_1
-    (0,0): inline$NoninterferenceChecker_impl_A_1$0$L1
+    (0,0): inline$NoninterferenceChecker_impl_A_1$0$L0
 
 Boogie program verifier finished with 4 verified, 1 error

--- a/Test/civl/verified-ft-define.bpl
+++ b/Test/civl/verified-ft-define.bpl
@@ -299,9 +299,6 @@ modifies shadow.VC;
 
 /****** Layer 10 -> 20 ******/
 
-procedure {:yield_invariant} {:layer 10} Yield_VCRepOk_10(v: Shadowable);
-     requires VCRepOk(shadow.VC[v]);
-
 procedure {:yield_invariant} {:layer 10} Yield_FTRepOk_10();
      requires FTRepOk(shadow.VC, sx.W, sx.R);
 
@@ -332,9 +329,6 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Leq"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, v1}
-{:yield_requires "Yield_Lock_10", tid, v2}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 VC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
@@ -395,9 +389,6 @@ modifies shadow.VC;
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Copy"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, v1}
-{:yield_requires "Yield_Lock_10", tid, v2}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Copy({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
@@ -453,9 +444,6 @@ modifies shadow.VC;
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Join"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, v1}
-{:yield_requires "Yield_Lock_10", tid, v2}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Join({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
@@ -513,11 +501,7 @@ modifies shadow.VC;
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Inc"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, v}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_VCRepOk_10", v}
 {:yield_ensures "Yield_FTRepOk_10"}
-{:yield_ensures "Yield_VCRepOk_10", v}
 {:yield_ensures "Yield_VCPreserved_10", tid, v, v, old(shadow.Lock), old(shadow.VC)}
 VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
 {
@@ -578,8 +562,6 @@ modifies shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicFork"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_ensures "Yield_FTRepOk_10"}
@@ -619,8 +601,6 @@ modifies shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicJoin"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_ensures "Yield_FTRepOk_10"}
@@ -656,12 +636,8 @@ modifies shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicAcquire"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 {:yield_ensures "Yield_FTRepOk_20"}
@@ -705,12 +681,8 @@ modifies shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicRelease"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableLock(l), old(shadow.Lock), old(shadow.VC)}
 {:yield_ensures "Yield_FTRepOk_20"}
@@ -776,7 +748,6 @@ modifies sx.W;
 procedure {:yields} {:layer 20} {:refines "AtomicWrite"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
@@ -888,7 +859,6 @@ modifies sx.R, shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicRead"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}

--- a/Test/civl/verified-ft-define.bpl
+++ b/Test/civl/verified-ft-define.bpl
@@ -92,7 +92,7 @@ function {:define} EpochInit(tid: Tid): Epoch {
  */
 type VC = [Tid]Epoch;
 
-// primite accessors to array
+// primitive accessors to array
 // len of VC is stored at -1.
 function {:define} VCArrayLen(vc: VC): int { clock#epoch(vc[-1]) }
 function {:define} VCArraySetLen(vc: VC, n: int): VC { vc[-1 := epoch(-1,n)] }

--- a/Test/civl/verified-ft-define.bpl
+++ b/Test/civl/verified-ft-define.bpl
@@ -313,19 +313,10 @@ procedure {:yield_invariant} {:layer 10} Yield_FTPreserved_10({:linear "tid"} ti
      requires ValidTid(tid);
      requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
 
-procedure {:yield_invariant} {:layer 10} Yield_LocksPreserved_10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid);
-     requires ValidTid(tid);
-     requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
-
 procedure {:yield_invariant} {:layer 10} Yield_VCPreserved_10({:linear "tid"} tid:Tid, v1: Shadowable, v2: Shadowable, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC);
 requires ValidTid(tid);
 requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
 requires (forall s: Shadowable :: s != v1 && s != v2 && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
-
-procedure {:yield_invariant} {:layer 10} Yield10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
-     requires ValidTid(tid);
-     requires FTRepOk(shadow.VC, sx.W, sx.R);
-     requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
 
 procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
@@ -339,11 +330,13 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
 }
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Leq"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, v1}
 {:yield_requires "Yield_Lock_10", tid, v2}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 VC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
   var vc1, vc2: VC;
@@ -400,7 +393,8 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Copy"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, v1}
 {:yield_requires "Yield_Lock_10", tid, v2}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
@@ -457,7 +451,8 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Join"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, v1}
 {:yield_requires "Yield_Lock_10", tid, v2}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
@@ -516,7 +511,8 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Inc"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, v}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_VCRepOk_10", v}
@@ -528,7 +524,6 @@ VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
   var e: Epoch;
 
   call e := VCGetElem(tid, v, i);
-
   call VCSetElem(tid, v, i, EpochInc(e));
 }
 
@@ -548,11 +543,8 @@ requires ValidTid(tid);
 requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
 requires (forall s: Shadowable :: s != v1 && s != v2 && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
 
-procedure {:yield_invariant} {:layer 20} Yield20({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
+procedure {:yield_invariant} {:layer 20} Yield_FTPreserved_20({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
     requires ValidTid(tid);
-    requires shadow.Lock[ShadowableTid(tid)] == tid;
-    requires FTRepOk(shadow.VC, sx.W, sx.R);
-    requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
     requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
 
 procedure {:atomic} {:layer 21,30} AtomicFork({:linear "tid"} tid:Tid, uid : Tid)
@@ -584,10 +576,12 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicFork"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(uid), old(shadow.Lock), old(shadow.VC)}
 {:yield_ensures "Yield_FTRepOk_20"}
@@ -595,7 +589,6 @@ procedure {:yields} {:layer 20} {:refines "AtomicFork"}
 Fork({:linear "tid"} tid:Tid, uid : Tid)
 {
   call VC.Join(tid, ShadowableTid(uid), ShadowableTid(tid));
-
   call VC.Inc(tid, ShadowableTid(tid), tid);
 }
 
@@ -624,10 +617,12 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicJoin"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 {:yield_ensures "Yield_FTRepOk_20"}
@@ -659,10 +654,12 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicAcquire"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
 {:yield_ensures "Yield_FTRepOk_10"}
@@ -706,10 +703,12 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicRelease"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
 {:yield_ensures "Yield_FTRepOk_10"}
@@ -722,7 +721,6 @@ Release({:linear "tid"} tid: Tid, l: Lock)
   var st : Shadowable;
 
   call VC.Copy(tid, ShadowableLock(l), ShadowableTid(tid));
-
   call VC.Inc(tid, ShadowableTid(tid), tid);
 }
 
@@ -776,12 +774,16 @@ modifies sx.W;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicWrite"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
-{:yield_ensures "Yield20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Write({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 {
   var e, w, vw, r, vr: Epoch;
@@ -796,8 +798,8 @@ Write({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
       return;
     }
 
-  call Yield10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
-  call Yield20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  par Yield_FTRepOk_10() | Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  par Yield_FTRepOk_20() | Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
 
   call AcquireVarLock(tid, x);
   call w := VarStateGetW(tid, x);
@@ -884,12 +886,16 @@ modifies sx.R, shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicRead"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
-{:yield_ensures "Yield20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 {
   var e, w, vw, r, vr: Epoch;
@@ -916,8 +922,8 @@ Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
        }
      }
 
-  call Yield10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
-  call Yield20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  par Yield_FTRepOk_10() | Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  par Yield_FTRepOk_20() | Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
 
   call AcquireVarLock(tid, x);
   call w := VarStateGetW(tid, x);
@@ -968,11 +974,9 @@ procedure {:yield_invariant} {:layer 30} Yield_ThreadState_30({:linear "tid"} ti
   requires thread.State[tid] == RUNNING();
   requires (forall t: Tid :: thread.State[t] == UNUSED() ==> shadow.Lock[ShadowableTid(t)] == nil);
 
-procedure {:yield_invariant} {:layer 30} Yield30({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.thread.State: [Tid]ThreadStatus);
+procedure {:yield_invariant} {:layer 30} Yield_Preserved_30({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.thread.State: [Tid]ThreadStatus);
   requires ValidTid(tid);
   requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
-  requires thread.State[tid] == RUNNING();
-  requires (forall t: Tid :: thread.State[t] == UNUSED() ==> shadow.Lock[ShadowableTid(t)] == nil);
   requires (forall t: Tid :: old.shadow.Lock[ShadowableTid(t)] == tid ==> thread.State[t] == old.thread.State[t]);
 
 procedure {:yields} {:layer 30}
@@ -1008,13 +1012,13 @@ Driver({:linear "tid"} tid:Tid) returns (ok: bool)
     } else if (*) {
       assert {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
       call l := ChooseLockToAcquire(tid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Acquire(tid, l);
     } else if (*) {
       call l := ChooseLockToRelease(tid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Release(tid, l);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call ReleaseChosenLock(tid, l);
     } else if (*) {
       call uid := AllocTid(tid);
@@ -1024,17 +1028,17 @@ Driver({:linear "tid"} tid:Tid) returns (ok: bool)
       assert {:layer 10,20,30} tid != uid;
       assert {:layer 10,20,30} ValidTid(tid);
       assert {:layer 10,20,30} ValidTid(uid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       assert {:layer 10,20,30} ValidTid(tid);
       assert {:layer 10,20,30} ValidTid(uid);
       call Fork(tid, uid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call StartThread(tid, uid);
     } else {
       call uid := ChooseThreadToJoin(tid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Join(tid, uid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call ReleaseJoinLock(tid, uid);
     }
     assert {:layer 20} shadow.Lock[ShadowableTid(tid)] == tid;

--- a/Test/civl/verified-ft-define.bpl
+++ b/Test/civl/verified-ft-define.bpl
@@ -299,12 +299,33 @@ modifies shadow.VC;
 
 /****** Layer 10 -> 20 ******/
 
- procedure {:yield_invariant} {:layer 10} Yield10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
+procedure {:yield_invariant} {:layer 10} Yield_VCRepOk_10(v: Shadowable);
+     requires VCRepOk(shadow.VC[v]);
+
+procedure {:yield_invariant} {:layer 10} Yield_FTRepOk_10();
+     requires FTRepOk(shadow.VC, sx.W, sx.R);
+
+procedure {:yield_invariant} {:layer 10} Yield_Lock_10({:linear "tid"} tid: Tid, v: Shadowable);
+requires ValidTid(tid);
+requires shadow.Lock[v] == tid;
+
+procedure {:yield_invariant} {:layer 10} Yield_FTPreserved_10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
+     requires ValidTid(tid);
+     requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
+
+procedure {:yield_invariant} {:layer 10} Yield_LocksPreserved_10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid);
+     requires ValidTid(tid);
+     requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
+
+procedure {:yield_invariant} {:layer 10} Yield_VCPreserved_10({:linear "tid"} tid:Tid, v: Shadowable, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC);
+requires ValidTid(tid);
+requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
+requires (forall s: Shadowable :: s != v && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
+
+procedure {:yield_invariant} {:layer 10} Yield10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
      requires ValidTid(tid);
      requires FTRepOk(shadow.VC, sx.W, sx.R);
-     requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
      requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
-     requires FTRepOk(shadow.VC, sx.W, sx.R);
 
 procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
@@ -319,19 +340,13 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Leq"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, v1}
+{:yield_requires "Yield_Lock_10", tid, v2}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 VC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
-  requires {:layer 10} ValidTid(tid);
-  requires {:layer 10} shadow.Lock[v1] == tid;
-  requires {:layer 10} shadow.Lock[v2] == tid;
-  requires {:layer 10} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
   requires {:layer 10} is#ShadowableVar(v1) ==> sx.R[x#ShadowableVar(v1)] == SHARED;
   requires {:layer 10} !is#ShadowableVar(v2);
-  ensures {:layer 10} ValidTid(tid);
-  ensures {:layer 10} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10} FTPreserved(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R), shadow.Lock, shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
 {
   var vc1, vc2: VC;
   var len1, len2 : int;
@@ -388,19 +403,15 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Copy"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, v1}
+{:yield_requires "Yield_Lock_10", tid, v2}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Copy({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
-  requires {:layer 10} ValidTid(tid);
   requires {:layer 10} v1 != v2;
-  requires {:layer 10} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10} shadow.Lock[v1] == tid;
-  requires {:layer 10} shadow.Lock[v2] == tid;
   requires {:layer 10} !is#ShadowableVar(v1);
   requires {:layer 10} !is#ShadowableVar(v2);
-  requires {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} ValidTid(tid);
-  ensures {:layer 10} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} (forall s: Shadowable :: s != v1 && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   var len1, len2 : int;
   var e1, e2: Epoch;
@@ -452,18 +463,14 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Join"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, v1}
+{:yield_requires "Yield_Lock_10", tid, v2}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Join({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
-  requires {:layer 10} ValidTid(tid);
-  requires {:layer 10} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10} shadow.Lock[v1] == tid;
-  requires {:layer 10} shadow.Lock[v2] == tid;
   requires {:layer 10} !is#ShadowableVar(v1);
   requires {:layer 10} !is#ShadowableVar(v2);
-  requires {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} ValidTid(tid);
-  ensures {:layer 10} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} (forall s: Shadowable :: s != v1 && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   var len1, len2 : int;
   var e1, e2: Epoch;
@@ -517,19 +524,15 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Inc"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, v}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_VCRepOk_10", v}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCRepOk_10", v}
+{:yield_ensures "Yield_VCPreserved_10", tid, v, old(shadow.Lock), old(shadow.VC)}
 VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
-  requires {:layer 10} ValidTid(tid);
-  requires {:layer 10} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10} shadow.Lock[v] == tid;
   requires {:layer 10} !is#ShadowableVar(v);
-  requires {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  requires {:layer 10} VCRepOk(shadow.VC[v]);
   requires {:layer 10} i >= 0;
-  ensures {:layer 10} ValidTid(tid);
-  ensures {:layer 10} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} VCRepOk(shadow.VC[v]);
-  ensures {:layer 10} (forall s: Shadowable :: s != v && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   var e: Epoch;
 
@@ -541,6 +544,18 @@ VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
 
 
 /****** Layer 20 --> 30 ******/
+
+procedure {:yield_invariant} {:layer 20} Yield_FTRepOk_20();
+     requires FTRepOk(shadow.VC, sx.W, sx.R);
+
+procedure {:yield_invariant} {:layer 20} Yield_Lock_20({:linear "tid"} tid: Tid, v: Shadowable);
+requires ValidTid(tid);
+requires shadow.Lock[v] == tid;
+
+procedure {:yield_invariant} {:layer 20} Yield_VCPreserved_20({:linear "tid"} tid:Tid, v: Shadowable, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC);
+requires ValidTid(tid);
+requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
+requires (forall s: Shadowable :: s != v && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
 
 procedure {:yield_invariant} {:layer 20} Yield20({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
     requires ValidTid(tid);
@@ -579,17 +594,15 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicFork"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_FTRepOk_20"}
 Fork({:linear "tid"} tid:Tid, uid : Tid)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} ValidTid(uid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(uid)] == tid;
   requires {:layer 10,20} tid != uid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
   ensures {:layer 10,20} ValidTid(tid);
   ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
   ensures {:layer 10,20} (forall s: Shadowable :: s != ShadowableTid(tid) && s != ShadowableTid(uid) ==>
                            (old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]));
 {
@@ -624,18 +637,15 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicJoin"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_VCPreserved_20", tid, ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 Join({:linear "tid"} tid:Tid, uid : Tid)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} ValidTid(uid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(uid)] == tid;
   requires {:layer 10,20} tid != uid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} (forall s: Shadowable :: s != ShadowableTid(tid) && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   call VC.Join(tid, ShadowableTid(tid), ShadowableTid(uid));
 }
@@ -663,16 +673,16 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicAcquire"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_VCPreserved_20", tid, ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 Acquire({:linear "tid"} tid: Tid, l: Lock)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} shadow.Lock[ShadowableLock(l)] == tid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} (forall s: Shadowable :: s != ShadowableTid(tid) && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   call VC.Join(tid, ShadowableTid(tid), ShadowableLock(l));
 }
@@ -710,15 +720,16 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicRelease"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_FTRepOk_20"}
 Release({:linear "tid"} tid: Tid, l: Lock)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} shadow.Lock[ShadowableLock(l)] == tid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
   ensures {:layer 10,20} ValidTid(tid);
   ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
   ensures {:layer 10,20} (forall s: Shadowable :: s != ShadowableTid(tid)  && s != ShadowableLock(l) && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   var sm : Shadowable;
@@ -780,16 +791,12 @@ modifies sx.W;
 
 procedure {:yields} {:layer 20} {:refines "AtomicWrite"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures "Yield20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Write({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
 {
   var e, w, vw, r, vr: Epoch;
 
@@ -892,16 +899,12 @@ modifies sx.R, shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicRead"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures "Yield20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
 {
   var e, w, vw, r, vr: Epoch;
   var xVC, stVC: VC;
@@ -969,8 +972,6 @@ Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 
 
 /****** Layer 30 --> 40 ******/
-
-
 
 procedure {:yield_invariant} {:layer 30} Yield30({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.thread.State: [Tid]ThreadStatus);
   requires ValidTid(tid);

--- a/Test/civl/verified-ft.bpl
+++ b/Test/civl/verified-ft.bpl
@@ -299,9 +299,6 @@ modifies shadow.VC;
 
 /****** Layer 10 -> 20 ******/
 
-procedure {:yield_invariant} {:layer 10} Yield_VCRepOk_10(v: Shadowable);
-     requires VCRepOk(shadow.VC[v]);
-
 procedure {:yield_invariant} {:layer 10} Yield_FTRepOk_10();
      requires FTRepOk(shadow.VC, sx.W, sx.R);
 
@@ -332,9 +329,6 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Leq"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, v1}
-{:yield_requires "Yield_Lock_10", tid, v2}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 VC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
@@ -395,9 +389,6 @@ modifies shadow.VC;
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Copy"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, v1}
-{:yield_requires "Yield_Lock_10", tid, v2}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Copy({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
@@ -453,9 +444,6 @@ modifies shadow.VC;
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Join"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, v1}
-{:yield_requires "Yield_Lock_10", tid, v2}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Join({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
@@ -513,11 +501,7 @@ modifies shadow.VC;
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Inc"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, v}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_VCRepOk_10", v}
 {:yield_ensures "Yield_FTRepOk_10"}
-{:yield_ensures "Yield_VCRepOk_10", v}
 {:yield_ensures "Yield_VCPreserved_10", tid, v, v, old(shadow.Lock), old(shadow.VC)}
 VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
 {
@@ -578,8 +562,6 @@ modifies shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicFork"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_ensures "Yield_FTRepOk_10"}
@@ -619,8 +601,6 @@ modifies shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicJoin"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_ensures "Yield_FTRepOk_10"}
@@ -656,12 +636,8 @@ modifies shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicAcquire"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 {:yield_ensures "Yield_FTRepOk_20"}
@@ -705,12 +681,8 @@ modifies shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicRelease"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableLock(l), old(shadow.Lock), old(shadow.VC)}
 {:yield_ensures "Yield_FTRepOk_20"}
@@ -776,7 +748,6 @@ modifies sx.W;
 procedure {:yields} {:layer 20} {:refines "AtomicWrite"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
@@ -888,7 +859,6 @@ modifies sx.R, shadow.VC;
 procedure {:yields} {:layer 20} {:refines "AtomicRead"}
 {:yield_requires "Yield_FTRepOk_10"}
 {:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_FTRepOk_20"}
 {:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}

--- a/Test/civl/verified-ft.bpl
+++ b/Test/civl/verified-ft.bpl
@@ -313,19 +313,10 @@ procedure {:yield_invariant} {:layer 10} Yield_FTPreserved_10({:linear "tid"} ti
      requires ValidTid(tid);
      requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
 
-procedure {:yield_invariant} {:layer 10} Yield_LocksPreserved_10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid);
-     requires ValidTid(tid);
-     requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
-
 procedure {:yield_invariant} {:layer 10} Yield_VCPreserved_10({:linear "tid"} tid:Tid, v1: Shadowable, v2: Shadowable, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC);
 requires ValidTid(tid);
 requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
 requires (forall s: Shadowable :: s != v1 && s != v2 && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
-
-procedure {:yield_invariant} {:layer 10} Yield10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
-     requires ValidTid(tid);
-     requires FTRepOk(shadow.VC, sx.W, sx.R);
-     requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
 
 procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
@@ -339,11 +330,13 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
 }
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Leq"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, v1}
 {:yield_requires "Yield_Lock_10", tid, v2}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 VC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
   var vc1, vc2: VC;
@@ -400,7 +393,8 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Copy"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, v1}
 {:yield_requires "Yield_Lock_10", tid, v2}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
@@ -457,7 +451,8 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Join"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, v1}
 {:yield_requires "Yield_Lock_10", tid, v2}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
@@ -516,7 +511,8 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Inc"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, v}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_VCRepOk_10", v}
@@ -528,7 +524,6 @@ VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
   var e: Epoch;
 
   call e := VCGetElem(tid, v, i);
-
   call VCSetElem(tid, v, i, EpochInc(e));
 }
 
@@ -548,11 +543,8 @@ requires ValidTid(tid);
 requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
 requires (forall s: Shadowable :: s != v1 && s != v2 && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
 
-procedure {:yield_invariant} {:layer 20} Yield20({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
+procedure {:yield_invariant} {:layer 20} Yield_FTPreserved_20({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
     requires ValidTid(tid);
-    requires shadow.Lock[ShadowableTid(tid)] == tid;
-    requires FTRepOk(shadow.VC, sx.W, sx.R);
-    requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
     requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
 
 procedure {:atomic} {:layer 21,30} AtomicFork({:linear "tid"} tid:Tid, uid : Tid)
@@ -584,10 +576,12 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicFork"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(uid), old(shadow.Lock), old(shadow.VC)}
 {:yield_ensures "Yield_FTRepOk_20"}
@@ -595,7 +589,6 @@ procedure {:yields} {:layer 20} {:refines "AtomicFork"}
 Fork({:linear "tid"} tid:Tid, uid : Tid)
 {
   call VC.Join(tid, ShadowableTid(uid), ShadowableTid(tid));
-
   call VC.Inc(tid, ShadowableTid(tid), tid);
 }
 
@@ -624,10 +617,12 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicJoin"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_ensures "Yield_FTRepOk_10"}
 {:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 {:yield_ensures "Yield_FTRepOk_20"}
@@ -659,10 +654,12 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicAcquire"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
 {:yield_ensures "Yield_FTRepOk_10"}
@@ -706,10 +703,12 @@ modifies shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicRelease"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
 {:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
 {:yield_ensures "Yield_FTRepOk_10"}
@@ -722,7 +721,6 @@ Release({:linear "tid"} tid: Tid, l: Lock)
   var st : Shadowable;
 
   call VC.Copy(tid, ShadowableLock(l), ShadowableTid(tid));
-
   call VC.Inc(tid, ShadowableTid(tid), tid);
 }
 
@@ -776,12 +774,16 @@ modifies sx.W;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicWrite"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
-{:yield_ensures "Yield20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Write({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 {
   var e, w, vw, r, vr: Epoch;
@@ -796,8 +798,8 @@ Write({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
       return;
     }
 
-  call Yield10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
-  call Yield20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  par Yield_FTRepOk_10() | Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  par Yield_FTRepOk_20() | Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
 
   call AcquireVarLock(tid, x);
   call w := VarStateGetW(tid, x);
@@ -884,12 +886,16 @@ modifies sx.R, shadow.VC;
 }
 
 procedure {:yields} {:layer 20} {:refines "AtomicRead"}
-{:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
-{:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
 {:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
-{:yield_ensures "Yield20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 {
   var e, w, vw, r, vr: Epoch;
@@ -916,8 +922,8 @@ Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
        }
      }
 
-  call Yield10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
-  call Yield20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  par Yield_FTRepOk_10() | Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  par Yield_FTRepOk_20() | Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
 
   call AcquireVarLock(tid, x);
   call w := VarStateGetW(tid, x);
@@ -968,11 +974,9 @@ procedure {:yield_invariant} {:layer 30} Yield_ThreadState_30({:linear "tid"} ti
   requires thread.State[tid] == RUNNING();
   requires (forall t: Tid :: thread.State[t] == UNUSED() ==> shadow.Lock[ShadowableTid(t)] == nil);
 
-procedure {:yield_invariant} {:layer 30} Yield30({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.thread.State: [Tid]ThreadStatus);
+procedure {:yield_invariant} {:layer 30} Yield_Preserved_30({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.thread.State: [Tid]ThreadStatus);
   requires ValidTid(tid);
   requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
-  requires thread.State[tid] == RUNNING();
-  requires (forall t: Tid :: thread.State[t] == UNUSED() ==> shadow.Lock[ShadowableTid(t)] == nil);
   requires (forall t: Tid :: old.shadow.Lock[ShadowableTid(t)] == tid ==> thread.State[t] == old.thread.State[t]);
 
 procedure {:yields} {:layer 30}
@@ -1008,13 +1012,13 @@ Driver({:linear "tid"} tid:Tid) returns (ok: bool)
     } else if (*) {
       assert {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
       call l := ChooseLockToAcquire(tid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Acquire(tid, l);
     } else if (*) {
       call l := ChooseLockToRelease(tid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Release(tid, l);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call ReleaseChosenLock(tid, l);
     } else if (*) {
       call uid := AllocTid(tid);
@@ -1024,17 +1028,17 @@ Driver({:linear "tid"} tid:Tid) returns (ok: bool)
       assert {:layer 10,20,30} tid != uid;
       assert {:layer 10,20,30} ValidTid(tid);
       assert {:layer 10,20,30} ValidTid(uid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       assert {:layer 10,20,30} ValidTid(tid);
       assert {:layer 10,20,30} ValidTid(uid);
       call Fork(tid, uid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call StartThread(tid, uid);
     } else {
       call uid := ChooseThreadToJoin(tid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Join(tid, uid);
-      call Yield30(tid, shadow.Lock, thread.State);
+      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call ReleaseJoinLock(tid, uid);
     }
     assert {:layer 20} shadow.Lock[ShadowableTid(tid)] == tid;

--- a/Test/civl/verified-ft.bpl
+++ b/Test/civl/verified-ft.bpl
@@ -92,7 +92,7 @@ function {:inline} EpochInit(tid: Tid): Epoch {
  */
 type VC = [Tid]Epoch;
 
-// primite accessors to array
+// primitive accessors to array
 // len of VC is stored at -1.
 function {:inline} VCArrayLen(vc: VC): int { clock#epoch(vc[-1]) }
 function {:inline} VCArraySetLen(vc: VC, n: int): VC { vc[-1 := epoch(-1,n)] }

--- a/Test/civl/verified-ft.bpl
+++ b/Test/civl/verified-ft.bpl
@@ -190,7 +190,7 @@ function {:inline} FTPreserved({:linear "tid" } tid:Tid,
 /****** Layer 0  ******/
 
 // VarState Lock
-procedure {:yields}  {:layer 0} {:refines "AtomicAcquireVarLock"} AcquireVarLock({:linear "tid"} tid: Tid, x : Var);
+procedure {:yields} {:layer 0} {:refines "AtomicAcquireVarLock"} AcquireVarLock({:linear "tid"} tid: Tid, x : Var);
 procedure {:right} {:layer 1,20} AtomicAcquireVarLock({:linear "tid"} tid: Tid, x : Var)
 modifies shadow.Lock;
 { assert ValidTid(tid); assume shadow.Lock[ShadowableVar(x)] == nil; shadow.Lock[ShadowableVar(x)] := tid; }
@@ -299,12 +299,33 @@ modifies shadow.VC;
 
 /****** Layer 10 -> 20 ******/
 
- procedure {:yield_invariant} {:layer 10} Yield10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
+procedure {:yield_invariant} {:layer 10} Yield_VCRepOk_10(v: Shadowable);
+     requires VCRepOk(shadow.VC[v]);
+
+procedure {:yield_invariant} {:layer 10} Yield_FTRepOk_10();
+     requires FTRepOk(shadow.VC, sx.W, sx.R);
+
+procedure {:yield_invariant} {:layer 10} Yield_Lock_10({:linear "tid"} tid: Tid, v: Shadowable);
+requires ValidTid(tid);
+requires shadow.Lock[v] == tid;
+
+procedure {:yield_invariant} {:layer 10} Yield_FTPreserved_10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
+     requires ValidTid(tid);
+     requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
+
+procedure {:yield_invariant} {:layer 10} Yield_LocksPreserved_10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid);
+     requires ValidTid(tid);
+     requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
+
+procedure {:yield_invariant} {:layer 10} Yield_VCPreserved_10({:linear "tid"} tid:Tid, v1: Shadowable, v2: Shadowable, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC);
+requires ValidTid(tid);
+requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
+requires (forall s: Shadowable :: s != v1 && s != v2 && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
+
+procedure {:yield_invariant} {:layer 10} Yield10({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
      requires ValidTid(tid);
      requires FTRepOk(shadow.VC, sx.W, sx.R);
-     requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
      requires FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
-     requires FTRepOk(shadow.VC, sx.W, sx.R);
 
 procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
@@ -319,19 +340,11 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Leq"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, v1}
+{:yield_requires "Yield_Lock_10", tid, v2}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 VC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
-  requires {:layer 10} ValidTid(tid);
-  requires {:layer 10} shadow.Lock[v1] == tid;
-  requires {:layer 10} shadow.Lock[v2] == tid;
-  requires {:layer 10} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  requires {:layer 10} is#ShadowableVar(v1) ==> sx.R[x#ShadowableVar(v1)] == SHARED;
-  requires {:layer 10} !is#ShadowableVar(v2);
-  ensures {:layer 10} ValidTid(tid);
-  ensures {:layer 10} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10} FTPreserved(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R), shadow.Lock, shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
 {
   var vc1, vc2: VC;
   var len1, len2 : int;
@@ -388,19 +401,12 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Copy"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, v1}
+{:yield_requires "Yield_Lock_10", tid, v2}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Copy({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
-  requires {:layer 10} ValidTid(tid);
-  requires {:layer 10} v1 != v2;
-  requires {:layer 10} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10} shadow.Lock[v1] == tid;
-  requires {:layer 10} shadow.Lock[v2] == tid;
-  requires {:layer 10} !is#ShadowableVar(v1);
-  requires {:layer 10} !is#ShadowableVar(v2);
-  requires {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} ValidTid(tid);
-  ensures {:layer 10} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} (forall s: Shadowable :: s != v1 && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   var len1, len2 : int;
   var e1, e2: Epoch;
@@ -452,18 +458,12 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Join"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, v1}
+{:yield_requires "Yield_Lock_10", tid, v2}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Join({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
-  requires {:layer 10} ValidTid(tid);
-  requires {:layer 10} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10} shadow.Lock[v1] == tid;
-  requires {:layer 10} shadow.Lock[v2] == tid;
-  requires {:layer 10} !is#ShadowableVar(v1);
-  requires {:layer 10} !is#ShadowableVar(v2);
-  requires {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} ValidTid(tid);
-  ensures {:layer 10} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} (forall s: Shadowable :: s != v1 && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   var len1, len2 : int;
   var e1, e2: Epoch;
@@ -517,19 +517,13 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Inc"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, v}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_VCRepOk_10", v}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCRepOk_10", v}
+{:yield_ensures "Yield_VCPreserved_10", tid, v, v, old(shadow.Lock), old(shadow.VC)}
 VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
-  requires {:layer 10} ValidTid(tid);
-  requires {:layer 10} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10} shadow.Lock[v] == tid;
-  requires {:layer 10} !is#ShadowableVar(v);
-  requires {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  requires {:layer 10} VCRepOk(shadow.VC[v]);
-  requires {:layer 10} i >= 0;
-  ensures {:layer 10} ValidTid(tid);
-  ensures {:layer 10} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10} VCRepOk(shadow.VC[v]);
-  ensures {:layer 10} (forall s: Shadowable :: s != v && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   var e: Epoch;
 
@@ -541,6 +535,18 @@ VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
 
 
 /****** Layer 20 --> 30 ******/
+
+procedure {:yield_invariant} {:layer 20} Yield_FTRepOk_20();
+     requires FTRepOk(shadow.VC, sx.W, sx.R);
+
+procedure {:yield_invariant} {:layer 20} Yield_Lock_20({:linear "tid"} tid: Tid, v: Shadowable);
+requires ValidTid(tid);
+requires shadow.Lock[v] == tid;
+
+procedure {:yield_invariant} {:layer 20} Yield_VCPreserved_20({:linear "tid"} tid:Tid, v1: Shadowable, v2: Shadowable, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC);
+requires ValidTid(tid);
+requires LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
+requires (forall s: Shadowable :: s != v1 && s != v2 && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
 
 procedure {:yield_invariant} {:layer 20} Yield20({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.shadow.VC: [Shadowable]VC, old.sx.W: [Var]Epoch, old.sx.R: [Var]Epoch);
     requires ValidTid(tid);
@@ -579,19 +585,14 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicFork"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(uid), old(shadow.Lock), old(shadow.VC)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(uid), old(shadow.Lock), old(shadow.VC)}
 Fork({:linear "tid"} tid:Tid, uid : Tid)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} ValidTid(uid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(uid)] == tid;
-  requires {:layer 10,20} tid != uid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} (forall s: Shadowable :: s != ShadowableTid(tid) && s != ShadowableTid(uid) ==>
-                           (old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]));
 {
   call VC.Join(tid, ShadowableTid(uid), ShadowableTid(tid));
 
@@ -624,18 +625,14 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicJoin"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(uid)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 Join({:linear "tid"} tid:Tid, uid : Tid)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} ValidTid(uid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(uid)] == tid;
-  requires {:layer 10,20} tid != uid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} (forall s: Shadowable :: s != ShadowableTid(tid) && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   call VC.Join(tid, ShadowableTid(tid), ShadowableTid(uid));
 }
@@ -663,16 +660,16 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicAcquire"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 Acquire({:linear "tid"} tid: Tid, l: Lock)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} shadow.Lock[ShadowableLock(l)] == tid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} (forall s: Shadowable :: s != ShadowableTid(tid) && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   call VC.Join(tid, ShadowableTid(tid), ShadowableLock(l));
 }
@@ -710,16 +707,16 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicRelease"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableLock(l)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_Lock_20", tid, ShadowableLock(l)}
+{:yield_ensures "Yield_FTRepOk_10"}
+{:yield_ensures "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableLock(l), old(shadow.Lock), old(shadow.VC)}
+{:yield_ensures "Yield_FTRepOk_20"}
+{:yield_ensures "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableLock(l), old(shadow.Lock), old(shadow.VC)}
 Release({:linear "tid"} tid: Tid, l: Lock)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} shadow.Lock[ShadowableLock(l)] == tid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} (forall s: Shadowable :: s != ShadowableTid(tid)  && s != ShadowableLock(l) && old(shadow.Lock)[s] == tid ==> old(shadow.VC)[s] == shadow.VC[s]);
 {
   var sm : Shadowable;
   var st : Shadowable;
@@ -780,16 +777,12 @@ modifies sx.W;
 
 procedure {:yields} {:layer 20} {:refines "AtomicWrite"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures "Yield20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Write({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
 {
   var e, w, vw, r, vr: Epoch;
 
@@ -892,16 +885,12 @@ modifies sx.R, shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicRead"}
 {:yield_requires "Yield10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
-{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
 {:yield_requires "Yield20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_ensures "Yield10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures "Yield20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
-  requires {:layer 10,20} ValidTid(tid);
-  requires {:layer 10,20} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
-  ensures {:layer 10,20} ValidTid(tid);
-  ensures {:layer 10,20} LocksPreserved(tid, old(shadow.Lock), shadow.Lock);
-  ensures {:layer 10,20} FTRepOk(shadow.VC, sx.W, sx.R);
 {
   var e, w, vw, r, vr: Epoch;
   var xVC, stVC: VC;
@@ -970,7 +959,14 @@ Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 
 /****** Layer 30 --> 40 ******/
 
+procedure {:yield_invariant} {:layer 30} Yield_Lock_30({:linear "tid"} tid: Tid, v: Shadowable);
+requires ValidTid(tid);
+requires shadow.Lock[v] == tid;
 
+procedure {:yield_invariant} {:layer 30} Yield_ThreadState_30({:linear "tid"} tid:Tid);
+  requires ValidTid(tid);
+  requires thread.State[tid] == RUNNING();
+  requires (forall t: Tid :: thread.State[t] == UNUSED() ==> shadow.Lock[ShadowableTid(t)] == nil);
 
 procedure {:yield_invariant} {:layer 30} Yield30({:linear "tid"} tid:Tid, old.shadow.Lock: [Shadowable]Tid, old.thread.State: [Tid]ThreadStatus);
   requires ValidTid(tid);
@@ -979,16 +975,14 @@ procedure {:yield_invariant} {:layer 30} Yield30({:linear "tid"} tid:Tid, old.sh
   requires (forall t: Tid :: thread.State[t] == UNUSED() ==> shadow.Lock[ShadowableTid(t)] == nil);
   requires (forall t: Tid :: old.shadow.Lock[ShadowableTid(t)] == tid ==> thread.State[t] == old.thread.State[t]);
 
-
 procedure {:yields} {:layer 30}
-{:yield_requires "Yield30", tid, shadow.Lock, thread.State}
+{:yield_requires "Yield_Lock_10", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_FTRepOk_10"}
+{:yield_requires "Yield_Lock_20", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_FTRepOk_20"}
+{:yield_requires "Yield_Lock_30", tid, ShadowableTid(tid)}
+{:yield_requires "Yield_ThreadState_30", tid}
 Driver({:linear "tid"} tid:Tid) returns (ok: bool)
-  requires {:layer 10,20,30} ValidTid(tid);
-  requires {:layer 10,20,30} shadow.Lock[ShadowableTid(tid)] == tid;
-  requires {:layer 10,20} (forall s: Shadowable :: VCRepOk(shadow.VC[s]));
-  requires {:layer 10,20} VarsRepOk(sx.W, sx.R);
-  requires {:layer 30} thread.State[tid] == RUNNING();
-  requires {:layer 30} (forall t: Tid :: thread.State[t] == UNUSED() ==> shadow.Lock[ShadowableTid(t)] == nil);
 {
   var x: Var;
   var l: Lock;
@@ -996,13 +990,14 @@ Driver({:linear "tid"} tid:Tid) returns (ok: bool)
 
   ok := true;
   while (ok)
-    invariant {:yields} {:layer 10,20,30} true;
-    invariant {:layer 10,20,30} ValidTid(tid);
-    invariant {:layer 10,20,30} shadow.Lock[ShadowableTid(tid)] == tid;
-    invariant {:layer 30} thread.State[tid] == RUNNING();
-    invariant {:layer 10,20} (forall s: Shadowable :: VCRepOk(shadow.VC[s]));
-    invariant {:layer 10,20} VarsRepOk(sx.W, sx.R);
-    invariant {:layer 30} (forall t: Tid :: thread.State[t] == UNUSED() ==> shadow.Lock[ShadowableTid(t)] == nil);
+    invariant {:yields} {:layer 10,20,30}
+    {:yield_loop "Yield_Lock_10", tid, ShadowableTid(tid)}
+    {:yield_loop "Yield_FTRepOk_10"}
+    {:yield_loop "Yield_Lock_20", tid, ShadowableTid(tid)}
+    {:yield_loop "Yield_FTRepOk_20"}
+    {:yield_loop "Yield_Lock_30", tid, ShadowableTid(tid)}
+    {:yield_loop "Yield_ThreadState_30", tid}
+    true;
   {
     if (*) {
       havoc x;

--- a/Test/floats/issue110.bpl.expect
+++ b/Test/floats/issue110.bpl.expect
@@ -1,3 +1,6 @@
+issue110.bpl(5,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    issue110.bpl(5,3): anon0
 *** MODEL
 a -> |T@[Int]float24e8!val!0|
 ControlFlow -> {
@@ -16,8 +19,5 @@ tickleBool -> {
   else -> true
 }
 *** END_MODEL
-issue110.bpl(5,3): Error BP5001: This assertion might not hold.
-Execution trace:
-    issue110.bpl(5,3): anon0
 
 Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
- Port verified-ft to use yield  invariants.
- Port GC to use yield invariants
- Miscellaneous changes in CIVL implementation including (1) bug fixes, (2) some refactoring, and (3) optimization to exclude yield predicates that do not access global variables from noninterference checking.