### PR TITLE
Debug printing of strings and values

### DIFF
--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1970,6 +1970,16 @@ namespace Microsoft.Boogie
        Prints <string> rather than the standard message for assertion failure.
        Also applicable to requires and ensures declarations. 
 
+---- On statements --------------------------------------------------
+
+     {:print e0, e1, e2, ...}
+       Indicates that expressions e0, e1, e2, ... must be printed.  Must be used 
+       in conjunction with /enhancedErrorMessages:n command-line option.  
+
+     {:captureState s}
+       Indicates that state must be captured under the name s.  Must be used
+       together with /mv:<string> command-line option.
+
   ---- The end ---------------------------------------------------------------
 ");
     }

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -851,7 +851,13 @@ namespace Microsoft.Boogie
         {
           return cmd;
         }
-        return BoundVarAndReplacingOldSubstituter.Apply(substMap, oldSubstMap, prefix, cmd);
+        var newCmd = BoundVarAndReplacingOldSubstituter.Apply(substMap, oldSubstMap, prefix, cmd);
+        if (cmd is ICarriesAttributes attrCmd && attrCmd.Attributes != null)
+        {
+          var attrCopy = (QKeyValue) attrCmd.Attributes.Clone();
+          ((ICarriesAttributes) newCmd).Attributes = Substituter.ApplyReplacingOldExprs(Subst, OldSubst, attrCopy);
+        }
+        return newCmd;
       }
 
       public Expr CopyExpr(Expr expr)

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1798,19 +1798,18 @@ namespace Microsoft.Boogie
             WriteErrorInformationToXmlSink(errorInfo, error.Trace);
           }
 
-          if (CommandLineOptions.Clo.EnhancedErrorMessages == 1)
-          {
-            foreach (string info in error.relatedInformation)
-            {
-              Contract.Assert(info != null);
-              errorInfo.Out.WriteLine("       " + info);
-            }
-          }
-
           if (CommandLineOptions.Clo.ErrorTrace > 0)
           {
             errorInfo.Out.WriteLine("Execution trace:");
             error.Print(4, errorInfo.Out, b => { errorInfo.AddAuxInfo(b.tok, b.Label, "Execution trace"); });
+            if (CommandLineOptions.Clo.EnhancedErrorMessages == 1 && error.AugmentedTrace != null && error.AugmentedTrace.Count > 0)
+            {
+              errorInfo.Out.WriteLine("Augmented execution trace:");
+              foreach (var elem in error.AugmentedTrace)
+              {
+                errorInfo.Out.Write(elem);
+              }
+            }
             if (CommandLineOptions.Clo.PrintErrorModel >= 1 && error.Model != null)
             {
               error.Model.Write(ExecutionEngine.ModelWriter == null ? errorInfo.Out : ExecutionEngine.ModelWriter);

--- a/Source/Houdini/Checker.cs
+++ b/Source/Houdini/Checker.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Boogie.Houdini
         new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "", Type.Bool), false));
       proverInterface.DefineMacro(macro, conjecture);
       conjecture = exprGen.Function(macro);
-      handler = new VCGen.ErrorReporter(gotoCmdOrigins, label2absy, impl.Blocks, vcgen.incarnationOriginMap, collector,
+      handler = new VCGen.ErrorReporter(gotoCmdOrigins, label2absy, impl.Blocks, vcgen.debugInfos, collector,
         mvInfo, proverInterface.Context, program);
     }
 

--- a/Source/VCGeneration/Couterexample.cs
+++ b/Source/VCGeneration/Couterexample.cs
@@ -66,15 +66,14 @@ namespace Microsoft.Boogie
     {
       Contract.Invariant(Trace != null);
       Contract.Invariant(Context != null);
-      Contract.Invariant(cce.NonNullElements(relatedInformation));
       Contract.Invariant(cce.NonNullDictionaryAndValues(calleeCounterexamples));
     }
 
     [Peer] public List<Block> Trace;
+    public List<object> AugmentedTrace;
     public Model Model;
     public VC.ModelViewInfo MvInfo;
     public ProverContext Context;
-    [Peer] public List<string> /*!>!*/ relatedInformation;
     public string OriginalRequestId;
     public string RequestId;
     public abstract byte[] Checksum { get; }
@@ -83,15 +82,15 @@ namespace Microsoft.Boogie
 
     public Dictionary<TraceLocation, CalleeCounterexampleInfo> calleeCounterexamples;
 
-    internal Counterexample(List<Block> trace, Model model, VC.ModelViewInfo mvInfo, ProverContext context)
+    internal Counterexample(List<Block> trace, List<object> augmentedTrace, Model model, VC.ModelViewInfo mvInfo, ProverContext context)
     {
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
       this.Trace = trace;
+      this.AugmentedTrace = augmentedTrace;
       this.Model = model;
       this.MvInfo = mvInfo;
       this.Context = context;
-      this.relatedInformation = new List<string>();
       this.calleeCounterexamples = new Dictionary<TraceLocation, CalleeCounterexampleInfo>();
     }
 
@@ -429,9 +428,9 @@ namespace Microsoft.Boogie
     }
 
 
-    public AssertCounterexample(List<Block> trace, AssertCmd failingAssert, Model model, VC.ModelViewInfo mvInfo,
+    public AssertCounterexample(List<Block> trace, List<object> augmentedTrace, AssertCmd failingAssert, Model model, VC.ModelViewInfo mvInfo,
       ProverContext context)
-      : base(trace, model, mvInfo, context)
+      : base(trace, augmentedTrace, model, mvInfo, context)
     {
       Contract.Requires(trace != null);
       Contract.Requires(failingAssert != null);
@@ -451,7 +450,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new AssertCounterexample(Trace, FailingAssert, Model, MvInfo, Context);
+      var ret = new AssertCounterexample(Trace, AugmentedTrace, FailingAssert, Model, MvInfo, Context);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -470,9 +469,9 @@ namespace Microsoft.Boogie
     }
 
 
-    public CallCounterexample(List<Block> trace, CallCmd failingCall, Requires failingRequires, Model model,
+    public CallCounterexample(List<Block> trace, List<object> augmentedTrace, CallCmd failingCall, Requires failingRequires, Model model,
       VC.ModelViewInfo mvInfo, ProverContext context, byte[] checksum = null)
-      : base(trace, model, mvInfo, context)
+      : base(trace, augmentedTrace, model, mvInfo, context)
     {
       Contract.Requires(!failingRequires.Free);
       Contract.Requires(trace != null);
@@ -499,7 +498,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new CallCounterexample(Trace, FailingCall, FailingRequires, Model, MvInfo, Context, Checksum);
+      var ret = new CallCounterexample(Trace, AugmentedTrace, FailingCall, FailingRequires, Model, MvInfo, Context, Checksum);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -518,9 +517,9 @@ namespace Microsoft.Boogie
     }
 
 
-    public ReturnCounterexample(List<Block> trace, TransferCmd failingReturn, Ensures failingEnsures, Model model,
+    public ReturnCounterexample(List<Block> trace, List<object> augmentedTrace, TransferCmd failingReturn, Ensures failingEnsures, Model model,
       VC.ModelViewInfo mvInfo, ProverContext context, byte[] checksum)
-      : base(trace, model, mvInfo, context)
+      : base(trace, augmentedTrace, model, mvInfo, context)
     {
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
@@ -549,7 +548,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new ReturnCounterexample(Trace, FailingReturn, FailingEnsures, Model, MvInfo, Context, checksum);
+      var ret = new ReturnCounterexample(Trace, AugmentedTrace, FailingReturn, FailingEnsures, Model, MvInfo, Context, checksum);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }

--- a/Source/VCGeneration/FixedpointVC.cs
+++ b/Source/VCGeneration/FixedpointVC.cs
@@ -1931,7 +1931,7 @@ namespace Microsoft.Boogie
               if (continuation_stack.Count == 0)
               {
                 Counterexample newCounterexample =
-                  AssertCmdToCounterexample((AssertCmd) cmd, transferCmd, trace, new Microsoft.Boogie.Model(),
+                  AssertCmdToCounterexample((AssertCmd) cmd, transferCmd, trace, null, new Microsoft.Boogie.Model(),
                     info.mvInfo,
                     boogieContext);
                 newCounterexample.AddCalleeCounterexample(calleeCounterexamples);

--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -2627,7 +2627,7 @@ namespace VC
               }
 
               Counterexample newCounterexample =
-                AssertCmdToCounterexample(acmd, transferCmd, trace, errModel, mvInfo, theoremProver.Context);
+                AssertCmdToCounterexample(acmd, transferCmd, trace, null, errModel, mvInfo, theoremProver.Context);
               newCounterexample.AddCalleeCounterexample(calleeCounterexamples);
               return newCounterexample;
             }
@@ -3002,7 +3002,7 @@ namespace VC
       translator.SetCodeExprConverter(cc.CodeExprToVerificationCondition);
       var implVc = gen.Not(GenerateVCAux(impl, null, label2absy, prover.Context));
 
-      handler = new VCGen.ErrorReporter(gotoCmdOrigins, label2absy, impl.Blocks, incarnationOriginMap, collector,
+      handler = new VCGen.ErrorReporter(gotoCmdOrigins, label2absy, impl.Blocks, debugInfos, collector,
         mvInfo, prover.Context, program);
 
       prover.Assert(implVc, true);

--- a/Test/prover/EQ_v2.Eval__v4.Eval_out.bpl.expect
+++ b/Test/prover/EQ_v2.Eval__v4.Eval_out.bpl.expect
@@ -2,10 +2,10 @@ EQ_v2.Eval__v4.Eval_out.bpl(2103,5): Error BP5003: A postcondition might not hol
 EQ_v2.Eval__v4.Eval_out.bpl(1717,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     EQ_v2.Eval__v4.Eval_out.bpl(1788,3): AA_INSTR_EQ_BODY
-    EQ_v2.Eval__v4.Eval_out.bpl(1877,3): inline$v2.Eval$0$label_11_case_1#2
+    EQ_v2.Eval__v4.Eval_out.bpl(1864,3): inline$v2.Eval$0$label_11_case_2#2
     EQ_v2.Eval__v4.Eval_out.bpl(1896,3): inline$v2.Eval$0$label_12#2
-    EQ_v2.Eval__v4.Eval_out.bpl(2034,3): inline$v4.Eval$0$label_11_case_1#2
-    EQ_v2.Eval__v4.Eval_out.bpl(2056,3): inline$v4.Eval$0$label_13_true#2
+    EQ_v2.Eval__v4.Eval_out.bpl(1991,3): inline$v4.Eval$0$label_11_case_2#2
+    EQ_v2.Eval__v4.Eval_out.bpl(2013,3): inline$v4.Eval$0$label_14_true#2
     EQ_v2.Eval__v4.Eval_out.bpl(2083,3): inline$v4.Eval$0$label_12#2
 EQ_v2.Eval__v4.Eval_out.bpl(2154,5): Error BP5003: A postcondition might not hold on this return path.
 EQ_v2.Eval__v4.Eval_out.bpl(2122,3): Related location: This is the postcondition that might not hold.

--- a/Test/test15/trace0.bpl
+++ b/Test/test15/trace0.bpl
@@ -1,0 +1,46 @@
+// RUN: %boogie "%s" -enhancedErrorMessages:1 > "%t"
+// RUN: %diff "%s.expect" "%t"
+procedure foo(i: int) returns (o: int)
+requires i == 42;
+ensures o < 44;
+{
+    assume {:print "line 22"} {:print "i = ", i} true;
+    o := i;
+    if (*) {
+        assume {:print "line 25"} {:print "o = ", o} true;
+        o := o + 1;
+    }
+    if (*) {
+        assume {:print "line 29"} {:print "o = ", o} true;
+        o := {:print "just to show off"} o + 1;
+    }
+    assert {:print "exit of foo"} {:print "o = ", o} true;
+}
+
+procedure bar(i: int) returns (o: int)
+requires i == 42;
+ensures o < 44;
+{
+    assume {:print "line 22"} {:print "i = ", i} true;
+    o := i;
+    if (*) {
+        call o := FirstIncr(o);
+    }
+    if (*) {
+        call o := SecondIncr(o);
+    }
+    assert {:print "exit of foo"} {:print "o = ", o} true;
+}
+
+procedure {:inline 1} FirstIncr(o: int) returns (o': int)
+{
+    assume {:print "line 25"} {:print "o = ", o} true;
+    o' := o + 1;
+}
+
+procedure {:inline 1} SecondIncr(o: int) returns (o': int)
+{
+    assume {:print "line 29"} {:print "o = ", o} true;
+    o' := {:print "just to show off"} o + 1;
+}
+

--- a/Test/test15/trace0.bpl.expect
+++ b/Test/test15/trace0.bpl.expect
@@ -1,0 +1,38 @@
+trace0.bpl(18,1): Error BP5003: A postcondition might not hold on this return path.
+trace0.bpl(5,1): Related location: This is the postcondition that might not hold.
+Execution trace:
+    trace0.bpl(7,5): anon0
+    trace0.bpl(10,9): anon5_Then
+    trace0.bpl(14,9): anon6_Then
+    trace0.bpl(17,5): anon4
+Augmented execution trace:
+line 22
+i = 42
+line 25
+o = 42
+line 29
+o = 43
+just to show off
+exit of foo
+o = 44
+trace0.bpl(33,1): Error BP5003: A postcondition might not hold on this return path.
+trace0.bpl(22,1): Related location: This is the postcondition that might not hold.
+Execution trace:
+    trace0.bpl(24,5): anon0
+    trace0.bpl(37,5): inline$FirstIncr$0$anon0
+    trace0.bpl(27,9): anon5_Then$1
+    trace0.bpl(43,5): inline$SecondIncr$0$anon0
+    trace0.bpl(30,9): anon6_Then$1
+    trace0.bpl(32,5): anon4
+Augmented execution trace:
+line 22
+i = 42
+line 25
+o = 42
+line 29
+o = 43
+just to show off
+exit of foo
+o = 44
+
+Boogie program verifier finished with 0 verified, 2 errors


### PR DESCRIPTION
This PR introduces the augmented trace feature which allows printing of arbitrary strings and variables via attributes on assignment, assert, and assume statements.  The feature is enabled if the special attribute "debug" is used  as in the procedure below and the command-line option /enhancedErrorMessages:1 is used.  As you may have guessed, the implementation of this feature requires examination of the model returned by the solver.  

```
procedure foo(i: int) returns (o: int)
requires i == 42;
ensures o == i;
{
    o := i;
    if (*) {
        assume {:debug "line 25"} {:debug "o = ", o} true;
        o := o + 1;
    }
    if (*) {
        assume {:debug "line 29"} {:debug "o = ", o} true;
        o := {:debug "just to show off"} o + 1;
    }
    assert {:debug "exit of foo"} {:debug "o = ", o} true;
}

```
For the above program, the augmented trace part of the output is as follows:
```
Augmented execution trace:
line 25
o = 42
line 29
o = 43
just to show off
exit of foo
o = 44
```
 
I am looking for feedback, especially if you have concerns about how this feature is exposed to the user. I have not documented the "debug" attribute yet; I will do it once the design is finalized based on your feedback.