### PR TITLE
Allow bound variables to shadow similarly-named variables in outer scope

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -2405,7 +2405,7 @@ namespace Microsoft.Boogie
     public override void Register(ResolutionContext rc)
     {
       //Contract.Requires(rc != null);
-      rc.AddVariable(this, true);
+      rc.AddVariable(this);
     }
 
     public override void Resolve(ResolutionContext rc)
@@ -2497,7 +2497,7 @@ namespace Microsoft.Boogie
     public override void Register(ResolutionContext rc)
     {
       //Contract.Requires(rc != null);
-      rc.AddVariable(this, true);
+      rc.AddVariable(this);
     }
 
     public override Absy StdDispatch(StandardVisitor visitor)
@@ -2535,7 +2535,7 @@ namespace Microsoft.Boogie
     public override void Register(ResolutionContext rc)
     {
       //Contract.Requires(rc != null);
-      rc.AddVariable(this, false);
+      rc.AddVariable(this);
     }
 
     /// <summary>
@@ -2591,7 +2591,7 @@ namespace Microsoft.Boogie
     public override void Register(ResolutionContext rc)
     {
       //Contract.Requires(rc != null);
-      rc.AddVariable(this, false);
+      rc.AddVariable(this);
     }
 
     public override Absy StdDispatch(StandardVisitor visitor)
@@ -2645,7 +2645,7 @@ namespace Microsoft.Boogie
     public override void Register(ResolutionContext rc)
     {
       //Contract.Requires(rc != null);
-      rc.AddVariable(this, false);
+      rc.AddVariable(this);
     }
 
     public override Absy StdDispatch(StandardVisitor visitor)
@@ -2961,7 +2961,7 @@ namespace Microsoft.Boogie
         Contract.Assert(f != null);
         if (f.Name != TypedIdent.NoName)
         {
-          rc.AddVariable(f, false);
+          rc.AddVariable(f);
         }
 
         f.Resolve(rc);

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -2369,7 +2369,7 @@ namespace Microsoft.Boogie
       foreach (Variable /*!*/ v in Locals)
       {
         Contract.Assert(v != null);
-        rc.AddVariable(v, false);
+        rc.AddVariable(v);
       }
 
       foreach (Cmd /*!*/ cmd in Cmds)

--- a/Source/Core/ResolutionContext.cs
+++ b/Source/Core/ResolutionContext.cs
@@ -420,10 +420,10 @@ namespace Microsoft.Boogie
       StatementIds.Add(name);
     }
 
-    public void AddVariable(Variable var, bool global)
+    public void AddVariable(Variable var)
     {
       Contract.Requires(var != null);
-      var previous = FindVariable(cce.NonNull(var.Name), !global);
+      var previous = FindVariable(cce.NonNull(var.Name), true);
       if (previous == null)
       {
         varContext.VarSymbols.Add(var.Name, var);
@@ -454,19 +454,13 @@ namespace Microsoft.Boogie
       return FindVariable(name, false);
     }
 
-    Variable FindVariable(string name, bool ignoreTopLevelVars)
+    Variable FindVariable(string name, bool lookInCurrentScopeOnly)
     {
       Contract.Requires(name != null);
       VarContextNode c = varContext;
       bool lookOnlyForConstants = false;
       do
       {
-        if (ignoreTopLevelVars && c.ParentContext == null)
-        {
-          // this is the top level and we're asked to ignore the top level; hence, we're done
-          break;
-        }
-
         Variable var = (Variable) c.VarSymbols[name];
         if (var != null && (!lookOnlyForConstants || var is Constant))
         {
@@ -479,10 +473,15 @@ namespace Microsoft.Boogie
           // from here on, only constants can be looked up
           lookOnlyForConstants = true;
         }
-
+        
+        if (lookInCurrentScopeOnly)
+        {
+          // we're asked to look only in the current scope; hence, we're done
+          break;
+        }
+        
         c = c.ParentContext;
       } while (c != null);
-
       // not present in the relevant levels
       return null;
     }

--- a/Test/test2/shadow0.bpl
+++ b/Test/test2/shadow0.bpl
@@ -1,0 +1,52 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function Inc2(x: int): int {
+  (var x' := x + 4; x' - 2)
+}
+
+procedure {:inline 1} Inc3(x: int) returns (y: int) {
+  y := (var y' := x + 3; y');
+}
+
+procedure P() {
+  var x: int;
+  var b: bool;
+
+  x := 10;
+  call x := Inc3(Inc2(x + 3));
+  assert x == 18;
+
+  b := (var y := x; (var y' := y + 1; (forall x': int :: x' == y' ==> x' == 19)));
+  assert b;
+  b := (var y := x; (forall x': int :: x' == y ==> (var x'' := x' + 20; x'' == 38)));
+  assert b;
+  b := (var y := x; (exists x': int :: x' < y && x' == 28));
+  assert !b;
+}
+
+
+function ShadowInc2(x: int): int {
+  (var x := x + 4; x - 2)
+}
+
+procedure {:inline 1} ShadowInc3(x: int) returns (y: int)
+{
+  y := (var y := x + 3; y);
+}
+
+procedure ShadowP() {
+  var x: int;
+  var b: bool;
+
+  x := 10;
+  call x := ShadowInc3(ShadowInc2(x + 3));
+  assert x == 18;
+
+  b := (var y := x; (var y := y + 1; (forall x: int :: x == y ==> x == 19)));
+  assert b;
+  b := (var y := x; (forall x: int :: x == y ==> (var x := x + 20; x == 38)));
+  assert b;
+  b := (var y := x; (exists x: int :: x < y && x == 28));
+  assert !b;
+}

--- a/Test/test2/shadow0.bpl.expect
+++ b/Test/test2/shadow0.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 2 verified, 0 errors

--- a/Test/test2/shadow1.bpl
+++ b/Test/test2/shadow1.bpl
@@ -1,0 +1,11 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var x:int;
+
+procedure P()
+requires x == 0;
+{
+  assert (forall y:int :: x == 0); // x should be global variable
+  assert (forall x:int :: x == 0); // x should be bound variable
+}

--- a/Test/test2/shadow1.bpl.expect
+++ b/Test/test2/shadow1.bpl.expect
@@ -1,0 +1,5 @@
+shadow1.bpl(10,3): Error BP5001: This assertion might not hold.
+Execution trace:
+    shadow1.bpl(9,3): anon0
+
+Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
This PR changes the resolver so that bound variables in quantifiers are allowed to shadow locals in outer scope.  Note that shadowing of globals was already allowed in Boogie.  I have verified that the correct thing is happening in the VC generation by examining the SMT output manually for the program shown below. I couldn't come up with sensible regression tests of the sort common in the Boogie test folder where the golden output is indicated with verification/errors on procedures.  I would be glad to incorporate suggestions from the reviewers about possible regression tests. 

```
var addr: int;

procedure {:inline 1} blah(i: int) {
    assume addr == 64;
}

procedure foo(addr: int) returns (i: int)
requires addr == 46;
ensures addr == 84;
{
    call blah(addr);
    assume addr == i;
    assume (forall addr: int:: (exists addr: int :: addr == 0));
    assert (forall addr: int:: (exists addr: int :: addr == 0));
}

```

This PR should  fix issue #280 .