### PR TITLE
Ensure yield sufficiency w.r.t. async calls

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Boogie
 {
   public enum MoverType
   {
-    Atomic,
+    Non,
     Right,
     Left,
     Both

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -999,7 +999,7 @@ namespace Microsoft.Boogie
     private MoverType GetActionMoverType(Procedure proc)
     {
       if (proc.HasAttribute(CivlAttributes.IS_INVARIANT))
-        return MoverType.Atomic;
+        return MoverType.Non;
       else if (proc.HasAttribute(CivlAttributes.IS_ABSTRACTION))
         return MoverType.Left;
       else
@@ -1018,7 +1018,7 @@ namespace Microsoft.Boogie
         {
           MoverType? x = null;
           if (kv.Key == CivlAttributes.ATOMIC)
-            x = MoverType.Atomic;
+            x = MoverType.Non;
           else if (kv.Key == CivlAttributes.RIGHT)
             x = MoverType.Right;
           else if (kv.Key == CivlAttributes.LEFT)

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -129,8 +129,7 @@ namespace Microsoft.Boogie
       if (checkingContext.ErrorCount > 0)
         return;
 
-      var yieldSufficiencyTypeChecker = new YieldSufficiencyTypeChecker(this);
-      yieldSufficiencyTypeChecker.TypeCheck();
+      YieldSufficiencyTypeChecker.TypeCheck(this);
     }
 
     private void TypeCheckRefinementLayers()

--- a/Test/civl/async-yield-sufficiency.bpl
+++ b/Test/civl/async-yield-sufficiency.bpl
@@ -1,0 +1,42 @@
+// RUN: %boogie -useArrayTheory "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,1} x:int;
+
+procedure {:yields}{:layer 1} P({:linear_in "tid"} tid1:int, {:linear "tid"} tid2:int)
+requires {:layer 1} tid1 == 1;
+requires {:layer 1} tid2 == 2;
+requires {:layer 1} x == 0;
+{
+  async call Q(tid1);
+  call write(); // This action invalidates the precondition of the above async call
+}
+
+procedure {:yields}{:layer 1} Q({:linear "tid"} tid1:int)
+requires {:layer 1} tid1 == 1;
+requires {:layer 1} x == 0; // This precondition is not valid at the end of procedure P
+{
+  call assertion();
+}
+
+procedure {:left}{:layer 1} WRITE()
+modifies x;
+{
+  x := 1;
+}
+
+procedure {:atomic}{:layer 1} ASSERTION()
+{
+  assert x == 0;
+}
+
+procedure {:yields}{:layer 0}{:refines "WRITE"} write();
+procedure {:yields}{:layer 0}{:refines "ASSERTION"} assertion();
+
+function {:builtin "MapConst"} MapConstBool(bool): [int]bool;
+function {:builtin "MapOr"} MapOr([int]bool, [int]bool) : [int]bool;
+
+function {:inline} {:linear "tid"} TidCollector(x: int) : [int]bool
+{
+  MapConstBool(false)[x := true]
+}

--- a/Test/civl/async-yield-sufficiency.bpl.expect
+++ b/Test/civl/async-yield-sufficiency.bpl.expect
@@ -1,0 +1,2 @@
+async-yield-sufficiency.bpl(6,30): Error: Implementation P fails async check at layer 1.
+1 type checking errors detected in async-yield-sufficiency.bpl

--- a/Test/civl/inductive-sequentialization/NBuyer.bpl
+++ b/Test/civl/inductive-sequentialization/NBuyer.bpl
@@ -487,7 +487,6 @@ requires {:layer 1} sellerID(pid);
 
   call old_QuoteCH := Snapshot_QuoteCH();
   call receive_req();
-  async call sellerFinish(pid);
   i := 1;
   while (i <= n)
   invariant {:layer 1}{:terminates} true;
@@ -497,6 +496,7 @@ requires {:layer 1} sellerID(pid);
     call send_quote(i, price);
     i := i + 1;
   }
+  async call sellerFinish(pid);
 }
 
 procedure {:yields}{:layer 1}{:refines "SellerFinish"}


### PR DESCRIPTION
We check that there is no update to global variables between an async call and the next yield. The check is based on the computation of a simulation relation between the appropriately labeled CFG of a procedure and a specification automaton.

The example `async-yield-sufficiency.bpl` demonstrates the unsoundness that existed without this check.

Some refactoring in the existing yield sufficiency check.