### PR TITLE
Fixes issue #112

### DIFF
--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -3008,43 +3008,7 @@ namespace Microsoft.Boogie
           return;
         }
       }
-
-      // Check that type parameters can be determined using the given
-      // actual i/o arguments. This is done already during resolution
-      // because CheckBoundVariableOccurrences needs a resolution
-      // context
-      List<Type> /*!*/
-        formalInTypes = new List<Type>();
-      List<Type> /*!*/
-        formalOutTypes = new List<Type>();
-      for (int i = 0; i < Ins.Count; ++i)
-        if (Ins[i] != null)
-          formalInTypes.Add(cce.NonNull(Proc.InParams[i]).TypedIdent.Type);
-      for (int i = 0; i < Outs.Count; ++i)
-        if (Outs[i] != null)
-          formalOutTypes.Add(cce.NonNull(Proc.OutParams[i]).TypedIdent.Type);
-
-      // we need to bind the type parameters for this
-      // (this is expected by CheckBoundVariableOccurrences)
-      int previousTypeBinderState = rc.TypeBinderState;
-      try
-      {
-        foreach (TypeVariable /*!*/ v in Proc.TypeParameters)
-        {
-          Contract.Assert(v != null);
-          rc.AddTypeBinder(v);
-        }
-
-        Type.CheckBoundVariableOccurrences(Proc.TypeParameters,
-          formalInTypes, formalOutTypes,
-          this.tok, "types of given arguments",
-          rc);
-      }
-      finally
-      {
-        rc.TypeBinderState = previousTypeBinderState;
-      }
-
+      
       var id = QKeyValue.FindStringAttribute(Attributes, "id");
       if (id != null)
       {
@@ -3076,7 +3040,7 @@ namespace Microsoft.Boogie
         vars.Add(AssignedAssumptionVariable);
       }
     }
-
+    
     public override void Typecheck(TypecheckingContext tc)
     {
       //Contract.Requires(tc != null);

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -848,7 +848,7 @@ namespace Microsoft.Boogie
     // Return true if some type parameters appear only among "moreArgumentTypes" and
     // not in "argumentTypes".
     [Pure]
-    public static bool CheckBoundVariableOccurrences(List<TypeVariable> /*!*/ typeParams,
+    public static void CheckBoundVariableOccurrences(List<TypeVariable> /*!*/ typeParams,
       List<Type> /*!*/ argumentTypes,
       List<Type> moreArgumentTypes,
       IToken /*!*/ resolutionSubject,
@@ -861,21 +861,19 @@ namespace Microsoft.Boogie
       Contract.Requires(subjectName != null);
       Contract.Requires(rc != null);
       List<TypeVariable> freeVarsInArgs = FreeVariablesIn(argumentTypes);
-      List<TypeVariable> moFreeVarsInArgs = moreArgumentTypes == null ? null : FreeVariablesIn(moreArgumentTypes);
-      bool someTypeParamsAppearOnlyAmongMo = false;
+      List<TypeVariable> moreFreeVarsInArgs = moreArgumentTypes == null ? new List<TypeVariable>() : FreeVariablesIn(moreArgumentTypes);
       foreach (TypeVariable /*!*/ var in typeParams)
       {
         Contract.Assert(var != null);
-        if (rc.LookUpTypeBinder(var.Name) == var
-        ) // avoid to complain twice about variables that are bound multiple times
+        if (rc.LookUpTypeBinder(var.Name) == var) // avoid to complain twice about variables that are bound multiple times
         {
           if (freeVarsInArgs.Contains(var))
           {
-            // cool
+            // ok
           }
-          else if (moFreeVarsInArgs != null && moFreeVarsInArgs.Contains(var))
+          else if (moreFreeVarsInArgs.Contains(var))
           {
-            someTypeParamsAppearOnlyAmongMo = true;
+            // ok
           }
           else
           {
@@ -885,8 +883,6 @@ namespace Microsoft.Boogie
           }
         }
       }
-
-      return someTypeParamsAppearOnlyAmongMo;
     }
 
     [Pure]

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -620,7 +620,7 @@ Procedure<out Procedure/*!*/ proc, out /*maybe null*/ Implementation impl>
   | { Spec<pre, mods, post> }
     ImplBody<out locals, out stmtList>
     (.
-      impl = new Implementation(x, x.val, new List<TypeVariable>(typeParams.Select(x => new TypeVariable(x.tok, x.Name))),
+      impl = new Implementation(x, x.val, typeParams.ConvertAll(x => new TypeVariable(x.tok, x.Name)),
                                 Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs), locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
     .)
   )

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -620,7 +620,7 @@ Procedure<out Procedure/*!*/ proc, out /*maybe null*/ Implementation impl>
   | { Spec<pre, mods, post> }
     ImplBody<out locals, out stmtList>
     (.
-      impl = new Implementation(x, x.val, typeParams,
+      impl = new Implementation(x, x.val, new List<TypeVariable>(typeParams.Select(x => new TypeVariable(x.tok, x.Name))),
                                 Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs), locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
     .)
   )

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -20,6 +20,7 @@ using Bpl = Microsoft.Boogie;
 
 using System;
 using System.Diagnostics.Contracts;
+using System.Linq;
 
 namespace Microsoft.Boogie {
 
@@ -511,7 +512,7 @@ private class BvBounds : Expr {
 				Spec(pre, mods, post);
 			}
 			ImplBody(out locals, out stmtList);
-			impl = new Implementation(x, x.val, typeParams,
+			impl = new Implementation(x, x.val, new List<TypeVariable>(typeParams.Select(x => new TypeVariable(x.tok, x.Name))),
 			                         Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs), locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
 			
 		} else SynErr(110);

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -20,7 +20,6 @@ using Bpl = Microsoft.Boogie;
 
 using System;
 using System.Diagnostics.Contracts;
-using System.Linq;
 
 namespace Microsoft.Boogie {
 
@@ -512,7 +511,7 @@ private class BvBounds : Expr {
 				Spec(pre, mods, post);
 			}
 			ImplBody(out locals, out stmtList);
-			impl = new Implementation(x, x.val, new List<TypeVariable>(typeParams.Select(x => new TypeVariable(x.tok, x.Name))),
+			impl = new Implementation(x, x.val, typeParams.ConvertAll(x => new TypeVariable(x.tok, x.Name)),
 			                         Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs), locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
 			
 		} else SynErr(110);

--- a/Source/Core/Parser.frame
+++ b/Source/Core/Parser.frame
@@ -27,6 +27,7 @@ Coco/R itself) does not fall under the GNU General Public License.
 -->begin
 using System;
 using System.Diagnostics.Contracts;
+using System.Linq;
 
 -->namespace
 

--- a/Source/Core/Parser.frame
+++ b/Source/Core/Parser.frame
@@ -27,7 +27,6 @@ Coco/R itself) does not fall under the GNU General Public License.
 -->begin
 using System;
 using System.Diagnostics.Contracts;
-using System.Linq;
 
 -->namespace
 

--- a/Test/test21/issue-112.bpl
+++ b/Test/test21/issue-112.bpl
@@ -1,0 +1,12 @@
+// RUN: %boogie -typeEncoding:p -logPrefix:0p "%s" > "%t"
+// RUN: %diff "%s.p.expect" "%t"
+// RUN: %boogie -typeEncoding:a -logPrefix:0a "%s" > "%t"
+// RUN: %diff "%s.a.expect" "%t"
+
+type List T;
+function tl<T>(List T): List T;
+
+procedure Foo<T>(L: List T)
+{
+  call Foo(tl(L));
+}

--- a/Test/test21/issue-112.bpl.a.expect
+++ b/Test/test21/issue-112.bpl.a.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/test21/issue-112.bpl.p.expect
+++ b/Test/test21/issue-112.bpl.p.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
This PR fixes two problems related to issue #112:
1. CheckBoundVariableOccurrences was being called during resolution of a procedure call.  A crash was happening in AddTypeBinder while preparing the state for the call to CheckBoundVariableOccurrences.  The call to CheckBoundVariableOccurrences seemed unnecessary to me since it checks whether each type parameter is used at least once in the type of some argument, a check that has already been performed at the declaration of the procedure.  So I removed the code that is setting up the call to CheckBoundVariableOccurrences.  This change is in AbsyCmd.cs.

2. During type checking of a recursive procedure call, when the substitution for the type parameters of the procedure is being calculated, there is a contract asserting that the free variables in the type of any actual are distinct from the type parameter of the procedure being called.  This assertion can be violated at a recursive polymorphic call since the type parameter in procedure and implementation are shared.  I solved this problem by eliminating the sharing and creating separate copies of the type parameter of the implementation in the parser (similar to the formals).  This change is BoogiePL.atg.

3. I also cleaned up the signature of CheckBoundVariableOccurrences whose return value is not being used.

This PR does not solve a related problem: Boogie crashes on a program in which a polymorphic recursive function calls itself as follows.  

```
type List T;
function {:inline} blah<T>(i: List T): List T {
  blah(i)
}
```

The problem here is the same as that described in 2 above.  But the fix is not the same since there is a single declaration for the function that comprises its signature and its body.  Any advice on fixing the recursive function issue would be much appreciated.