### PR TITLE
add capability to include a library file

### DIFF
--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -29,13 +29,13 @@ readonly StructuredCmd/*!*/ dummyStructuredCmd;
 
 public static int ParseLibraryDefinitions(out Program program)
 {
-	string libraryDefinitionsFileName = "LibraryDefinitions.bpl";
-	Assembly asm = Assembly.GetExecutingAssembly();
-	var resourceName = asm.GetManifestResourceNames().First(s => s.EndsWith(libraryDefinitionsFileName, StringComparison.CurrentCultureIgnoreCase));
-	using (Stream resourceStream = asm.GetManifestResourceStream(resourceName))
-	{
-		return Parse(new StreamReader(resourceStream), libraryDefinitionsFileName, new List<string>(), out program);
-	}
+  string libraryDefinitionsFileName = "LibraryDefinitions.bpl";
+  Assembly asm = Assembly.GetExecutingAssembly();
+  var resourceName = "Core-NetCore.LibraryDefinitions.bpl";
+  using (Stream resourceStream = asm.GetManifestResourceStream(resourceName))
+  {
+    return Parse(new StreamReader(resourceStream), libraryDefinitionsFileName, new List<string>(), out program);
+  }
 }
 
 ///<summary>

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -27,11 +27,22 @@ readonly List<Expr>/*!*/ dummyExprSeq;
 readonly TransferCmd/*!*/ dummyTransferCmd;
 readonly StructuredCmd/*!*/ dummyStructuredCmd;
 
+public static int ParseLibraryDefinitions(out Program program)
+{
+	string libraryDefinitionsFileName = "LibraryDefinitions.bpl";
+	Assembly asm = Assembly.GetExecutingAssembly();
+	var resourceName = asm.GetManifestResourceNames().First(s => s.EndsWith(libraryDefinitionsFileName, StringComparison.CurrentCultureIgnoreCase));
+	using (Stream resourceStream = asm.GetManifestResourceStream(resourceName))
+	{
+		return Parse(new StreamReader(resourceStream), libraryDefinitionsFileName, new List<string>(), out program);
+	}
+}
+
 ///<summary>
 ///Returns the number of parsing errors encountered.  If 0, "program" returns as
 ///the parsed program.
 ///</summary>
-public static int Parse (string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
+public static int Parse(string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(filename != null);
   Contract.Requires(cce.NonNullElements(defines,true));
 
@@ -52,7 +63,7 @@ public static int Parse(TextReader stream, string/*!*/ filename, List<string> de
   return Parse(preprocessedSource, filename, out program, useBaseName);
 }
 
-public static int Parse (string s, string/*!*/ filename, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
+public static int Parse(string s, string/*!*/ filename, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(s != null);
   Contract.Requires(filename != null);
 

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -2022,7 +2022,7 @@ namespace Microsoft.Boogie
   Multiple .bpl files supplied on the command line are concatenated into one
   Boogie program.
 
-  /lib           : Include definitions in LibraryDefinitions.bpl
+  /lib           : Include library definitions
   /proc:<p>      : Only check procedures matched by pattern <p>. This option
                    may be specified multiple times to match multiple patterns.
                    The pattern <p> matches the whole procedure name and may

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -848,6 +848,8 @@ namespace Microsoft.Boogie
       }
     }
 
+    public bool UseLibrary = false;
+    
     // Note that procsToCheck stores all patterns <p> supplied with /proc:<p>
     // (and similarly procsToIgnore for /noProc:<p>). Thus, if procsToCheck
     // is empty it means that all procedures should be checked.
@@ -944,6 +946,14 @@ namespace Microsoft.Boogie
 
           return true;
 
+        case "lib":
+          if (ps.ConfirmArgumentCount(0))
+          {
+            this.UseLibrary = true;
+          }
+
+          return true;
+        
         case "proc":
           if (ps.ConfirmArgumentCount(1))
           {
@@ -2012,6 +2022,7 @@ namespace Microsoft.Boogie
   Multiple .bpl files supplied on the command line are concatenated into one
   Boogie program.
 
+  /lib           : Include definitions in LibraryDefinitions.bpl
   /proc:<p>      : Only check procedures matched by pattern <p>. This option
                    may be specified multiple times to match multiple patterns.
                    The pattern <p> matches the whole procedure name and may

--- a/Source/Core/Core-NetCore.csproj
+++ b/Source/Core/Core-NetCore.csproj
@@ -11,5 +11,10 @@
     <ProjectReference Include="..\CodeContractsExtender\CodeContractsExtender-NetCore.csproj" />
     <ProjectReference Include="..\Graph\Graph-NetCore.csproj" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <None Remove="LibraryDefinitions.bpl" />
+    <EmbeddedResource Include="LibraryDefinitions.bpl" />
+  </ItemGroup>
+
 </Project>

--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -1,0 +1,19 @@
+function {:builtin "MapConst"} MapConst<T,U>(U): [T]U;
+function {:builtin "MapEq"} MapEq<T,U>([T]U, [T]U) : [T]bool;
+function {:builtin "MapIte"} MapIte<T,U>([T]bool, [T]U, [T]U) : [T]U;
+
+function {:builtin "MapOr"} MapOr<T>([T]bool, [T]bool) : [T]bool;
+function {:builtin "MapAnd"} MapAnd<T>([T]bool, [T]bool) : [T]bool;
+function {:builtin "MapNot"} MapNot<T>([T]bool) : [T]bool;
+function {:builtin "MapImp"} MapImp<T>([T]bool, [T]bool) : [T]bool;
+function {:builtin "MapIff"} MapIff<T>([T]bool, [T]bool) : [T]bool;
+
+function {:builtin "MapAdd"} MapAdd<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapSub"} MapSub<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapMul"} MapMul<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapDiv"} MapDiv<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapMod"} MapMod<T>([T]int, [T]int) : [T]int;
+function {:builtin "MapGt"} MapGt<T>([T]int, [T]int) : [T]bool;
+function {:builtin "MapGe"} MapGe<T>([T]int, [T]int) : [T]bool;
+function {:builtin "MapLt"} MapLt<T>([T]int, [T]int) : [T]bool;
+function {:builtin "MapLe"} MapLe<T>([T]int, [T]int) : [T]bool;

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -20,7 +20,6 @@ using Bpl = Microsoft.Boogie;
 
 using System;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Reflection;
 
 namespace Microsoft.Boogie {
@@ -61,13 +60,13 @@ readonly StructuredCmd/*!*/ dummyStructuredCmd;
 
 public static int ParseLibraryDefinitions(out Program program)
 {
-	string libraryDefinitionsFileName = "LibraryDefinitions.bpl";
-	Assembly asm = Assembly.GetExecutingAssembly();
-	var resourceName = asm.GetManifestResourceNames().First(s => s.EndsWith(libraryDefinitionsFileName, StringComparison.CurrentCultureIgnoreCase));
-	using (Stream resourceStream = asm.GetManifestResourceStream(resourceName))
-	{
-		return Parse(new StreamReader(resourceStream), libraryDefinitionsFileName, new List<string>(), out program);
-	}
+  string libraryDefinitionsFileName = "LibraryDefinitions.bpl";
+  Assembly asm = Assembly.GetExecutingAssembly();
+  var resourceName = "Core-NetCore.LibraryDefinitions.bpl";
+  using (Stream resourceStream = asm.GetManifestResourceStream(resourceName))
+  {
+    return Parse(new StreamReader(resourceStream), libraryDefinitionsFileName, new List<string>(), out program);
+  }
 }
 
 ///<summary>

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -20,6 +20,8 @@ using Bpl = Microsoft.Boogie;
 
 using System;
 using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.Boogie {
 
@@ -57,11 +59,22 @@ readonly List<Expr>/*!*/ dummyExprSeq;
 readonly TransferCmd/*!*/ dummyTransferCmd;
 readonly StructuredCmd/*!*/ dummyStructuredCmd;
 
+public static int ParseLibraryDefinitions(out Program program)
+{
+	string libraryDefinitionsFileName = "LibraryDefinitions.bpl";
+	Assembly asm = Assembly.GetExecutingAssembly();
+	var resourceName = asm.GetManifestResourceNames().First(s => s.EndsWith(libraryDefinitionsFileName, StringComparison.CurrentCultureIgnoreCase));
+	using (Stream resourceStream = asm.GetManifestResourceStream(resourceName))
+	{
+		return Parse(new StreamReader(resourceStream), libraryDefinitionsFileName, new List<string>(), out program);
+	}
+}
+
 ///<summary>
 ///Returns the number of parsing errors encountered.  If 0, "program" returns as
 ///the parsed program.
 ///</summary>
-public static int Parse (string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
+public static int Parse(string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(filename != null);
   Contract.Requires(cce.NonNullElements(defines,true));
 
@@ -82,7 +95,7 @@ public static int Parse(TextReader stream, string/*!*/ filename, List<string> de
   return Parse(preprocessedSource, filename, out program, useBaseName);
 }
 
-public static int Parse (string s, string/*!*/ filename, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
+public static int Parse(string s, string/*!*/ filename, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(s != null);
   Contract.Requires(filename != null);
 

--- a/Source/Core/Parser.frame
+++ b/Source/Core/Parser.frame
@@ -27,6 +27,8 @@ Coco/R itself) does not fall under the GNU General Public License.
 -->begin
 using System;
 using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
 
 -->namespace
 

--- a/Source/Core/Parser.frame
+++ b/Source/Core/Parser.frame
@@ -27,7 +27,6 @@ Coco/R itself) does not fall under the GNU General Public License.
 -->begin
 using System;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Reflection;
 
 -->namespace

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -624,6 +624,10 @@ namespace Microsoft.Boogie
       Contract.Requires(cce.NonNullElements(fileNames));
 
       Program program = null;
+      if (CommandLineOptions.Clo.UseLibrary)
+      {
+        Parser.ParseLibraryDefinitions(out program);
+      }
       bool okay = true;
       for (int fileId = 0; fileId < fileNames.Count; fileId++)
       {

--- a/Test/monomorphize/monomorphize1.bpl
+++ b/Test/monomorphize/monomorphize1.bpl
@@ -1,33 +1,12 @@
 
-// RUN: %boogie /monomorphize /useArrayTheory "%s" > "%t"
+// RUN: %boogie /lib /monomorphize /useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-
-function {:builtin "MapConst"} MapConst<T,U>(U): [T]U;
-function {:builtin "MapEq"} MapEq<T,U>([T]U, [T]U) : [T]bool;
-function {:builtin "MapIte"} MapIte<T,U>([T]bool, [T]U, [T]U) : [T]U;
-
-function {:builtin "MapOr"} MapOr<T>([T]bool, [T]bool) : [T]bool;
-function {:builtin "MapAnd"} MapAnd<T>([T]bool, [T]bool) : [T]bool;
-function {:builtin "MapNot"} MapNot<T>([T]bool) : [T]bool;
-function {:builtin "MapImp"} MapImp<T>([T]bool, [T]bool) : [T]bool;
-function {:builtin "MapIff"} MapIff<T>([T]bool, [T]bool) : [T]bool;
-
-function {:builtin "MapAdd"} MapAdd<T>([T]int, [T]int) : [T]int;
-function {:builtin "MapSub"} MapSub<T>([T]int, [T]int) : [T]int;
-function {:builtin "MapMul"} MapMul<T>([T]int, [T]int) : [T]int;
-function {:builtin "MapDiv"} MapDiv<T>([T]int, [T]int) : [T]int;
-function {:builtin "MapMod"} MapMod<T>([T]int, [T]int) : [T]int;
-function {:builtin "MapGt"} MapGt<T>([T]int, [T]int) : [T]bool;
-function {:builtin "MapGe"} MapGe<T>([T]int, [T]int) : [T]bool;
-function {:builtin "MapLt"} MapLt<T>([T]int, [T]int) : [T]bool;
-function {:builtin "MapLe"} MapLe<T>([T]int, [T]int) : [T]bool;
 
 procedure add(set: [int]bool, elem: int) returns (set': [int]bool)
 ensures set' == MapOr(set, MapConst(false)[elem := true]);
 {
     set' := set[elem := true];
 }
-
 
 type {:datatype} Wrapper _;
 function {:constructor} Set<E>(set: [E]bool): Wrapper E;

--- a/Test/monomorphize/monomorphize1.bpl
+++ b/Test/monomorphize/monomorphize1.bpl
@@ -1,5 +1,5 @@
 
-// RUN: %boogie /lib /monomorphize /useArrayTheory "%s" > "%t"
+// RUN: %boogie -lib -monomorphize -useArrayTheory "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 procedure add(set: [int]bool, elem: int) returns (set': [int]bool)

--- a/Test/monomorphize/monomorphize2.bpl
+++ b/Test/monomorphize/monomorphize2.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie /monomorphize "%s" > "%t"
+// RUN: %boogie -monomorphize "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type Vec T;

--- a/Test/monomorphize/monomorphize3.bpl
+++ b/Test/monomorphize/monomorphize3.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie /monomorphize "%s" > "%t"
+// RUN: %boogie -monomorphize "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type {:datatype} List _;

--- a/Test/monomorphize/monomorphize4.bpl
+++ b/Test/monomorphize/monomorphize4.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie /monomorphize "%s" > "%t"
+// RUN: %boogie -monomorphize "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type {:datatype} List _;


### PR DESCRIPTION
This PR introduces the /lib option to included a library of definitions automatically with the user-supplied Boogie files.  The library definitions are embedded a resource in the Core project and parsed if /lib is supplied on the command line.