### PR TITLE
Bring model printing in line with counterexample printing

### DIFF
--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -450,6 +450,21 @@ namespace Microsoft.Boogie
 
     static ThreadTaskScheduler Scheduler = new ThreadTaskScheduler(16 * 1024 * 1024);
 
+    private static TextWriter modelWriter = null;
+    public static TextWriter ModelWriter {
+      get {
+        if (CommandLineOptions.Clo.PrintErrorModelFile == null)
+        {
+          return null;
+        }
+        if (ExecutionEngine.modelWriter == null)
+        {
+          ExecutionEngine.modelWriter = new StreamWriter(CommandLineOptions.Clo.PrintErrorModelFile, false);
+        }
+        return ExecutionEngine.modelWriter;
+      }
+    }
+    
     public static void ProcessFiles(List<string> fileNames, bool lookForSnapshots = true, string programId = null)
     {
       Contract.Requires(cce.NonNullElements(fileNames));
@@ -1677,6 +1692,10 @@ namespace Microsoft.Boogie
           {
             errorInfo.Out.WriteLine("Execution trace:");
             error.Print(4, errorInfo.Out, b => { errorInfo.AddAuxInfo(b.tok, b.Label, "Execution trace"); });
+            if (CommandLineOptions.Clo.PrintErrorModel >= 1 && error.Model != null)
+            {
+              error.Model.Write(ExecutionEngine.ModelWriter == null ? errorInfo.Out : ExecutionEngine.ModelWriter);
+            }
           }
           if (CommandLineOptions.Clo.ModelViewFile != null)
           {

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -450,21 +450,8 @@ namespace Microsoft.Boogie
 
     static ThreadTaskScheduler Scheduler = new ThreadTaskScheduler(16 * 1024 * 1024);
 
-    private static TextWriter modelWriter = null;
-    public static TextWriter ModelWriter {
-      get {
-        if (CommandLineOptions.Clo.PrintErrorModelFile == null)
-        {
-          return null;
-        }
-        if (ExecutionEngine.modelWriter == null)
-        {
-          ExecutionEngine.modelWriter = new StreamWriter(CommandLineOptions.Clo.PrintErrorModelFile, false);
-        }
-        return ExecutionEngine.modelWriter;
-      }
-    }
-    
+    static TextWriter ModelWriter = null;
+
     public static void ProcessFiles(List<string> fileNames, bool lookForSnapshots = true, string programId = null)
     {
       Contract.Requires(cce.NonNullElements(fileNames));
@@ -841,6 +828,11 @@ namespace Microsoft.Boogie
       if (requestId == null)
       {
         requestId = FreshRequestId();
+      }
+
+      if (CommandLineOptions.Clo.PrintErrorModelFile != null)
+      {
+        ExecutionEngine.ModelWriter = new StreamWriter(CommandLineOptions.Clo.PrintErrorModelFile, false);
       }
 
       var start = DateTime.UtcNow;

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -635,8 +635,6 @@ namespace VC {
     protected string/*?*/ logFilePath;
     protected bool appendLogFile;
 
-    public static List<Model> errorModelList;
-
     public ConditionGeneration(Program p, List<Checker> checkers) {
       Contract.Requires(p != null && checkers != null && cce.NonNullElements(checkers));
       program = p;
@@ -679,19 +677,11 @@ namespace VC {
     /// each counterexample consisting of an array of labels.
     /// </summary>
     /// <param name="impl"></param>
-    public Outcome VerifyImplementation(Implementation impl, out List<Counterexample> errors, out List<Model> errorsModel)
+    public Outcome VerifyImplementation(Implementation impl, out List<Counterexample> errors)
     {
         Contract.Ensures(Contract.Result<Outcome>() != Outcome.Errors || Contract.ValueAtReturn(out errors) != null);
         Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
-        List<Counterexample> errorsOut;
-
-        Outcome outcome;
-        errorModelList = new List<Model>();
-        outcome = VerifyImplementation(impl, out errorsOut);
-        errors = errorsOut;
-        errorsModel = errorModelList;
-
-        return outcome;
+        return VerifyImplementation(impl, out errors);
     }
 
     public abstract Outcome VerifyImplementation(Implementation impl, VerifierCallback callback);

--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -2104,11 +2104,6 @@ namespace VC {
       }
 
       public override void OnModel(IList<string/*!*/>/*!*/ labels, Model model, ProverInterface.Outcome proverOutcome) {
-        if (CommandLineOptions.Clo.PrintErrorModel >= 1 && model != null) {
-          model.Write(ErrorReporter.ModelWriter);
-          ErrorReporter.ModelWriter.Flush();
-        }
-
         // Timeout?
         if (proverOutcome != ProverInterface.Outcome.Invalid)
             return;

--- a/Source/VCGeneration/VC.cs
+++ b/Source/VCGeneration/VC.cs
@@ -1960,7 +1960,7 @@ namespace VC {
       protected VerifierCallback/*!*/ callback;
       protected ModelViewInfo MvInfo;
       internal string resourceExceededMessage;
-      static System.IO.TextWriter modelWriter;
+      
       [ContractInvariantMethod]
       void ObjectInvariant() {
         Contract.Invariant(gotoCmdOrigins != null);
@@ -1970,17 +1970,6 @@ namespace VC {
         Contract.Invariant(callback != null);
         Contract.Invariant(context != null);
         Contract.Invariant(program != null);
-      }
-
-
-      public static TextWriter ModelWriter {
-        get {
-          Contract.Ensures(Contract.Result<TextWriter>() != null);
-
-          if (ErrorReporter.modelWriter == null)
-            ErrorReporter.modelWriter = CommandLineOptions.Clo.PrintErrorModelFile == null ? Console.Out : new StreamWriter(CommandLineOptions.Clo.PrintErrorModelFile, false);
-          return ErrorReporter.modelWriter;
-        }
       }
 
       protected ProverContext/*!*/ context;
@@ -2023,17 +2012,6 @@ namespace VC {
       }
 
       public override void OnModel(IList<string/*!*/>/*!*/ labels, Model model, ProverInterface.Outcome proverOutcome) {
-        //Contract.Requires(cce.NonNullElements(labels));
-        if (CommandLineOptions.Clo.PrintErrorModel >= 1 && model != null) {
-          if (VC.ConditionGeneration.errorModelList != null)
-          {
-            VC.ConditionGeneration.errorModelList.Add(model);
-          }
-          
-          model.Write(ErrorReporter.ModelWriter);
-          ErrorReporter.ModelWriter.Flush();
-        }
-
         // no counter examples reported.
         if (labels.Count == 0) return;
 

--- a/Test/test15/IntInModel.bpl.expect
+++ b/Test/test15/IntInModel.bpl.expect
@@ -1,3 +1,6 @@
+IntInModel.bpl(4,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    IntInModel.bpl(4,3): anon0
 *** MODEL
 i -> 0
 ControlFlow -> {
@@ -12,8 +15,5 @@ tickleBool -> {
   else -> true
 }
 *** END_MODEL
-IntInModel.bpl(4,3): Error BP5001: This assertion might not hold.
-Execution trace:
-    IntInModel.bpl(4,3): anon0
 
 Boogie program verifier finished with 0 verified, 1 error

--- a/Test/test15/ModelTest.bpl.expect
+++ b/Test/test15/ModelTest.bpl.expect
@@ -1,3 +1,6 @@
+ModelTest.bpl(9,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    ModelTest.bpl(5,5): anon0
 *** MODEL
 i@0 -> 1
 j@0 -> 2
@@ -17,8 +20,5 @@ tickleBool -> {
   else -> true
 }
 *** END_MODEL
-ModelTest.bpl(9,3): Error BP5001: This assertion might not hold.
-Execution trace:
-    ModelTest.bpl(5,5): anon0
 
 Boogie program verifier finished with 0 verified, 1 error

--- a/Test/test15/NullInModel.bpl.expect
+++ b/Test/test15/NullInModel.bpl.expect
@@ -1,3 +1,6 @@
+NullInModel.bpl(4,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    NullInModel.bpl(4,3): anon0
 *** MODEL
 null -> T@ref!val!0
 s -> T@ref!val!0
@@ -13,8 +16,5 @@ tickleBool -> {
   else -> true
 }
 *** END_MODEL
-NullInModel.bpl(4,3): Error BP5001: This assertion might not hold.
-Execution trace:
-    NullInModel.bpl(4,3): anon0
 
 Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
Before this PR, counterexample printing and  model printing are happening at two different places, the former in ExecutionEngine and the latter inside the guts of VerifyImplementation.  This is undesirable for two reasons:
- Each counterexample corresponds to a particular model.  They should be printed together to make it easy to correlate the counterexample with the model.
- ExecutionEngine has synchronization in place to ensure that even when implementations are being verified in parallel, counterexample printing is serialized.  However, model printing does not have such protection. Consequently, if model printing is enabled with parallel verification, printed models are garbled (see issue #244).

This PR fixes the above problems by moving model printing to ExecutionEngine and exploiting the synchronization existing there to serialize model printing.

This PR also cleans up code  that is redundant (earlier and also as a result of this PR).