### PR TITLE
Monomorphize subset of Boogie programs

### DIFF
--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -3397,7 +3397,7 @@ Contract.Requires(that != null);
 
   //=====================================================================
 
-  // Used to annotate types with type synoyms that were used in the
+  // Used to annotate types with type synonyms that were used in the
   // original unresolved types. Such types should be considered as
   // equivalent to ExpandedType, the annotations are only used to enable
   // better pretty-printing
@@ -3774,7 +3774,7 @@ Contract.Requires(that != null);
 
     public bool IsDatatype()
     {
-      return QKeyValue.FindBoolAttribute(Decl.Attributes, "datatype");
+      return Decl is DatatypeTypeCtorDecl;
     }
 
     // This attribute is used to tell Boogie that this type is built into SMT-LIB and should
@@ -3782,14 +3782,6 @@ Contract.Requires(that != null);
     public string GetBuiltin()
     {
       return this.Decl.FindStringAttribute("builtin");
-    }
-
-    // This attribute can be used to tell Boogie that a datatype depends on another datatype
-    // in case Boogie can't figure this out itself (as may happen, for example when a type
-    // has the ":builtin" attribute).
-    public string GetTypeDependency()
-    {
-      return this.Decl.FindStringAttribute("dependson");
     }
 
     //-----------  Cloning  ----------------------------------

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -827,6 +827,8 @@ namespace Microsoft.Boogie
 
     public TypeEncoding TypeEncodingMethod = TypeEncoding.Predicates;
 
+    public bool Monomorphize = false;
+
     public bool ReflectAdd = false;
 
     public int LiveVariableAnalysis = 1;
@@ -1481,7 +1483,7 @@ namespace Microsoft.Boogie
           }
 
           return true;
-
+        
         case "typeEncoding":
           if (ps.ConfirmArgumentCount(1))
           {
@@ -1501,6 +1503,14 @@ namespace Microsoft.Boogie
             }
           }
 
+          return true;
+
+        case "monomorphize":
+          if (ps.ConfirmArgumentCount(0))
+          {
+            Monomorphize = true;
+          }
+          
           return true;
 
         case "instrumentInfer":
@@ -2173,6 +2183,8 @@ namespace Microsoft.Boogie
                    a = arguments
                 Boogie automatically detects monomorphic programs and enables
                 monomorphic VC generation, thereby overriding the above option.
+  /monomorphize
+                Monomorphize program
   /useArrayTheory
                 Use the SMT theory of arrays (as opposed to axioms). Supported
                 only for monomorphic programs.

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -1,0 +1,544 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics.Contracts;
+using System.Reflection.Metadata;
+
+namespace Microsoft.Boogie
+{
+  class PolymorphismChecker : ReadOnlyVisitor
+  {
+    public static bool IsMonomorphic(Program program)
+    {
+      var checker = new PolymorphismChecker();
+      checker.VisitProgram(program);
+      return checker.isMonomorphic;
+    }
+    
+    bool isMonomorphic;
+
+    private PolymorphismChecker()
+    {
+      isMonomorphic = true;
+    }
+    
+    public override DeclWithFormals VisitDeclWithFormals(DeclWithFormals node)
+    {
+      if (node.TypeParameters.Count > 0)
+      {
+        isMonomorphic = false;
+      }
+
+      return base.VisitDeclWithFormals(node);
+    }
+
+    public override BinderExpr VisitBinderExpr(BinderExpr node)
+    {
+      if (node.TypeParameters.Count > 0)
+      {
+        isMonomorphic = false;
+      }
+
+      return base.VisitBinderExpr(node);
+    }
+
+    public override MapType VisitMapType(MapType node)
+    {
+      if (node.TypeParameters.Count > 0)
+      {
+        isMonomorphic = false;
+      }
+
+      return base.VisitMapType(node);
+    }
+
+    public override Expr VisitNAryExpr(NAryExpr node)
+    {
+      BinaryOperator op = node.Fun as BinaryOperator;
+      if (op != null && op.Op == BinaryOperator.Opcode.Subtype)
+      {
+        isMonomorphic = false;
+      }
+
+      return base.VisitNAryExpr(node);
+    }
+  }
+
+  class MonomorphizableChecker : ReadOnlyVisitor
+  {
+    public static HashSet<Axiom> IsMonomorphizable(Program program)
+    {
+      var checker = new MonomorphizableChecker(program);
+      checker.VisitProgram(program);
+      return checker.isMonomorphizable ? checker.axiomsToBeInstantiated : null;
+    }
+    
+    private Program program;
+    private bool isMonomorphizable;
+    private HashSet<Axiom> axiomsToBeInstantiated;
+
+    private MonomorphizableChecker(Program program)
+    {
+      this.program = program;
+      this.isMonomorphizable = true;
+      this.axiomsToBeInstantiated = new HashSet<Axiom>();
+    }
+
+    public override BinderExpr VisitBinderExpr(BinderExpr node)
+    {
+      if (node.TypeParameters.Count > 0)
+      {
+        isMonomorphizable = false;
+      }
+      return base.VisitBinderExpr(node);
+    }
+
+    public override Expr VisitNAryExpr(NAryExpr node)
+    {
+      BinaryOperator op = node.Fun as BinaryOperator;
+      if (op != null && op.Op == BinaryOperator.Opcode.Subtype)
+      {
+        isMonomorphizable = false;
+      }
+      return base.VisitNAryExpr(node);
+    }
+
+    public override MapType VisitMapType(MapType node)
+    {
+      if (node.TypeParameters.Count > 0)
+      {
+        isMonomorphizable = false;
+      }
+      return base.VisitMapType(node);
+    }
+
+    public override Implementation VisitImplementation(Implementation node)
+    {
+      if (node.TypeParameters.Count > 0)
+      {
+        isMonomorphizable = false;
+        return node;
+      }
+      return base.VisitImplementation(node);
+    }
+
+    private void CheckTypeCtorInstantiatedAxiom(Axiom axiom, string typeCtorName)
+    {
+      var tcDecl = program.TopLevelDeclarations.OfType<TypeCtorDecl>().FirstOrDefault(tcd => tcd.Name == typeCtorName);
+      if (tcDecl == null)
+      {
+        isMonomorphizable = false;
+        return;
+      }
+      var forallExpr = (ForallExpr) axiom.Expr;
+      if (tcDecl.Arity != forallExpr.TypeParameters.Count)
+      {
+        isMonomorphizable = false;
+        return;
+      }
+      axiomsToBeInstantiated.Add(axiom);
+      VisitExpr(forallExpr.Body);
+    }
+
+    public override Axiom VisitAxiom(Axiom node)
+    {
+      var typeCtorName = node.FindStringAttribute("ctor");
+      if (typeCtorName == null || !(node.Expr is ForallExpr))
+      {
+        return base.VisitAxiom(node);
+      }
+      CheckTypeCtorInstantiatedAxiom(node, typeCtorName);
+      return node;
+    }
+  }
+  
+  class ExprMonomorphizationVisitor : Duplicator
+  {
+    private class TypeInstantiationComparer : IEqualityComparer<List<Type>>
+    {
+      public bool Equals(List<Type> l1, List<Type> l2)
+      {
+        if (l1.Count != l2.Count)
+        {
+          return false;
+        }
+
+        for (int i = 0; i < l1.Count; i++)
+        {
+          if (!l1[i].Equals(l2[i]))
+          {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      public int GetHashCode(List<Type> l)
+      {
+        int hCode = 0;
+        l.Iter(x => { hCode = hCode ^ x.GetHashCode(); });
+        return hCode.GetHashCode();
+      }
+    }
+
+    private Dictionary<Function, Dictionary<List<Type>, Function>> functionInstantiations;
+    private Dictionary<DatatypeTypeCtorDecl, Dictionary<List<Type>, DatatypeTypeCtorDecl>> datatypeInstantiations;
+    private Dictionary<TypeCtorDecl, HashSet<CtorType>> triggerTypes;
+    private Dictionary<TypeCtorDecl, HashSet<CtorType>> newTriggerTypes;
+    private Dictionary<TypeVariable, Type> typeParamInstantiation;
+    private Dictionary<Variable, Variable> variableMapping;
+
+    public ExprMonomorphizationVisitor(
+      Dictionary<Function, Dictionary<List<Type>, Function>> functionInstantiations,
+      Dictionary<DatatypeTypeCtorDecl, Dictionary<List<Type>, DatatypeTypeCtorDecl>> datatypeInstantiations,
+      Dictionary<TypeCtorDecl, HashSet<CtorType>> triggerTypes,
+      Dictionary<TypeCtorDecl, HashSet<CtorType>> newTriggerTypes)
+    {
+      this.functionInstantiations = functionInstantiations;
+      this.datatypeInstantiations = datatypeInstantiations;
+      this.triggerTypes = triggerTypes;
+      this.newTriggerTypes = newTriggerTypes;
+      typeParamInstantiation = new Dictionary<TypeVariable, Type>();
+      variableMapping = new Dictionary<Variable, Variable>();
+    }
+
+    private ExprMonomorphizationVisitor(
+      Dictionary<Function, Dictionary<List<Type>, Function>> functionInstantiations,
+      Dictionary<DatatypeTypeCtorDecl, Dictionary<List<Type>, DatatypeTypeCtorDecl>> datatypeInstantiations,
+      Dictionary<TypeCtorDecl, HashSet<CtorType>> triggerTypes,
+      Dictionary<TypeCtorDecl, HashSet<CtorType>> newTriggerTypes,
+      Dictionary<TypeVariable, Type> typeParamInstantiation,
+      Dictionary<Variable, Variable> variableMapping)
+    {
+      this.functionInstantiations = functionInstantiations;
+      this.datatypeInstantiations = datatypeInstantiations;
+      this.triggerTypes = triggerTypes;
+      this.newTriggerTypes = newTriggerTypes;
+      this.typeParamInstantiation = typeParamInstantiation;
+      this.variableMapping = variableMapping;
+    }
+
+    public static List<Axiom> InstantiateAxiom(
+      Dictionary<Function, Dictionary<List<Type>, Function>> functionInstantiations,
+      Dictionary<DatatypeTypeCtorDecl, Dictionary<List<Type>, DatatypeTypeCtorDecl>> datatypeInstantiations,
+      Dictionary<TypeCtorDecl, HashSet<CtorType>> triggerTypes,
+      Dictionary<TypeCtorDecl, HashSet<CtorType>> newTriggerTypes,
+      Axiom axiom,
+      HashSet<CtorType> triggers)
+    {
+      var instantiatedAxioms = new List<Axiom>();
+      foreach (var trigger in triggers)
+      {
+        var forallExpr = (ForallExpr) axiom.Expr;
+        var visitor = new ExprMonomorphizationVisitor(functionInstantiations, datatypeInstantiations, triggerTypes, newTriggerTypes,
+          LinqExtender.Map(forallExpr.TypeParameters, trigger.Arguments),
+          new Dictionary<Variable, Variable>());
+        var newAxiom = new Axiom(axiom.tok, visitor.VisitExpr(forallExpr.Body), axiom.Comment, axiom.Attributes);
+        instantiatedAxioms.Add(newAxiom);
+      }
+      return instantiatedAxioms;
+    }
+
+    private Function InstantiateFunction(Function func, List<Type> funcTypeParamInstantiations, Dictionary<TypeVariable, Type> funcTypeParamInstantiation)
+    {
+      if (!functionInstantiations.ContainsKey(func))
+      {
+        functionInstantiations[func] = new Dictionary<List<Type>, Function>(new TypeInstantiationComparer());
+      }
+      if (!functionInstantiations[func].ContainsKey(funcTypeParamInstantiations))
+      {
+        var instantiatedFunction = InstantiateFunctionSignature(func, funcTypeParamInstantiations, funcTypeParamInstantiation);
+        var savedTypeParamInstantiation = this.typeParamInstantiation;
+        this.typeParamInstantiation = funcTypeParamInstantiation;
+        var savedVariableMapping = this.variableMapping;
+        this.variableMapping = LinqExtender.Map(func.InParams, instantiatedFunction.InParams);
+        if (func.Body != null)
+        {
+          instantiatedFunction.Body = VisitExpr(func.Body);
+        }
+        else if (func.DefinitionBody != null)
+        {
+          instantiatedFunction.DefinitionBody = (NAryExpr) VisitExpr(func.DefinitionBody);
+        }
+        this.variableMapping = savedVariableMapping;
+        this.typeParamInstantiation = savedTypeParamInstantiation;
+        functionInstantiations[func][funcTypeParamInstantiations] = instantiatedFunction;
+      }
+      return functionInstantiations[func][funcTypeParamInstantiations];
+    }
+
+    private Function InstantiateFunctionSignature(Function func, List<Type> funcTypeParamInstantiations, Dictionary<TypeVariable, Type> funcTypeParamInstantiation)
+    {
+      var savedTypeParamInstantiation = this.typeParamInstantiation;
+      this.typeParamInstantiation = funcTypeParamInstantiation;
+      var instantiatedInParams =
+        func.InParams.Select(x =>
+            new Formal(x.tok, new TypedIdent(x.TypedIdent.tok, x.TypedIdent.Name, VisitType(x.TypedIdent.Type)),
+              true))
+          .ToList<Variable>();
+      var instantiatedOutParams =
+        func.OutParams.Select(x =>
+            new Formal(x.tok, new TypedIdent(x.TypedIdent.tok, x.TypedIdent.Name, VisitType(x.TypedIdent.Type)),
+              false))
+          .ToList<Variable>();
+      var instantiatedFunction = new Function(
+        func.tok, 
+        MkInstanceName(func.Name, funcTypeParamInstantiations),
+        new List<TypeVariable>(),
+        instantiatedInParams, 
+        instantiatedOutParams.First(), 
+        func.Comment, 
+        func.Attributes); 
+      this.typeParamInstantiation = savedTypeParamInstantiation;
+      return instantiatedFunction;
+    }
+
+    private void InstantiateDatatype(DatatypeTypeCtorDecl datatypeTypeCtorDecl,
+      List<Type> typeParamInstantiations)
+    {
+      if (!datatypeInstantiations.ContainsKey(datatypeTypeCtorDecl))
+      {
+        datatypeInstantiations[datatypeTypeCtorDecl] =
+          new Dictionary<List<Type>, DatatypeTypeCtorDecl>(new TypeInstantiationComparer());
+      }
+      if (!datatypeInstantiations[datatypeTypeCtorDecl].ContainsKey(typeParamInstantiations))
+      {
+        var newDatatypeTypeCtorDecl = new DatatypeTypeCtorDecl(
+          new TypeCtorDecl(datatypeTypeCtorDecl.tok, MkInstanceName(datatypeTypeCtorDecl.Name, typeParamInstantiations),
+            0, datatypeTypeCtorDecl.Attributes));
+        datatypeInstantiations[datatypeTypeCtorDecl].Add(typeParamInstantiations, newDatatypeTypeCtorDecl);
+        datatypeTypeCtorDecl.Constructors.Iter(constructor =>
+          InstantiateDatatypeConstructor(newDatatypeTypeCtorDecl, constructor, typeParamInstantiations));
+      }
+    }
+
+    private void InstantiateDatatypeConstructor(DatatypeTypeCtorDecl newDatatypeTypeCtorDecl, DatatypeConstructor constructor, List<Type> typeParamInstantiations)
+    {
+      var newConstructor = new DatatypeConstructor(newDatatypeTypeCtorDecl,
+        InstantiateFunctionSignature(constructor, typeParamInstantiations, LinqExtender.Map(constructor.TypeParameters, typeParamInstantiations)));
+      newConstructor.membership = DatatypeMembership.NewDatatypeMembership(newConstructor);
+      for (int i = 0; i < newConstructor.InParams.Count; i++)
+      {
+        newConstructor.selectors.Add(DatatypeSelector.NewDatatypeSelector(newConstructor, i));
+      }
+    }
+    
+    private static string MkInstanceName(string name, List<Type> typeParamInstantiations)
+    {
+      typeParamInstantiations.Iter(x => name = $"{name}_{x.UniqueId}");
+      return name;
+    }
+
+    public override Expr VisitNAryExpr(NAryExpr node)
+    {
+      var returnExpr = (NAryExpr) base.VisitNAryExpr(node);
+      if (returnExpr.Fun is TypeCoercion)
+      {
+        return returnExpr.Args[0];
+      }
+      if (returnExpr.Fun is FunctionCall functionCall)
+      {
+        if (functionCall.Func.TypeParameters.Count > 0)
+        {
+          var typeParamInstantiations =
+            returnExpr.TypeParameters.FormalTypeParams.Select(x =>
+              TypeProxy.FollowProxy(returnExpr.TypeParameters[x]).Substitute(typeParamInstantiation)).ToList();
+          if (functionCall.Func is DatatypeMembership membership)
+          {
+            InstantiateDatatype(membership.constructor.datatypeTypeCtorDecl, typeParamInstantiations);
+            var datatypeTypeCtorDecl =
+              datatypeInstantiations[membership.constructor.datatypeTypeCtorDecl][typeParamInstantiations];
+            returnExpr.Fun = new FunctionCall(datatypeTypeCtorDecl.Constructors[membership.constructor.index].membership);
+          }
+          else if (functionCall.Func is DatatypeSelector selector)
+          {
+            InstantiateDatatype(selector.constructor.datatypeTypeCtorDecl, typeParamInstantiations);
+            var datatypeTypeCtorDecl =
+              datatypeInstantiations[selector.constructor.datatypeTypeCtorDecl][typeParamInstantiations];
+            returnExpr.Fun = new FunctionCall(datatypeTypeCtorDecl.Constructors[selector.constructor.index].selectors[selector.index]);
+          }
+          else if (functionCall.Func is DatatypeConstructor constructor)
+          {
+            InstantiateDatatype(constructor.datatypeTypeCtorDecl, typeParamInstantiations);
+            var datatypeTypeCtorDecl =
+              datatypeInstantiations[constructor.datatypeTypeCtorDecl][typeParamInstantiations];
+            returnExpr.Fun = new FunctionCall(datatypeTypeCtorDecl.Constructors[constructor.index]);
+          }
+          else
+          {
+            var funcTypeParamInstantiation = LinqExtender.Map(returnExpr.TypeParameters.FormalTypeParams, typeParamInstantiations);
+            returnExpr.Fun = new FunctionCall(InstantiateFunction(functionCall.Func, typeParamInstantiations, funcTypeParamInstantiation));
+          }
+          returnExpr.TypeParameters = SimpleTypeParamInstantiation.EMPTY;
+          returnExpr.Type = TypeProxy.FollowProxy(returnExpr.Type);
+        }
+      }
+      return returnExpr;
+    }
+    
+    public override Type VisitTypeVariable(TypeVariable node)
+    {
+      if (typeParamInstantiation.Count == 0)
+      {
+        return node;
+      }
+      return typeParamInstantiation[node];
+    }
+
+    public override MapType VisitMapType(MapType node)
+    {
+      node = (MapType) node.Clone();
+      for (int i = 0; i < node.Arguments.Count; ++i)
+      {
+        node.Arguments[i] = (Type) this.Visit(node.Arguments[i]);
+      }
+      node.Result = (Type) this.Visit(node.Result);
+      return node;
+    }
+
+    public override CtorType VisitCtorType(CtorType node)
+    {
+      node = (CtorType) node.Clone();
+      for (int i = 0; i < node.Arguments.Count; ++i)
+      {
+        node.Arguments[i] = (Type) this.Visit(node.Arguments[i]);
+      }
+      var typeCtorDecl = node.Decl;
+      if (typeCtorDecl is DatatypeTypeCtorDecl datatypeTypeCtorDecl && typeCtorDecl.Arity > 0)
+      {
+        InstantiateDatatype(datatypeTypeCtorDecl, node.Arguments);
+        return new CtorType(node.tok, datatypeInstantiations[datatypeTypeCtorDecl][node.Arguments], new List<Type>());
+      } 
+      if (triggerTypes.ContainsKey(typeCtorDecl) && !triggerTypes[typeCtorDecl].Contains(node))
+      {
+        triggerTypes[typeCtorDecl].Add(node);
+        newTriggerTypes[typeCtorDecl].Add(node);
+      }
+      return node;
+    }
+
+    public override Type VisitType(Type node)
+    {
+      return (Type) Visit(node);
+    }
+
+    public override Expr VisitExpr(Expr node)
+    {
+      node = base.VisitExpr(node);
+      node.Type = VisitType(node.Type);
+      return node;
+    }
+
+    public override Expr VisitIdentifierExpr(IdentifierExpr node)
+    {
+      if (!variableMapping.ContainsKey(node.Decl))
+      {
+        return base.VisitIdentifierExpr(node);
+      }
+      return new IdentifierExpr(node.tok, variableMapping[node.Decl], node.Immutable);
+    }
+  }
+
+  public class MonomorphizationVisitor : StandardVisitor
+  {
+    public static bool Monomorphize(Program program)
+    {
+      if (PolymorphismChecker.IsMonomorphic(program))
+      {
+        return true;
+      }
+      var axiomsToBeInstantiated = MonomorphizableChecker.IsMonomorphizable(program);
+      if (axiomsToBeInstantiated != null)
+      {
+        var visitor = new MonomorphizationVisitor(program, axiomsToBeInstantiated);
+        visitor.VisitProgram(program);
+        visitor.InstantiateAxioms(axiomsToBeInstantiated);
+        program.RemoveTopLevelDeclarations(x => x is Function && ((Function) x).TypeParameters.Count > 0);
+        program.RemoveTopLevelDeclarations(x => axiomsToBeInstantiated.Contains(x));
+        program.RemoveTopLevelDeclarations(x => x is DatatypeTypeCtorDecl y && y.Arity > 0);
+        visitor.functionInstantiations.Values.Iter(x => program.AddTopLevelDeclarations(x.Values));
+        program.AddTopLevelDeclarations(visitor.axiomInstantiations);
+        visitor.datatypeInstantiations.Values.Iter(x => program.AddTopLevelDeclarations(x.Values));
+        Contract.Assert(PolymorphismChecker.IsMonomorphic(program));
+        return true;
+      }
+      return false;
+    }
+    
+    private Program program;
+    private HashSet<Axiom> axiomsToBeInstantiated;
+    private Dictionary<Function, Dictionary<List<Type>, Function>> functionInstantiations;
+    private Dictionary<DatatypeTypeCtorDecl, Dictionary<List<Type>, DatatypeTypeCtorDecl>> datatypeInstantiations;
+    private List<Axiom> axiomInstantiations;
+    private Dictionary<TypeCtorDecl, HashSet<CtorType>> triggerTypes;
+    private Dictionary<TypeCtorDecl, HashSet<CtorType>> newTriggerTypes;
+    
+    private MonomorphizationVisitor(Program program, HashSet<Axiom> axiomsToBeInstantiated)
+    {
+      this.program = program;
+      this.axiomsToBeInstantiated = axiomsToBeInstantiated;
+      functionInstantiations = new Dictionary<Function, Dictionary<List<Type>, Function>>();
+      datatypeInstantiations = new Dictionary<DatatypeTypeCtorDecl, Dictionary<List<Type>, DatatypeTypeCtorDecl>>();
+      axiomInstantiations = new List<Axiom>();
+      triggerTypes = new Dictionary<TypeCtorDecl, HashSet<CtorType>>();
+      newTriggerTypes = new Dictionary<TypeCtorDecl, HashSet<CtorType>>();
+      axiomsToBeInstantiated.Iter(axiom =>
+      {
+        triggerTypes.Add(GetTypeCtorDecl(axiom), new HashSet<CtorType>());
+        newTriggerTypes.Add(GetTypeCtorDecl(axiom), new HashSet<CtorType>());
+      });
+    }
+
+    private TypeCtorDecl GetTypeCtorDecl(Axiom axiom)
+    {
+      return program.TopLevelDeclarations.OfType<TypeCtorDecl>()
+        .First(tcd => tcd.Name == axiom.FindStringAttribute("ctor"));
+    }
+
+    private void InstantiateAxioms(HashSet<Axiom> axiomsToBeInstantiated)
+    {
+      while (newTriggerTypes.Any(x => x.Value.Count != 0))
+      {
+        var nextTriggerTypes = this.newTriggerTypes;
+        newTriggerTypes = new Dictionary<TypeCtorDecl, HashSet<CtorType>>();
+        nextTriggerTypes.Iter(x => { newTriggerTypes.Add(x.Key, new HashSet<CtorType>()); });
+        foreach (var axiom in axiomsToBeInstantiated)
+        {
+          axiomInstantiations.AddRange(
+            ExprMonomorphizationVisitor.InstantiateAxiom(functionInstantiations, datatypeInstantiations,
+            triggerTypes, newTriggerTypes, axiom, nextTriggerTypes[GetTypeCtorDecl(axiom)]));
+        }
+      }
+    }
+
+    public override CtorType VisitCtorType(CtorType node)
+    {
+      var exprVisitor = new ExprMonomorphizationVisitor(functionInstantiations, datatypeInstantiations, triggerTypes, newTriggerTypes);
+      return (CtorType) exprVisitor.VisitType(node);
+    }
+    
+    public override Expr VisitExpr(Expr node)
+    {
+      var exprVisitor = new ExprMonomorphizationVisitor(functionInstantiations, datatypeInstantiations, triggerTypes, newTriggerTypes);
+      return exprVisitor.VisitExpr(node);
+    }
+
+    public override Function VisitFunction(Function node)
+    {
+      if (node.TypeParameters.Count > 0)
+      {
+        return node;
+      }
+      return base.VisitFunction(node);
+    }
+
+    public override Axiom VisitAxiom(Axiom node)
+    {
+      if (axiomsToBeInstantiated.Contains(node))
+      {
+        return node;
+      }
+      return base.VisitAxiom(node);
+    }
+  }
+}

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -5,7 +5,7 @@ using System.Reflection.Metadata;
 
 namespace Microsoft.Boogie
 {
-  class PolymorphismChecker : ReadOnlyVisitor
+  public class PolymorphismChecker : ReadOnlyVisitor
   {
     public static bool IsMonomorphic(Program program)
     {
@@ -501,10 +501,6 @@ namespace Microsoft.Boogie
   {
     public static bool Monomorphize(Program program)
     {
-      if (PolymorphismChecker.IsMonomorphic(program))
-      {
-        return true;
-      }
       var axiomsToBeInstantiated = MonomorphizableChecker.IsMonomorphizable(program);
       if (axiomsToBeInstantiated != null)
       {

--- a/Source/Core/Util.cs
+++ b/Source/Core/Util.cs
@@ -68,6 +68,19 @@ namespace Microsoft.Boogie
     {
       return source1.Zip(source2, (e1, e2) => new Tuple<TSource1, TSource2>(e1, e2));
     }
+    
+    /// <summary>
+    /// Creates a map from telems to uelems.  telems and uelems must have the same number of elements.
+    /// </summary>
+    /// <param name="telems"></param>
+    /// <param name="uelems"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="U"></typeparam>
+    /// <returns></returns>
+    public static Dictionary<T, U> Map<T,U>(IEnumerable<T> telems, IEnumerable<U> uelems)
+    {
+      return telems.Zip(uelems).ToDictionary(x => x.Item1, x => x.Item2);
+    }
   }
 
   public class TokenTextWriter : IDisposable

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -739,16 +739,27 @@ namespace Microsoft.Boogie
         Console.WriteLine("{0} type checking errors detected in {1}", errorCount, GetFileNameForConsole(bplFileName));
         return PipelineOutcome.TypeCheckingError;
       }
-      
-      if (MonomorphizationVisitor.Monomorphize(program))
+
+      if (PolymorphismChecker.IsMonomorphic(program))
       {
         CommandLineOptions.Clo.TypeEncodingMethod = CommandLineOptions.TypeEncoding.Monomorphic;
+      }
+      else if (CommandLineOptions.Clo.Monomorphize)
+      {
+        if (MonomorphizationVisitor.Monomorphize(program))
+        {
+          CommandLineOptions.Clo.TypeEncodingMethod = CommandLineOptions.TypeEncoding.Monomorphic;
+        }
+        else
+        {
+          Console.WriteLine("Unable to monomorphize input program {0}");
+          return PipelineOutcome.FatalError;
+        }
       }
       else if (CommandLineOptions.Clo.UseArrayTheory)
       {
         Console.WriteLine(
-          "Option /useArrayTheory only supported for monomorphic programs and polymorphism is detected in {0}",
-          GetFileNameForConsole(bplFileName));
+          "Option /useArrayTheory only supported for monomorphic programs and polymorphism is detected in input program");
         return PipelineOutcome.FatalError;
       }
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -752,7 +752,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          Console.WriteLine("Unable to monomorphize input program {0}");
+          Console.WriteLine("Unable to monomorphize input program");
           return PipelineOutcome.FatalError;
         }
       }

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -376,49 +376,7 @@ namespace Microsoft.Boogie
       AssertionChecksums = implementation.AssertionChecksums;
     }
   }
-
-
-  public class PolymorphismChecker : ReadOnlyVisitor
-  {
-    bool isMonomorphic = true;
-
-    public override DeclWithFormals VisitDeclWithFormals(DeclWithFormals node)
-    {
-      if (node.TypeParameters.Count > 0)
-        isMonomorphic = false;
-      return base.VisitDeclWithFormals(node);
-    }
-
-    public override BinderExpr VisitBinderExpr(BinderExpr node)
-    {
-      if (node.TypeParameters.Count > 0)
-        isMonomorphic = false;
-      return base.VisitBinderExpr(node);
-    }
-
-    public override MapType VisitMapType(MapType node)
-    {
-      if (node.TypeParameters.Count > 0)
-        isMonomorphic = false;
-      return base.VisitMapType(node);
-    }
-
-    public override Expr VisitNAryExpr(NAryExpr node)
-    {
-      BinaryOperator op = node.Fun as BinaryOperator;
-      if (op != null && op.Op == BinaryOperator.Opcode.Subtype)
-        isMonomorphic = false;
-      return base.VisitNAryExpr(node);
-    }
-
-    public static bool IsMonomorphic(Program program)
-    {
-      var checker = new PolymorphismChecker();
-      checker.VisitProgram(program);
-      return checker.isMonomorphic;
-    }
-  }
-
+  
   public class ExecutionEngine
   {
     public static OutputPrinter printer;
@@ -781,8 +739,8 @@ namespace Microsoft.Boogie
         Console.WriteLine("{0} type checking errors detected in {1}", errorCount, GetFileNameForConsole(bplFileName));
         return PipelineOutcome.TypeCheckingError;
       }
-
-      if (PolymorphismChecker.IsMonomorphic(program))
+      
+      if (MonomorphizationVisitor.Monomorphize(program))
       {
         CommandLineOptions.Clo.TypeEncodingMethod = CommandLineOptions.TypeEncoding.Monomorphic;
       }

--- a/Test/monomorphize/monomorphize0.bpl
+++ b/Test/monomorphize/monomorphize0.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie "%s" > "%t"
+// RUN: %boogie /monomorphize "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 function {:inline} foo<T>(x: T): T {

--- a/Test/monomorphize/monomorphize0.bpl
+++ b/Test/monomorphize/monomorphize0.bpl
@@ -5,18 +5,23 @@ function {:inline} foo<T>(x: T): T {
     x
 }
 
+function {:inline} foo'<T>(x: T): T {
+    (var y := x; foo(y))
+}
+
 function {:inline} bar1<T>(x: T): T {
-    foo(x)
+    foo'(x)
 }
 
 function {:inline} bar2<T>(x: T): T {
-    foo(x)
+    foo'(x)
 }
 
 procedure A(a: int) returns (a': int)
 ensures a' == a;
 {
     a' := foo(a);
+    a' := foo'(a);
 }
 
 procedure B(a: int) returns (a': int)
@@ -24,4 +29,38 @@ ensures a' == a;
 {
     a' := bar1(a);
     a' := bar2(a');
+}
+
+procedure C(a: int) returns (a':int)
+ensures a' == a;
+{
+    a':= bar1(bar2(a));
+}
+
+procedure D(a: int) returns (a':int)
+ensures a' == a;
+{
+    a' := a - 1;
+    a':= bar1((var x := a'; bar2(a')) + 1);
+}
+
+type X;
+procedure A'(a: X) returns (a': X)
+ensures a' == a;
+{
+    a' := foo(a);
+    a' := foo'(a);
+}
+
+procedure B'(a: X) returns (a': X)
+ensures a' == a;
+{
+    a' := bar1(a);
+    a' := bar2(a');
+}
+
+procedure C'(a: X) returns (a': X)
+ensures a' == a;
+{
+    a':= bar1(bar2(a));
 }

--- a/Test/monomorphize/monomorphize0.bpl
+++ b/Test/monomorphize/monomorphize0.bpl
@@ -1,0 +1,27 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:inline} foo<T>(x: T): T {
+    x
+}
+
+function {:inline} bar1<T>(x: T): T {
+    foo(x)
+}
+
+function {:inline} bar2<T>(x: T): T {
+    foo(x)
+}
+
+procedure A(a: int) returns (a': int)
+ensures a' == a;
+{
+    a' := foo(a);
+}
+
+procedure B(a: int) returns (a': int)
+ensures a' == a;
+{
+    a' := bar1(a);
+    a' := bar2(a');
+}

--- a/Test/monomorphize/monomorphize0.bpl.expect
+++ b/Test/monomorphize/monomorphize0.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 2 verified, 0 errors

--- a/Test/monomorphize/monomorphize0.bpl.expect
+++ b/Test/monomorphize/monomorphize0.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 2 verified, 0 errors
+Boogie program verifier finished with 7 verified, 0 errors

--- a/Test/monomorphize/monomorphize1.bpl
+++ b/Test/monomorphize/monomorphize1.bpl
@@ -1,0 +1,57 @@
+
+// RUN: %boogie /useArrayTheory "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:builtin "MapConst"} MapConst<T,U>(U): [T]U;
+function {:builtin "MapEq"} MapEq<T,U>([T]U, [T]U) : [T]bool;
+function {:builtin "MapIte"} MapIte<T,U>([T]bool, [T]U, [T]U) : [T]U;
+
+function {:builtin "MapOr"} MapOr<T>([T]bool, [T]bool) : [T]bool;
+function {:builtin "MapAnd"} MapAnd<T>([T]bool, [T]bool) : [T]bool;
+function {:builtin "MapNot"} MapNot<T>([T]bool) : [T]bool;
+function {:builtin "MapImp"} MapImp<T>([T]bool, [T]bool) : [T]bool;
+function {:builtin "MapIff"} MapIff<T>([T]bool, [T]bool) : [T]bool;
+
+function {:builtin "MapAdd"} MapAdd<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapSub"} MapSub<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapMul"} MapMul<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapDiv"} MapDiv<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapMod"} MapMod<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapGt"} MapGt<T>([T]int, [T]int) : [T]bool;
+function {:builtin "MapGe"} MapGe<T>([T]int, [T]int) : [T]bool;
+function {:builtin "MapLt"} MapLt<T>([T]int, [T]int) : [T]bool;
+function {:builtin "MapLe"} MapLe<T>([T]int, [T]int) : [T]bool;
+
+procedure add(set: [int]bool, elem: int) returns (set': [int]bool)
+ensures set' == MapOr(set, MapConst(false)[elem := true]);
+{
+    set' := set[elem := true];
+}
+
+
+type {:datatype} Wrapper _;
+function {:constructor} Set<E>(set: [E]bool): Wrapper E;
+function {:constructor} Multiset<E>(multiset: [E]int): Wrapper E;
+
+type X;
+procedure wrapper_add(w: Wrapper X, elem: X) returns (w': Wrapper X)
+requires is#Set(w);
+ensures is#Set(w');
+ensures set#Set(w') == MapOr(set#Set(w), MapConst(false)[elem := true]);
+{
+    var xset: [X]bool;
+    xset := set#Set(w);
+    xset := xset[elem := true];
+    w' := Set(xset);
+}
+
+procedure wrapper_incr(w: Wrapper X, elem: X) returns (w': Wrapper X)
+requires is#Multiset(w) && multiset#Multiset(w) == MapConst(42);
+ensures is#Multiset(w');
+ensures multiset#Multiset(w') == MapIte(MapConst(false)[elem := true], MapConst(0), MapConst(42));
+{
+    var xmultiset: [X]int;
+    xmultiset := multiset#Multiset(w);
+    xmultiset[elem] := 0;
+    w' := Multiset(xmultiset);
+}

--- a/Test/monomorphize/monomorphize1.bpl
+++ b/Test/monomorphize/monomorphize1.bpl
@@ -1,5 +1,5 @@
 
-// RUN: %boogie /useArrayTheory "%s" > "%t"
+// RUN: %boogie /monomorphize /useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 function {:builtin "MapConst"} MapConst<T,U>(U): [T]U;

--- a/Test/monomorphize/monomorphize1.bpl.expect
+++ b/Test/monomorphize/monomorphize1.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 3 verified, 0 errors

--- a/Test/monomorphize/monomorphize2.bpl
+++ b/Test/monomorphize/monomorphize2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie "%s" > "%t"
+// RUN: %boogie /monomorphize "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type Vec T;

--- a/Test/monomorphize/monomorphize2.bpl
+++ b/Test/monomorphize/monomorphize2.bpl
@@ -1,0 +1,31 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Vec T;
+function Vec#Empty<T>(): Vec T;
+function Vec#Unit<T>(t: T): Vec T;
+function Vec#Concat<T>(s1: Vec T, s2: Vec T): Vec T;
+function Vec#Extract<T>(s: Vec T, pos: int, len: int): Vec T;
+function Vec#Update<T>(s: Vec T, pos: int, t: T): Vec T;
+function Vec#Len<T>(s: Vec T): int;
+function Vec#Select<T>(s: Vec T, pos: int): T;
+function Vec#IsEqual<T>(s1: Vec T, s2: Vec T): bool;
+axiom {:ctor "Vec"} (forall<U> :: Vec#Len(Vec#Empty() : Vec U) == 0);
+
+procedure foo() returns (v: Vec int)
+ensures Vec#Len(v) == 0;
+{
+    v := Vec#Empty();
+}
+
+type Set T;
+function Set#Empty<T>(): Set T;
+function Set#Unit<T>(t: T): Set T;
+function Set#Add<T>(s: Set T, t: T): Set T;
+function Set#Remove<T>(s: Set T, t: T): Set T;
+function Set#Union<T>(s1: Set T, s2: Set T): Set T;
+function Set#Intersection<T>(s1: Set T, s2: Set T): Set T;
+function Set#Difference<T>(s1: Set T, s2: Set T): Set T;
+function Set#Size<T>(s: Set T): int;
+function Set#Contains<T>(s: Set T, t: T): bool;
+function Set#IsEqual<T>(s1: Set T, s2: Set T): bool;

--- a/Test/monomorphize/monomorphize2.bpl
+++ b/Test/monomorphize/monomorphize2.bpl
@@ -11,12 +11,7 @@ function Vec#Len<T>(s: Vec T): int;
 function Vec#Select<T>(s: Vec T, pos: int): T;
 function Vec#IsEqual<T>(s1: Vec T, s2: Vec T): bool;
 axiom {:ctor "Vec"} (forall<U> :: Vec#Len(Vec#Empty() : Vec U) == 0);
-
-procedure foo() returns (v: Vec int)
-ensures Vec#Len(v) == 0;
-{
-    v := Vec#Empty();
-}
+axiom {:ctor "Vec"} (forall<U> e: U :: Vec#Len(Vec#Unit(e)) == 1);
 
 type Set T;
 function Set#Empty<T>(): Set T;
@@ -29,3 +24,44 @@ function Set#Difference<T>(s1: Set T, s2: Set T): Set T;
 function Set#Size<T>(s: Set T): int;
 function Set#Contains<T>(s: Set T, t: T): bool;
 function Set#IsEqual<T>(s1: Set T, s2: Set T): bool;
+axiom {:ctor "Set"} (forall<U> :: Set#Size(Set#Empty() : Set U) == 0);
+axiom {:ctor "Set"} (forall<U> e: U :: Set#Size(Set#Unit(e)) == 1);
+
+procedure empty_vec() returns (v: Vec int)
+ensures Vec#Len(v) == 0;
+{
+    v := Vec#Empty();
+}
+
+procedure unit_vec(e: int) returns (v: Vec int)
+ensures Vec#Len(v) == 1;
+{
+    v := Vec#Unit(e);
+}
+
+procedure empty_set() returns (v: Set int)
+ensures Set#Size(v) == 0;
+{
+    v := Set#Empty();
+}
+
+procedure unit_set(e: int) returns (v: Set int)
+ensures Set#Size(v) == 1;
+{
+    v := Set#Unit(e);
+}
+
+type K;
+
+procedure empty_vec_k() returns (v: Vec K)
+ensures Vec#Len(v) == 0;
+{
+    v := Vec#Empty();
+}
+
+procedure empty_set_k() returns (v: Set K)
+ensures Set#Size(v) == 0;
+{
+    v := Set#Empty();
+}
+

--- a/Test/monomorphize/monomorphize2.bpl.expect
+++ b/Test/monomorphize/monomorphize2.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/monomorphize/monomorphize2.bpl.expect
+++ b/Test/monomorphize/monomorphize2.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 1 verified, 0 errors
+Boogie program verifier finished with 6 verified, 0 errors

--- a/Test/monomorphize/monomorphize3.bpl
+++ b/Test/monomorphize/monomorphize3.bpl
@@ -1,0 +1,33 @@
+// RUN: %boogie /monomorphize "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type {:datatype} List _;
+function {:constructor} cons<U>(x: U, ls: List U) : List U;
+function {:constructor} nil<U>() : List U;
+
+function len<T>(ls: List T): int {
+    if (ls == nil()) then 0 else 1 + len(ls#cons(ls))
+}
+
+type X;
+procedure find_length_X(ls: List X) returns (length: int)
+ensures length == len(ls);
+{
+    if (ls == nil()) {
+        length := 0;
+    } else {
+        call length := find_length_X(ls#cons(ls));
+        length := length + 1;
+    }
+}
+
+procedure find_length_int(ls: List int) returns (length: int)
+ensures length == len(ls);
+{
+    if (ls == nil()) {
+        length := 0;
+    } else {
+        call length := find_length_int(ls#cons(ls));
+        length := length + 1;
+    }
+}

--- a/Test/monomorphize/monomorphize3.bpl.expect
+++ b/Test/monomorphize/monomorphize3.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 2 verified, 0 errors

--- a/Test/monomorphize/monomorphize4.bpl
+++ b/Test/monomorphize/monomorphize4.bpl
@@ -1,0 +1,10 @@
+// RUN: %boogie /monomorphize "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type {:datatype} List _;
+function {:constructor} cons<U>(x: U, ls: List U) : List U;
+function {:constructor} nil<U>() : List U;
+
+function len<T>(ls: List T): int {
+    if (ls == nil()) then 0 else len(cons(ls, nil()))
+}

--- a/Test/monomorphize/monomorphize4.bpl.expect
+++ b/Test/monomorphize/monomorphize4.bpl.expect
@@ -1,0 +1,1 @@
+Unable to monomorphize input program

--- a/Test/test0/AttributeParsing.bpl.expect
+++ b/Test/test0/AttributeParsing.bpl.expect
@@ -1,6 +1,12 @@
 
 type {:sourcefile "test.ssc"} T;
 
+type ref;
+
+type any;
+
+type name;
+
 function {:source "test.scc"} f(int) : int;
 
 const {:description "The largest integer value"} unique MAXINT: int;
@@ -30,12 +36,6 @@ implementation {:id 2} foo(x: int) returns (n: int)
 }
 
 
-
-type ref;
-
-type any;
-
-type name;
 
 procedure {:myAttribute "h\n\"ello\"", "again", "and\\" a\"gain\"", again} P();
 

--- a/Test/test0/Quoting.bpl.expect
+++ b/Test/test0/Quoting.bpl.expect
@@ -1,7 +1,7 @@
 
-function \true() : bool;
-
 type \procedure;
+
+function \true() : bool;
 
 procedure \old(any: \procedure) returns (\var: \procedure);
 

--- a/Test/test20/TypeSynonyms0.bpl.print.expect
+++ b/Test/test20/TypeSynonyms0.bpl.print.expect
@@ -1,7 +1,11 @@
 
-type Set a = [a]bool;
-
 type Field _;
+
+type C _ _;
+
+type ref;
+
+type Set a = [a]bool;
 
 type Heap = <a>[ref,Field a]a;
 
@@ -12,8 +16,6 @@ type Cyclic0 = Cyclic1;
 type Cyclic1 = Cyclic0;
 
 type AlsoCyclic a = <b>[AlsoCyclic b]int;
-
-type C _ _;
 
 type C2 b a = C a b;
 
@@ -26,12 +28,10 @@ const y: Field int bool;
 const z: Set int bool;
 
 const d: <a,b>[notAllParams a b]int;
-
-type ref;
-<console>(10,-1): Error: type synonym could not be resolved because of cycles: Cyclic0 (replacing body with "bool" to continue resolving)
-<console>(12,-1): Error: type synonym could not be resolved because of cycles: Cyclic1 (replacing body with "bool" to continue resolving)
-<console>(14,-1): Error: type synonym could not be resolved because of cycles: AlsoCyclic (replacing body with "bool" to continue resolving)
-<console>(24,8): Error: type constructor received wrong number of arguments: Field
-<console>(26,8): Error: type synonym received wrong number of arguments: Set
-<console>(28,8): Error: type variable must occur in map arguments: a
+<console>(14,-1): Error: type synonym could not be resolved because of cycles: Cyclic0 (replacing body with "bool" to continue resolving)
+<console>(16,-1): Error: type synonym could not be resolved because of cycles: Cyclic1 (replacing body with "bool" to continue resolving)
+<console>(18,-1): Error: type synonym could not be resolved because of cycles: AlsoCyclic (replacing body with "bool" to continue resolving)
+<console>(26,8): Error: type constructor received wrong number of arguments: Field
+<console>(28,8): Error: type synonym received wrong number of arguments: Set
+<console>(30,8): Error: type variable must occur in map arguments: a
 6 name resolution errors detected in TypeSynonyms0.bpl


### PR DESCRIPTION
This PR contains an initial attempt to monomorphize a subset of polymorphic Boogie. This subset excludes polymorphic  procedures, implementations, and maps but includes polymorphic functions and datatypes.  The subset allows only universal quantified type parameters at the outermost level in axioms.  The motivation behind this work is to build a reusable library of useful function definitions and axioms (see examples in the new tests).

The monomorphization flow is as follows:
- If the program is monomorphic, do nothing.
- Otherwise, check if the program meets the restrictions under which the current approach is  guaranteed to produce a monomorphic program.  If not, do nothing.
- Otherwise, monormophize as explained below.

Monomorphization approach:
- Walk over all procedures, implementations, and monomorphic axioms recursively discovering invocations of polymorphic functions and uses of polymorphic datatypes and creating monomorphic instantiations.  If a function call is discovered, it is also walked over recursively.
- Each axiom with universal type parameters is allowed to be annotated with the name of a type constructor whose arity should match the number of type parameters of the axiom.  This axiom will be instantiated with the arguments of every type constructed with that type constructor discovered during step 1.
- Axiom instantiation can discover other type terms which feed into axiom instantiation until a fixpoint is reached. 

To accomplish the aforementioned main objective of this PR, the implementation of datatypes is also refactored.  The main changes are as  follows:
- Allow datatypes to be polymorphic.
- Add DatatypeTypeCtorDecl which extends TypeCtorDecl and contains all the constructors inside it.  Constructors, selectors, and membership functions are no long put into TopLevelDeclarations; rather they are nested inside their instance of DatatypeTypeCtorDecl.