### PR TITLE
Allow using a Stream to parse a program that still need to be pre-processed

### DIFF
--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -31,26 +31,26 @@ readonly StructuredCmd/*!*/ dummyStructuredCmd;
 ///Returns the number of parsing errors encountered.  If 0, "program" returns as
 ///the parsed program.
 ///</summary>
-public static int Parse (string/*!*/ filename, /*maybe null*/ List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
+public static int Parse (string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(filename != null);
   Contract.Requires(cce.NonNullElements(defines,true));
 
-  if (defines == null) {
-    defines = new List<string/*!*/>();
-  }
-
   if (filename == "stdin.bpl") {
-    var s = ParserHelper.Fill(Console.In, defines);
-    return Parse(s, filename, out program, useBaseName);
-  } else {
-    FileStream stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read);
-    var s = ParserHelper.Fill(stream, defines);
-    var ret = Parse(s, filename, out program, useBaseName);
-    stream.Close();
-    return ret;
+    return Parse(Console.In, filename, defines, out program, useBaseName);
+  } else
+  {
+    using (FileStream stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read))
+    {
+      return Parse(new StreamReader(stream), filename, defines, out program, useBaseName);
+    }
   }
 }
 
+public static int Parse(TextReader stream, string/*!*/ filename, List<string> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ 
+{
+  var preprocessedSource = ParserHelper.Fill(stream, defines);
+  return Parse(preprocessedSource, filename, out program, useBaseName);
+}
 
 public static int Parse (string s, string/*!*/ filename, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(s != null);

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -58,26 +58,26 @@ readonly StructuredCmd/*!*/ dummyStructuredCmd;
 ///Returns the number of parsing errors encountered.  If 0, "program" returns as
 ///the parsed program.
 ///</summary>
-public static int Parse (string/*!*/ filename, /*maybe null*/ List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
+public static int Parse (string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(filename != null);
   Contract.Requires(cce.NonNullElements(defines,true));
 
-  if (defines == null) {
-    defines = new List<string/*!*/>();
-  }
-
   if (filename == "stdin.bpl") {
-    var s = ParserHelper.Fill(Console.In, defines);
-    return Parse(s, filename, out program, useBaseName);
-  } else {
-    FileStream stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read);
-    var s = ParserHelper.Fill(stream, defines);
-    var ret = Parse(s, filename, out program, useBaseName);
-    stream.Close();
-    return ret;
+    return Parse(Console.In, filename, defines, out program, useBaseName);
+  } else
+  {
+    using (FileStream stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read))
+    {
+      return Parse(new StreamReader(stream), filename, defines, out program, useBaseName);
+    }
   }
 }
 
+public static int Parse(TextReader stream, string/*!*/ filename, List<string> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ 
+{
+  var preprocessedSource = ParserHelper.Fill(stream, defines);
+  return Parse(preprocessedSource, filename, out program, useBaseName);
+}
 
 public static int Parse (string s, string/*!*/ filename, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(s != null);


### PR DESCRIPTION
### Changes
Allow using a Stream to parse a program that still need to be pre-processed. This change is required for [this Dafny PR](https://github.com/dafny-lang/dafny/pull/761).

### Testing
Since this is a small refactoring we can rely on existing tests