### PR TITLE
fix bug in implementation of :print

### DIFF
--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -810,6 +810,16 @@ namespace Microsoft.Boogie
         return oldSubstMap[v];
       }
       
+      public Expr PartialSubst(Variable v)
+      {
+        return substMap.ContainsKey(v) ? substMap[v] : null;
+      }
+      
+      public Expr PartialOldSubst(Variable v)
+      {
+        return oldSubstMap.ContainsKey(v) ? oldSubstMap[v] : null;
+      }
+      
       public List<Cmd> CopyCmdSeq(List<Cmd> cmds)
       {
         Contract.Requires(cmds != null);
@@ -855,7 +865,7 @@ namespace Microsoft.Boogie
         if (cmd is ICarriesAttributes attrCmd && attrCmd.Attributes != null)
         {
           var attrCopy = (QKeyValue) attrCmd.Attributes.Clone();
-          ((ICarriesAttributes) newCmd).Attributes = Substituter.ApplyReplacingOldExprs(Subst, OldSubst, attrCopy);
+          ((ICarriesAttributes) newCmd).Attributes = Substituter.ApplyReplacingOldExprs(PartialSubst, PartialOldSubst, attrCopy);
         }
         return newCmd;
       }

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1807,7 +1807,14 @@ namespace Microsoft.Boogie
               errorInfo.Out.WriteLine("Augmented execution trace:");
               foreach (var elem in error.AugmentedTrace)
               {
-                errorInfo.Out.Write(elem);
+                if (elem is IdentifierExpr identifierExpr)
+                {
+                  errorInfo.Out.Write(error.GetModelValue(identifierExpr.Decl));
+                }
+                else
+                {
+                  errorInfo.Out.Write(elem);
+                }
               }
             }
             if (CommandLineOptions.Clo.PrintErrorModel >= 1 && error.Model != null)

--- a/Source/Model/Model.cs
+++ b/Source/Model/Model.cs
@@ -384,7 +384,10 @@ namespace Microsoft.Boogie
         if (Arity != 0)
           throw new ArgumentException();
         if (apps.Count == 0)
-          SetConstant(Model.MkElement("**" + Name));
+        {
+          // value missing in the returned model
+          return null;
+        }
         return apps[0].Result;
       }
 

--- a/Source/VCGeneration/Couterexample.cs
+++ b/Source/VCGeneration/Couterexample.cs
@@ -229,19 +229,19 @@ namespace Microsoft.Boogie
       }
     }
 
-    void ApplyRedirections(Model m)
+    void ApplyRedirections()
     {
       var mapping = new Dictionary<Model.Element, Model.Element>();
       foreach (var name in new string[] {"U_2_bool", "U_2_int"})
       {
-        Model.Func f = m.TryGetFunc(name);
+        Model.Func f = Model.TryGetFunc(name);
         if (f != null && f.Arity == 1)
         {
           foreach (var ft in f.Apps) mapping[ft.Args[0]] = ft.Result;
         }
       }
 
-      m.Substitute(mapping);
+      Model.Substitute(mapping);
     }
 
     public void PopulateModelWithStates()
@@ -249,7 +249,7 @@ namespace Microsoft.Boogie
       Contract.Requires(Model != null);
 
       Model m = Model;
-      ApplyRedirections(m);
+      ApplyRedirections();
 
       var mvstates = m.TryGetFunc("$mv_state");
       if (MvInfo == null || mvstates == null || (mvstates.Arity == 1 && mvstates.Apps.Count() == 0))
@@ -259,7 +259,7 @@ namespace Microsoft.Boogie
 
       foreach (Variable v in MvInfo.AllVariables)
       {
-        m.InitialState.AddBinding(v.Name, GetModelValue(m, v));
+        m.InitialState.AddBinding(v.Name, GetModelValue(v));
       }
 
       var states = new List<int>();
@@ -290,7 +290,7 @@ namespace Microsoft.Boogie
             if (e is IdentifierExpr)
             {
               IdentifierExpr ide = (IdentifierExpr) e;
-              elt = GetModelValue(m, ide.Decl);
+              elt = GetModelValue(ide.Decl);
             }
             else if (e is LiteralExpr)
             {
@@ -312,7 +312,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    private Model.Element GetModelValue(Model m, Variable v)
+    public Model.Element GetModelValue(Variable v)
     {
       Model.Element elt;
       // first, get the unique name
@@ -327,10 +327,10 @@ namespace Microsoft.Boogie
         uniqueName = Context.Lookup(vvar);
       }
 
-      var f = m.TryGetFunc(uniqueName);
+      var f = Model.TryGetFunc(uniqueName);
       if (f == null)
       {
-        f = m.MkFunc(uniqueName, 0);
+        f = Model.MkFunc(uniqueName, 0);
       }
 
       elt = f.GetConstant();

--- a/Source/VCGeneration/VC.cs
+++ b/Source/VCGeneration/VC.cs
@@ -3690,22 +3690,7 @@ namespace VC
           // update augmentedTrace
           if (errModel != null && debugInfos != null && debugInfos.ContainsKey(cmd))
           {
-            foreach (var expr in debugInfos[cmd])
-            {
-              if (expr is LiteralExpr literalExpr)
-              {
-                augmentedTrace.Add(literalExpr.Val);
-              }
-              else if (expr is IdentifierExpr identifierExpr)
-              {
-                var func = errModel.GetFunc(identifierExpr.Name);
-                augmentedTrace.Add(func.GetConstant());
-              }
-              else
-              {
-                augmentedTrace.Add(expr);
-              }
-            }
+            augmentedTrace.AddRange(debugInfos[cmd]);
           }
           
           // Skip if 'cmd' not contained in the trace or not an assert

--- a/Test/test15/CaptureState.bpl.expect
+++ b/Test/test15/CaptureState.bpl.expect
@@ -8,12 +8,12 @@ Execution trace:
 $mv_state_const -> 3
 F -> T@FieldName!val!0
 Heap -> |T@[Ref,FieldName]Int!val!0|
-m -> **m
+m ->
 m@0 -> (- 8)
 m@1 -> (- 7)
 m@2 -> 0
 m@3 -> (- 7)
-r -> **r
+r ->
 r@0 -> (- 14)
 this -> T@Ref!val!0
 x -> 40
@@ -44,8 +44,8 @@ tickleBool -> {
 }
 *** STATE <initial>
   Heap -> |T@[Ref,FieldName]Int!val!0|
-  m -> **m
-  r -> **r
+  m ->
+  r ->
   this -> T@Ref!val!0
   x -> 40
   y -> 0

--- a/Test/test15/trace1.bpl
+++ b/Test/test15/trace1.bpl
@@ -1,0 +1,20 @@
+// RUN: %boogie "%s" -enhancedErrorMessages:1 > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var g: int;
+
+procedure main()
+requires g == 0;
+ensures g == 2;
+modifies g;
+{
+    call foo();
+}
+
+procedure {:inline 1} foo()
+modifies g;
+{
+    assume {:print "g (before increment) = ", g} true;
+    g := g + 1;
+    assume {:print "g (after increment) = ", g} true;
+}

--- a/Test/test15/trace1.bpl.expect
+++ b/Test/test15/trace1.bpl.expect
@@ -1,0 +1,11 @@
+trace1.bpl(12,1): Error BP5003: A postcondition might not hold on this return path.
+trace1.bpl(8,1): Related location: This is the postcondition that might not hold.
+Execution trace:
+    trace1.bpl(11,5): anon0
+    trace1.bpl(17,5): inline$foo$0$anon0
+    trace1.bpl(11,5): anon0$1
+Augmented execution trace:
+g (before increment) = 0
+g (after increment) = 1
+
+Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
This PR fixes two bugs in the implementation of :print attribute.
- the implementation did not account for renaming by UniqueNamer; this bug is addressed by using existing code in Counterexample
- the inliner was crashing when inlining code containing expressions inside attributes that referred to global variables; this bug was fixed by making the substitution map partial

This PR also  changes model printing so that if a constant's value is not supplied by the solver then null is returned which prints as nothing. 