### PR TITLE
Allow default random_seed setting via /proverOpt:O:smt.random_seed=... command line option

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -1572,10 +1572,9 @@ namespace Microsoft.Boogie
       return QKeyValue.FindStringAttribute(this.Attributes, name);
     }
 
-    // Look for {:name N} or {:name N} in list of attributes. Return result in 'result'
-    // (which is not touched if there is no attribute specified).
-    //
-    // Returns false is there was an error processing the flag, true otherwise.
+    // Look for {:name N} in list of attributes. Return false if attribute
+    // 'name' does not exist or if N is not an integer constant.  Otherwise,
+    // return true and update 'result' with N.
     public bool CheckIntAttribute(string name, ref int result)
     {
       Contract.Requires(name != null);
@@ -1585,14 +1584,11 @@ namespace Microsoft.Boogie
         if (expr is LiteralExpr && ((LiteralExpr) expr).isBigNum)
         {
           result = ((LiteralExpr) expr).asBigNum.ToInt;
-        }
-        else
-        {
-          return false;
+          return true;
         }
       }
 
-      return true;
+      return false;
     }
 
     public void AddAttribute(string name, params object[] vals)
@@ -1830,17 +1826,16 @@ namespace Microsoft.Boogie
       }
     }
 
-    public int RandomSeed
+    public int? RandomSeed
     {
       get
       {
         int rs = 0;
-        CheckIntAttribute("random_seed", ref rs);
-        if (rs < 0)
+        if (CheckIntAttribute("random_seed", ref rs))
         {
-          rs = 0;
+          return rs;
         }
-        return rs;
+        return null;
       }
     }
     

--- a/Source/Core/VCExp.cs
+++ b/Source/Core/VCExp.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Boogie
     public bool ForceLogStatus = false;
     public int TimeLimit = 0;
     public int ResourceLimit = 0;
-    public int RandomSeed = 0;
+    public int? RandomSeed = null;
     public int MemoryLimit = 0;
     public int Verbosity = 0;
     public string ProverName;

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -575,7 +575,10 @@ namespace Microsoft.Boogie.SMTLib
       {
         SendThisVC("(set-option :" + Z3.TimeoutOption + " " + options.TimeLimit + ")");
         SendThisVC("(set-option :" + Z3.RlimitOption + " " + options.ResourceLimit + ")");
-        SendThisVC("(set-option :" + Z3.RandomSeedOption + " " + options.RandomSeed + ")");
+        if (options.RandomSeed.HasValue)
+        {
+          SendThisVC("(set-option :" + Z3.RandomSeedOption + " " + options.RandomSeed.Value + ")");
+        }
       }
       SendThisVC(vcString);
 
@@ -2628,7 +2631,7 @@ namespace Microsoft.Boogie.SMTLib
       options.ResourceLimit = limit;
     }
 
-    public override void SetRandomSeed(int randomSeed)
+    public override void SetRandomSeed(int? randomSeed)
     {
       options.RandomSeed = randomSeed;
     }

--- a/Source/VCGeneration/Check.cs
+++ b/Source/VCGeneration/Check.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Boogie
       TheoremProver.SetRlimit(rlimit);
     }
 
-    private void SetRandomSeed(int randomSeed)
+    private void SetRandomSeed(int? randomSeed)
     {
       TheoremProver.SetRandomSeed(randomSeed);
     }
@@ -350,7 +350,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, int timeout, int rlimit, int randomSeed = 0)
+    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, int timeout, int rlimit, int? randomSeed)
     {
       Contract.Requires(descriptiveName != null);
       Contract.Requires(vc != null);
@@ -661,7 +661,7 @@ namespace Microsoft.Boogie
     {
     }
 
-    public virtual void SetRandomSeed(int randomSeed)
+    public virtual void SetRandomSeed(int? randomSeed)
     {
     }
     

--- a/Source/VCGeneration/VC.cs
+++ b/Source/VCGeneration/VC.cs
@@ -369,7 +369,7 @@ namespace VC
             }
 
             ch.BeginCheck(cce.NonNull(impl.Name + "_smoke" + id++), vc, new ErrorHandler(label2Absy, this.callback), 
-              CommandLineOptions.Clo.SmokeTimeout, CommandLineOptions.Clo.ResourceLimit);
+              CommandLineOptions.Clo.SmokeTimeout, CommandLineOptions.Clo.ResourceLimit, null);
           }
 
           ch.ProverTask.Wait();
@@ -1882,11 +1882,11 @@ namespace VC
     {
       Contract.Requires(impl != null);
       Contract.Requires(name != null);
-      if (!(cce.NonNull(impl.Proc).CheckIntAttribute(name, ref val) || !impl.CheckIntAttribute(name, ref val)))
+      if (impl.FindAttribute(name) == null || impl.CheckIntAttribute(name, ref val))
       {
-        Console.WriteLine("ignoring ill-formed {:{0} ...} attribute on {1}, parameter should be an int", name,
-          impl.Name);
+        return;
       }
+      Console.WriteLine("ignoring ill-formed {:{0} ...} attribute on {1}, parameter should be an int", name, impl.Name);
     }
 
     public override Outcome VerifyImplementation(Implementation /*!*/ impl, VerifierCallback /*!*/ callback)

--- a/Test/test2/RandomSeed.bpl
+++ b/Test/test2/RandomSeed.bpl
@@ -1,10 +1,22 @@
-// RUN: %boogie -proverLog:%t "%s"
+// RUN: %boogie -proverOpt:O:smt.random_seed=55 -proverLog:%t "%s"
 // RUN: %OutputCheck --file-to-check "%t" "%s"
+// CHECK-L: (set-info :boogie-vc-id WithRandomSeed0)
 // CHECK-L: (set-option :smt.random_seed 100)
-// CHECK-L: (set-option :smt.random_seed 0)
-procedure {:random_seed 100} WithRandomSeed()
+// CHECK-L: (set-option :smt.random_seed 55)
+// CHECK-L: (set-info :boogie-vc-id WithoutRandomSeed0)
+// CHECK-L: (set-info :boogie-vc-id WithRandomSeed1)
+// CHECK-L: (set-option :smt.random_seed 99)
+// CHECK-L: (set-option :smt.random_seed 55)
+// CHECK-L: (set-info :boogie-vc-id WithoutRandomSeed1)
+procedure {:random_seed 100} WithRandomSeed0()
 {
 }
-procedure WithoutRandomSeed()
+procedure WithoutRandomSeed0()
+{
+}
+procedure {:random_seed 99} WithRandomSeed1()
+{
+}
+procedure WithoutRandomSeed1()
 {
 }


### PR DESCRIPTION
This PR allows random seed of an implementation to be null in which case any seed supplied globally via proverOpt:0:smt.random_seed=... becomes applicable.  The output generated via /proverLog:... for Test\test2\RandomSeed.bpl is instructive.