### PR TITLE
Fix issue #322

### DIFF
--- a/Source/Core/VCExp.cs
+++ b/Source/Core/VCExp.cs
@@ -181,7 +181,7 @@ The generic options may or may not be used by the prover plugin.
     protected void ReportError(string msg)
     {
       Contract.Requires(msg != null);
-      throw new ProverOptionException(msg + "\n\n" + Help);
+      throw new ProverOptionException(msg);
     }
 
     protected virtual bool ParseString(string opt, string name, ref string field)
@@ -341,7 +341,7 @@ The generic options may or may not be used by the prover plugin.
     }
   }
 
-  public class ProverOptionException : Exception
+  public class ProverOptionException : ProverException
   {
     public ProverOptionException(string msg)
       : base(msg)

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1027,16 +1027,14 @@ namespace Microsoft.Boogie
       {
         ae.Handle(e =>
         {
-          var pe = e as ProverException;
-          if (pe != null)
+          if (e is ProverException)
           {
-            printer.ErrorWriteLine(Console.Out, "Fatal Error: ProverException: {0}", e);
+            printer.ErrorWriteLine(Console.Out, "Fatal Error: ProverException: {0}", e.Message);
             outcome = PipelineOutcome.FatalError;
             return true;
           }
 
-          var oce = e as OperationCanceledException;
-          if (oce != null)
+          if (e is OperationCanceledException)
           {
             return true;
           }

--- a/Test/prover/issue-322.bpl
+++ b/Test/prover/issue-322.bpl
@@ -1,0 +1,5 @@
+// RUN: %boogie -proverOpt:PROVER_PATH=bogus-path "%s" > "%t"
+// RUN: %boogie -proverOpt:bogus-option "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure foo() {}

--- a/Test/prover/issue-322.bpl.expect
+++ b/Test/prover/issue-322.bpl.expect
@@ -1,0 +1,2 @@
+Fatal Error: ProverException: Cannot find specified prover: bogus-path
+Fatal Error: ProverException: Unrecognised prover option: bogus-option


### PR DESCRIPTION
@RustanLeino, Boogie actually catches the `ProverException` and does not crash. It just looked like a crash because it dumped the stack trace in the exception handler.

You are right, the exception is thrown in a worker thread. That's why it has to be caught as part of an `AggregateException`. The fix in this PR is to only print the message of a `ProverException`, but not the stack trace. The contract with clients of `InferAndVerify` is that `PipelineOutcome.FatalError` is returned if something went wrong and Boogie already printed an error message (also for errors caused by something other than a `ProverException`).

Now the only message you will see on the command line is:
```
Fatal Error: ProverException: Cannot find specified prover: bogus-path
```

