### PR TITLE
[CIVL] Require old around globals in parameters to yield_requires

### DIFF
--- a/Test/civl/DeviceCache.bpl
+++ b/Test/civl/DeviceCache.bpl
@@ -95,7 +95,7 @@ COPY_TO_BUFFER:
 
 procedure {:yields} {:layer 1}
 {:yield_preserves "Yield"}
-{:yield_preserves "YieldToWriteCache", tid, currsize, newsize}
+{:yield_preserves "YieldToWriteCache", tid, old(currsize), old(newsize)}
 WriteCache({:linear "tid"} tid: X, index: int)
 {
     var j: int;
@@ -112,7 +112,7 @@ WriteCache({:linear "tid"} tid: X, index: int)
 
 procedure {:yields} {:layer 1}
 {:yield_preserves "Yield"}
-{:yield_preserves "YieldToReadCache", tid, currsize}
+{:yield_preserves "YieldToReadCache", tid, old(currsize)}
 ReadCache({:linear "tid"} tid: X, start: int, bytesRead: int)
 requires {:layer 1} 0 <= start && 0 <= bytesRead;
 requires {:layer 1} (bytesRead == 0 || start + bytesRead <= currsize);

--- a/Test/civl/GC.bpl
+++ b/Test/civl/GC.bpl
@@ -266,7 +266,7 @@ requires {:layer 100} (forall x: idx :: rootAddr(x) ==> rootAbs[x] == Int(0));
 
 procedure {:yields} {:layer 100}
 {:yield_requires "Yield_Initialize_100", tid, mutatorTids}
-{:yield_requires "Yield_InitVars99", mutatorTids, MapConstBool(false), rootScanBarrier}
+{:yield_requires "Yield_InitVars99", mutatorTids, MapConstBool(false), old(rootScanBarrier)}
 {:yield_ensures "Yield_Iso"}
 {:yield_ensures "Yield_RootScanBarrierInv"}
 {:yield_ensures "Yield_InitVars99", mutatorTids, MapConstBool(false), numMutators}
@@ -389,10 +389,10 @@ requires {:layer 97,98,99,100} tid == GcTid;
 
 procedure {:yields} {:layer 100}
 {:yield_preserves "Yield_Iso"}
-{:yield_requires  "YieldMarkBegin", tid, Color}
+{:yield_requires  "YieldMarkBegin", tid, old(Color)}
 {:yield_ensures   "YieldMarkEnd", tid}
 {:yield_preserves "Yield_MsWellFormed", tid, 0}
-{:yield_preserves "Yield_CollectorPhase_98", tid, collectorPhase}
+{:yield_preserves "Yield_CollectorPhase_98", tid, old(collectorPhase)}
 {:yield_preserves "Yield_RootScanBarrierInv"}
 MarkOuterLoop({:linear "tid"} tid:Tid)
 {
@@ -418,9 +418,9 @@ MarkOuterLoop({:linear "tid"} tid:Tid)
 
 procedure {:yields} {:layer 100}
 {:yield_preserves "Yield_Iso"}
-{:yield_preserves "YieldMark", tid, Color}
+{:yield_preserves "YieldMark", tid, old(Color)}
 {:yield_preserves "Yield_MsWellFormed", tid, 0}
-{:yield_preserves "Yield_CollectorPhase_98", tid, collectorPhase}
+{:yield_preserves "Yield_CollectorPhase_98", tid, old(collectorPhase)}
 {:yield_preserves "Yield_RootScanBarrierInv"}
 MarkInnerLoop({:linear "tid"} tid:Tid)
 {
@@ -466,7 +466,7 @@ procedure {:yields} {:layer 100}
 {:yield_preserves "Yield_Iso"}
 {:yield_preserves "Yield_MsWellFormed", tid, 0}
 {:yield_preserves "Yield_RootScanBarrierInv"}
-{:yield_requires  "YieldSweepBegin", tid, false, Color}
+{:yield_requires  "YieldSweepBegin", tid, false, old(Color)}
 {:yield_ensures   "YieldSweepEnd", tid}
 Sweep({:linear "tid"} tid:Tid)
 requires {:layer 98,99,100} tid == GcTid;
@@ -529,7 +529,7 @@ requires mutatorsInRootScanBarrier[i#Tid(tid)];
 
 procedure {:yields} {:layer 99}
 {:yield_ensures  "Yield_InitVars98", tid, mutatorTids, 0}
-{:yield_requires "Yield_InitVars99", mutatorTids, mutatorsInRootScanBarrier, rootScanBarrier}
+{:yield_requires "Yield_InitVars99", mutatorTids, old(mutatorsInRootScanBarrier), old(rootScanBarrier)}
 {:yield_ensures  "Yield_InitVars99", mutatorTids, old(mutatorsInRootScanBarrier), numMutators}
 InitVars99({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 requires {:layer 98,99} gcAndMutatorTids(tid, mutatorTids);
@@ -571,7 +571,7 @@ modifies Color;
 
 procedure {:yields} {:layer 99} {:refines "AtomicCanMarkStop"}
 {:yield_preserves "Yield_MsWellFormed", tid, 0}
-{:yield_preserves "Yield_CollectorPhase_98", tid, collectorPhase}
+{:yield_preserves "Yield_CollectorPhase_98", tid, old(collectorPhase)}
 {:yield_preserves "Yield_RootScanBarrierInv"}
 CanMarkStop({:linear "tid"} tid:Tid) returns (canStop: bool)
 requires {:layer 99} tid == GcTid;
@@ -741,7 +741,7 @@ requires gcAndMutatorTids(tid, mutatorTids);
 requires MarkStackPtr == tick_MarkStackPtr;
 
 procedure {:yields} {:layer 98}
-{:yield_requires "Yield_InitVars98", tid, mutatorTids, MarkStackPtr}
+{:yield_requires "Yield_InitVars98", tid, mutatorTids, old(MarkStackPtr)}
 {:yield_ensures  "Yield_InitVars98", tid, mutatorTids, 0}
 InitVars98({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 {
@@ -824,7 +824,7 @@ procedure {:left} {:layer 99} AtomicNoGrayInRootScanBarrier({:linear "tid"} tid:
 
 procedure {:yields} {:layer 98} {:refines "AtomicNoGrayInRootScanBarrier"}
 {:yield_preserves "Yield_MsWellFormed", tid, 0}
-{:yield_preserves "Yield_CollectorPhase_98", tid, collectorPhase}
+{:yield_preserves "Yield_CollectorPhase_98", tid, old(collectorPhase)}
 NoGrayInRootScanBarrier({:linear "tid"} tid:Tid) returns (noGray: bool)
 {
     call noGray := MsIsEmpty(tid);
@@ -842,7 +842,7 @@ modifies Color;
 
 procedure {:yields} {:layer 98} {:refines "AtomicInsertIntoSetIfWhiteInRootScanBarrier"}
 {:yield_preserves "Yield_MsWellFormed", tid, 0}
-{:yield_preserves "Yield_CollectorPhase_98", tid, collectorPhase}
+{:yield_preserves "Yield_CollectorPhase_98", tid, old(collectorPhase)}
 InsertIntoSetIfWhiteInRootScanBarrier({:linear "tid"} tid:Tid, memLocal:int)
 {
     call MsPushByCollector(tid, memLocal);
@@ -861,7 +861,7 @@ modifies Color;
 
 procedure {:yields} {:layer 98} {:refines "AtomicSET_InsertIntoSetIfWhite"}
 {:yield_preserves "Yield_MsWellFormed", tid, parent}
-{:yield_preserves "Yield_CollectorPhase_98", tid, collectorPhase}
+{:yield_preserves "Yield_CollectorPhase_98", tid, old(collectorPhase)}
 SET_InsertIntoSetIfWhite({:linear "tid"} tid:Tid, parent: int, child:int)
 requires {:layer 98} memAddr(parent) && memAddr(child);
 {
@@ -884,7 +884,7 @@ procedure {:right} {:layer 99,100} AtomicSET_Peek({:linear "tid"} tid:Tid) retur
 procedure {:yields} {:layer 98} {:refines "AtomicSET_Peek"}
 {:yield_requires  "Yield_MsWellFormed", tid, 0}
 {:yield_ensures   "Yield_MsWellFormed", tid, if isEmpty then 0 else val}
-{:yield_preserves "Yield_CollectorPhase_98", tid, collectorPhase}
+{:yield_preserves "Yield_CollectorPhase_98", tid, old(collectorPhase)}
 SET_Peek({:linear "tid"} tid:Tid) returns (isEmpty: bool, val:int)
 {
     assert {:layer 98} MST(MarkStackPtr - 1);

--- a/Test/civl/Program4.bpl
+++ b/Test/civl/Program4.bpl
@@ -16,7 +16,7 @@ p1()
 }
 
 procedure {:yields} {:layer 1}
-{:yield_requires "yield_x", x}
+{:yield_requires "yield_x", old(x)}
 {:yield_ensures "yield_x", old(x) + 3}
 p2()
 {

--- a/Test/civl/alloc-tid.bpl
+++ b/Test/civl/alloc-tid.bpl
@@ -27,7 +27,7 @@ main()
 
 procedure {:yields} {:layer 2}
 {:yield_preserves "Yield1"}
-{:yield_requires "Yield2", tid, a[tid]}
+{:yield_requires "Yield2", tid, old(a)[tid]}
 {:yield_ensures  "Yield2", tid, old(a)[tid] + 1}
 P({:layer 1,2} {:linear "tid"} tid: int, i: int)
 requires {:layer 1} tid == i;

--- a/Test/civl/verified-ft-define.bpl
+++ b/Test/civl/verified-ft-define.bpl
@@ -328,7 +328,7 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Leq"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_preserves "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 VC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
   var vc1, vc2: VC;
@@ -386,7 +386,7 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Copy"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Copy({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
 {
@@ -440,7 +440,7 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Join"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Join({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
 {
@@ -496,7 +496,7 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Inc"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, v, v, old(shadow.Lock), old(shadow.VC)}
 VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
 {
@@ -556,10 +556,10 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicFork"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(uid), old(shadow.Lock), old(shadow.VC)}
 {:yield_preserves "Yield_FTRepOk_20"}
-{:yield_requires  "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(uid), old(shadow.Lock), old(shadow.VC)}
 Fork({:linear "tid"} tid:Tid, uid : Tid)
 {
@@ -593,10 +593,10 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicJoin"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 {:yield_preserves "Yield_FTRepOk_20"}
-{:yield_requires  "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 Join({:linear "tid"} tid:Tid, uid : Tid)
 {
@@ -626,10 +626,10 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicAcquire"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 {:yield_preserves "Yield_FTRepOk_20"}
-{:yield_requires  "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 Acquire({:linear "tid"} tid: Tid, l: Lock)
 {
@@ -669,10 +669,10 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicRelease"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableLock(l), old(shadow.Lock), old(shadow.VC)}
 {:yield_preserves "Yield_FTRepOk_20"}
-{:yield_requires  "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableLock(l), old(shadow.Lock), old(shadow.VC)}
 Release({:linear "tid"} tid: Tid, l: Lock)
 {
@@ -734,10 +734,10 @@ modifies sx.W;
 
 procedure {:yields} {:layer 20} {:refines "AtomicWrite"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_preserves "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_preserves "Yield_FTRepOk_20"}
 {:yield_requires  "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_preserves "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Write({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 {
   var e, w, vw, r, vr: Epoch;
@@ -841,10 +841,10 @@ modifies sx.R, shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicRead"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_preserves "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_preserves "Yield_FTRepOk_20"}
 {:yield_requires  "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_preserves "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 {
   var e, w, vw, r, vr: Epoch;

--- a/Test/civl/verified-ft.bpl
+++ b/Test/civl/verified-ft.bpl
@@ -328,7 +328,7 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Leq"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_preserves "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 VC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
   var vc1, vc2: VC;
@@ -386,7 +386,7 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Copy"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Copy({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
 {
@@ -440,7 +440,7 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Join"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, v1, v1, old(shadow.Lock), old(shadow.VC)}
 VC.Join({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
 {
@@ -496,7 +496,7 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 10} {:refines "AtomicVC.Inc"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, v, v, old(shadow.Lock), old(shadow.VC)}
 VC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
 {
@@ -556,10 +556,10 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicFork"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(uid), old(shadow.Lock), old(shadow.VC)}
 {:yield_preserves "Yield_FTRepOk_20"}
-{:yield_requires  "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(uid), old(shadow.Lock), old(shadow.VC)}
 Fork({:linear "tid"} tid:Tid, uid : Tid)
 {
@@ -593,10 +593,10 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicJoin"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 {:yield_preserves "Yield_FTRepOk_20"}
-{:yield_requires  "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 Join({:linear "tid"} tid:Tid, uid : Tid)
 {
@@ -626,10 +626,10 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicAcquire"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 {:yield_preserves "Yield_FTRepOk_20"}
-{:yield_requires  "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableTid(tid), old(shadow.Lock), old(shadow.VC)}
 Acquire({:linear "tid"} tid: Tid, l: Lock)
 {
@@ -669,10 +669,10 @@ modifies shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicRelease"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_requires  "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_10", tid, ShadowableTid(tid), ShadowableLock(l), old(shadow.Lock), old(shadow.VC)}
 {:yield_preserves "Yield_FTRepOk_20"}
-{:yield_requires  "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_requires  "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_ensures   "Yield_VCPreserved_20", tid, ShadowableTid(tid), ShadowableLock(l), old(shadow.Lock), old(shadow.VC)}
 Release({:linear "tid"} tid: Tid, l: Lock)
 {
@@ -734,10 +734,10 @@ modifies sx.W;
 
 procedure {:yields} {:layer 20} {:refines "AtomicWrite"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_preserves "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_preserves "Yield_FTRepOk_20"}
 {:yield_requires  "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_preserves "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Write({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 {
   var e, w, vw, r, vr: Epoch;
@@ -841,10 +841,10 @@ modifies sx.R, shadow.VC;
 
 procedure {:yields} {:layer 20} {:refines "AtomicRead"}
 {:yield_preserves "Yield_FTRepOk_10"}
-{:yield_preserves "Yield_FTPreserved_10", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_10", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 {:yield_preserves "Yield_FTRepOk_20"}
 {:yield_requires  "Yield_Lock_20", tid, ShadowableTid(tid)}
-{:yield_preserves "Yield_FTPreserved_20", tid, shadow.Lock, shadow.VC, sx.W, sx.R}
+{:yield_preserves "Yield_FTPreserved_20", tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R)}
 Read({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 {
   var e, w, vw, r, vr: Epoch;


### PR DESCRIPTION
A global variable in a parameter to both `yield_requires` and `yield_ensures` always refers to the value before the call (in particular, before the yield at entry). Thus, for clarity, global variables should always be wrapped inside `old`. Internally, we strip away the `old` expression in `yield_requires`.