### PR TITLE
Allow long quantifier identifiers

### DIFF
--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -665,12 +665,8 @@ namespace Microsoft.Boogie.VCExprAST
       {
         // generate default name (line:column position in .bpl file)
         Variable v = vars[0];
-        Contract.Assert(v != null); // Rustan's claim!
-        // Include the first 8 characters of the filename in QID (helpful in case we use /concat)
-        // We limit it to 8, so the SX file doesn't grow too big, and who on earth would need
-        // more than 8 characters in a filename anyways.
-        int max = 8;
-        StringBuilder buf = new StringBuilder(max + 20);
+        Contract.Assert(v != null);
+        StringBuilder buf = new StringBuilder(20);
         string filename = v.tok.filename;
         if (filename == null)
           filename = "unknown";
@@ -678,7 +674,7 @@ namespace Microsoft.Boogie.VCExprAST
         {
           if (filename[i] == '/' || filename[i] == '\\')
             buf.Length = 0;
-          if (buf.Length < max && char.IsLetterOrDigit(filename[i]))
+          if (char.IsLetterOrDigit(filename[i]))
           {
             if (buf.Length == 0 && char.IsDigit(filename[i]))
             {


### PR DESCRIPTION
When generating a verification condition, Boogie automatically gives ":qid"s to quantifiers based on their position in the source files. These names are especially helpful when profiling quantifier instantiation performance. However, Boogie previously limited the filename to the first 8 characters, which sometimes made it difficult to tell which exact file was being referenced. This PR removes this upper limit.

I am open to discussion on the approach, because I didn't really understand the comments in the code. It says the filenames were limited in length "so the SX file doesn't grow too big". I'm not sure what SX means, but assuming it means the `.smt2` file, this doesn't seem like a big issue to me. If people feel otherwise, we could make it a configurable option, but I kind of feel like that's overkill for this feature.