### PR TITLE
Add noninterference checking against pending asyncs (fix #255)

### DIFF
--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -867,6 +867,16 @@ namespace Microsoft.Boogie
             localVarToLayerRange[impl.OutParams[i]] = localVarToLayerRange[v];
         }
       }
+
+      // Also add parameters of atomic actions to localVarToLayerRange,
+      // assigning to them the layer range of the action.
+      foreach (var a in procToAtomicAction.Values)
+      {
+        foreach (var v in a.proc.InParams.Union(a.proc.OutParams).Union(a.impl.InParams).Union(a.impl.OutParams))
+        {
+          localVarToLayerRange[v] = a.layerRange;
+        }
+      }
     }
 
     private void TypeCheckPendingAsyncMachinery()

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -80,6 +80,11 @@ namespace Microsoft.Boogie
         {Proc = callee};
     }
 
+    public static CallCmd CallCmd(Procedure callee, List<Variable> ins, List<Variable> outs)
+    {
+      return CallCmd(callee, ins.Select(Expr.Ident).ToList<Expr>(), outs.Select(Expr.Ident).ToList());
+    }
+
     public static AssumeCmd AssumeCmd(Expr expr)
     {
       return new AssumeCmd(Token.NoToken, expr);

--- a/Source/Concurrency/LinearPermissionInstrumentation.cs
+++ b/Source/Concurrency/LinearPermissionInstrumentation.cs
@@ -179,17 +179,18 @@ namespace Microsoft.Boogie
 
     private IEnumerable<Variable> FilterInParams(IEnumerable<Variable> locals)
     {
-      Predicate<LinearKind> isLinear = x => x == LinearKind.LINEAR || x == LinearKind.LINEAR_IN;
-      return locals.Where(v =>
-        isLinear(linearTypeChecker.FindLinearKind(v)) &&
-        civlTypeChecker.LocalVariableLayerRange(v).Contains(layerNum));
+      return Filter(locals, x => x == LinearKind.LINEAR || x == LinearKind.LINEAR_IN);
     }
 
     private IEnumerable<Variable> FilterInOutParams(IEnumerable<Variable> locals)
     {
-      Predicate<LinearKind> isLinear = x => x == LinearKind.LINEAR || x == LinearKind.LINEAR_OUT;
+      return Filter(locals, x => x == LinearKind.LINEAR || x == LinearKind.LINEAR_OUT);
+    }
+
+    private IEnumerable<Variable> Filter(IEnumerable<Variable> locals, Predicate<LinearKind> pred)
+    {
       return locals.Where(v =>
-        isLinear(linearTypeChecker.FindLinearKind(v)) &&
+        pred(linearTypeChecker.FindLinearKind(v)) &&
         civlTypeChecker.LocalVariableLayerRange(v).Contains(layerNum));
     }
 

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -1183,15 +1183,14 @@ namespace Microsoft.Boogie
       }
 
       // Create blocks
-      List<Block> blocks = new List<Block>();
+      List<Block> blocks = new List<Block>()
       {
-        CallCmd cmd = new CallCmd(Token.NoToken, impl.Name,
-          inputs.Select(Expr.Ident).ToList<Expr>(),
-          outputs.Select(Expr.Ident).ToList());
-        cmd.Proc = action.proc;
-        Block block = new Block(Token.NoToken, "entry", new List<Cmd> {cmd}, new ReturnCmd(Token.NoToken));
-        blocks.Add(block);
-      }
+        new Block(
+          Token.NoToken,
+          "entry",
+          new List<Cmd> {CmdHelper.CallCmd(action.proc, inputs, outputs)},
+          CmdHelper.ReturnCmd)
+      };
 
       // Create the whole check procedure
       string checkerName = $"LinearityChecker_{action.proc.Name}";

--- a/Test/civl/hide-params-pa-2.bpl.expect
+++ b/Test/civl/hide-params-pa-2.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 4 verified, 0 errors
+Boogie program verifier finished with 5 verified, 0 errors

--- a/Test/civl/pending-async-1.bpl.expect
+++ b/Test/civl/pending-async-1.bpl.expect
@@ -13,4 +13,4 @@ Execution trace:
     pending-async-1.bpl(23,9): inline$C$0$anon2_Then
     pending-async-1.bpl(64,3): anon0$1
 
-Boogie program verifier finished with 9 verified, 2 errors
+Boogie program verifier finished with 10 verified, 2 errors

--- a/Test/civl/pending-async-noninterference-fail.bpl
+++ b/Test/civl/pending-async-noninterference-fail.bpl
@@ -1,0 +1,26 @@
+// RUN: %boogie -useArrayTheory "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,1} x:int;
+
+procedure {:yield_invariant} {:layer 1} yield_x(n: int);
+requires x >= n;
+
+type {:pending_async}{:datatype} PA;
+function {:pending_async "A"}{:constructor} A_PA() : PA;
+
+function {:inline} NoPAs () : [PA]int
+{ (lambda pa:PA :: 0) }
+
+procedure {:atomic}{:layer 1} A ()
+modifies x;
+{
+  x := x - 1;
+}
+
+procedure {:left}{:layer 1} ASYNC_A () returns ({:pending_async "A"} PAs:[PA]int)
+{
+  PAs := NoPAs()[A_PA() := 1];
+}
+
+procedure {:yields}{:layer 1} dummy () {}

--- a/Test/civl/pending-async-noninterference-fail.bpl.expect
+++ b/Test/civl/pending-async-noninterference-fail.bpl.expect
@@ -1,0 +1,7 @@
+pending-async-noninterference-fail.bpl(7,1): Error: Non-interference check failed
+Execution trace:
+    pending-async-noninterference-fail.bpl(15,31): inline$A$0$Entry
+    pending-async-noninterference-fail.bpl(18,5): inline$A$0$anon0
+    pending-async-noninterference-fail.bpl(15,31): inline$A$0$Return
+
+Boogie program verifier finished with 2 verified, 1 error

--- a/Test/civl/pending-async-noninterference-linear.bpl
+++ b/Test/civl/pending-async-noninterference-linear.bpl
@@ -1,0 +1,38 @@
+// RUN: %boogie -useArrayTheory "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,1} x:[int]int;
+
+procedure {:yield_invariant} {:layer 1} yield_x({:linear "tid"} tid:int);
+requires x[tid] == 0;
+
+type {:pending_async}{:datatype} PA;
+function {:pending_async "A"}{:constructor} A_PA(tid:int) : PA;
+
+function {:inline} NoPAs () : [PA]int
+{ (lambda pa:PA :: 0) }
+
+procedure {:atomic}{:layer 1} A ({:linear "tid"} tid:int)
+modifies x;
+{
+  x[tid] := 1;
+}
+
+procedure {:left}{:layer 1} ASYNC_A ({:linear_in "tid"} tid:int) returns ({:pending_async "A"} PAs:[PA]int)
+{
+  PAs := NoPAs()[A_PA(tid) := 1];
+}
+
+procedure {:yields}{:layer 1} dummy () {}
+
+function {:builtin "MapConst"} MapConstBool(bool): [int]bool;
+function {:builtin "MapOr"} MapOr([int]bool, [int]bool) : [int]bool;
+
+function {:inline} {:linear "tid"} TidCollector(x: int) : [int]bool
+{
+  MapConstBool(false)[x := true]
+}
+function {:inline} {:linear "tid"} TidSetCollector(x: [int]bool) : [int]bool
+{
+  x
+}

--- a/Test/civl/pending-async-noninterference-linear.bpl.expect
+++ b/Test/civl/pending-async-noninterference-linear.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 4 verified, 0 errors

--- a/Test/civl/pending-async-noninterference-ok.bpl
+++ b/Test/civl/pending-async-noninterference-ok.bpl
@@ -1,0 +1,26 @@
+// RUN: %boogie -useArrayTheory "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,1} x:int;
+
+procedure {:yield_invariant} {:layer 1} yield_x(n: int);
+requires x >= n;
+
+type {:pending_async}{:datatype} PA;
+function {:pending_async "A"}{:constructor} A_PA() : PA;
+
+function {:inline} NoPAs () : [PA]int
+{ (lambda pa:PA :: 0) }
+
+procedure {:atomic}{:layer 1} A ()
+modifies x;
+{
+  x := x + 1;
+}
+
+procedure {:left}{:layer 1} ASYNC_A () returns ({:pending_async "A"} PAs:[PA]int)
+{
+  PAs := NoPAs()[A_PA() := 1];
+}
+
+procedure {:yields}{:layer 1} dummy () {}

--- a/Test/civl/pending-async-noninterference-ok.bpl.expect
+++ b/Test/civl/pending-async-noninterference-ok.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 3 verified, 0 errors


### PR DESCRIPTION
One notable refactoring step is that in `YieldingProcInstrumentation` only a single `GlobalSnapshotInstrumentation` and `NoninterferenceInstrumentation` object is allocated (in the constructor) and reused to instrument all implementations, instead of allocating fresh ones for every implementation.
The reason is that these objects have no dependency on the instrumented implementation, and are now also use to construct the noninterference checkers for pending asyncs.