### PR TITLE
Fixed bug in inliner

### DIFF
--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -821,7 +821,7 @@ namespace Microsoft.Boogie
     // ----------------------------- Substitutions for CmdSeq -------------------------------
 
     /// <summary>
-    /// Apply a substitution to a command.  Any variables not in domain(subst)
+    /// Apply a substitution to a command sequence.  Any variables not in domain(subst)
     /// is not changed.  The substitutions apply within the "old", but the "old"
     /// expression remains.
     /// </summary>
@@ -834,7 +834,7 @@ namespace Microsoft.Boogie
     }
 
     /// <summary>
-    /// Apply a substitution to a command.  
+    /// Apply a substitution to a command sequence.  
     /// Outside "old" expressions, the substitution "always" is applied; any variable not in
     /// domain(always) is not changed.  Inside "old" expressions, apply map "forOld" to
     /// variables in domain(forOld), apply map "always" to variables in
@@ -850,7 +850,7 @@ namespace Microsoft.Boogie
     }
 
     /// <summary>
-    /// Apply a substitution to a command replacing "old" expressions.
+    /// Apply a substitution to a command sequence replacing "old" expressions.
     /// Outside "old" expressions, the substitution "always" is applied; any variable not in
     /// domain(always) is not changed.  Inside "old" expressions, apply map "forOld" to
     /// variables in domain(forOld), apply map "always" to variables in

--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -1174,6 +1174,28 @@ namespace Microsoft.Boogie
       // Don't remove this implementation! Triggers should be duplicated in VisitBinderExpr.
       return (QuantifierExpr) this.VisitBinderExpr(node);
     }
+
+    public override Expr VisitLetExpr(LetExpr node)
+    {
+      var oldToNew = node.Dummies.ToDictionary(x => x,
+        x => new BoundVariable(Token.NoToken, new TypedIdent(Token.NoToken, prefix + x.Name, x.TypedIdent.Type),
+          x.Attributes));
+
+      foreach (var x in node.Dummies)
+      {
+        boundVarSubst.Add(x, Expr.Ident(oldToNew[x]));
+      }
+
+      var expr = (LetExpr) base.VisitLetExpr(node);
+      expr.Dummies = node.Dummies.Select(x => oldToNew[x]).ToList<Variable>();
+
+      foreach (var x in node.Dummies)
+      {
+        boundVarSubst.Remove(x);
+      }
+
+      return expr;
+    }
   }
   #endregion
 }

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -33,9 +33,6 @@ namespace Microsoft.Boogie
     protected List<Variable> /*!*/
       newLocalVars;
 
-    protected List<IdentifierExpr> /*!*/
-      newModifies;
-
     protected string prefix;
     
     private InlineCallback inlineCallback;
@@ -47,7 +44,6 @@ namespace Microsoft.Boogie
     {
       Contract.Invariant(program != null);
       Contract.Invariant(newLocalVars != null);
-      Contract.Invariant(newModifies != null);
       Contract.Invariant(codeCopier != null);
       Contract.Invariant(recursiveProcUnrollMap != null);
       Contract.Invariant(inlinedProcLblMap != null);
@@ -100,7 +96,6 @@ namespace Microsoft.Boogie
       this.codeCopier = new CodeCopier();
       this.inlineCallback = cb;
       this.newLocalVars = new List<Variable>();
-      this.newModifies = new List<IdentifierExpr>();
       this.prefix = null;
     }
 
@@ -158,7 +153,6 @@ namespace Microsoft.Boogie
       inliner.ComputePrefix(program, impl);
 
       inliner.newLocalVars.AddRange(impl.LocVars);
-      inliner.newModifies.AddRange(impl.Proc.Modifies);
 
       bool inlined = false;
       List<Block> newBlocks = inliner.DoInlineBlocks(impl.Blocks, ref inlined);
@@ -170,7 +164,6 @@ namespace Microsoft.Boogie
       impl.InParams = new List<Variable>(impl.InParams);
       impl.OutParams = new List<Variable>(impl.OutParams);
       impl.LocVars = inliner.newLocalVars;
-      impl.Proc.Modifies = inliner.newModifies;
       impl.Blocks = newBlocks;
 
       impl.ResetImplFormalMap();
@@ -475,7 +468,6 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(impl != null);
       Contract.Requires(impl.Proc != null);
-      Contract.Requires(newModifies != null);
       Contract.Requires(newLocalVars != null);
 
       Dictionary<Variable, Expr> substMap = new Dictionary<Variable, Expr>();
@@ -543,13 +535,6 @@ namespace Microsoft.Boogie
         if (!substMapOld.ContainsKey(mVar))
         {
           substMapOld.Add(mVar, ie);
-        }
-
-        // FIXME why are we doing this? the modifies list should already include them.
-        // add the modified variable to the modifies list of the procedure
-        if (!newModifies.Contains(mie))
-        {
-          newModifies.Add(mie);
         }
       }
 

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -454,7 +454,7 @@ namespace Microsoft.Boogie
           }
         }
 
-        Block newBlock = new Block(block.tok, ((lblCount == 0) ? (block.Label) : (block.Label + "$" + lblCount)),
+        Block newBlock = new Block(block.tok, lblCount == 0 ? block.Label : block.Label + "$" + lblCount,
           newCmds, codeCopier.CopyTransferCmd(transferCmd));
         newBlocks.Add(newBlock);
       }

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -4,8 +4,6 @@
 //
 //-----------------------------------------------------------------------------
 
-using System.Runtime.Serialization;
-
 namespace Microsoft.Boogie
 {
   using System;
@@ -836,29 +834,21 @@ namespace Microsoft.Boogie
       {
         Contract.Requires(cmd != null);
         Contract.Ensures(Contract.Result<TransferCmd>() != null);
-        TransferCmd transferCmd;
-        GotoCmd gotocmd = cmd as GotoCmd;
-        if (gotocmd != null)
+        if (cmd is GotoCmd gotocmd)
         {
           Contract.Assert(gotocmd.labelNames != null);
           List<String> labels = new List<String>();
           labels.AddRange(gotocmd.labelNames);
-          transferCmd = new GotoCmd(cmd.tok, labels);
+          return new GotoCmd(cmd.tok, labels);
+        }
+        else if (cmd is ReturnExprCmd returnExprCmd)
+        {
+          return new ReturnExprCmd(cmd.tok, CopyExpr(returnExprCmd.Expr));
         }
         else
         {
-          ReturnExprCmd returnExprCmd = cmd as ReturnExprCmd;
-          if (returnExprCmd != null)
-          {
-            transferCmd = new ReturnExprCmd(cmd.tok, CopyExpr(returnExprCmd.Expr));
-          }
-          else
-          {
-            transferCmd = new ReturnCmd(cmd.tok);
-          }
+          return new ReturnCmd(cmd.tok);
         }
-
-        return transferCmd;
       }
 
       public Cmd CopyCmd(Cmd cmd)

--- a/Source/Houdini/AbstractHoudini.cs
+++ b/Source/Houdini/AbstractHoudini.cs
@@ -2488,9 +2488,9 @@ namespace Microsoft.Boogie.Houdini
             impl.InParams, impl.OutParams, new List<Variable>(impl.LocVars), new List<Block>());
           foreach (var blk in impl.Blocks)
           {
-            var cd = new CodeCopier();
+            var cd = new Duplicator();
             nimpl.Blocks.Add(new Block(Token.NoToken, blk.Label,
-              cd.CopyCmdSeq(blk.Cmds), cd.CopyTransferCmd(blk.TransferCmd)));
+              cd.VisitCmdSeq(blk.Cmds), cd.VisitTransferCmd(blk.TransferCmd)));
           }
 
           copy.Add(impl.Name, nimpl);

--- a/Test/inline/test7.bpl
+++ b/Test/inline/test7.bpl
@@ -8,6 +8,8 @@ modifies arr;
 ensures (forall a:int  :: {arr[a]} a < 10 ==> arr[a] == 0);
 {
   assert (forall a:int  :: {arr[a]} a < 10 ==> arr[a] == 0);
+  assert arr == (lambda a: int :: 10);
+  assert (var a := 42; a == 42);
 }
 procedure foo(a:ref)
 modifies arr;

--- a/Test/inline/test7.bpl
+++ b/Test/inline/test7.bpl
@@ -1,0 +1,16 @@
+// RUN: %boogie -inline:spec -print:- -env:0 -printInlined "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+type ref;
+var arr:[int]int;
+
+procedure {:inline 1} b()
+modifies arr;
+ensures (forall a:int  :: {arr[a]} a < 10 ==> arr[a] == 0);
+{
+  assert (forall a:int  :: {arr[a]} a < 10 ==> arr[a] == 0);
+}
+procedure foo(a:ref)
+modifies arr;
+{
+   call b();
+}

--- a/Test/inline/test7.bpl.expect
+++ b/Test/inline/test7.bpl.expect
@@ -1,0 +1,73 @@
+
+type ref;
+
+var arr: [int]int;
+
+procedure {:inline 1} b();
+  modifies arr;
+  ensures (forall a: int :: { arr[a] } a < 10 ==> arr[a] == 0);
+
+
+
+implementation {:inline 1} b()
+{
+
+  anon0:
+    assert (forall a: int :: { arr[a] } a < 10 ==> arr[a] == 0);
+    return;
+}
+
+
+
+procedure foo(a: ref);
+  modifies arr;
+
+
+
+implementation foo(a: ref)
+{
+
+  anon0:
+    call b();
+    return;
+}
+
+
+after inlining procedure calls
+procedure foo(a: ref);
+  modifies arr;
+
+
+implementation foo(a: ref)
+{
+  var inline$b$0$arr: [int]int;
+
+  anon0:
+    goto inline$b$0$Entry;
+
+  inline$b$0$Entry:
+    inline$b$0$arr := arr;
+    goto inline$b$0$anon0;
+
+  inline$b$0$anon0:
+    assert (forall inline$b$0$a: int :: { arr[inline$b$0$a] } inline$b$0$a < 10 ==> arr[inline$b$0$a] == 0);
+    goto inline$b$0$Return;
+
+  inline$b$0$Return:
+    assert (forall inline$b$0$a: int :: { arr[inline$b$0$a] } inline$b$0$a < 10 ==> arr[inline$b$0$a] == 0);
+    goto anon0$1;
+
+  anon0$1:
+    return;
+}
+
+
+<console>(16,4): Error BP5001: This assertion might not hold.
+Execution trace:
+    <console>(15,0): anon0
+<console>(13,4): Error BP5001: This assertion might not hold.
+Execution trace:
+    <console>(5,0): anon0
+    <console>(12,0): inline$b$0$anon0
+
+Boogie program verifier finished with 0 verified, 2 errors

--- a/Test/inline/test7.bpl.expect
+++ b/Test/inline/test7.bpl.expect
@@ -14,6 +14,8 @@ implementation {:inline 1} b()
 
   anon0:
     assert (forall a: int :: { arr[a] } a < 10 ==> arr[a] == 0);
+    assert arr == (lambda a: int :: 10);
+    assert (var a := 42; a == 42);
     return;
 }
 
@@ -51,6 +53,8 @@ implementation foo(a: ref)
 
   inline$b$0$anon0:
     assert (forall inline$b$0$a: int :: { arr[inline$b$0$a] } inline$b$0$a < 10 ==> arr[inline$b$0$a] == 0);
+    assert arr == (lambda inline$b$0$a: int :: 10);
+    assert (var inline$b$0$a := 42; inline$b$0$a == 42);
     goto inline$b$0$Return;
 
   inline$b$0$Return:
@@ -65,9 +69,16 @@ implementation foo(a: ref)
 <console>(16,4): Error BP5001: This assertion might not hold.
 Execution trace:
     <console>(15,0): anon0
+<console>(17,4): Error BP5001: This assertion might not hold.
+Execution trace:
+    <console>(15,0): anon0
 <console>(13,4): Error BP5001: This assertion might not hold.
 Execution trace:
     <console>(5,0): anon0
     <console>(12,0): inline$b$0$anon0
+<console>(14,4): Error BP5001: This assertion might not hold.
+Execution trace:
+    <console>(5,0): anon0
+    <console>(12,0): inline$b$0$anon0
 
-Boogie program verifier finished with 0 verified, 2 errors
+Boogie program verifier finished with 0 verified, 4 errors


### PR DESCRIPTION
This PR closes issue #19. 
- Make CodeCopier a private class of Inliner; external uses of CodeCopier are retargeted to Duplicator.
- Add renaming of bound variables in lambdas, quantifiers, and let expressions during inlining.
- Remove unnecessary modifies computation during inlining.

Sorry it has taken such a long time to fix this issue.