### PR TITLE
Add support for per implementation random seed

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -1912,6 +1912,10 @@ namespace Microsoft.Boogie
       {
         int tl = CommandLineOptions.Clo.TimeLimit;
         CheckIntAttribute("timeLimit", ref tl);
+        if (tl < 0)
+        {
+          tl = CommandLineOptions.Clo.TimeLimit;
+        }
         return tl;
       }
     }
@@ -1922,16 +1926,25 @@ namespace Microsoft.Boogie
       {
         int rl = CommandLineOptions.Clo.ResourceLimit;
         CheckIntAttribute("rlimit", ref rl);
+        if (rl < 0)
+        {
+          rl = CommandLineOptions.Clo.ResourceLimit;
+        }
         return rl;
       }
     }
 
-    public int? RandomSeed
+    public int RandomSeed
     {
       get
       {
         int rs = 0;
-        return CheckIntAttribute("random_seed", ref rs) ? (int?) rs : null;
+        CheckIntAttribute("random_seed", ref rs);
+        if (rs < 0)
+        {
+          rs = 0;
+        }
+        return rs;
       }
     }
     

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -1910,7 +1910,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        int tl = CommandLineOptions.Clo.ProverKillTime;
+        int tl = CommandLineOptions.Clo.TimeLimit;
         CheckIntAttribute("timeLimit", ref tl);
         return tl;
       }
@@ -1920,12 +1920,21 @@ namespace Microsoft.Boogie
     {
       get
       {
-        int rl = CommandLineOptions.Clo.Resourcelimit;
+        int rl = CommandLineOptions.Clo.ResourceLimit;
         CheckIntAttribute("rlimit", ref rl);
         return rl;
       }
     }
 
+    public int? RandomSeed
+    {
+      get
+      {
+        int rs = 0;
+        return CheckIntAttribute("random_seed", ref rs) ? (int?) rs : null;
+      }
+    }
+    
     public NamedDeclaration(IToken /*!*/ tok, string /*!*/ name)
       : base(tok)
     {

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -733,8 +733,8 @@ namespace Microsoft.Boogie
       }
     }
 
-    public int ProverKillTime = -1; // -1 means not specified
-    public int Resourcelimit = 0; // default to 0
+    public int TimeLimit = -1; // -1 means not specified
+    public int ResourceLimit = 0; // default to 0
     public int SmokeTimeout = 10; // default to 10s
     public int ProverCCLimit = 5;
     public bool RestartProverPerVC = false;
@@ -1637,11 +1637,11 @@ namespace Microsoft.Boogie
           return true;
 
         case "timeLimit":
-          ps.GetNumericArgument(ref ProverKillTime);
+          ps.GetNumericArgument(ref TimeLimit);
           return true;
 
         case "rlimit":
-          ps.GetNumericArgument(ref Resourcelimit);
+          ps.GetNumericArgument(ref ResourceLimit);
           return true;
 
         case "timeLimitPerAssertionInPercent":
@@ -1926,10 +1926,13 @@ namespace Microsoft.Boogie
        result caching (default: ""<impl. name>:0"").
 
      {:timeLimit N}
-       Set the time limit for a given implementation.
+       Set the time limit for verifying a given implementation.
 
      {:rlimit N}
-       Set the Z3 resource limit for a given implementation.
+       Set the Z3 resource limit for verifying a given implementation.
+
+     {:random_seed N}
+       Set the random seed for verifying a given implementation.
 
   ---- On functions ----------------------------------------------------------
 

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public int TimeLimit = -1; // -1 means not specified
+    public int TimeLimit = 0; // 0 means no limit
     public int ResourceLimit = 0; // default to 0
     public int SmokeTimeout = 10; // default to 10s
     public int ProverCCLimit = 5;
@@ -992,7 +992,7 @@ namespace Microsoft.Boogie
 
           return true;
 
-        case "CivlDesugaredFile":
+        case "civlDesugaredFile":
           if (ps.ConfirmArgumentCount(1))
           {
             CivlDesugaredFile = args[ps.i];

--- a/Source/Core/VCExp.cs
+++ b/Source/Core/VCExp.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Boogie
     public bool ForceLogStatus = false;
     public int TimeLimit = 0;
     public int ResourceLimit = 0;
+    public int RandomSeed = 0;
     public int MemoryLimit = 0;
     public int Verbosity = 0;
     public string ProverName;

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1452,7 +1452,7 @@ namespace Microsoft.Boogie
 
       foreach (Houdini.VCGenOutcome x in outcome.implementationOutcomes.Values)
       {
-        ProcessOutcome(x.outcome, x.errors, "", stats, Console.Out, CommandLineOptions.Clo.ProverKillTime, er);
+        ProcessOutcome(x.outcome, x.errors, "", stats, Console.Out, CommandLineOptions.Clo.TimeLimit, er);
         ProcessErrors(x.errors, x.outcome, Console.Out, er);
       }
 
@@ -1504,7 +1504,7 @@ namespace Microsoft.Boogie
 
       foreach (Houdini.VCGenOutcome x in outcome.implementationOutcomes.Values)
       {
-        ProcessOutcome(x.outcome, x.errors, "", stats, Console.Out, CommandLineOptions.Clo.ProverKillTime, er);
+        ProcessOutcome(x.outcome, x.errors, "", stats, Console.Out, CommandLineOptions.Clo.TimeLimit, er);
         ProcessErrors(x.errors, x.outcome, Console.Out, er);
       }
 
@@ -1528,7 +1528,7 @@ namespace Microsoft.Boogie
       // Run Abstract Houdini
       var abs = new Houdini.AbsHoudini(program, domain);
       var absout = abs.ComputeSummaries();
-      ProcessOutcome(absout.outcome, absout.errors, "", stats, Console.Out, CommandLineOptions.Clo.ProverKillTime, er);
+      ProcessOutcome(absout.outcome, absout.errors, "", stats, Console.Out, CommandLineOptions.Clo.TimeLimit, er);
       ProcessErrors(absout.errors, absout.outcome, Console.Out, er);
 
       //Houdini.PredicateAbs.Initialize(program);

--- a/Source/Houdini/AbstractHoudini.cs
+++ b/Source/Houdini/AbstractHoudini.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Boogie.Houdini
       this.vcgen = new VCGen(program, CommandLineOptions.Clo.ProverLogFilePath,
         CommandLineOptions.Clo.ProverLogFileAppend, new List<Checker>());
       this.prover = ProverInterface.CreateProver(program, CommandLineOptions.Clo.ProverLogFilePath,
-        CommandLineOptions.Clo.ProverLogFileAppend, CommandLineOptions.Clo.ProverKillTime);
+        CommandLineOptions.Clo.ProverLogFileAppend, CommandLineOptions.Clo.TimeLimit);
 
       this.proverTime = TimeSpan.Zero;
       this.numProverQueries = 0;
@@ -2405,10 +2405,10 @@ namespace Microsoft.Boogie.Houdini
       this.impl2Summary = new Dictionary<string, ISummaryElement>();
       this.name2Impl = SimpleUtil.nameImplMapping(program);
 
-      if (CommandLineOptions.Clo.ProverKillTime > 0)
+      if (CommandLineOptions.Clo.TimeLimit > 0)
         CommandLineOptions.Clo.ProverOptions =
           CommandLineOptions.Clo.ProverOptions.Concat1(string.Format("TIME_LIMIT={0}",
-            CommandLineOptions.Clo.ProverKillTime));
+            CommandLineOptions.Clo.TimeLimit));
 
       this.vcgen = new VCGen(program, CommandLineOptions.Clo.ProverLogFilePath,
         CommandLineOptions.Clo.ProverLogFileAppend, new List<Checker>());

--- a/Source/Houdini/Houdini.cs
+++ b/Source/Houdini/Houdini.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Boogie.Houdini
       this.vcgen = new VCGen(program, CommandLineOptions.Clo.ProverLogFilePath,
         CommandLineOptions.Clo.ProverLogFileAppend, new List<Checker>());
       this.proverInterface = ProverInterface.CreateProver(program, CommandLineOptions.Clo.ProverLogFilePath,
-        CommandLineOptions.Clo.ProverLogFileAppend, CommandLineOptions.Clo.ProverKillTime, taskID: GetTaskID());
+        CommandLineOptions.Clo.ProverLogFileAppend, CommandLineOptions.Clo.TimeLimit, taskID: GetTaskID());
 
       vcgenFailures = new HashSet<Implementation>();
       Dictionary<Implementation, HoudiniSession> houdiniSessions = new Dictionary<Implementation, HoudiniSession>();

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -431,7 +431,7 @@ namespace Microsoft.Boogie.SMTLib
           SendCommon("(set-option :produce-models true)");
         foreach (var opt in options.SmtOptions)
         {
-          SendThisVC("(set-option :" + opt.Option + " " + opt.Value + ")");
+          SendCommon("(set-option :" + opt.Option + " " + opt.Value + ")");
         }
         
         if (!string.IsNullOrEmpty(options.Logic))

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -433,7 +433,7 @@ namespace Microsoft.Boogie.SMTLib
         {
           SendCommon("(set-option :" + opt.Option + " " + opt.Value + ")");
         }
-        
+
         if (!string.IsNullOrEmpty(options.Logic))
         {
           SendCommon("(set-logic " + options.Logic + ")");

--- a/Source/Provers/SMTLib/SMTLibProverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibProverOptions.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Boogie.SMTLib
   public class SMTLibProverOptions : ProverOptions
   {
     public bool UseWeights = true;
-    public bool SupportsLabels => Solver == SolverKind.Z3;
     public bool UseTickleBool => Solver == SolverKind.Z3;
     public SolverKind Solver = SolverKind.Z3;
     public List<OptionValue> SmtOptions = new List<OptionValue>();

--- a/Source/Provers/SMTLib/Z3.cs
+++ b/Source/Provers/SMTLib/Z3.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Boogie.SMTLib
 
     public static string RlimitOption = "rlimit";
 
+    public static string RandomSeedOption = "smt.random_seed";
+    
     public static void SetDefaultOptions(SMTLibProverOptions options)
     {
       options.AddWeakSmtOption("smt.mbqi", "false"); // default: true

--- a/Source/VCGeneration/Check.cs
+++ b/Source/VCGeneration/Check.cs
@@ -214,29 +214,14 @@ namespace Microsoft.Boogie
       Setup(prog, ctx);
     }
 
-
     private void SetTimeout(int timeout)
     {
-      if (0 < timeout)
-      {
-        TheoremProver.SetTimeout(timeout * 1000);
-      }
-      else
-      {
-        TheoremProver.SetTimeout(0);
-      }
+      TheoremProver.SetTimeout(timeout * 1000);
     }
 
     private void SetRlimit(int rlimit)
     {
-      if (0 < rlimit)
-      {
-        TheoremProver.SetRlimit(rlimit);
-      }
-      else
-      {
-        TheoremProver.SetRlimit(0);
-      }
+      TheoremProver.SetRlimit(rlimit);
     }
 
     private void SetRandomSeed(int randomSeed)
@@ -379,7 +364,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, int timeout, int rlimit, int? randomSeed)
+    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, int timeout, int rlimit, int randomSeed = 0)
     {
       Contract.Requires(descriptiveName != null);
       Contract.Requires(vc != null);
@@ -394,10 +379,7 @@ namespace Microsoft.Boogie
       thmProver.Reset(gen);
       SetTimeout(timeout);
       SetRlimit(rlimit);
-      if (randomSeed.HasValue)
-      {
-        SetRandomSeed(randomSeed.Value);
-      }
+      SetRandomSeed(randomSeed);
       proverStart = DateTime.UtcNow;
       thmProver.BeginCheck(descriptiveName, vc, handler);
       //  gen.ClearSharedFormulas();    PR: don't know yet what to do with this guy

--- a/Source/VCGeneration/Check.cs
+++ b/Source/VCGeneration/Check.cs
@@ -46,9 +46,7 @@ namespace Microsoft.Boogie
     private readonly VCExpressionGenerator gen;
 
     private ProverInterface thmProver;
-    private int timeout;
-    private int rlimit;
-
+    
     // state for the async interface
     private volatile ProverInterface.Outcome outcome;
     private volatile bool hasOutput;
@@ -75,10 +73,9 @@ namespace Microsoft.Boogie
 
     public Task ProverTask { get; set; }
 
-    public bool WillingToHandle(int timeout, int rlimit, Program prog)
+    public bool WillingToHandle(Program prog)
     {
-      return status == CheckerStatus.Idle && timeout == this.timeout && rlimit == this.rlimit &&
-             (prog == null || Program == prog);
+      return status == CheckerStatus.Idle && (prog == null || Program == prog);
     }
 
     public VCExpressionGenerator VCExprGen
@@ -144,13 +141,11 @@ namespace Microsoft.Boogie
     /// Constructor.  Initialize a checker with the program and log file.
     /// Optionally, use prover context provided by parameter "ctx". 
     /// </summary>
-    public Checker(VC.ConditionGeneration vcgen, Program prog, string /*?*/ logFilePath, bool appendLogFile,
-      int timeout, int rlimit = 0, ProverContext ctx = null)
+    public Checker(VC.ConditionGeneration vcgen, Program prog, string /*?*/ logFilePath, bool appendLogFile, 
+      ProverContext ctx = null)
     {
       Contract.Requires(vcgen != null);
       Contract.Requires(prog != null);
-      this.timeout = timeout;
-      this.rlimit = rlimit;
       this.Program = prog;
 
       ProverOptions options = cce.NonNull(CommandLineOptions.Clo.TheProverFactory).BlankProverOptions();
@@ -160,20 +155,6 @@ namespace Microsoft.Boogie
         options.LogFilename = logFilePath;
         if (appendLogFile)
           options.AppendLogFile = appendLogFile;
-      }
-
-      if (timeout > 0)
-      {
-        options.TimeLimit = timeout * 1000;
-      }
-
-      if (rlimit > 0)
-      {
-        options.ResourceLimit = rlimit;
-      }
-      else
-      {
-        options.ResourceLimit = 0;
       }
 
       options.Parse(CommandLineOptions.Clo.ProverOptions);
@@ -213,7 +194,7 @@ namespace Microsoft.Boogie
       this.gen = prover.VCExprGen;
     }
 
-    public void Retarget(Program prog, ProverContext ctx, int timeout = 0, int rlimit = 0)
+    public void Retarget(Program prog, ProverContext ctx)
     {
       lock (this)
       {
@@ -224,10 +205,6 @@ namespace Microsoft.Boogie
         TheoremProver.FullReset(gen);
         ctx.Reset();
         Setup(prog, ctx);
-        this.timeout = timeout;
-        SetTimeout();
-        this.rlimit = rlimit;
-        SetRlimit();
       }
     }
 
@@ -238,19 +215,19 @@ namespace Microsoft.Boogie
     }
 
 
-    public void SetTimeout()
+    private void SetTimeout(int timeout)
     {
       if (0 < timeout)
       {
-        TheoremProver.SetTimeOut(timeout * 1000);
+        TheoremProver.SetTimeout(timeout * 1000);
       }
       else
       {
-        TheoremProver.SetTimeOut(0);
+        TheoremProver.SetTimeout(0);
       }
     }
 
-    public void SetRlimit()
+    private void SetRlimit(int rlimit)
     {
       if (0 < rlimit)
       {
@@ -262,6 +239,11 @@ namespace Microsoft.Boogie
       }
     }
 
+    private void SetRandomSeed(int randomSeed)
+    {
+      TheoremProver.SetRandomSeed(randomSeed);
+    }
+    
     /// <summary>
     /// Set up the context.
     /// </summary>
@@ -397,7 +379,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler)
+    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, int timeout, int rlimit, int? randomSeed)
     {
       Contract.Requires(descriptiveName != null);
       Contract.Requires(vc != null);
@@ -410,8 +392,12 @@ namespace Microsoft.Boogie
       this.handler = handler;
 
       thmProver.Reset(gen);
-      SetTimeout();
-      SetRlimit();
+      SetTimeout(timeout);
+      SetRlimit(rlimit);
+      if (randomSeed.HasValue)
+      {
+        SetRandomSeed(randomSeed.Value);
+      }
       proverStart = DateTime.UtcNow;
       thmProver.BeginCheck(descriptiveName, vc, handler);
       //  gen.ClearSharedFormulas();    PR: don't know yet what to do with this guy
@@ -699,7 +685,7 @@ namespace Microsoft.Boogie
     }
 
     // Set theorem prover timeout for the next "check-sat"
-    public virtual void SetTimeOut(int ms)
+    public virtual void SetTimeout(int ms)
     {
     }
 
@@ -707,6 +693,10 @@ namespace Microsoft.Boogie
     {
     }
 
+    public virtual void SetRandomSeed(int randomSeed)
+    {
+    }
+    
     public abstract ProverContext Context { get; }
 
     public abstract VCExpressionGenerator VCExprGen { get; }

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -1133,8 +1133,7 @@ namespace VC
     #endregion
 
 
-    protected Checker FindCheckerFor(int timeout, int rlimit = 0, bool isBlocking = true, int waitTimeinMs = 50,
-      int maxRetries = 3)
+    protected Checker FindCheckerFor(bool isBlocking = true, int waitTimeinMs = 50, int maxRetries = 3)
     {
       Contract.Requires(0 <= waitTimeinMs && 0 <= maxRetries);
       Contract.Ensures(!isBlocking || Contract.Result<Checker>() != null);
@@ -1150,7 +1149,7 @@ namespace VC
           {
             try
             {
-              if (c.WillingToHandle(timeout, rlimit, program))
+              if (c.WillingToHandle(program))
               {
                 c.GetReady();
                 return c;
@@ -1159,7 +1158,7 @@ namespace VC
               {
                 if (c.IsIdle)
                 {
-                  c.Retarget(program, c.TheoremProver.Context, timeout, rlimit);
+                  c.Retarget(program, c.TheoremProver.Context);
                   c.GetReady();
                   return c;
                 }
@@ -1203,7 +1202,7 @@ namespace VC
           log = log + "." + checkers.Count;
         }
 
-        Checker ch = new Checker(this, program, log, appendLogFile, timeout, rlimit);
+        Checker ch = new Checker(this, program, log, appendLogFile);
         ch.GetReady();
         checkers.Add(ch);
         return ch;

--- a/Source/VCGeneration/FixedpointVC.cs
+++ b/Source/VCGeneration/FixedpointVC.cs
@@ -139,8 +139,7 @@ namespace Microsoft.Boogie
       program = _program;
       gen = ctx;
       if (old_checker == null)
-        checker = new Checker(this, program, logFilePath, appendLogFile, CommandLineOptions.Clo.ProverKillTime,
-          CommandLineOptions.Clo.Resourcelimit, null);
+        checker = new Checker(this, program, logFilePath, appendLogFile, null);
       else
       {
         checker = old_checker;

--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -1365,7 +1365,7 @@ namespace VC
       while (true)
       {
         // Check timeout
-        if (CommandLineOptions.Clo.TimeLimit != -1)
+        if (CommandLineOptions.Clo.TimeLimit != 0)
         {
           if ((DateTime.UtcNow - startTime).TotalSeconds > CommandLineOptions.Clo.TimeLimit)
           {

--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -663,7 +663,7 @@ namespace VC
       : base(program, logFilePath, appendLogFile, checkers)
     {
       implName2StratifiedInliningInfo = new Dictionary<string, StratifiedInliningInfo>();
-      prover = ProverInterface.CreateProver(program, logFilePath, appendLogFile, CommandLineOptions.Clo.ProverKillTime);
+      prover = ProverInterface.CreateProver(program, logFilePath, appendLogFile, CommandLineOptions.Clo.TimeLimit);
       foreach (var impl in program.Implementations)
       {
         implName2StratifiedInliningInfo[impl.Name] = new StratifiedInliningInfo(impl, this, PassiveImplInstrumentation);
@@ -1365,9 +1365,9 @@ namespace VC
       while (true)
       {
         // Check timeout
-        if (CommandLineOptions.Clo.ProverKillTime != -1)
+        if (CommandLineOptions.Clo.TimeLimit != -1)
         {
-          if ((DateTime.UtcNow - startTime).TotalSeconds > CommandLineOptions.Clo.ProverKillTime)
+          if ((DateTime.UtcNow - startTime).TotalSeconds > CommandLineOptions.Clo.TimeLimit)
           {
             ret = Outcome.TimedOut;
             break;
@@ -3151,7 +3151,7 @@ namespace VC
       var startTime = DateTime.UtcNow;
 
       CommandLineOptions.Clo.ProverCCLimit = 1;
-      prover = ProverInterface.CreateProver(program, logFilePath, appendLogFile, CommandLineOptions.Clo.ProverKillTime);
+      prover = ProverInterface.CreateProver(program, logFilePath, appendLogFile, CommandLineOptions.Clo.TimeLimit);
 
       // Flush any axioms that came with the program before we start SI on this implementation
       prover.AssertAxioms();

--- a/Source/VCGeneration/VC.cs
+++ b/Source/VCGeneration/VC.cs
@@ -347,7 +347,7 @@ namespace VC
         ModelViewInfo mvInfo;
         parent.PassifyImpl(impl, out mvInfo);
         Dictionary<int, Absy> label2Absy;
-        Checker ch = parent.FindCheckerFor(CommandLineOptions.Clo.SmokeTimeout, CommandLineOptions.Clo.Resourcelimit);
+        Checker ch = parent.FindCheckerFor();
         Contract.Assert(ch != null);
 
         ProverInterface.Outcome outcome = ProverInterface.Outcome.Undetermined;
@@ -375,7 +375,8 @@ namespace VC
               Emit();
             }
 
-            ch.BeginCheck(cce.NonNull(impl.Name + "_smoke" + id++), vc, new ErrorHandler(label2Absy, this.callback));
+            ch.BeginCheck(cce.NonNull(impl.Name + "_smoke" + id++), vc, new ErrorHandler(label2Absy, this.callback), 
+              CommandLineOptions.Clo.SmokeTimeout, CommandLineOptions.Clo.ResourceLimit, null);
           }
 
           ch.ProverTask.Wait();
@@ -1674,7 +1675,7 @@ namespace VC
       /// <summary>
       /// As a side effect, updates "this.parent.CumulativeAssertionCount".
       /// </summary>
-      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, int timeout)
+      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, int timeout, int rlimit)
       {
         Contract.Requires(checker != null);
         Contract.Requires(callback != null);
@@ -1714,7 +1715,7 @@ namespace VC
         string desc = cce.NonNull(impl.Name);
         if (no >= 0)
           desc += "_split" + no;
-        checker.BeginCheck(desc, vc, reporter);
+        checker.BeginCheck(desc, vc, reporter, timeout, rlimit, impl.RandomSeed);
       }
 
       private void SoundnessCheck(HashSet<List<Block> /*!*/> /*!*/ cache, Block /*!*/ orig,
@@ -2155,7 +2156,7 @@ namespace VC
               keep_going ? CommandLineOptions.Clo.VcsKeepGoingTimeout :
               impl.TimeLimit;
 
-            var checker = s.parent.FindCheckerFor(timeout, impl.ResourceLimit, false);
+            var checker = s.parent.FindCheckerFor(false);
             try
             {
               if (checker == null)
@@ -2179,7 +2180,7 @@ namespace VC
               Contract.Assert(s.parent == this);
               lock (checker)
               {
-                s.BeginCheck(checker, callback, mvInfo, no, timeout);
+                s.BeginCheck(checker, callback, mvInfo, no, timeout, impl.ResourceLimit);
               }
 
               no++;

--- a/Source/VCGeneration/VC.cs
+++ b/Source/VCGeneration/VC.cs
@@ -376,7 +376,7 @@ namespace VC
             }
 
             ch.BeginCheck(cce.NonNull(impl.Name + "_smoke" + id++), vc, new ErrorHandler(label2Absy, this.callback), 
-              CommandLineOptions.Clo.SmokeTimeout, CommandLineOptions.Clo.ResourceLimit, null);
+              CommandLineOptions.Clo.SmokeTimeout, CommandLineOptions.Clo.ResourceLimit);
           }
 
           ch.ProverTask.Wait();

--- a/Test/test2/RandomSeed.bpl
+++ b/Test/test2/RandomSeed.bpl
@@ -1,0 +1,6 @@
+// RUN: %boogie -proverLog:%t "%s"
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+// CHECK-L: (set-option :smt.random_seed 100)
+procedure {:random_seed 100} TestTimeouts0()
+{
+}

--- a/Test/test2/RandomSeed.bpl
+++ b/Test/test2/RandomSeed.bpl
@@ -1,6 +1,10 @@
 // RUN: %boogie -proverLog:%t "%s"
 // RUN: %OutputCheck --file-to-check "%t" "%s"
 // CHECK-L: (set-option :smt.random_seed 100)
-procedure {:random_seed 100} TestTimeouts0()
+// CHECK-L: (set-option :smt.random_seed 0)
+procedure {:random_seed 100} WithRandomSeed()
+{
+}
+procedure WithoutRandomSeed()
 {
 }

--- a/Test/test2/Timeouts0.bpl
+++ b/Test/test2/Timeouts0.bpl
@@ -1,5 +1,10 @@
 // RUN: %boogie -timeLimit:4 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+// RUN: %boogie -timeLimit:4 -proverLog:%t "%s"
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+// CHECK-L: (set-option :timeout 4000)
+// CHECK-L: (set-option :timeout 8000)
+// CHECK-L: (set-option :timeout 2000)
 procedure TestTimeouts0(in: [int]int, len: int) returns (out: [int]int)
   requires in[0] == 0 && (forall i: int :: 0 <= i ==> in[i + 1] == in[i] + 1);
   requires 0 < len;

--- a/Test/test2/Timeouts0.bpl.expect
+++ b/Test/test2/Timeouts0.bpl.expect
@@ -1,47 +1,47 @@
-Timeouts0.bpl(21,5): Error BP5003: A postcondition might not hold on this return path.
-Timeouts0.bpl(6,3): Related location: This is the postcondition that might not hold.
+Timeouts0.bpl(26,5): Error BP5003: A postcondition might not hold on this return path.
+Timeouts0.bpl(11,3): Related location: This is the postcondition that might not hold.
 Execution trace:
-    Timeouts0.bpl(10,7): anon0
-    Timeouts0.bpl(12,5): anon4_LoopHead
-    Timeouts0.bpl(12,5): anon4_LoopDone
-    Timeouts0.bpl(21,5): anon5_LoopHead
-    Timeouts0.bpl(21,5): anon5_LoopDone
-Timeouts0.bpl(23,7): Error BP5005: This loop invariant might not be maintained by the loop.
+    Timeouts0.bpl(15,7): anon0
+    Timeouts0.bpl(17,5): anon4_LoopHead
+    Timeouts0.bpl(17,5): anon4_LoopDone
+    Timeouts0.bpl(26,5): anon5_LoopHead
+    Timeouts0.bpl(26,5): anon5_LoopDone
+Timeouts0.bpl(28,7): Error BP5005: This loop invariant might not be maintained by the loop.
 Execution trace:
-    Timeouts0.bpl(10,7): anon0
-    Timeouts0.bpl(12,5): anon4_LoopHead
-    Timeouts0.bpl(12,5): anon4_LoopDone
-    Timeouts0.bpl(21,5): anon5_LoopHead
-    Timeouts0.bpl(25,11): anon5_LoopBody
-Timeouts0.bpl(50,5): Error BP5003: A postcondition might not hold on this return path.
-Timeouts0.bpl(33,3): Related location: This is the postcondition that might not hold.
+    Timeouts0.bpl(15,7): anon0
+    Timeouts0.bpl(17,5): anon4_LoopHead
+    Timeouts0.bpl(17,5): anon4_LoopDone
+    Timeouts0.bpl(26,5): anon5_LoopHead
+    Timeouts0.bpl(30,11): anon5_LoopBody
+Timeouts0.bpl(55,5): Error BP5003: A postcondition might not hold on this return path.
+Timeouts0.bpl(38,3): Related location: This is the postcondition that might not hold.
 Execution trace:
-    Timeouts0.bpl(39,7): anon0
-    Timeouts0.bpl(41,5): anon4_LoopHead
-    Timeouts0.bpl(41,5): anon4_LoopDone
-    Timeouts0.bpl(50,5): anon5_LoopHead
-    Timeouts0.bpl(50,5): anon5_LoopDone
-Timeouts0.bpl(52,7): Error BP5005: This loop invariant might not be maintained by the loop.
+    Timeouts0.bpl(44,7): anon0
+    Timeouts0.bpl(46,5): anon4_LoopHead
+    Timeouts0.bpl(46,5): anon4_LoopDone
+    Timeouts0.bpl(55,5): anon5_LoopHead
+    Timeouts0.bpl(55,5): anon5_LoopDone
+Timeouts0.bpl(57,7): Error BP5005: This loop invariant might not be maintained by the loop.
 Execution trace:
-    Timeouts0.bpl(39,7): anon0
-    Timeouts0.bpl(41,5): anon4_LoopHead
-    Timeouts0.bpl(41,5): anon4_LoopDone
-    Timeouts0.bpl(50,5): anon5_LoopHead
-    Timeouts0.bpl(54,11): anon5_LoopBody
-Timeouts0.bpl(79,5): Error BP5003: A postcondition might not hold on this return path.
-Timeouts0.bpl(62,3): Related location: This is the postcondition that might not hold.
+    Timeouts0.bpl(44,7): anon0
+    Timeouts0.bpl(46,5): anon4_LoopHead
+    Timeouts0.bpl(46,5): anon4_LoopDone
+    Timeouts0.bpl(55,5): anon5_LoopHead
+    Timeouts0.bpl(59,11): anon5_LoopBody
+Timeouts0.bpl(84,5): Error BP5003: A postcondition might not hold on this return path.
+Timeouts0.bpl(67,3): Related location: This is the postcondition that might not hold.
 Execution trace:
-    Timeouts0.bpl(68,7): anon0
-    Timeouts0.bpl(70,5): anon4_LoopHead
-    Timeouts0.bpl(70,5): anon4_LoopDone
-    Timeouts0.bpl(79,5): anon5_LoopHead
-    Timeouts0.bpl(79,5): anon5_LoopDone
-Timeouts0.bpl(81,7): Error BP5005: This loop invariant might not be maintained by the loop.
+    Timeouts0.bpl(73,7): anon0
+    Timeouts0.bpl(75,5): anon4_LoopHead
+    Timeouts0.bpl(75,5): anon4_LoopDone
+    Timeouts0.bpl(84,5): anon5_LoopHead
+    Timeouts0.bpl(84,5): anon5_LoopDone
+Timeouts0.bpl(86,7): Error BP5005: This loop invariant might not be maintained by the loop.
 Execution trace:
-    Timeouts0.bpl(68,7): anon0
-    Timeouts0.bpl(70,5): anon4_LoopHead
-    Timeouts0.bpl(70,5): anon4_LoopDone
-    Timeouts0.bpl(79,5): anon5_LoopHead
-    Timeouts0.bpl(83,11): anon5_LoopBody
+    Timeouts0.bpl(73,7): anon0
+    Timeouts0.bpl(75,5): anon4_LoopHead
+    Timeouts0.bpl(75,5): anon4_LoopDone
+    Timeouts0.bpl(84,5): anon5_LoopHead
+    Timeouts0.bpl(88,11): anon5_LoopBody
 
 Boogie program verifier finished with 0 verified, 6 errors


### PR DESCRIPTION
1. Before this PR, Timeout and Rlimit were set in PrepareCommon.  Therefore, it was not possible to set these limits in a fine-grained way per verification problem. Now, these are set for each verification problem inside BeginCheck.  

2. This  PR adds support for adding a random seed for each implementation.  This is useful for experimenting with different random seeds and then affixing one to the implementation once discovered so that deterministic execution is possible across machines. A key change accompanying this feature addition is that the random seed is reset to 0 before each VC is verified.  Thus, each VC is verified from the same initial random seed, thus reducing nondeterministic behavior I have observed in the past where VC may be verified or not depending on how many other VCs in the file are being verified.

3. ProverKillTime is renamed to TimeLimit and its default value is changed to 0 (as opposed to -1) leading to clean up in various parts of the code.

4. The option CivlDesugaredFile is renamed to civlDesugaredFile for consistency.