### PR TITLE
Make rlimit support more robust

### DIFF
--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -2355,6 +2355,8 @@ namespace Microsoft.Boogie.SMTLib
           {
             switch (resp[0].Name)
             {
+              case "(incomplete quantifiers)":
+                break;
               case "memout":
                 currentErrorHandler.OnResourceExceeded("memory");
                 result = Outcome.OutOfMemory;
@@ -2386,11 +2388,14 @@ namespace Microsoft.Boogie.SMTLib
                 result = Outcome.OutOfResource;
                 break;
               default:
+                result = Outcome.Undetermined;
+                HandleProverError("Unexpected prover response (getting info about 'unknown' response): " + resp.ToString());
                 break;
             }
           }
           else
           {
+            result = Outcome.Undetermined;
             HandleProverError("Unexpected prover response (getting info about 'unknown' response): " + resp.ToString());
           }
         }

--- a/Source/VCGeneration/Check.cs
+++ b/Source/VCGeneration/Check.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Boogie
 
     private void SetRlimit(int rlimit)
     {
-      TheoremProver.SetRlimit(rlimit);
+      TheoremProver.SetRlimit(rlimit * 1000);
     }
 
     private void SetRandomSeed(int? randomSeed)
@@ -363,6 +363,10 @@ namespace Microsoft.Boogie
       this.handler = handler;
 
       thmProver.Reset(gen);
+      if (0 < rlimit)
+      {
+        timeout = 0;
+      }
       SetTimeout(timeout);
       SetRlimit(rlimit);
       SetRandomSeed(randomSeed);

--- a/Test/test2/Rlimitouts0.bpl
+++ b/Test/test2/Rlimitouts0.bpl
@@ -1,27 +1,27 @@
-// This test shows the usage of the rlimit command-line option and attribute.
-// Maintaining appropriate timeout values got tedious, so we do not run
-// this test as part of the regressions anymore.
-
-// UNSUPPORTED: true
-// RUN: %boogie -rlimit:100 "%s" | %OutputCheck "%s"
-
-procedure TestRlimit0(in: [int]int, len: int) returns (out: [int]int);
+// RUN: %boogie -rlimit:800 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+// RUN: %boogie -rlimit:800 -proverLog:%t "%s"
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+// CHECK-L: (set-option :timeout 0)
+// CHECK-L: (set-option :rlimit 800000)
+// CHECK-L: (set-option :timeout 0)
+// CHECK-L: (set-option :rlimit 900000)
+// CHECK-L: (set-option :timeout 0)
+// CHECK-L: (set-option :rlimit 1000000)
+procedure {:timeLimit 4} /* timeLimit overridden by rlimit */ TestTimeouts0(in: [int]int, len: int) returns (out: [int]int)
   requires in[0] == 0 && (forall i: int :: 0 <= i ==> in[i + 1] == in[i] + 1);
   requires 0 < len;
-  ensures (forall j: int :: 0 <= j && j < len ==> out[j] == in[j]);
-
-implementation TestRlimit0(in: [int]int, len: int) returns (out: [int]int)
+  ensures (forall j: int :: 0 <= j && j < len ==> out[j] == j);
 {
-    // CHECK-L: ${CHECKFILE_NAME}(${LINE:-2},16): Verification out of resource (TestRlimit0)
     var i : int;
 
     i := 0;
     out[i] := 0;
     while (i < len)
       invariant 0 <= i && i <= len;
-      invariant out[0] == 0 && (forall j: int :: 0 <= j && j < i ==> out[j] == in[j]);
+      invariant out[0] == 0 && (forall j: int :: 0 <= j && j < i ==> out[j + 1] == out[j] + 1);
     {
-        out[i] := in[i];
+        out[i + 1] := out[i] + 1;
         i := i + 1;
     }
 
@@ -34,12 +34,13 @@ implementation TestRlimit0(in: [int]int, len: int) returns (out: [int]int)
     }
 }
 
-procedure TestRlimit1(in: [int]int, len: int) returns (out: [int]int);
+
+procedure TestTimeouts1(in: [int]int, len: int) returns (out: [int]int);
   requires in[0] == 0 && (forall i: int :: 0 <= i ==> in[i + 1] == in[i] + 1);
   requires 0 < len;
-  ensures (forall j: int :: 0 <= j && j < len ==> out[j] == in[j]);
+  ensures (forall j: int :: 0 <= j && j < len ==> out[j] == j);
 
-implementation {:rlimit 6000000} TestRlimit1(in: [int]int, len: int) returns (out: [int]int)
+implementation {:rlimit 900} TestTimeouts1(in: [int]int, len: int) returns (out: [int]int)
 {
     var i : int;
 
@@ -47,9 +48,9 @@ implementation {:rlimit 6000000} TestRlimit1(in: [int]int, len: int) returns (ou
     out[i] := 0;
     while (i < len)
       invariant 0 <= i && i <= len;
-      invariant out[0] == 0 && (forall j: int :: 0 <= j && j < i ==> out[j] == in[j]);
+      invariant out[0] == 0 && (forall j: int :: 0 <= j && j < i ==> out[j + 1] == out[j] + 1);
     {
-        out[i] := in[i];
+        out[i + 1] := out[i] + 1;
         i := i + 1;
     }
 
@@ -62,23 +63,23 @@ implementation {:rlimit 6000000} TestRlimit1(in: [int]int, len: int) returns (ou
     }
 }
 
-procedure TestRlimit2(in: [int]int, len: int) returns (out: [int]int);
+
+procedure TestTimeouts2(in: [int]int, len: int) returns (out: [int]int);
   requires in[0] == 0 && (forall i: int :: 0 <= i ==> in[i + 1] == in[i] + 1);
   requires 0 < len;
-  ensures (forall j: int :: 0 <= j && j < len ==> out[j] == in[j]);
+  ensures (forall j: int :: 0 <= j && j < len ==> out[j] == j);
 
-implementation {:rlimit 200} TestRlimit2(in: [int]int, len: int) returns (out: [int]int)
+implementation {:rlimit 1000} TestTimeouts2(in: [int]int, len: int) returns (out: [int]int)
 {
-    // CHECK-L: ${CHECKFILE_NAME}(${LINE:-2},30): Verification out of resource (TestRlimit2)
     var i : int;
 
     i := 0;
     out[i] := 0;
     while (i < len)
       invariant 0 <= i && i <= len;
-      invariant out[0] == 0 && (forall j: int :: 0 <= j && j < i ==> out[j] == in[j]);
+      invariant out[0] == 0 && (forall j: int :: 0 <= j && j < i ==> out[j + 1] == out[j] + 1);
     {
-        out[i] := in[i];
+        out[i + 1] := out[i] + 1;
         i := i + 1;
     }
 
@@ -90,4 +91,3 @@ implementation {:rlimit 200} TestRlimit2(in: [int]int, len: int) returns (out: [
         i := i + 1;
     }
 }
-// CHECK-L: Boogie program verifier finished with 1 verified, 0 errors, 2 out of resource

--- a/Test/test2/Rlimitouts0.bpl.expect
+++ b/Test/test2/Rlimitouts0.bpl.expect
@@ -1,0 +1,47 @@
+Rlimitouts0.bpl(29,5): Error BP5003: A postcondition might not hold on this return path.
+Rlimitouts0.bpl(14,3): Related location: This is the postcondition that might not hold.
+Execution trace:
+    Rlimitouts0.bpl(18,7): anon0
+    Rlimitouts0.bpl(20,5): anon4_LoopHead
+    Rlimitouts0.bpl(20,5): anon4_LoopDone
+    Rlimitouts0.bpl(29,5): anon5_LoopHead
+    Rlimitouts0.bpl(29,5): anon5_LoopDone
+Rlimitouts0.bpl(31,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Execution trace:
+    Rlimitouts0.bpl(18,7): anon0
+    Rlimitouts0.bpl(20,5): anon4_LoopHead
+    Rlimitouts0.bpl(20,5): anon4_LoopDone
+    Rlimitouts0.bpl(29,5): anon5_LoopHead
+    Rlimitouts0.bpl(33,11): anon5_LoopBody
+Rlimitouts0.bpl(58,5): Error BP5003: A postcondition might not hold on this return path.
+Rlimitouts0.bpl(41,3): Related location: This is the postcondition that might not hold.
+Execution trace:
+    Rlimitouts0.bpl(47,7): anon0
+    Rlimitouts0.bpl(49,5): anon4_LoopHead
+    Rlimitouts0.bpl(49,5): anon4_LoopDone
+    Rlimitouts0.bpl(58,5): anon5_LoopHead
+    Rlimitouts0.bpl(58,5): anon5_LoopDone
+Rlimitouts0.bpl(60,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Execution trace:
+    Rlimitouts0.bpl(47,7): anon0
+    Rlimitouts0.bpl(49,5): anon4_LoopHead
+    Rlimitouts0.bpl(49,5): anon4_LoopDone
+    Rlimitouts0.bpl(58,5): anon5_LoopHead
+    Rlimitouts0.bpl(62,11): anon5_LoopBody
+Rlimitouts0.bpl(87,5): Error BP5003: A postcondition might not hold on this return path.
+Rlimitouts0.bpl(70,3): Related location: This is the postcondition that might not hold.
+Execution trace:
+    Rlimitouts0.bpl(76,7): anon0
+    Rlimitouts0.bpl(78,5): anon4_LoopHead
+    Rlimitouts0.bpl(78,5): anon4_LoopDone
+    Rlimitouts0.bpl(87,5): anon5_LoopHead
+    Rlimitouts0.bpl(87,5): anon5_LoopDone
+Rlimitouts0.bpl(89,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Execution trace:
+    Rlimitouts0.bpl(76,7): anon0
+    Rlimitouts0.bpl(78,5): anon4_LoopHead
+    Rlimitouts0.bpl(78,5): anon4_LoopDone
+    Rlimitouts0.bpl(87,5): anon5_LoopHead
+    Rlimitouts0.bpl(91,11): anon5_LoopBody
+
+Boogie program verifier finished with 0 verified, 6 errors


### PR DESCRIPTION
This PR attempts to add more robust support for global (and per-procedure) rlimit.  Specifically, the following changes are made.

1. The reason calculation for proof failure in prover interface was not robust.  If reason was unknown or expected, it did set outcome back to Undetermined.  This is now fixed by this PR.

2. Through experiments I determined that even for small programs, rlimit required by Z3 ranges in 100s of thousands. To simplify life for the user, I multiply the rlimit parameter by 100 internally before passing the result to the solver.

3. Boogie currently allows the user to supply both timeLimit and rlimit.  This PR makes a change so that if rlimit is provided it overrides timeLimit.  This avoids confusion and also allows Boogie to report more accurate feedback in case resource exhaustion happens.

A test for rlimit checking similar to timeout checking is also enabled.

A note here for Boogie users using the rlimit option:  If rlimit supplied is very low, the response from Z3 in case of resource exhaustion (very likely) is "unknown" which will result in Boogie producing an unhelpful warning about unexpected prover output.  For larger and reasonable rlimit, a reasonable response is received.  This is all based on experimentation.