### PR TITLE
CIVL cleanup: simplified Absy construction and consistent use of AssertCmd

### DIFF
--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -83,24 +83,19 @@ namespace Microsoft.Boogie
         }
       }
 
-      var skipProcedure = new Procedure(
-        Token.NoToken,
+      var skipProcedure = DeclHelper.Procedure(
         AddNamePrefix("Skip"),
-        new List<TypeVariable>(),
         new List<Variable>(),
         new List<Variable>(),
         new List<Requires>(),
         new List<IdentifierExpr>(),
         new List<Ensures>());
-      var skipImplementation = new Implementation(
-          Token.NoToken,
-          skipProcedure.Name,
-          new List<TypeVariable>(),
-          new List<Variable>(),
-          new List<Variable>(),
-          new List<Variable>(),
-          new List<Block> {new Block(Token.NoToken, "init", new List<Cmd>(), new ReturnCmd(Token.NoToken))})
-        {Proc = skipProcedure};
+      var skipImplementation = DeclHelper.Implementation(
+        skipProcedure,
+        new List<Variable>(),
+        new List<Variable>(),
+        new List<Variable>(),
+        new List<Block> {BlockHelper.Block("init", new List<Cmd>())});
       SkipAtomicAction = new AtomicAction(skipProcedure, skipImplementation, LayerRange.MinMax, MoverType.Both);
     }
 

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -76,6 +76,21 @@ namespace Microsoft.Boogie
       return new OldExpr(Token.NoToken, expr);
     }
 
+    public static ExistsExpr ExistsExpr(List<Variable> dummies, Expr body)
+    {
+      return new ExistsExpr(Token.NoToken, dummies, body);
+    }
+
+    public static ExistsExpr ExistsExpr(List<Variable> dummies, Trigger triggers, Expr body)
+    {
+      return new ExistsExpr(Token.NoToken, dummies, triggers, body);
+    }
+
+    public static ForallExpr ForallExpr(List<Variable> dummies, Expr body)
+    {
+      return new ForallExpr(Token.NoToken, dummies, body);
+    }
+
     public static void FlattenAnd(Expr x, List<Expr> xs)
     {
       if (x is NAryExpr naryExpr && naryExpr.Fun.FunctionName == "&&")
@@ -97,7 +112,7 @@ namespace Microsoft.Boogie
     public static CallCmd CallCmd(Procedure callee, List<Expr> ins, List<IdentifierExpr> outs)
     {
       return new CallCmd(Token.NoToken, callee.Name, ins, outs)
-        {Proc = callee};
+        { Proc = callee };
     }
 
     public static CallCmd CallCmd(Procedure callee, List<Variable> ins, List<Variable> outs)
@@ -110,6 +125,12 @@ namespace Microsoft.Boogie
       return new AssumeCmd(Token.NoToken, expr);
     }
 
+    public static AssertCmd AssertCmd(IToken tok, Expr expr, string msg)
+    {
+      return new AssertCmd(tok, expr)
+        { ErrorData = msg };
+    }
+
     public static AssignCmd AssignCmd(Variable v, Expr x)
     {
       var lhs = new SimpleAssignLhs(Token.NoToken, Expr.Ident(v));
@@ -120,6 +141,42 @@ namespace Microsoft.Boogie
     {
       var assignLhss = lhss.Select(lhs => new SimpleAssignLhs(Token.NoToken, lhs)).ToList<AssignLhs>();
       return new AssignCmd(Token.NoToken, assignLhss, rhss);
+    }
+
+    public static HavocCmd HavocCmd(List<IdentifierExpr> vars)
+    {
+      return new HavocCmd(Token.NoToken, vars);
+    }
+  }
+
+  public static class BlockHelper
+  {
+    public static Block Block(string label, List<Cmd> cmds)
+    {
+      return new Block(Token.NoToken, label, cmds, CmdHelper.ReturnCmd);
+    }
+
+    public static Block Block(string label, List<Cmd> cmds, List<Block> gotoTargets)
+    {
+      return new Block(Token.NoToken, label, cmds, new GotoCmd(Token.NoToken, gotoTargets));
+    }
+  }
+
+  public static class DeclHelper
+  {
+    public static Procedure Procedure(string name,
+      List<Variable> inParams, List<Variable> outParams,
+      List<Requires> requires, List<IdentifierExpr> modifies, List<Ensures> ensures,
+      QKeyValue kv = null)
+    {
+      return new Procedure(Token.NoToken, name, new List<TypeVariable>(), inParams, outParams, requires, modifies, ensures, kv);
+    }
+
+    public static Implementation Implementation(Procedure proc,
+      List<Variable> inParams, List<Variable> outParams, List<Variable> localVariables,
+      List<Block> blocks, QKeyValue kv = null)
+    {
+      return new Implementation(Token.NoToken, proc.Name, new List<TypeVariable>(), inParams, outParams, localVariables, blocks, kv) { Proc = proc };
     }
   }
 
@@ -214,11 +271,6 @@ namespace Microsoft.Boogie
           from acc in accumulator
           from item in sequence
           select acc.Concat(new[] {item}));
-    }
-
-    public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<TKey> keys, Func<TKey, TValue> f)
-    {
-      return keys.ToDictionary(k => k, k => f(k));
     }
   }
 }

--- a/Source/Concurrency/GlobalSnapshotInstrumentation.cs
+++ b/Source/Concurrency/GlobalSnapshotInstrumentation.cs
@@ -27,18 +27,18 @@ namespace Microsoft.Boogie
 
     public List<Cmd> CreateUpdatesToOldGlobalVars()
     {
-      List<AssignLhs> lhss = new List<AssignLhs>();
+      List<IdentifierExpr> lhss = new List<IdentifierExpr>();
       List<Expr> rhss = new List<Expr>();
       foreach (Variable g in oldGlobalMap.Keys)
       {
-        lhss.Add(new SimpleAssignLhs(Token.NoToken, Expr.Ident(oldGlobalMap[g])));
+        lhss.Add(Expr.Ident(oldGlobalMap[g]));
         rhss.Add(Expr.Ident(g));
       }
 
       var cmds = new List<Cmd>();
       if (lhss.Count > 0)
       {
-        cmds.Add(new AssignCmd(Token.NoToken, lhss, rhss));
+        cmds.Add(CmdHelper.AssignCmd(lhss, rhss));
       }
 
       return cmds;
@@ -46,18 +46,18 @@ namespace Microsoft.Boogie
 
     public List<Cmd> CreateInitCmds()
     {
-      List<AssignLhs> lhss = new List<AssignLhs>();
+      List<IdentifierExpr> lhss = new List<IdentifierExpr>();
       List<Expr> rhss = new List<Expr>();
       foreach (Variable g in oldGlobalMap.Keys)
       {
-        lhss.Add(new SimpleAssignLhs(Token.NoToken, Expr.Ident(oldGlobalMap[g])));
+        lhss.Add(Expr.Ident(oldGlobalMap[g]));
         rhss.Add(Expr.Ident(g));
       }
 
       var initCmds = new List<Cmd>();
       if (lhss.Count > 0)
       {
-        initCmds.Add(new AssignCmd(Token.NoToken, lhss, rhss));
+        initCmds.Add(CmdHelper.AssignCmd(lhss, rhss));
       }
 
       return initCmds;

--- a/Source/Concurrency/LinearPermissionInstrumentation.cs
+++ b/Source/Concurrency/LinearPermissionInstrumentation.cs
@@ -43,13 +43,13 @@ namespace Microsoft.Boogie
       IEnumerable<Variable> availableVars = atEntry
         ? FilterInParams(proc.InParams)
         : FilterInOutParams(proc.InParams.Union(proc.OutParams));
-      return DisjointnessExprs(availableVars).Select(expr => new AssumeCmd(Token.NoToken, expr)).ToList<Cmd>();
+      return DisjointnessExprs(availableVars).Select(expr => CmdHelper.AssumeCmd(expr)).ToList<Cmd>();
     }
 
     public List<Cmd> DisjointnessAssumeCmds(Absy absy, bool addGlobals)
     {
       var availableVars = AvailableLinearLocalVars(absy).Union(addGlobals ? LinearGlobalVars() : new List<Variable>());
-      return DisjointnessExprs(availableVars).Select(expr => new AssumeCmd(Token.NoToken, expr)).ToList<Cmd>();
+      return DisjointnessExprs(availableVars).Select(expr => CmdHelper.AssumeCmd(expr)).ToList<Cmd>();
     }
 
     public List<Expr> DisjointnessExprs(Absy absy, bool addGlobals)

--- a/Source/Concurrency/NoninterferenceInstrumentation.cs
+++ b/Source/Concurrency/NoninterferenceInstrumentation.cs
@@ -68,18 +68,18 @@ namespace Microsoft.Boogie
     public List<Cmd> CreateInitCmds(Implementation impl)
     {
       Dictionary<string, Expr> domainNameToExpr = linearPermissionInstrumentation.PermissionExprs(impl);
-      List<AssignLhs> lhss = new List<AssignLhs>();
+      List<IdentifierExpr> lhss = new List<IdentifierExpr>();
       List<Expr> rhss = new List<Expr>();
       foreach (string domainName in linearTypeChecker.linearDomains.Keys)
       {
-        lhss.Add(new SimpleAssignLhs(Token.NoToken, Expr.Ident(domainNameToHoleVar[domainName])));
+        lhss.Add(Expr.Ident(domainNameToHoleVar[domainName]));
         rhss.Add(domainNameToExpr[domainName]);
       }
 
       var initCmds = new List<Cmd>();
       if (lhss.Count > 0)
       {
-        initCmds.Add(new AssignCmd(Token.NoToken, lhss, rhss));
+        initCmds.Add(CmdHelper.AssignCmd(lhss, rhss));
       }
 
       return initCmds;
@@ -88,18 +88,18 @@ namespace Microsoft.Boogie
     public List<Cmd> CreateUpdatesToPermissionCollector(Absy absy)
     {
       Dictionary<string, Expr> domainNameToExpr = linearPermissionInstrumentation.PermissionExprs(absy);
-      List<AssignLhs> lhss = new List<AssignLhs>();
+      List<IdentifierExpr> lhss = new List<IdentifierExpr>();
       List<Expr> rhss = new List<Expr>();
       foreach (var domainName in linearTypeChecker.linearDomains.Keys)
       {
-        lhss.Add(new SimpleAssignLhs(Token.NoToken, Expr.Ident(domainNameToHoleVar[domainName])));
+        lhss.Add(Expr.Ident(domainNameToHoleVar[domainName]));
         rhss.Add(domainNameToExpr[domainName]);
       }
 
       var cmds = new List<Cmd>();
       if (lhss.Count > 0)
       {
-        cmds.Add(new AssignCmd(Token.NoToken, lhss, rhss));
+        cmds.Add(CmdHelper.AssignCmd(lhss, rhss));
       }
 
       return cmds;
@@ -107,19 +107,18 @@ namespace Microsoft.Boogie
 
     public List<Cmd> CreateCallToYieldProc()
     {
-      List<Expr> exprSeq = new List<Expr>();
+      List<Variable> inputs = new List<Variable>();
       foreach (string domainName in linearTypeChecker.linearDomains.Keys)
       {
-        exprSeq.Add(Expr.Ident(domainNameToHoleVar[domainName]));
+        inputs.Add(domainNameToHoleVar[domainName]);
       }
 
       foreach (Variable g in civlTypeChecker.GlobalVariables)
       {
-        exprSeq.Add(Expr.Ident(oldGlobalMap[g]));
+        inputs.Add(oldGlobalMap[g]);
       }
 
-      CallCmd yieldCallCmd = new CallCmd(Token.NoToken, yieldProc.Name, exprSeq, new List<IdentifierExpr>());
-      yieldCallCmd.Proc = yieldProc;
+      CallCmd yieldCallCmd = CmdHelper.CallCmd(yieldProc, inputs, new List<Variable>());
       return new List<Cmd> {yieldCallCmd};
     }
   }

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Boogie
             }
           }
 
-          TransitionRelationExpr = new ExistsExpr(Token.NoToken,
+          TransitionRelationExpr = ExprHelper.ExistsExpr(
             existsVarMap.Values.ToList<Variable>(), trigger, TransitionRelationExpr);
         }
       }
@@ -470,7 +470,7 @@ namespace Microsoft.Boogie
       private void AddBoundVariablesForRemainingVars()
       {
         var remainingVars = NotEliminatedVars.Except(IntermediateFrameWithWitnesses);
-        existsVarMap = remainingVars.ToDictionary(v => (Variable) VarHelper.BoundVariable(v.Name, v.TypedIdent.Type));
+        existsVarMap = remainingVars.ToDictionary(v => v, v => (Variable) VarHelper.BoundVariable(v.Name, v.TypedIdent.Type));
         pathExprs = SubstitutionHelper.Apply(existsVarMap, pathExprs).ToList();
       }
 
@@ -571,8 +571,8 @@ namespace Microsoft.Boogie
                 assumeExprs.Add(Expr.Eq(lhss[k].AsExpr, rhss[k]));
               }
 
-              cmds.Add(new AssumeCmd(Token.NoToken, Expr.And(assumeExprs)));
-              cmds.Add(new HavocCmd(Token.NoToken, lhss.Select(x => x.DeepAssignedIdentifier).ToList()));
+              cmds.Add(CmdHelper.AssumeCmd(Expr.And(assumeExprs)));
+              cmds.Add(CmdHelper.HavocCmd(lhss.Select(x => x.DeepAssignedIdentifier).ToList()));
             }
           }
           else

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -4241,6 +4241,18 @@ namespace Microsoft.Boogie
       this.labelNames.Add(b.Label);
     }
 
+    public void AddTargets(IEnumerable<Block> blocks)
+    {
+      Contract.Requires(blocks != null);
+      Contract.Requires(cce.NonNullElements(blocks));
+      Contract.Requires(this.labelTargets != null);
+      Contract.Requires(this.labelNames != null);
+      foreach (var block in blocks)
+      {
+        AddTarget(block);
+      }
+    }
+
     public override void Emit(TokenTextWriter stream, int level)
     {
       //Contract.Requires(stream != null);

--- a/Source/UnitTests/README.md
+++ b/Source/UnitTests/README.md
@@ -1,7 +1,7 @@
 Unit testing infrastructure
 ===========================
 
-Boogie uses the [NUnit](http://www.nunit.org/) unit testing framework. 
+Boogie uses the [NUnit](http://www.nunit.org/) unit testing framework.
 We currently use NUnit 3.12.0.
 
 Run the tests as follows:

--- a/Test/civl/async/pending-async-test.bpl
+++ b/Test/civl/async/pending-async-test.bpl
@@ -2,7 +2,7 @@
 // RUN: %diff "%s.expect" "%t"
 // XFAIL: *
 
-var {:layer 0,3} x:int;  
+var {:layer 0,3} x:int;
 
 procedure {:both}{:layer 3} Client_atomic ()
 modifies x;

--- a/Test/civl/chris2.bpl
+++ b/Test/civl/chris2.bpl
@@ -11,8 +11,8 @@ procedure{:yields}{:layer 20} {:refines "atomic_p_gt1_lower"} p_gt1_lower();
 procedure{:both}{:layer 26,40} atomic_p_gt1()
 modifies x;
 { x := x + 1; }
-  
-procedure{:yields}{:layer 25} {:refines "atomic_p_gt1"} p_gt1()  
+
+procedure{:yields}{:layer 25} {:refines "atomic_p_gt1"} p_gt1()
 {
   call p_gt1_lower();
 }

--- a/Test/civl/chris2.bpl.expect
+++ b/Test/civl/chris2.bpl.expect
@@ -1,23 +1,19 @@
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(21,3): Related location: Gate of atomic_p_gt2 not preserved by atomic_p_gt1_lower
+chris2.bpl(21,3): Error BP5001: Gate of atomic_p_gt2 not preserved by atomic_p_gt1_lower
 Execution trace:
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Entry
     chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(21,3): Related location: Gate of atomic_p_gt2 not preserved by atomic_p_gt1
+chris2.bpl(21,3): Error BP5001: Gate of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
     chris2.bpl(11,32): inline$atomic_p_gt1$0$Entry
     chris2.bpl(13,5): inline$atomic_p_gt1$0$anon0
     chris2.bpl(11,32): inline$atomic_p_gt1$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(20,32): Related location: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
+chris2.bpl(20,32): Error BP5001: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
 Execution trace:
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Entry
     chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-chris2.bpl(20,32): Related location: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1
+chris2.bpl(20,32): Error BP5001: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
     chris2.bpl(11,32): inline$atomic_p_gt1$0$Entry
     chris2.bpl(13,5): inline$atomic_p_gt1$0$anon0

--- a/Test/civl/chris3.bpl
+++ b/Test/civl/chris3.bpl
@@ -6,7 +6,7 @@ procedure{:atomic}{:layer 95} skip() { }
 procedure{:yields}{:layer 94} {:refines "skip"} H()
 {
 }
-  
+
 procedure{:yields}{:layer 94} {:refines "skip"} A()
 {
 }

--- a/Test/civl/hide-params-pa.bpl
+++ b/Test/civl/hide-params-pa.bpl
@@ -14,7 +14,7 @@ procedure {:yields}{:layer 1}{:refines "SKIP"} b ()
   var i':int;
   var {:layer 0} r:real;
   var {:layer 0} r':real;
-  
+
   i := 1;
   call b', i', r' := a(b, i, r);
   // at layer 1 this call must be rewritten to

--- a/Test/civl/intro-nonblocking.bpl.expect
+++ b/Test/civl/intro-nonblocking.bpl.expect
@@ -1,5 +1,5 @@
 intro-nonblocking.bpl(4,30): Error BP5001: Non-blocking check for intro failed
 Execution trace:
-    intro-nonblocking.bpl(4,30): L
+    (0,0): init
 
 Boogie program verifier finished with 1 verified, 1 error

--- a/Test/civl/intro.bpl
+++ b/Test/civl/intro.bpl
@@ -24,7 +24,7 @@ requires {:layer 1} x == y;
   call set_y_to_x();
 }
 
-procedure {:intro} {:layer 1,1} set_y_to_x ()
+procedure {:intro} {:layer 1} set_y_to_x ()
 modifies y;
 {
   y := x;

--- a/Test/civl/lamport_prophecy.bpl
+++ b/Test/civl/lamport_prophecy.bpl
@@ -28,8 +28,8 @@ var {:layer 1, 1} p : int;
 const c: int;
 
 function {:inline} Invariant(i: int, p: int, c: int, x: [int]int) : bool {
-  IsProcId(i) && 
-  IsProcId(p) && 
+  IsProcId(i) &&
+  IsProcId(p) &&
   IsProcId(c) &&
   (p == c || x[c] == 1)
 }
@@ -75,7 +75,7 @@ requires {:layer 1} Invariant(i, p, c, x);
 	call update_x(i);
 	call backward_assign_p(i);
   yield;
-	assert {:layer 1} x[c] == 1;	
+	assert {:layer 1} x[c] == 1;
   call update_y(i);
   yield;
 }
@@ -107,7 +107,7 @@ procedure {:layer 1}{:atomic} atomic_update_x(i: int)
 modifies x;
 {
   x[i] := 1;
-} 
+}
 
 procedure {:layer 1}{:atomic} atomic_update_y(i: int)
 modifies y;

--- a/Test/civl/left-mover.bpl
+++ b/Test/civl/left-mover.bpl
@@ -9,19 +9,19 @@ modifies x;
 
 // Error: Gate failure of ass_eq_1 not preserved by inc
 procedure {:atomic} {:layer 1} ass_eq_1 ()
-{ assert x == 1; } 
+{ assert x == 1; }
 
 // Correct
 procedure {:atomic} {:layer 1} ass_leq_1 ()
-{ assert x <= 1; }   
+{ assert x <= 1; }
 
 // Error: init and inc do not commute
 procedure {:atomic} {:layer 1} init ()
 modifies x;
-{ x := 0; }          
+{ x := 0; }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 // Error block is blocking
 procedure {:left} {:layer 2} block ()
-{ assume x >= 0; } 
+{ assume x >= 0; }

--- a/Test/civl/left-mover.bpl.expect
+++ b/Test/civl/left-mover.bpl.expect
@@ -1,17 +1,15 @@
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-left-mover.bpl(11,32): Related location: Gate failure of ass_eq_1 not preserved by inc
+left-mover.bpl(11,32): Error BP5001: Gate failure of ass_eq_1 not preserved by inc
 Execution trace:
     left-mover.bpl(6,30): inline$inc$0$Entry
     left-mover.bpl(8,5): inline$inc$0$anon0
     left-mover.bpl(6,30): inline$inc$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-left-mover.bpl(19,32): Related location: Commutativity check between init and inc failed
+left-mover.bpl(19,32): Error BP5001: Commutativity check between init and inc failed
 Execution trace:
     left-mover.bpl(19,32): inline$init$0$Entry
     left-mover.bpl(8,5): inline$inc$0$anon0
     left-mover.bpl(6,30): inline$inc$0$Return
 left-mover.bpl(26,30): Error BP5001: Non-blocking check for block failed
 Execution trace:
-    left-mover.bpl(26,30): L
+    (0,0): init
 
 Boogie program verifier finished with 1 verified, 3 errors

--- a/Test/civl/linear_out_bug.bpl.expect
+++ b/Test/civl/linear_out_bug.bpl.expect
@@ -1,12 +1,10 @@
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-linear_out_bug.bpl(10,34): Related location: Commutativity check between AddAddr and RemoveAddr_2 failed
+linear_out_bug.bpl(10,34): Error BP5001: Commutativity check between AddAddr and RemoveAddr_2 failed
 Execution trace:
     linear_out_bug.bpl(10,34): inline$AddAddr$0$Entry
     linear_out_bug.bpl(13,14): inline$AddAddr$0$anon0
     linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0
     linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-linear_out_bug.bpl(20,5): Related location: Gate of RemoveAddr_1 not preserved by RemoveAddr_1
+linear_out_bug.bpl(20,5): Error BP5001: Gate of RemoveAddr_1 not preserved by RemoveAddr_1
 Execution trace:
     linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Entry
     linear_out_bug.bpl(20,5): inline$RemoveAddr_1$0$anon0

--- a/Test/civl/linearity-bug-1.bpl.expect
+++ b/Test/civl/linearity-bug-1.bpl.expect
@@ -1,5 +1,4 @@
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-linearity-bug-1.bpl(19,31): Related location: Commutativity check between atomic_read_n and atomic_inc_n failed
+linearity-bug-1.bpl(19,31): Error BP5001: Commutativity check between atomic_read_n and atomic_inc_n failed
 Execution trace:
     linearity-bug-1.bpl(19,31): inline$atomic_read_n$0$Entry
     linearity-bug-1.bpl(15,3): inline$atomic_inc_n$0$anon0

--- a/Test/civl/parallel6.bpl.expect
+++ b/Test/civl/parallel6.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: Transition invariant violated in final state
+parallel6.bpl(8,64): Error BP5001: Transition invariant violated in final state
 Execution trace:
     parallel6.bpl(10,5): anon0
     parallel6.bpl(28,7): inline$atomic_incr$0$anon0

--- a/Test/civl/pending-async-1.bpl.expect
+++ b/Test/civl/pending-async-1.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: Failed to execute atomic action before procedure return
+pending-async-1.bpl(48,49): Error BP5001: Failed to execute atomic action before procedure return
 Execution trace:
     pending-async-1.bpl(50,3): anon0
     pending-async-1.bpl(16,7): inline$B$0$anon0

--- a/Test/civl/pending-async-2.bpl.expect
+++ b/Test/civl/pending-async-2.bpl.expect
@@ -1,11 +1,9 @@
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-(0,0): Related location: Action C might create undeclared pending asyncs
+pending-async-2.bpl(19,29): Error BP5001: Action C might create undeclared pending asyncs
 Execution trace:
     pending-async-2.bpl(19,29): inline$C$0$Entry
     pending-async-2.bpl(22,7): inline$C$0$anon0
     pending-async-2.bpl(19,29): inline$C$0$Return
-(0,0): Error BP5003: A postcondition might not hold on this return path.
-(0,0): Related location: Action D might create negative pending asyncs
+pending-async-2.bpl(25,29): Error BP5001: Action D might create negative pending asyncs
 Execution trace:
     pending-async-2.bpl(25,29): inline$D$0$Entry
     pending-async-2.bpl(25,29): inline$D$0$Return

--- a/Test/civl/r2.bpl.expect
+++ b/Test/civl/r2.bpl.expect
@@ -1,10 +1,10 @@
-(0,0): Error BP5001: Failed to execute atomic action before procedure return
+r2.bpl(10,57): Error BP5001: Failed to execute atomic action before procedure return
 Execution trace:
     r2.bpl(11,5): anon0
     (0,0): Civl_call_refinement_4
     r2.bpl(21,34): inline$atomic_nop$0$Return
     (0,0): Civl_ReturnChecker
-(0,0): Error BP5001: Globals must not be modified
+r2.bpl(10,57): Error BP5001: Globals must not be modified
 Execution trace:
     r2.bpl(11,5): anon0
     (0,0): Civl_call_refinement_3

--- a/Test/civl/refinement.bpl
+++ b/Test/civl/refinement.bpl
@@ -27,8 +27,13 @@ procedure {:yields}{:layer 1}{:refines "INCR"} r ()
   yield;
   call incr();
   call incr();
-  call decr(); 
+  call decr();
   call decr(); // SKIP
+}
+
+procedure {:yields}{:layer 1}{:refines "INCR"} s ()
+{
+  // Error: Failed to execute atomic action before procedure return
 }
 
 procedure {:both} {:layer 1,2} INCR ()
@@ -36,7 +41,6 @@ modifies x;
 {
   x := x + 1;
 }
-
 
 procedure {:both} {:layer 1,2} DECR ()
 modifies x;

--- a/Test/civl/refinement.bpl.expect
+++ b/Test/civl/refinement.bpl.expect
@@ -1,21 +1,25 @@
-(0,0): Error BP5001: Transition invariant violated in final state
+refinement.bpl(6,48): Error BP5001: Transition invariant violated in final state
 Execution trace:
     refinement.bpl(8,3): anon0
-    refinement.bpl(37,5): inline$INCR$0$anon0
+    refinement.bpl(42,5): inline$INCR$0$anon0
     refinement.bpl(8,3): anon0_0
-    refinement.bpl(37,5): inline$INCR$1$anon0
+    refinement.bpl(42,5): inline$INCR$1$anon0
     (0,0): Civl_ReturnChecker
-(0,0): Error BP5001: Transition invariant violated in initial state
+refinement.bpl(14,48): Error BP5001: Transition invariant violated in initial state
 Execution trace:
     refinement.bpl(16,3): anon0
-    refinement.bpl(44,5): inline$DECR$0$anon0
+    refinement.bpl(48,5): inline$DECR$0$anon0
     (0,0): Civl_RefinementChecker
-(0,0): Error BP5001: Transition invariant violated in final state
+refinement.bpl(14,48): Error BP5001: Transition invariant violated in final state
 Execution trace:
     refinement.bpl(16,3): anon0
-    refinement.bpl(44,5): inline$DECR$0$anon0
+    refinement.bpl(48,5): inline$DECR$0$anon0
     refinement.bpl(16,3): anon0_0
-    refinement.bpl(37,5): inline$INCR$0$anon0
+    refinement.bpl(42,5): inline$INCR$0$anon0
+    (0,0): Civl_ReturnChecker
+refinement.bpl(34,48): Error BP5001: Failed to execute atomic action before procedure return
+Execution trace:
+    refinement.bpl(37,1): anon0
     (0,0): Civl_ReturnChecker
 
-Boogie program verifier finished with 3 verified, 3 errors
+Boogie program verifier finished with 3 verified, 4 errors


### PR DESCRIPTION
This PR cleans up the construction of `Absy` objects throughout the CIVL codebaes using helper functions. Now we don't have to pass `Token.NoToken` everywhere, and the construction of certain objects like `AssertCmd`, `CallCmd`, `Block`, etc. is further simplified.

Also, every CIVL check is now formulated as `AssertCmd` instead of `Ensures` (of course except the checks that actually come from postconditions in the input program).