### PR TITLE
Fix bug which causes redundant declarations to be generated in the VC

### DIFF
--- a/Source/VCExpr/TypeErasurePremisses.cs
+++ b/Source/VCExpr/TypeErasurePremisses.cs
@@ -1340,7 +1340,7 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Assert(cce.NonNullElements(furtherTriggers));
       Contract.Assert(typePremisses != null);
       List<VCTrigger /*!*/> /*!*/
-        newTriggers = MutateTriggers(node.Triggers, bindings);
+        newTriggers = new List<VCTrigger>(MutateTriggers(node.Triggers, bindings));
       Contract.Assert(cce.NonNullElements(newTriggers));
       newTriggers.AddRange(furtherTriggers);
       newTriggers = AddLets2Triggers(newTriggers, typeVarBindings);

--- a/Source/VCExpr/VCExprASTVisitors.cs
+++ b/Source/VCExpr/VCExprASTVisitors.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.Boogie.VCExprAST
         }
       }
 
-      if (!changed) 
+      if (!changed)
         return triggers;
       return newTriggers;
     }

--- a/Source/VCExpr/VCExprASTVisitors.cs
+++ b/Source/VCExpr/VCExprASTVisitors.cs
@@ -1234,8 +1234,8 @@ namespace Microsoft.Boogie.VCExprAST
         }
       }
 
-      if (!changed)
-        return new List<VCTrigger>(triggers);
+      if (!changed) 
+        return triggers;
       return newTriggers;
     }
 

--- a/Source/VCExpr/VCExprASTVisitors.cs
+++ b/Source/VCExpr/VCExprASTVisitors.cs
@@ -1235,7 +1235,7 @@ namespace Microsoft.Boogie.VCExprAST
       }
 
       if (!changed)
-        return triggers;
+        return new List<VCTrigger>(triggers);
       return newTriggers;
     }
 


### PR DESCRIPTION
Boogie generates redundant declarations in certain cases in the VC of polymorphic programs. For example, consider the following Boogie program

```
type Foo _;
function f<T>(x: Foo T, y: int) : bool;

procedure polarity_test() {
    var y1: int;
    var y2: int;
    var y3: int;

    assume (forall <T> x: int, y: Foo T :: f(y,x));
    assert (forall <T> x: int, y: Foo T :: f(y,x));

    assume y2 > 0;
    assume y3 > 0;
    assert y2 + y3 > 0;
}
```

In the corresponding VC generated by Boogie, the two following redundant declarations are generated (which also appear in some parts of the VC, but should not be there, as far as I can tell)

```
(declare-fun type@@0 (T@U) T@U)
(declare-fun TType () T@T)
```

I think the reason they are generated is as follows:

By default, Boogie's VC generation generates the VC `A /\ (A ==> ...)` for an `assert A` statement. In the code, Boogie uses the same object for both VCExpr `A` (on the left of the conjunct and on the left of the implication). When the types are erased, then the first occurrence of `A` is erased first, followed by the second occurrence. This erasure process includes possibly adding triggers. However, when generating the new triggers, the code does not always generate a new trigger list. Thus, when the second instance of A is erased, the triggers generated for the first instance are taken into account and this leads to redundant declarations being generated (in this particular example, the trigger "type y" is added to the first occurrence, which in turn leads to the `TType` being generated when processing the second occurrence).

As a solution, I propose to ensure that erasure creates a new trigger list.

As a final remark: It could be that for some reason this generation of seemingly redundant declarations is intended, but I would not know why.

I have attached the two VCs below (first: the one after the fix).

## VC after fix
```
(set-option :print-success false)
(set-info :smt-lib-version 2.6)
(set-option :smt.mbqi false)
(set-option :model.compact false)
(set-option :model.v2 true)
(set-option :pp.bv_literals false)
; done setting options


(set-info :category "industrial")
(declare-sort |T@U| 0)
(declare-sort |T@T| 0)
(declare-fun real_pow (Real Real) Real)
(declare-fun UOrdering2 (|T@U| |T@U|) Bool)
(declare-fun UOrdering3 (|T@T| |T@U| |T@U|) Bool)
(declare-fun tickleBool (Bool) Bool)
(assert (and (tickleBool true) (tickleBool false)))
(declare-fun U_2_int (T@U) Int)
(declare-fun U_2_bool (T@U) Bool)
(declare-fun Ctor (T@T) Int)
(declare-fun intType () T@T)
(declare-fun realType () T@T)
(declare-fun boolType () T@T)
(declare-fun rmodeType () T@T)
(declare-fun stringType () T@T)
(declare-fun regexType () T@T)
(declare-fun int_2_U (Int) T@U)
(declare-fun type (T@U) T@T)
(declare-fun real_2_U (Real) T@U)
(declare-fun U_2_real (T@U) Real)
(declare-fun bool_2_U (Bool) T@U)
(declare-fun rmode_2_U (RoundingMode) T@U)
(declare-fun U_2_rmode (T@U) RoundingMode)
(declare-fun string_2_U (String) T@U)
(declare-fun U_2_string (T@U) String)
(declare-fun regex_2_U ((RegEx String)) T@U)
(declare-fun U_2_regex (T@U) (RegEx String))
(assert  (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (= (Ctor intType) 0) (= (Ctor realType) 1)) (= (Ctor boolType) 2)) (= (Ctor rmodeType) 3)) (= (Ctor stringType) 4)) (= (Ctor regexType) 5)) (forall ((arg0 Int) ) (! (= (U_2_int (int_2_U arg0)) arg0)
 :qid |typeInv:U_2_int|
 :pattern ( (int_2_U arg0))
))) (forall ((x T@U) ) (!  (=> (= (type x) intType) (= (int_2_U (U_2_int x)) x))
 :qid |cast:U_2_int|
 :pattern ( (U_2_int x))
))) (forall ((arg0@@0 Int) ) (! (= (type (int_2_U arg0@@0)) intType)
 :qid |funType:int_2_U|
 :pattern ( (int_2_U arg0@@0))
))) (forall ((arg0@@1 Real) ) (! (= (U_2_real (real_2_U arg0@@1)) arg0@@1)
 :qid |typeInv:U_2_real|
 :pattern ( (real_2_U arg0@@1))
))) (forall ((x@@0 T@U) ) (!  (=> (= (type x@@0) realType) (= (real_2_U (U_2_real x@@0)) x@@0))
 :qid |cast:U_2_real|
 :pattern ( (U_2_real x@@0))
))) (forall ((arg0@@2 Real) ) (! (= (type (real_2_U arg0@@2)) realType)
 :qid |funType:real_2_U|
 :pattern ( (real_2_U arg0@@2))
))) (forall ((arg0@@3 Bool) ) (! (= (U_2_bool (bool_2_U arg0@@3)) arg0@@3)
 :qid |typeInv:U_2_bool|
 :pattern ( (bool_2_U arg0@@3))
))) (forall ((x@@1 T@U) ) (!  (=> (= (type x@@1) boolType) (= (bool_2_U (U_2_bool x@@1)) x@@1))
 :qid |cast:U_2_bool|
 :pattern ( (U_2_bool x@@1))
))) (forall ((arg0@@4 Bool) ) (! (= (type (bool_2_U arg0@@4)) boolType)
 :qid |funType:bool_2_U|
 :pattern ( (bool_2_U arg0@@4))
))) (forall ((arg0@@5 RoundingMode) ) (! (= (U_2_rmode (rmode_2_U arg0@@5)) arg0@@5)
 :qid |typeInv:U_2_rmode|
 :pattern ( (rmode_2_U arg0@@5))
))) (forall ((x@@2 T@U) ) (!  (=> (= (type x@@2) rmodeType) (= (rmode_2_U (U_2_rmode x@@2)) x@@2))
 :qid |cast:U_2_rmode|
 :pattern ( (U_2_rmode x@@2))
))) (forall ((arg0@@6 RoundingMode) ) (! (= (type (rmode_2_U arg0@@6)) rmodeType)
 :qid |funType:rmode_2_U|
 :pattern ( (rmode_2_U arg0@@6))
))) (forall ((arg0@@7 String) ) (! (= (U_2_string (string_2_U arg0@@7)) arg0@@7)
 :qid |typeInv:U_2_string|
 :pattern ( (string_2_U arg0@@7))
))) (forall ((x@@3 T@U) ) (!  (=> (= (type x@@3) stringType) (= (string_2_U (U_2_string x@@3)) x@@3))
 :qid |cast:U_2_string|
 :pattern ( (U_2_string x@@3))
))) (forall ((arg0@@8 String) ) (! (= (type (string_2_U arg0@@8)) stringType)
 :qid |funType:string_2_U|
 :pattern ( (string_2_U arg0@@8))
))) (forall ((arg0@@9 (RegEx String)) ) (! (= (U_2_regex (regex_2_U arg0@@9)) arg0@@9)
 :qid |typeInv:U_2_regex|
 :pattern ( (regex_2_U arg0@@9))
))) (forall ((x@@4 T@U) ) (!  (=> (= (type x@@4) regexType) (= (regex_2_U (U_2_regex x@@4)) x@@4))
 :qid |cast:U_2_regex|
 :pattern ( (U_2_regex x@@4))
))) (forall ((arg0@@10 (RegEx String)) ) (! (= (type (regex_2_U arg0@@10)) regexType)
 :qid |funType:regex_2_U|
 :pattern ( (regex_2_U arg0@@10))
))))
(assert (forall ((x@@5 T@U) ) (! (UOrdering2 x@@5 x@@5)
 :qid |bg:subtype-refl|
 :no-pattern (U_2_int x@@5)
 :no-pattern (U_2_bool x@@5)
)))
(assert (forall ((x@@6 T@U) (y T@U) (z T@U) ) (! (let ((alpha (type x@@6)))
 (=> (and (and (= (type y) alpha) (= (type z) alpha)) (and (UOrdering2 x@@6 y) (UOrdering2 y z))) (UOrdering2 x@@6 z)))
 :qid |bg:subtype-trans|
 :pattern ( (UOrdering2 x@@6 y) (UOrdering2 y z))
)))
(assert (forall ((x@@7 T@U) (y@@0 T@U) ) (! (let ((alpha@@0 (type x@@7)))
 (=> (= (type y@@0) alpha@@0) (=> (and (UOrdering2 x@@7 y@@0) (UOrdering2 y@@0 x@@7)) (= x@@7 y@@0))))
 :qid |bg:subtype-antisymm|
 :pattern ( (UOrdering2 x@@7 y@@0) (UOrdering2 y@@0 x@@7))
)))
(declare-fun ControlFlow (Int Int) Int)
(declare-fun FooTypeInv0 (T@T) T@T)
(declare-fun FooType (T@T) T@T)
(declare-fun f (T@U Int) Bool)
(declare-fun y2 () Int)
(declare-fun y3 () Int)
(assert  (and (forall ((arg0@@11 T@T) ) (! (= (Ctor (FooType arg0@@11)) 6)
 :qid |ctor:FooType|
)) (forall ((arg0@@12 T@T) ) (! (= (FooTypeInv0 (FooType arg0@@12)) arg0@@12)
 :qid |typeInv:FooTypeInv0|
 :pattern ( (FooType arg0@@12))
))))
(push 1)
(set-info :boogie-vc-id polarity_test)
(set-option :timeout 0)
(set-option :rlimit 0)
(assert (not
 (=> (= (ControlFlow 0 0) 114) (let ((anon0_correct  (=> (forall ((x@@8 Int) (y@@1 T@U) ) (! (let ((T (FooTypeInv0 (type y@@1))))
 (=> (= (type y@@1) (FooType T)) (f y@@1 x@@8)))
 :qid |polaritytestbpl.10:24|
 :skolemid |0|
 :no-pattern (type y@@1)
 :no-pattern (U_2_int y@@1)
 :no-pattern (U_2_bool y@@1)
)) (and (=> (= (ControlFlow 0 82) (- 0 124)) (forall ((x@@9 Int) (y@@2 T@U) ) (! (let ((T@@0 (FooTypeInv0 (type y@@2))))
 (=> (= (type y@@2) (FooType T@@0)) (f y@@2 x@@9)))
 :qid |polaritytestbpl.11:24|
 :skolemid |1|
 :no-pattern (type y@@2)
 :no-pattern (U_2_int y@@2)
 :no-pattern (U_2_bool y@@2)
))) (=> (forall ((x@@10 Int) (y@@3 T@U) ) (! (let ((T@@1 (FooTypeInv0 (type y@@3))))
 (=> (= (type y@@3) (FooType T@@1)) (f y@@3 x@@10)))
 :qid |polaritytestbpl.11:24|
 :skolemid |1|
 :no-pattern (type y@@3)
 :no-pattern (U_2_int y@@3)
 :no-pattern (U_2_bool y@@3)
)) (=> (> y2 0) (=> (and (> y3 0) (= (ControlFlow 0 82) (- 0 145))) (> (+ y2 y3) 0))))))))
(let ((PreconditionGeneratedEntry_correct  (=> (= (ControlFlow 0 114) 82) anon0_correct)))
PreconditionGeneratedEntry_correct)))
))
(check-sat)
(pop 1)
; Valid
```

## VC before fix

```
(set-option :print-success false)
(set-info :smt-lib-version 2.6)
(set-option :smt.mbqi false)
(set-option :model.compact false)
(set-option :model.v2 true)
(set-option :pp.bv_literals false)
; done setting options


(set-info :category "industrial")
(declare-sort |T@U| 0)
(declare-sort |T@T| 0)
(declare-fun real_pow (Real Real) Real)
(declare-fun UOrdering2 (|T@U| |T@U|) Bool)
(declare-fun UOrdering3 (|T@T| |T@U| |T@U|) Bool)
(declare-fun tickleBool (Bool) Bool)
(assert (and (tickleBool true) (tickleBool false)))
(declare-fun U_2_int (T@U) Int)
(declare-fun U_2_bool (T@U) Bool)
(declare-fun Ctor (T@T) Int)
(declare-fun intType () T@T)
(declare-fun realType () T@T)
(declare-fun boolType () T@T)
(declare-fun rmodeType () T@T)
(declare-fun stringType () T@T)
(declare-fun regexType () T@T)
(declare-fun int_2_U (Int) T@U)
(declare-fun type (T@U) T@T)
(declare-fun real_2_U (Real) T@U)
(declare-fun U_2_real (T@U) Real)
(declare-fun bool_2_U (Bool) T@U)
(declare-fun rmode_2_U (RoundingMode) T@U)
(declare-fun U_2_rmode (T@U) RoundingMode)
(declare-fun string_2_U (String) T@U)
(declare-fun U_2_string (T@U) String)
(declare-fun regex_2_U ((RegEx String)) T@U)
(declare-fun U_2_regex (T@U) (RegEx String))
(assert  (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (and (= (Ctor intType) 0) (= (Ctor realType) 1)) (= (Ctor boolType) 2)) (= (Ctor rmodeType) 3)) (= (Ctor stringType) 4)) (= (Ctor regexType) 5)) (forall ((arg0 Int) ) (! (= (U_2_int (int_2_U arg0)) arg0)
 :qid |typeInv:U_2_int|
 :pattern ( (int_2_U arg0))
))) (forall ((x T@U) ) (!  (=> (= (type x) intType) (= (int_2_U (U_2_int x)) x))
 :qid |cast:U_2_int|
 :pattern ( (U_2_int x))
))) (forall ((arg0@@0 Int) ) (! (= (type (int_2_U arg0@@0)) intType)
 :qid |funType:int_2_U|
 :pattern ( (int_2_U arg0@@0))
))) (forall ((arg0@@1 Real) ) (! (= (U_2_real (real_2_U arg0@@1)) arg0@@1)
 :qid |typeInv:U_2_real|
 :pattern ( (real_2_U arg0@@1))
))) (forall ((x@@0 T@U) ) (!  (=> (= (type x@@0) realType) (= (real_2_U (U_2_real x@@0)) x@@0))
 :qid |cast:U_2_real|
 :pattern ( (U_2_real x@@0))
))) (forall ((arg0@@2 Real) ) (! (= (type (real_2_U arg0@@2)) realType)
 :qid |funType:real_2_U|
 :pattern ( (real_2_U arg0@@2))
))) (forall ((arg0@@3 Bool) ) (! (= (U_2_bool (bool_2_U arg0@@3)) arg0@@3)
 :qid |typeInv:U_2_bool|
 :pattern ( (bool_2_U arg0@@3))
))) (forall ((x@@1 T@U) ) (!  (=> (= (type x@@1) boolType) (= (bool_2_U (U_2_bool x@@1)) x@@1))
 :qid |cast:U_2_bool|
 :pattern ( (U_2_bool x@@1))
))) (forall ((arg0@@4 Bool) ) (! (= (type (bool_2_U arg0@@4)) boolType)
 :qid |funType:bool_2_U|
 :pattern ( (bool_2_U arg0@@4))
))) (forall ((arg0@@5 RoundingMode) ) (! (= (U_2_rmode (rmode_2_U arg0@@5)) arg0@@5)
 :qid |typeInv:U_2_rmode|
 :pattern ( (rmode_2_U arg0@@5))
))) (forall ((x@@2 T@U) ) (!  (=> (= (type x@@2) rmodeType) (= (rmode_2_U (U_2_rmode x@@2)) x@@2))
 :qid |cast:U_2_rmode|
 :pattern ( (U_2_rmode x@@2))
))) (forall ((arg0@@6 RoundingMode) ) (! (= (type (rmode_2_U arg0@@6)) rmodeType)
 :qid |funType:rmode_2_U|
 :pattern ( (rmode_2_U arg0@@6))
))) (forall ((arg0@@7 String) ) (! (= (U_2_string (string_2_U arg0@@7)) arg0@@7)
 :qid |typeInv:U_2_string|
 :pattern ( (string_2_U arg0@@7))
))) (forall ((x@@3 T@U) ) (!  (=> (= (type x@@3) stringType) (= (string_2_U (U_2_string x@@3)) x@@3))
 :qid |cast:U_2_string|
 :pattern ( (U_2_string x@@3))
))) (forall ((arg0@@8 String) ) (! (= (type (string_2_U arg0@@8)) stringType)
 :qid |funType:string_2_U|
 :pattern ( (string_2_U arg0@@8))
))) (forall ((arg0@@9 (RegEx String)) ) (! (= (U_2_regex (regex_2_U arg0@@9)) arg0@@9)
 :qid |typeInv:U_2_regex|
 :pattern ( (regex_2_U arg0@@9))
))) (forall ((x@@4 T@U) ) (!  (=> (= (type x@@4) regexType) (= (regex_2_U (U_2_regex x@@4)) x@@4))
 :qid |cast:U_2_regex|
 :pattern ( (U_2_regex x@@4))
))) (forall ((arg0@@10 (RegEx String)) ) (! (= (type (regex_2_U arg0@@10)) regexType)
 :qid |funType:regex_2_U|
 :pattern ( (regex_2_U arg0@@10))
))))
(assert (forall ((x@@5 T@U) ) (! (UOrdering2 x@@5 x@@5)
 :qid |bg:subtype-refl|
 :no-pattern (U_2_int x@@5)
 :no-pattern (U_2_bool x@@5)
)))
(assert (forall ((x@@6 T@U) (y T@U) (z T@U) ) (! (let ((alpha (type x@@6)))
 (=> (and (and (= (type y) alpha) (= (type z) alpha)) (and (UOrdering2 x@@6 y) (UOrdering2 y z))) (UOrdering2 x@@6 z)))
 :qid |bg:subtype-trans|
 :pattern ( (UOrdering2 x@@6 y) (UOrdering2 y z))
)))
(assert (forall ((x@@7 T@U) (y@@0 T@U) ) (! (let ((alpha@@0 (type x@@7)))
 (=> (= (type y@@0) alpha@@0) (=> (and (UOrdering2 x@@7 y@@0) (UOrdering2 y@@0 x@@7)) (= x@@7 y@@0))))
 :qid |bg:subtype-antisymm|
 :pattern ( (UOrdering2 x@@7 y@@0) (UOrdering2 y@@0 x@@7))
)))
(declare-fun ControlFlow (Int Int) Int)
(declare-fun FooTypeInv0 (T@T) T@T)
(declare-fun FooType (T@T) T@T)
(declare-fun f (T@U Int) Bool)
(declare-fun type@@0 (T@U) T@U)
(declare-fun y@@1 () T@U)
(declare-fun y2 () Int)
(declare-fun y3 () Int)
(declare-fun TType () T@T)
(assert  (and (and (and (forall ((arg0@@11 T@T) ) (! (= (Ctor (FooType arg0@@11)) 6)
 :qid |ctor:FooType|
)) (forall ((arg0@@12 T@T) ) (! (= (FooTypeInv0 (FooType arg0@@12)) arg0@@12)
 :qid |typeInv:FooTypeInv0|
 :pattern ( (FooType arg0@@12))
))) (= (Ctor TType) 7)) (forall ((arg0@@13 T@U) ) (! (= (type (type@@0 arg0@@13)) TType)
 :qid |funType:type|
 :pattern ( (type@@0 arg0@@13))
))))
(push 1)
(set-info :boogie-vc-id polarity_test)
(set-option :timeout 0)
(set-option :rlimit 0)
(assert (not
 (=> (= (ControlFlow 0 0) 114) (let ((anon0_correct  (=> (forall ((x@@8 Int) (y@@2 T@U) ) (! (let ((T (FooTypeInv0 (type y@@2))))
 (=> (= (type y@@2) (FooType T)) (f y@@2 x@@8)))
 :qid |polaritytestbpl.9:24|
 :skolemid |0|
 :no-pattern (type y@@2)
 :no-pattern (U_2_int y@@2)
 :no-pattern (U_2_bool y@@2)
)) (and (=> (= (ControlFlow 0 82) (- 0 124)) (forall ((x@@9 Int) (y@@3 T@U) ) (! (let ((T@@0 (FooTypeInv0 (type y@@3))))
 (=> (= (type y@@3) (FooType T@@0)) (f y@@3 x@@9)))
 :qid |polaritytestbpl.10:24|
 :skolemid |1|
 :no-pattern (type y@@3)
 :no-pattern (U_2_int y@@3)
 :no-pattern (U_2_bool y@@3)
))) (=> (forall ((x@@10 Int) (y@@4 T@U) ) (! (let ((T@@1 (FooTypeInv0 (type y@@4))))
 (=> (= (type y@@4) (FooType T@@1)) (f y@@4 x@@10)))
 :qid |polaritytestbpl.10:24|
 :skolemid |1|
 :no-pattern (type@@0 y@@1)
 :no-pattern (type y@@4)
 :no-pattern (U_2_int y@@4)
 :no-pattern (U_2_bool y@@4)
)) (=> (> y2 0) (=> (and (> y3 0) (= (ControlFlow 0 82) (- 0 145))) (> (+ y2 y3) 0))))))))
(let ((PreconditionGeneratedEntry_correct  (=> (= (ControlFlow 0 114) 82) anon0_correct)))
PreconditionGeneratedEntry_correct)))
))
(check-sat)
(pop 1)
; Valid
```