### PR TITLE
Fix contract and usages of LabelOrCmd in parser

### DIFF
--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -705,15 +705,14 @@ StmtList<out StmtList/*!*/ stmtList>
 
   {
   ( LabelOrCmd<out c, out label>
-    (. if (c != null) {
+    (. Contract.Assert(c == null || label == null);
+       if (c != null) {
          // LabelOrCmd read a Cmd
-         Contract.Assert(label == null);
          if (startToken == null) { startToken = c.tok;  cs = new List<Cmd>(); }
          Contract.Assert(cs != null);
          cs.Add(c);
-       } else {
+       } else if (label != null) {
          // LabelOrCmd read a label
-         Contract.Assert(label != null);
          if (startToken != null) {
            Contract.Assert(cs != null);
            // dump the built-up state into a BigBlock
@@ -854,7 +853,7 @@ BreakCmd<out BreakCmd/*!*/ bcmd>
 /*------------------------------------------------------------------------*/
 
 LabelOrCmd<out Cmd c, out IToken label>
-/* ensures (c == null) != (label != null) */
+/* ensures (c == null) || (label == null) */
 = (. IToken/*!*/ x; Expr/*!*/ e;
      List<IToken>/*!*/ xs;
      List<IdentifierExpr> ids;
@@ -1362,11 +1361,10 @@ SpecBlock<out Block/*!*/ b>
   .)
   Ident<out x> ":"
   { LabelOrCmd<out c, out label>
-                       (. if (c != null) {
-                            Contract.Assert(label == null);
+                       (. Contract.Assert(c == null || label == null);
+                          if (c != null) {
                             cs.Add(c);
-                          } else {
-                            Contract.Assert(label != null);
+                          } else if (label != null) {
                             SemErr("SpecBlock's can only have one label");
                           }
                        .)

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -952,15 +952,14 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		while (StartOf(7)) {
 			if (StartOf(8)) {
 				LabelOrCmd(out c, out label);
+				Contract.Assert(c == null || label == null);
 				if (c != null) {
 				 // LabelOrCmd read a Cmd
-				 Contract.Assert(label == null);
 				 if (startToken == null) { startToken = c.tok;  cs = new List<Cmd>(); }
 				 Contract.Assert(cs != null);
 				 cs.Add(c);
-				} else {
+				} else if (label != null) {
 				 // LabelOrCmd read a label
-				 Contract.Assert(label != null);
 				 if (startToken != null) {
 				   Contract.Assert(cs != null);
 				   // dump the built-up state into a BigBlock
@@ -2082,11 +2081,10 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		Expect(12);
 		while (StartOf(8)) {
 			LabelOrCmd(out c, out label);
+			Contract.Assert(c == null || label == null);
 			if (c != null) {
-			 Contract.Assert(label == null);
 			 cs.Add(c);
-			} else {
-			 Contract.Assert(label != null);
+			} else if (label != null) {
 			 SemErr("SpecBlock's can only have one label");
 			}
 			


### PR DESCRIPTION
Invalid programs like
```
procedure foo ()
{
  call
}
```
caused the following assertion violation and crash in Boogie:
```
crash.bpl(4,1): error: ident expected
Process terminated. Assertion failed.
   at Microsoft.Boogie.Parser.StmtList(StmtList& stmtList) in /home/bkragl/Code/boogie/Source/Core/Parser.cs:line 963
   ...
```

The contract `(c == null) != (label != null)` of `LabelOrCmd` was bogus. I guess what was meant is `(c == null) != (label == null)`, stating that either `c` is non-null or `label` is non-null (but not both). However, this does not seem to be true. In case of parsing a program with syntax errors, both `c` and `label` can be null. I fixed the two usages of `LabelOrCmd` by doing nothing in this case. I assume this is fine, because an error must have been already recorded somewhere.