### PR TITLE
Remove Boogie error codes

### DIFF
--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -254,7 +254,6 @@ namespace Microsoft.Boogie
     public readonly IToken Tok;
     public string Msg;
     public string Category { get; set; }
-    public string BoogieErrorCode { get; set; }
     public readonly List<AuxErrorInfo> Aux = new List<AuxErrorInfo>();
     public string OriginalRequestId { get; set; }
     public string RequestId { get; set; }
@@ -267,13 +266,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        var prefix = Category;
-        if (BoogieErrorCode != null)
-        {
-          prefix = prefix == null ? BoogieErrorCode : prefix + " " + BoogieErrorCode;
-        }
-
-        return prefix != null ? string.Format("{0}: {1}", prefix, Msg) : Msg;
+        return Category != null ? string.Format("{0}: {1}", Category, Msg) : Msg;
       }
     }
 
@@ -1239,7 +1232,6 @@ namespace Microsoft.Boogie
           {
             var errorInfo = errorInformationFactory.CreateErrorInformation(impl.tok,
               String.Format("{0} (encountered in implementation {1}).", e.Message, impl.Name), requestId, "Error");
-            errorInfo.BoogieErrorCode = "BP5010";
             errorInfo.ImplementationName = impl.Name;
             printer.WriteErrorInformation(errorInfo, output);
             if (er != null)
@@ -1812,12 +1804,6 @@ namespace Microsoft.Boogie
 
     private static ErrorInformation CreateErrorInformation(Counterexample error, VC.VCGen.Outcome outcome)
     {
-      // BP1xxx: Parsing errors
-      // BP2xxx: Name resolution errors
-      // BP3xxx: Typechecking errors
-      // BP4xxx: Abstract interpretation errors (Is there such a thing?)
-      // BP5xxx: Verification errors
-
       ErrorInformation errorInfo;
       var cause = "Error";
       if (outcome == VCGen.Outcome.TimedOut)
@@ -1840,7 +1826,6 @@ namespace Microsoft.Boogie
           errorInfo = errorInformationFactory.CreateErrorInformation(callError.FailingCall.tok,
             callError.FailingCall.ErrorData as string ?? "A precondition for this call might not hold.",
             callError.RequestId, callError.OriginalRequestId, cause);
-          errorInfo.BoogieErrorCode = "BP5002";
           errorInfo.Kind = ErrorKind.Precondition;
           errorInfo.AddAuxInfo(callError.FailingRequires.tok,
             callError.FailingRequires.ErrorData as string ?? "This is the precondition that might not hold.",
@@ -1860,7 +1845,6 @@ namespace Microsoft.Boogie
           errorInfo = errorInformationFactory.CreateErrorInformation(returnError.FailingReturn.tok,
             "A postcondition might not hold on this return path.",
             returnError.RequestId, returnError.OriginalRequestId, cause);
-          errorInfo.BoogieErrorCode = "BP5003";
           errorInfo.Kind = ErrorKind.Postcondition;
           errorInfo.AddAuxInfo(returnError.FailingEnsures.tok,
             returnError.FailingEnsures.ErrorData as string ?? "This is the postcondition that might not hold.",
@@ -1882,7 +1866,6 @@ namespace Microsoft.Boogie
           errorInfo = errorInformationFactory.CreateErrorInformation(assertError.FailingAssert.tok,
             "This loop invariant might not hold on entry.",
             assertError.RequestId, assertError.OriginalRequestId, cause);
-          errorInfo.BoogieErrorCode = "BP5004";
           errorInfo.Kind = ErrorKind.InvariantEntry;
           if ((assertError.FailingAssert.ErrorData as string) != null)
           {
@@ -1895,7 +1878,6 @@ namespace Microsoft.Boogie
           errorInfo = errorInformationFactory.CreateErrorInformation(assertError.FailingAssert.tok,
             "This loop invariant might not be maintained by the loop.",
             assertError.RequestId, assertError.OriginalRequestId, cause);
-          errorInfo.BoogieErrorCode = "BP5005";
           errorInfo.Kind = ErrorKind.InvariantMaintainance;
           if ((assertError.FailingAssert.ErrorData as string) != null)
           {
@@ -1906,12 +1888,10 @@ namespace Microsoft.Boogie
         else
         {
           string msg = null;
-          string bec = null;
 
           if (assertError.FailingAssert.ErrorMessage == null || CommandLineOptions.Clo.ForceBplErrors)
           {
             msg = assertError.FailingAssert.ErrorData as string ?? "This assertion might not hold.";
-            bec = "BP5001";
           }
           else
           {
@@ -1920,7 +1900,6 @@ namespace Microsoft.Boogie
 
           errorInfo = errorInformationFactory.CreateErrorInformation(assertError.FailingAssert.tok, msg,
             assertError.RequestId, assertError.OriginalRequestId, cause);
-          errorInfo.BoogieErrorCode = bec;
           errorInfo.Kind = ErrorKind.Assertion;
         }
       }

--- a/Test/aitest0/Intervals.bpl.expect
+++ b/Test/aitest0/Intervals.bpl.expect
@@ -1,54 +1,54 @@
-Intervals.bpl(64,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(64,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(59,5): anon0
     Intervals.bpl(60,3): anon3_LoopHead
     Intervals.bpl(60,3): anon3_LoopDone
-Intervals.bpl(75,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(75,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(70,5): anon0
     Intervals.bpl(71,3): anon3_LoopHead
     Intervals.bpl(71,3): anon3_LoopDone
-Intervals.bpl(94,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(94,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(89,5): anon0
     Intervals.bpl(90,3): loop_head
     Intervals.bpl(93,3): after_loop
-Intervals.bpl(140,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(140,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(135,5): anon0
     Intervals.bpl(136,3): anon3_LoopHead
     Intervals.bpl(136,3): anon3_LoopDone
-Intervals.bpl(151,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(151,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(146,5): anon0
     Intervals.bpl(147,3): anon3_LoopHead
     Intervals.bpl(147,3): anon3_LoopDone
-Intervals.bpl(202,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(202,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(192,8): anon0
     Intervals.bpl(193,3): anon4_LoopHead
     Intervals.bpl(193,3): anon4_LoopDone
-Intervals.bpl(240,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(240,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(235,5): anon0
     Intervals.bpl(236,3): anon3_LoopHead
     Intervals.bpl(236,3): anon3_LoopDone
-Intervals.bpl(252,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(252,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(246,8): anon0
     Intervals.bpl(247,3): anon3_LoopHead
     Intervals.bpl(247,3): anon3_LoopDone
-Intervals.bpl(263,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(263,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(258,5): anon0
     Intervals.bpl(259,3): anon3_LoopHead
     Intervals.bpl(259,3): anon3_LoopDone
-Intervals.bpl(285,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(285,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(280,5): anon0
     Intervals.bpl(281,3): anon3_LoopHead
     Intervals.bpl(281,3): anon3_LoopDone
-Intervals.bpl(307,3): Error BP5001: This assertion might not hold.
+Intervals.bpl(307,3): Error: This assertion might not hold.
 Execution trace:
     Intervals.bpl(302,5): anon0
     Intervals.bpl(303,3): anon3_LoopHead

--- a/Test/aitest0/Issue25.bpl.expect
+++ b/Test/aitest0/Issue25.bpl.expect
@@ -1,4 +1,4 @@
-Issue25.bpl(12,1): Error BP5003: A postcondition might not hold on this return path.
+Issue25.bpl(12,1): Error: A postcondition might not hold on this return path.
 Issue25.bpl(8,1): Related location: This is the postcondition that might not hold.
 Execution trace:
     Issue25.bpl(11,3): anon0

--- a/Test/aitest1/Bound.bpl.expect
+++ b/Test/aitest1/Bound.bpl.expect
@@ -1,4 +1,4 @@
-Bound.bpl(26,3): Error BP5001: This assertion might not hold.
+Bound.bpl(26,3): Error: This assertion might not hold.
 Execution trace:
     Bound.bpl(10,1): start
     Bound.bpl(16,1): LoopHead

--- a/Test/aitest9/TestIntervals.bpl.expect
+++ b/Test/aitest9/TestIntervals.bpl.expect
@@ -1,4 +1,4 @@
-TestIntervals.bpl(25,3): Error BP5001: This assertion might not hold.
+TestIntervals.bpl(25,3): Error: This assertion might not hold.
 Execution trace:
     TestIntervals.bpl(7,5): anon0
     TestIntervals.bpl(8,3): anon9_LoopHead
@@ -6,12 +6,12 @@ Execution trace:
     TestIntervals.bpl(15,14): anon11_Then
     TestIntervals.bpl(16,3): anon12_Else
     TestIntervals.bpl(19,5): anon8
-TestIntervals.bpl(70,3): Error BP5001: This assertion might not hold.
+TestIntervals.bpl(70,3): Error: This assertion might not hold.
 Execution trace:
     TestIntervals.bpl(62,3): anon0
     TestIntervals.bpl(67,3): anon3_LoopHead
     TestIntervals.bpl(67,3): anon3_LoopDone
-TestIntervals.bpl(71,3): Error BP5001: This assertion might not hold.
+TestIntervals.bpl(71,3): Error: This assertion might not hold.
 Execution trace:
     TestIntervals.bpl(62,3): anon0
     TestIntervals.bpl(67,3): anon3_LoopHead

--- a/Test/aitest9/VarMapFixpoint.bpl.expect
+++ b/Test/aitest9/VarMapFixpoint.bpl.expect
@@ -1,4 +1,4 @@
-VarMapFixpoint.bpl(13,5): Error BP5005: This loop invariant might not be maintained by the loop.
+VarMapFixpoint.bpl(13,5): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     VarMapFixpoint.bpl(7,3): start
     VarMapFixpoint.bpl(12,3): LoopHead

--- a/Test/bitvectors/bv5.bpl.expect
+++ b/Test/bitvectors/bv5.bpl.expect
@@ -1,4 +1,4 @@
-bv5.bpl(12,3): Error BP5001: This assertion might not hold.
+bv5.bpl(12,3): Error: This assertion might not hold.
 Execution trace:
     bv5.bpl(7,12): anon0
 

--- a/Test/bitvectors/bv6.bpl.expect
+++ b/Test/bitvectors/bv6.bpl.expect
@@ -1,4 +1,4 @@
-bv6.bpl(10,3): Error BP5001: This assertion might not hold.
+bv6.bpl(10,3): Error: This assertion might not hold.
 Execution trace:
     bv6.bpl(7,5): anon0
 

--- a/Test/civl/Program4-fail.bpl.expect
+++ b/Test/civl/Program4-fail.bpl.expect
@@ -1,4 +1,4 @@
-Program4-fail.bpl(26,1): Error BP5003: A postcondition might not hold on this return path.
+Program4-fail.bpl(26,1): Error: A postcondition might not hold on this return path.
 Program4-fail.bpl(6,1): Related location: This is the postcondition that might not hold.
 Execution trace:
     Program4-fail.bpl(23,3): anon0

--- a/Test/civl/bar.bpl.expect
+++ b/Test/civl/bar.bpl.expect
@@ -1,9 +1,9 @@
-bar.bpl(23,1): Error BP5001: Non-interference check failed
+bar.bpl(23,1): Error: Non-interference check failed
 Execution trace:
     bar.bpl(7,3): anon0
     bar.bpl(12,5): inline$AtomicIncr$0$anon0
     (0,0): inline$Civl_NoninterferenceChecker_yield_PC$0$L0
-bar.bpl(23,1): Error BP5001: Non-interference check failed
+bar.bpl(23,1): Error: Non-interference check failed
 Execution trace:
     bar.bpl(32,3): anon0
     (0,0): inline$Civl_NoninterferenceChecker_yield_PC$0$L0

--- a/Test/civl/chris2.bpl.expect
+++ b/Test/civl/chris2.bpl.expect
@@ -1,19 +1,19 @@
-chris2.bpl(21,3): Error BP5001: Gate of atomic_p_gt2 not preserved by atomic_p_gt1_lower
+chris2.bpl(21,3): Error: Gate of atomic_p_gt2 not preserved by atomic_p_gt1_lower
 Execution trace:
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Entry
     chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
-chris2.bpl(21,3): Error BP5001: Gate of atomic_p_gt2 not preserved by atomic_p_gt1
+chris2.bpl(21,3): Error: Gate of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
     chris2.bpl(11,32): inline$atomic_p_gt1$0$Entry
     chris2.bpl(13,5): inline$atomic_p_gt1$0$anon0
     chris2.bpl(11,32): inline$atomic_p_gt1$0$Return
-chris2.bpl(20,32): Error BP5001: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
+chris2.bpl(20,32): Error: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
 Execution trace:
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Entry
     chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
     chris2.bpl(5,32): inline$atomic_p_gt1_lower$0$Return
-chris2.bpl(20,32): Error BP5001: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1
+chris2.bpl(20,32): Error: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
     chris2.bpl(11,32): inline$atomic_p_gt1$0$Entry
     chris2.bpl(13,5): inline$atomic_p_gt1$0$anon0

--- a/Test/civl/chris4.bpl.expect
+++ b/Test/civl/chris4.bpl.expect
@@ -1,4 +1,4 @@
-chris4.bpl(13,3): Error BP5001: This assertion might not hold.
+chris4.bpl(13,3): Error: This assertion might not hold.
 Execution trace:
     chris4.bpl(12,3): anon0
     chris4.bpl(12,3): anon0_0

--- a/Test/civl/chris5.bpl.expect
+++ b/Test/civl/chris5.bpl.expect
@@ -1,4 +1,4 @@
-chris5.bpl(7,3): Error BP5001: This gate of P might not hold.
+chris5.bpl(7,3): Error: This gate of P might not hold.
 Execution trace:
     chris5.bpl(12,3): anon0
 

--- a/Test/civl/chris6.bpl.expect
+++ b/Test/civl/chris6.bpl.expect
@@ -1,4 +1,4 @@
-chris6.bpl(11,3): Error BP5001: This assertion might not hold.
+chris6.bpl(11,3): Error: This assertion might not hold.
 Execution trace:
     chris6.bpl(11,3): anon0
 

--- a/Test/civl/foo.bpl.expect
+++ b/Test/civl/foo.bpl.expect
@@ -1,4 +1,4 @@
-foo.bpl(23,1): Error BP5001: Non-interference check failed
+foo.bpl(23,1): Error: Non-interference check failed
 Execution trace:
     foo.bpl(7,3): anon0
     foo.bpl(12,5): inline$AtomicIncr$0$anon0

--- a/Test/civl/intro-nonblocking.bpl.expect
+++ b/Test/civl/intro-nonblocking.bpl.expect
@@ -1,4 +1,4 @@
-intro-nonblocking.bpl(4,30): Error BP5001: Cooperation check for intro failed
+intro-nonblocking.bpl(4,30): Error: Cooperation check for intro failed
 Execution trace:
     (0,0): init
 

--- a/Test/civl/left-mover.bpl.expect
+++ b/Test/civl/left-mover.bpl.expect
@@ -1,14 +1,14 @@
-left-mover.bpl(11,32): Error BP5001: Gate failure of ass_eq_1 not preserved by inc
+left-mover.bpl(11,32): Error: Gate failure of ass_eq_1 not preserved by inc
 Execution trace:
     left-mover.bpl(6,30): inline$inc$0$Entry
     left-mover.bpl(8,5): inline$inc$0$anon0
     left-mover.bpl(6,30): inline$inc$0$Return
-left-mover.bpl(19,32): Error BP5001: Commutativity check between init and inc failed
+left-mover.bpl(19,32): Error: Commutativity check between init and inc failed
 Execution trace:
     left-mover.bpl(19,32): inline$init$0$Entry
     left-mover.bpl(8,5): inline$inc$0$anon0
     left-mover.bpl(6,30): inline$inc$0$Return
-left-mover.bpl(26,30): Error BP5001: Cooperation check for block failed
+left-mover.bpl(26,30): Error: Cooperation check for block failed
 Execution trace:
     (0,0): init
 

--- a/Test/civl/linear/allocator.bpl.expect
+++ b/Test/civl/linear/allocator.bpl.expect
@@ -1,4 +1,4 @@
-allocator.bpl(16,3): Error BP5001: This assertion might not hold.
+allocator.bpl(16,3): Error: This assertion might not hold.
 Execution trace:
     allocator.bpl(14,5): anon0
 

--- a/Test/civl/linear/bug.bpl.expect
+++ b/Test/civl/linear/bug.bpl.expect
@@ -1,4 +1,4 @@
-bug.bpl(15,3): Error BP5001: This assertion might not hold.
+bug.bpl(15,3): Error: This assertion might not hold.
 Execution trace:
     bug.bpl(14,3): anon0
 

--- a/Test/civl/linear/f1.bpl.expect
+++ b/Test/civl/linear/f1.bpl.expect
@@ -1,4 +1,4 @@
-f1.bpl(40,4): Error BP5001: This assertion might not hold.
+f1.bpl(40,4): Error: This assertion might not hold.
 Execution trace:
     f1.bpl(34,6): anon0
 

--- a/Test/civl/linear/f2.bpl.expect
+++ b/Test/civl/linear/f2.bpl.expect
@@ -1,4 +1,4 @@
-f2.bpl(26,4): Error BP5001: This assertion might not hold.
+f2.bpl(26,4): Error: This assertion might not hold.
 Execution trace:
     f2.bpl(22,4): anon0
 

--- a/Test/civl/linear_out_bug.bpl.expect
+++ b/Test/civl/linear_out_bug.bpl.expect
@@ -1,15 +1,15 @@
-linear_out_bug.bpl(10,34): Error BP5001: Commutativity check between AddAddr and RemoveAddr_2 failed
+linear_out_bug.bpl(10,34): Error: Commutativity check between AddAddr and RemoveAddr_2 failed
 Execution trace:
     linear_out_bug.bpl(10,34): inline$AddAddr$0$Entry
     linear_out_bug.bpl(13,14): inline$AddAddr$0$anon0
     linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0
     linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Return
-linear_out_bug.bpl(20,5): Error BP5001: Gate of RemoveAddr_1 not preserved by RemoveAddr_1
+linear_out_bug.bpl(20,5): Error: Gate of RemoveAddr_1 not preserved by RemoveAddr_1
 Execution trace:
     linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Entry
     linear_out_bug.bpl(20,5): inline$RemoveAddr_1$0$anon0
     linear_out_bug.bpl(17,30): inline$RemoveAddr_1$0$Return
-linear_out_bug.bpl(25,30): Error BP5001: Potential linearity violation in outputs for domain addr.
+linear_out_bug.bpl(25,30): Error: Potential linearity violation in outputs for domain addr.
 Execution trace:
     linear_out_bug.bpl(25,30): inline$RemoveAddr_2$0$Entry
     linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0

--- a/Test/civl/linearity-bug-1.bpl.expect
+++ b/Test/civl/linearity-bug-1.bpl.expect
@@ -1,4 +1,4 @@
-linearity-bug-1.bpl(19,31): Error BP5001: Commutativity check between atomic_read_n and atomic_inc_n failed
+linearity-bug-1.bpl(19,31): Error: Commutativity check between atomic_read_n and atomic_inc_n failed
 Execution trace:
     linearity-bug-1.bpl(19,31): inline$atomic_read_n$0$Entry
     linearity-bug-1.bpl(15,3): inline$atomic_inc_n$0$anon0

--- a/Test/civl/linearity-bug-2.bpl.expect
+++ b/Test/civl/linearity-bug-2.bpl.expect
@@ -1,4 +1,4 @@
-linearity-bug-2.bpl(6,32): Error BP5001: Potential linearity violation in outputs for domain lin.
+linearity-bug-2.bpl(6,32): Error: Potential linearity violation in outputs for domain lin.
 Execution trace:
     linearity-bug-2.bpl(6,32): inline$atomic_foo$0$Entry
     linearity-bug-2.bpl(8,10): inline$atomic_foo$0$anon0

--- a/Test/civl/parallel1.bpl.expect
+++ b/Test/civl/parallel1.bpl.expect
@@ -1,4 +1,4 @@
-parallel1.bpl(23,1): Error BP5001: Non-interference check failed
+parallel1.bpl(23,1): Error: Non-interference check failed
 Execution trace:
     parallel1.bpl(7,3): anon0
     parallel1.bpl(12,5): inline$AtomicIncr$0$anon0

--- a/Test/civl/parallel4.bpl.expect
+++ b/Test/civl/parallel4.bpl.expect
@@ -1,4 +1,4 @@
-parallel4.bpl(26,3): Error BP5001: This assertion might not hold.
+parallel4.bpl(26,3): Error: This assertion might not hold.
 Execution trace:
     parallel4.bpl(24,5): anon0
     parallel4.bpl(24,5): anon0_0

--- a/Test/civl/parallel6.bpl.expect
+++ b/Test/civl/parallel6.bpl.expect
@@ -1,4 +1,4 @@
-parallel6.bpl(8,64): Error BP5001: A yield-to-yield fragment modifies layer-2 state subsequent to a yield-to-yield fragment that already modified layer-2 state
+parallel6.bpl(8,64): Error: A yield-to-yield fragment modifies layer-2 state subsequent to a yield-to-yield fragment that already modified layer-2 state
 Execution trace:
     parallel6.bpl(10,5): anon0
     parallel6.bpl(28,7): inline$atomic_incr$0$anon0

--- a/Test/civl/pending-async-1.bpl.expect
+++ b/Test/civl/pending-async-1.bpl.expect
@@ -1,4 +1,4 @@
-pending-async-1.bpl(48,49): Error BP5001: On some path no yield-to-yield fragment matched the refined atomic action
+pending-async-1.bpl(48,49): Error: On some path no yield-to-yield fragment matched the refined atomic action
 Execution trace:
     pending-async-1.bpl(50,3): anon0
     pending-async-1.bpl(16,7): inline$B$0$anon0
@@ -6,7 +6,7 @@ Execution trace:
     pending-async-1.bpl(16,7): inline$B$1$anon0
     pending-async-1.bpl(50,3): anon0$2
     (0,0): Civl_ReturnChecker
-pending-async-1.bpl(64,3): Error BP5001: Pending asyncs created by this call are not summarized
+pending-async-1.bpl(64,3): Error: Pending asyncs created by this call are not summarized
 Execution trace:
     pending-async-1.bpl(64,3): anon0
     pending-async-1.bpl(21,7): inline$C$0$anon0

--- a/Test/civl/pending-async-2.bpl.expect
+++ b/Test/civl/pending-async-2.bpl.expect
@@ -1,9 +1,9 @@
-pending-async-2.bpl(19,29): Error BP5001: Action C might create undeclared pending asyncs
+pending-async-2.bpl(19,29): Error: Action C might create undeclared pending asyncs
 Execution trace:
     pending-async-2.bpl(19,29): inline$C$0$Entry
     pending-async-2.bpl(22,7): inline$C$0$anon0
     pending-async-2.bpl(19,29): inline$C$0$Return
-pending-async-2.bpl(25,29): Error BP5001: Action D might create negative pending asyncs
+pending-async-2.bpl(25,29): Error: Action D might create negative pending asyncs
 Execution trace:
     pending-async-2.bpl(25,29): inline$D$0$Entry
     pending-async-2.bpl(25,29): inline$D$0$Return

--- a/Test/civl/pending-async-linearity.bpl.expect
+++ b/Test/civl/pending-async-linearity.bpl.expect
@@ -1,24 +1,24 @@
-pending-async-linearity.bpl(22,1): Error BP5001: Potential linearity violation in outputs and pending async of A for domain pid.
+pending-async-linearity.bpl(22,1): Error: Potential linearity violation in outputs and pending async of A for domain pid.
 Execution trace:
     pending-async-linearity.bpl(22,1): inline$M0$0$Entry
     pending-async-linearity.bpl(25,7): inline$M0$0$anon0
     (0,0): single_A
-pending-async-linearity.bpl(36,1): Error BP5001: Potential linearity violation in outputs and pending async of A for domain pid.
+pending-async-linearity.bpl(36,1): Error: Potential linearity violation in outputs and pending async of A for domain pid.
 Execution trace:
     pending-async-linearity.bpl(36,1): inline$M2$0$Entry
     pending-async-linearity.bpl(39,7): inline$M2$0$anon0
     (0,0): single_A
-pending-async-linearity.bpl(50,1): Error BP5001: Potential lnearity violation in pending asyncs of A and B for domain pid.
+pending-async-linearity.bpl(50,1): Error: Potential lnearity violation in pending asyncs of A and B for domain pid.
 Execution trace:
     pending-async-linearity.bpl(50,1): inline$M4$0$Entry
     pending-async-linearity.bpl(53,7): inline$M4$0$anon0
     (0,0): distinct_A_B
-pending-async-linearity.bpl(57,1): Error BP5001: Potential linearity violation in outputs and pending async of A for domain pid.
+pending-async-linearity.bpl(57,1): Error: Potential linearity violation in outputs and pending async of A for domain pid.
 Execution trace:
     pending-async-linearity.bpl(57,1): inline$M5$0$Entry
     pending-async-linearity.bpl(60,11): inline$M5$0$anon0
     (0,0): single_A
-pending-async-linearity.bpl(81,1): Error BP5001: Potential linearity violation in outputs and pending async of A for domain pid.
+pending-async-linearity.bpl(81,1): Error: Potential linearity violation in outputs and pending async of A for domain pid.
 Execution trace:
     pending-async-linearity.bpl(81,1): inline$M8$0$Entry
     pending-async-linearity.bpl(84,3): inline$M8$0$anon0

--- a/Test/civl/pending-async-noninterference-fail.bpl.expect
+++ b/Test/civl/pending-async-noninterference-fail.bpl.expect
@@ -1,4 +1,4 @@
-pending-async-noninterference-fail.bpl(7,1): Error BP5001: Non-interference check failed
+pending-async-noninterference-fail.bpl(7,1): Error: Non-interference check failed
 Execution trace:
     pending-async-noninterference-fail.bpl(15,31): inline$A$0$Entry
     pending-async-noninterference-fail.bpl(18,5): inline$A$0$anon0

--- a/Test/civl/r2.bpl.expect
+++ b/Test/civl/r2.bpl.expect
@@ -1,10 +1,10 @@
-r2.bpl(10,57): Error BP5001: On some path no yield-to-yield fragment matched the refined atomic action
+r2.bpl(10,57): Error: On some path no yield-to-yield fragment matched the refined atomic action
 Execution trace:
     r2.bpl(11,5): anon0
     (0,0): Civl_call_refinement_4
     r2.bpl(21,34): inline$atomic_nop$0$Return
     (0,0): Civl_ReturnChecker
-r2.bpl(10,57): Error BP5001: A yield-to-yield fragment illegally modifies layer-2 globals
+r2.bpl(10,57): Error: A yield-to-yield fragment illegally modifies layer-2 globals
 Execution trace:
     r2.bpl(11,5): anon0
     (0,0): Civl_call_refinement_3

--- a/Test/civl/refinement.bpl.expect
+++ b/Test/civl/refinement.bpl.expect
@@ -1,27 +1,27 @@
-refinement.bpl(6,48): Error BP5001: A yield-to-yield fragment modifies layer-2 state subsequent to a yield-to-yield fragment that already modified layer-2 state
+refinement.bpl(6,48): Error: A yield-to-yield fragment modifies layer-2 state subsequent to a yield-to-yield fragment that already modified layer-2 state
 Execution trace:
     refinement.bpl(8,3): anon0
     refinement.bpl(52,5): inline$INCR$0$anon0
     refinement.bpl(8,3): anon0_0
     refinement.bpl(52,5): inline$INCR$1$anon0
     (0,0): Civl_ReturnChecker
-refinement.bpl(13,48): Error BP5001: A yield-to-yield fragment modifies layer-2 state in a way that does not match the refined atomic action
+refinement.bpl(13,48): Error: A yield-to-yield fragment modifies layer-2 state in a way that does not match the refined atomic action
 Execution trace:
     refinement.bpl(15,3): anon0
     refinement.bpl(58,5): inline$DECR$0$anon0
     (0,0): Civl_RefinementChecker
-refinement.bpl(13,48): Error BP5001: A yield-to-yield fragment modifies layer-2 state subsequent to a yield-to-yield fragment that already modified layer-2 state
+refinement.bpl(13,48): Error: A yield-to-yield fragment modifies layer-2 state subsequent to a yield-to-yield fragment that already modified layer-2 state
 Execution trace:
     refinement.bpl(15,3): anon0
     refinement.bpl(58,5): inline$DECR$0$anon0
     refinement.bpl(15,3): anon0_0
     refinement.bpl(52,5): inline$INCR$0$anon0
     (0,0): Civl_ReturnChecker
-refinement.bpl(33,48): Error BP5001: On some path no yield-to-yield fragment matched the refined atomic action
+refinement.bpl(33,48): Error: On some path no yield-to-yield fragment matched the refined atomic action
 Execution trace:
     refinement.bpl(36,1): anon0
     (0,0): Civl_ReturnChecker
-refinement.bpl(38,48): Error BP5001: A yield-to-yield fragment illegally modifies layer-2 globals
+refinement.bpl(38,48): Error: A yield-to-yield fragment illegally modifies layer-2 globals
 Execution trace:
     refinement.bpl(40,3): anon0
     refinement.bpl(52,5): inline$INCR$0$anon0

--- a/Test/civl/t1.bpl.expect
+++ b/Test/civl/t1.bpl.expect
@@ -1,4 +1,4 @@
-t1.bpl(55,5): Error BP5001: Non-interference check failed
+t1.bpl(55,5): Error: Non-interference check failed
 Execution trace:
     t1.bpl(74,13): anon0
     t1.bpl(74,13): anon0_1

--- a/Test/civl/yield-invariant-fails.bpl.expect
+++ b/Test/civl/yield-invariant-fails.bpl.expect
@@ -1,4 +1,4 @@
-yield-invariant-fails.bpl(7,1): Error BP5001: Non-interference check failed
+yield-invariant-fails.bpl(7,1): Error: Non-interference check failed
 Execution trace:
     yield-invariant-fails.bpl(11,5): anon0
     yield-invariant-fails.bpl(18,7): inline$atomic_A$0$anon0

--- a/Test/codeexpr/CodeExpr0.bpl.expect
+++ b/Test/codeexpr/CodeExpr0.bpl.expect
@@ -1,10 +1,10 @@
-CodeExpr0.bpl(17,3): Error BP5001: This assertion might not hold.
+CodeExpr0.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     CodeExpr0.bpl(17,3): anon0
-CodeExpr0.bpl(22,3): Error BP5001: This assertion might not hold.
+CodeExpr0.bpl(22,3): Error: This assertion might not hold.
 Execution trace:
     CodeExpr0.bpl(22,3): anon0
-CodeExpr0.bpl(54,3): Error BP5001: This assertion might not hold.
+CodeExpr0.bpl(54,3): Error: This assertion might not hold.
 Execution trace:
     CodeExpr0.bpl(54,3): anon0
 

--- a/Test/codeexpr/CodeExpr1.bpl.expect
+++ b/Test/codeexpr/CodeExpr1.bpl.expect
@@ -1,11 +1,11 @@
-CodeExpr1.bpl(46,5): Error BP5003: A postcondition might not hold on this return path.
+CodeExpr1.bpl(46,5): Error: A postcondition might not hold on this return path.
 CodeExpr1.bpl(42,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     CodeExpr1.bpl(44,3): start
-CodeExpr1.bpl(54,5): Error BP5001: This assertion might not hold.
+CodeExpr1.bpl(54,5): Error: This assertion might not hold.
 Execution trace:
     CodeExpr1.bpl(51,3): start
-CodeExpr1.bpl(68,5): Error BP5001: This assertion might not hold.
+CodeExpr1.bpl(68,5): Error: This assertion might not hold.
 Execution trace:
     CodeExpr1.bpl(59,3): start
 

--- a/Test/commandline/noProc.bpl.1.expect
+++ b/Test/commandline/noProc.bpl.1.expect
@@ -1,7 +1,7 @@
-noProc.bpl(10,3): Error BP5001: This assertion might not hold.
+noProc.bpl(10,3): Error: This assertion might not hold.
 Execution trace:
     noProc.bpl(10,3): anon0
-noProc.bpl(15,3): Error BP5001: This assertion might not hold.
+noProc.bpl(15,3): Error: This assertion might not hold.
 Execution trace:
     noProc.bpl(15,3): anon0
 

--- a/Test/commandline/noProc.bpl.2.expect
+++ b/Test/commandline/noProc.bpl.2.expect
@@ -1,4 +1,4 @@
-noProc.bpl(10,3): Error BP5001: This assertion might not hold.
+noProc.bpl(10,3): Error: This assertion might not hold.
 Execution trace:
     noProc.bpl(10,3): anon0
 

--- a/Test/commandline/noProc.bpl.3.expect
+++ b/Test/commandline/noProc.bpl.3.expect
@@ -1,7 +1,7 @@
-noProc.bpl(10,3): Error BP5001: This assertion might not hold.
+noProc.bpl(10,3): Error: This assertion might not hold.
 Execution trace:
     noProc.bpl(10,3): anon0
-noProc.bpl(15,3): Error BP5001: This assertion might not hold.
+noProc.bpl(15,3): Error: This assertion might not hold.
 Execution trace:
     noProc.bpl(15,3): anon0
 

--- a/Test/datatypes/t1.bpl.expect
+++ b/Test/datatypes/t1.bpl.expect
@@ -1,4 +1,4 @@
-t1.bpl(25,3): Error BP5001: This assertion might not hold.
+t1.bpl(25,3): Error: This assertion might not hold.
 Execution trace:
     t1.bpl(18,3): anon0
 

--- a/Test/datatypes/t2.bpl.expect
+++ b/Test/datatypes/t2.bpl.expect
@@ -1,4 +1,4 @@
-t2.bpl(25,3): Error BP5001: This assertion might not hold.
+t2.bpl(25,3): Error: This assertion might not hold.
 Execution trace:
     t2.bpl(18,3): anon0
 

--- a/Test/extractloops/detLoopExtractNested.bpl.expect
+++ b/Test/extractloops/detLoopExtractNested.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     detLoopExtractNested.bpl(12,12): anon0
     detLoopExtractNested.bpl(14,8): anon5_LoopBody

--- a/Test/extractloops/t1.bpl.expect
+++ b/Test/extractloops/t1.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     t1.bpl(19,3): anon0
     t1.bpl(24,3): anon3_LoopHead

--- a/Test/extractloops/t2.bpl.expect
+++ b/Test/extractloops/t2.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     t2.bpl(18,3): anon0
     t2.bpl(23,3): anon3_LoopHead

--- a/Test/extractloops/t3.bpl.rb4.expect
+++ b/Test/extractloops/t3.bpl.rb4.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     t3.bpl(19,3): anon0
     t3.bpl(28,3): anon3_LoopBody

--- a/Test/floats/BasicOperators3.bpl.expect
+++ b/Test/floats/BasicOperators3.bpl.expect
@@ -1,4 +1,4 @@
-BasicOperators3.bpl(12,3): Error BP5001: This assertion might not hold.
+BasicOperators3.bpl(12,3): Error: This assertion might not hold.
 Execution trace:
     BasicOperators3.bpl(8,5): anon0
 

--- a/Test/floats/Equal1.bpl.expect
+++ b/Test/floats/Equal1.bpl.expect
@@ -1,4 +1,4 @@
-Equal1.bpl(14,3): Error BP5001: This assertion might not hold.
+Equal1.bpl(14,3): Error: This assertion might not hold.
 Execution trace:
     Equal1.bpl(12,3): anon0
 

--- a/Test/floats/Havoc.bpl.expect
+++ b/Test/floats/Havoc.bpl.expect
@@ -1,4 +1,4 @@
-Havoc.bpl(17,3): Error BP5001: This assertion might not hold.
+Havoc.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     Havoc.bpl(16,3): anon0
 

--- a/Test/floats/RoundoffError.bpl.expect
+++ b/Test/floats/RoundoffError.bpl.expect
@@ -1,4 +1,4 @@
-RoundoffError.bpl(21,3): Error BP5001: This assertion might not hold.
+RoundoffError.bpl(21,3): Error: This assertion might not hold.
 Execution trace:
     RoundoffError.bpl(12,8): anon0
     RoundoffError.bpl(16,3): anon3_LoopDone

--- a/Test/floats/git-issue80.bpl.expect
+++ b/Test/floats/git-issue80.bpl.expect
@@ -1,4 +1,4 @@
-git-issue80.bpl(11,3): Error BP5001: This assertion might not hold.
+git-issue80.bpl(11,3): Error: This assertion might not hold.
 Execution trace:
     git-issue80.bpl(11,3): anon0
 

--- a/Test/floats/issue110.bpl.expect
+++ b/Test/floats/issue110.bpl.expect
@@ -1,4 +1,4 @@
-issue110.bpl(5,3): Error BP5001: This assertion might not hold.
+issue110.bpl(5,3): Error: This assertion might not hold.
 Execution trace:
     issue110.bpl(5,3): anon0
 *** MODEL

--- a/Test/functiondefine/fundef2.bpl.expect
+++ b/Test/functiondefine/fundef2.bpl.expect
@@ -1,4 +1,4 @@
-fundef2.bpl(24,3): Error BP5003: A postcondition might not hold on this return path.
+fundef2.bpl(24,3): Error: A postcondition might not hold on this return path.
 fundef2.bpl(20,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     fundef2.bpl(22,3): anon0

--- a/Test/functiondefine/fundef7.bpl.expect
+++ b/Test/functiondefine/fundef7.bpl.expect
@@ -1,4 +1,4 @@
-fundef7.bpl(32,5): Error BP5001: This assertion might not hold.
+fundef7.bpl(32,5): Error: This assertion might not hold.
 Execution trace:
     fundef7.bpl(28,3): anon0
     fundef7.bpl(32,5): anon3_Then

--- a/Test/houdini/houd10.bpl.expect
+++ b/Test/houdini/houd10.bpl.expect
@@ -2,7 +2,7 @@ Assignment computed by Houdini:
 b1 = True
 b2 = True
 b3 = True
-houd10.bpl(17,3): Error BP5002: A precondition for this call might not hold.
+houd10.bpl(17,3): Error: A precondition for this call might not hold.
 houd10.bpl(22,1): Related location: This is the precondition that might not hold.
 Execution trace:
     houd10.bpl(16,9): anon0

--- a/Test/houdini/houd11.bpl.expect
+++ b/Test/houdini/houd11.bpl.expect
@@ -1,5 +1,5 @@
 Assignment computed by Houdini:
-houd11.bpl(10,3): Error BP5001: This assertion might not hold.
+houd11.bpl(10,3): Error: This assertion might not hold.
 Execution trace:
     houd11.bpl(9,9): anon0
 

--- a/Test/houdini/houd2.bpl.expect
+++ b/Test/houdini/houd2.bpl.expect
@@ -1,7 +1,7 @@
 Assignment computed by Houdini:
 b1 = False
 b2 = True
-houd2.bpl(14,1): Error BP5003: A postcondition might not hold on this return path.
+houd2.bpl(14,1): Error: A postcondition might not hold on this return path.
 houd2.bpl(11,1): Related location: This is the postcondition that might not hold.
 Execution trace:
     houd2.bpl(13,3): anon0

--- a/Test/houdini/houd9.bpl.expect
+++ b/Test/houdini/houd9.bpl.expect
@@ -2,7 +2,7 @@ Assignment computed by Houdini:
 b1 = True
 b2 = True
 b3 = True
-houd9.bpl(21,3): Error BP5001: This assertion might not hold.
+houd9.bpl(21,3): Error: This assertion might not hold.
 Execution trace:
     houd9.bpl(20,9): anon0
 

--- a/Test/inline/Elevator.bpl.expect
+++ b/Test/inline/Elevator.bpl.expect
@@ -1,4 +1,4 @@
-Elevator.bpl(20,5): Error BP5005: This loop invariant might not be maintained by the loop.
+Elevator.bpl(20,5): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Elevator.bpl(18,3): anon0
     Elevator.bpl(18,3): anon0$1
@@ -8,7 +8,7 @@ Execution trace:
     Elevator.bpl(27,7): anon13_Then$1
 
 Boogie program verifier finished with 1 verified, 1 error
-Elevator.bpl(20,5): Error BP5005: This loop invariant might not be maintained by the loop.
+Elevator.bpl(20,5): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Elevator.bpl(18,3): anon0
     Elevator.bpl(71,23): inline$Initialize$0$Entry

--- a/Test/inline/InliningAndLoops.bpl.expect
+++ b/Test/inline/InliningAndLoops.bpl.expect
@@ -1,4 +1,4 @@
-InliningAndLoops.bpl(14,5): Error BP5001: This assertion might not hold.
+InliningAndLoops.bpl(14,5): Error: This assertion might not hold.
 Execution trace:
     InliningAndLoops.bpl(7,10): anon0#3
     InliningAndLoops.bpl(10,5): anon4_LoopBody#3

--- a/Test/inline/codeexpr.bpl.expect
+++ b/Test/inline/codeexpr.bpl.expect
@@ -1,4 +1,4 @@
-codeexpr.bpl(42,5): Error BP5001: This assertion might not hold.
+codeexpr.bpl(42,5): Error: This assertion might not hold.
 Execution trace:
     codeexpr.bpl(41,7): anon0
 

--- a/Test/inline/fundef2.bpl.expect
+++ b/Test/inline/fundef2.bpl.expect
@@ -1,4 +1,4 @@
-fundef2.bpl(8,3): Error BP5001: This assertion might not hold.
+fundef2.bpl(8,3): Error: This assertion might not hold.
 Execution trace:
     fundef2.bpl(7,3): anon0
 

--- a/Test/inline/polyInline.bpl.expect
+++ b/Test/inline/polyInline.bpl.expect
@@ -1,10 +1,10 @@
 polyInline.bpl(30,9): Warning: type parameter alpha is ambiguous, instantiating to int
 polyInline.bpl(34,9): Warning: type parameter alpha is ambiguous, instantiating to int
 polyInline.bpl(38,9): Warning: type parameter alpha is ambiguous, instantiating to int
-polyInline.bpl(26,3): Error BP5001: This assertion might not hold.
+polyInline.bpl(26,3): Error: This assertion might not hold.
 Execution trace:
     polyInline.bpl(23,3): anon0
-polyInline.bpl(42,3): Error BP5001: This assertion might not hold.
+polyInline.bpl(42,3): Error: This assertion might not hold.
 Execution trace:
     polyInline.bpl(30,3): anon0
 
@@ -12,10 +12,10 @@ Boogie program verifier finished with 0 verified, 2 errors
 polyInline.bpl(30,9): Warning: type parameter alpha is ambiguous, instantiating to int
 polyInline.bpl(34,9): Warning: type parameter alpha is ambiguous, instantiating to int
 polyInline.bpl(38,9): Warning: type parameter alpha is ambiguous, instantiating to int
-polyInline.bpl(26,3): Error BP5001: This assertion might not hold.
+polyInline.bpl(26,3): Error: This assertion might not hold.
 Execution trace:
     polyInline.bpl(23,3): anon0
-polyInline.bpl(42,3): Error BP5001: This assertion might not hold.
+polyInline.bpl(42,3): Error: This assertion might not hold.
 Execution trace:
     polyInline.bpl(30,3): anon0
 

--- a/Test/inline/test0.bpl.expect
+++ b/Test/inline/test0.bpl.expect
@@ -1,4 +1,4 @@
-test0.bpl(32,5): Error BP5001: This assertion might not hold.
+test0.bpl(32,5): Error: This assertion might not hold.
 Execution trace:
     test0.bpl(28,3): anon0
     test0.bpl(32,5): anon3_Then

--- a/Test/inline/test4.bpl.expect
+++ b/Test/inline/test4.bpl.expect
@@ -295,7 +295,7 @@ implementation {:inline 1} find(A: [int]int, size: int, x: int) returns (ret: in
 }
 
 
-<console>(70,4): Error BP5003: A postcondition might not hold on this return path.
+<console>(70,4): Error: A postcondition might not hold on this return path.
 <console>(78,2): Related location: This is the postcondition that might not hold.
 Execution trace:
     <console>(19,0): anon0
@@ -304,7 +304,7 @@ Execution trace:
     <console>(43,0): inline$check$0$Entry
     <console>(54,0): inline$check$0$anon4_Else
     <console>(67,0): inline$check$0$Return
-<console>(109,4): Error BP5001: This assertion might not hold.
+<console>(109,4): Error: This assertion might not hold.
 Execution trace:
     <console>(19,0): anon0
     <console>(29,0): inline$find$0$anon0
@@ -314,7 +314,7 @@ Execution trace:
     <console>(67,0): inline$check$0$Return
     <console>(79,0): inline$find$0$anon5_Then
     <console>(107,0): anon3_Then
-<console>(51,4): Error BP5003: A postcondition might not hold on this return path.
+<console>(51,4): Error: A postcondition might not hold on this return path.
 <console>(78,2): Related location: This is the postcondition that might not hold.
 Execution trace:
     <console>(10,0): anon0
@@ -322,7 +322,7 @@ Execution trace:
     <console>(24,0): inline$check$0$Entry
     <console>(35,0): inline$check$0$anon4_Else
     <console>(48,0): inline$check$0$Return
-<console>(99,0): Error BP5003: A postcondition might not hold on this return path.
+<console>(99,0): Error: A postcondition might not hold on this return path.
 <console>(78,2): Related location: This is the postcondition that might not hold.
 Execution trace:
     <console>(85,0): anon0

--- a/Test/inline/test5.bpl.expect
+++ b/Test/inline/test5.bpl.expect
@@ -1,4 +1,4 @@
-test5.bpl(39,3): Error BP5001: This assertion might not hold.
+test5.bpl(39,3): Error: This assertion might not hold.
 Execution trace:
     test5.bpl(36,10): anon0
     test5.bpl(30,10): inline$P$0$anon0

--- a/Test/inline/test7.bpl.expect
+++ b/Test/inline/test7.bpl.expect
@@ -66,17 +66,17 @@ implementation foo(a: ref)
 }
 
 
-<console>(16,4): Error BP5001: This assertion might not hold.
+<console>(16,4): Error: This assertion might not hold.
 Execution trace:
     <console>(15,0): anon0
-<console>(17,4): Error BP5001: This assertion might not hold.
+<console>(17,4): Error: This assertion might not hold.
 Execution trace:
     <console>(15,0): anon0
-<console>(13,4): Error BP5001: This assertion might not hold.
+<console>(13,4): Error: This assertion might not hold.
 Execution trace:
     <console>(5,0): anon0
     <console>(12,0): inline$b$0$anon0
-<console>(14,4): Error BP5001: This assertion might not hold.
+<console>(14,4): Error: This assertion might not hold.
 Execution trace:
     <console>(5,0): anon0
     <console>(12,0): inline$b$0$anon0

--- a/Test/livevars/bla1.bpl.expect
+++ b/Test/livevars/bla1.bpl.expect
@@ -1,4 +1,4 @@
-bla1.bpl(2097,5): Error BP5001: This assertion might not hold.
+bla1.bpl(2097,5): Error: This assertion might not hold.
 Execution trace:
     bla1.bpl(751,3): start#1
     bla1.bpl(791,3): anon10_Then#1

--- a/Test/livevars/daytona_bug2_ioctl_example_2.bpl.expect
+++ b/Test/livevars/daytona_bug2_ioctl_example_2.bpl.expect
@@ -1,3 +1,3 @@
-daytona_bug2_ioctl_example_2.bpl(4835,5): Error BP5001: This assertion might not hold.
+daytona_bug2_ioctl_example_2.bpl(4835,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error

--- a/Test/livevars/stack_overflow.bpl.expect
+++ b/Test/livevars/stack_overflow.bpl.expect
@@ -1,4 +1,4 @@
-stack_overflow.bpl(97944,5): Error BP5001: This assertion might not hold.
+stack_overflow.bpl(97944,5): Error: This assertion might not hold.
 Execution trace:
     stack_overflow.bpl(1143,3): start#1
     stack_overflow.bpl(1199,3): inline$storm_IoAllocateIrp$0$label_8_case_1#1

--- a/Test/lock/LockIncorrect.bpl.expect
+++ b/Test/lock/LockIncorrect.bpl.expect
@@ -1,4 +1,4 @@
-LockIncorrect.bpl(19,3): Error BP5001: This assertion might not hold.
+LockIncorrect.bpl(19,3): Error: This assertion might not hold.
 Execution trace:
     LockIncorrect.bpl(11,1): start
     LockIncorrect.bpl(16,1): LoopHead

--- a/Test/optimization/Optimization0.bpl.expect
+++ b/Test/optimization/Optimization0.bpl.expect
@@ -13,7 +13,7 @@ may_fail -> {
   else -> false
 }
 *** END_MODEL
-Optimization0.bpl(13,5): Error BP5001: This assertion might not hold.
+Optimization0.bpl(13,5): Error: This assertion might not hold.
 Execution trace:
     Optimization0.bpl(10,5): anon0
 *** MODEL
@@ -32,7 +32,7 @@ may_fail -> {
   else -> false
 }
 *** END_MODEL
-Optimization0.bpl(25,5): Error BP5001: This assertion might not hold.
+Optimization0.bpl(25,5): Error: This assertion might not hold.
 Execution trace:
     Optimization0.bpl(20,7): anon0
     Optimization0.bpl(21,5): anon3_Else
@@ -49,7 +49,7 @@ tickleBool -> {
   else -> true
 }
 *** END_MODEL
-Optimization0.bpl(37,5): Error BP5001: This assertion might not hold.
+Optimization0.bpl(37,5): Error: This assertion might not hold.
 Execution trace:
     Optimization0.bpl(32,7): anon0
     Optimization0.bpl(33,5): anon3_LoopHead
@@ -69,7 +69,7 @@ may_fail -> {
   else -> false
 }
 *** END_MODEL
-Optimization0.bpl(47,5): Error BP5001: This assertion might not hold.
+Optimization0.bpl(47,5): Error: This assertion might not hold.
 Execution trace:
     Optimization0.bpl(44,5): anon0
 *** MODEL
@@ -88,7 +88,7 @@ may_fail -> {
   else -> false
 }
 *** END_MODEL
-Optimization0.bpl(59,5): Error BP5001: This assertion might not hold.
+Optimization0.bpl(59,5): Error: This assertion might not hold.
 Execution trace:
     Optimization0.bpl(54,7): anon0
     Optimization0.bpl(56,11): anon3_Then
@@ -105,7 +105,7 @@ tickleBool -> {
   else -> true
 }
 *** END_MODEL
-Optimization0.bpl(71,5): Error BP5001: This assertion might not hold.
+Optimization0.bpl(71,5): Error: This assertion might not hold.
 Execution trace:
     Optimization0.bpl(66,7): anon0
     Optimization0.bpl(67,5): anon3_LoopHead
@@ -126,7 +126,7 @@ may_fail -> {
   else -> false
 }
 *** END_MODEL
-Optimization0.bpl(83,5): Error BP5001: This assertion might not hold.
+Optimization0.bpl(83,5): Error: This assertion might not hold.
 Execution trace:
     Optimization0.bpl(78,7): anon0
     Optimization0.bpl(80,11): anon3_Then

--- a/Test/optimization/Optimization3.bpl.expect
+++ b/Test/optimization/Optimization3.bpl.expect
@@ -9,7 +9,7 @@ tickleBool -> {
   else -> true
 }
 *** END_MODEL
-Optimization3.bpl(10,5): Error BP5001: This assertion might not hold.
+Optimization3.bpl(10,5): Error: This assertion might not hold.
 Execution trace:
     Optimization3.bpl(8,5): anon0
 *** MODEL
@@ -24,7 +24,7 @@ tickleBool -> {
   else -> true
 }
 *** END_MODEL
-Optimization3.bpl(19,5): Error BP5001: This assertion might not hold.
+Optimization3.bpl(19,5): Error: This assertion might not hold.
 Execution trace:
     Optimization3.bpl(17,5): anon0
 

--- a/Test/prover/EQ_v2.Eval__v4.Eval_out.bpl.expect
+++ b/Test/prover/EQ_v2.Eval__v4.Eval_out.bpl.expect
@@ -1,4 +1,4 @@
-EQ_v2.Eval__v4.Eval_out.bpl(2103,5): Error BP5003: A postcondition might not hold on this return path.
+EQ_v2.Eval__v4.Eval_out.bpl(2103,5): Error: A postcondition might not hold on this return path.
 EQ_v2.Eval__v4.Eval_out.bpl(1717,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     EQ_v2.Eval__v4.Eval_out.bpl(1788,3): AA_INSTR_EQ_BODY
@@ -7,11 +7,11 @@ Execution trace:
     EQ_v2.Eval__v4.Eval_out.bpl(1991,3): inline$v4.Eval$0$label_11_case_2#2
     EQ_v2.Eval__v4.Eval_out.bpl(2013,3): inline$v4.Eval$0$label_14_true#2
     EQ_v2.Eval__v4.Eval_out.bpl(2083,3): inline$v4.Eval$0$label_12#2
-EQ_v2.Eval__v4.Eval_out.bpl(2154,5): Error BP5003: A postcondition might not hold on this return path.
+EQ_v2.Eval__v4.Eval_out.bpl(2154,5): Error: A postcondition might not hold on this return path.
 EQ_v2.Eval__v4.Eval_out.bpl(2122,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     EQ_v2.Eval__v4.Eval_out.bpl(2135,3): AA_INSTR_EQ_BODY
-EQ_v2.Eval__v4.Eval_out.bpl(2194,5): Error BP5003: A postcondition might not hold on this return path.
+EQ_v2.Eval__v4.Eval_out.bpl(2194,5): Error: A postcondition might not hold on this return path.
 EQ_v2.Eval__v4.Eval_out.bpl(2169,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     EQ_v2.Eval__v4.Eval_out.bpl(2180,3): AA_INSTR_EQ_BODY

--- a/Test/prover/z3mutl.bpl.expect
+++ b/Test/prover/z3mutl.bpl.expect
@@ -1,4 +1,4 @@
-z3mutl.bpl(22,5): Error BP5001: This assertion might not hold.
+z3mutl.bpl(22,5): Error: This assertion might not hold.
 Execution trace:
     z3mutl.bpl(7,1): start
     z3mutl.bpl(13,1): L2

--- a/Test/snapshots/runtest.AI.snapshot.expect
+++ b/Test/snapshots/runtest.AI.snapshot.expect
@@ -4,6 +4,6 @@ Processing command (at Snapshots29.v0.bpl(14,5)) assert i == 0;
 Boogie program verifier finished with 1 verified, 0 errors
 Processing command (at Snapshots29.v1.bpl(14,5)) assert i == 0;
   >>> DoNothingToAssert
-Snapshots29.v1.bpl(14,5): Error BP5001: This assertion might not hold.
+Snapshots29.v1.bpl(14,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error

--- a/Test/snapshots/runtest.snapshot.expect
+++ b/Test/snapshots/runtest.snapshot.expect
@@ -1,28 +1,28 @@
 Processing command (at Snapshots0.v0.bpl(41,5)) assert false;
   >>> DoNothingToAssert
-Snapshots0.v0.bpl(41,5): Error BP5001: This assertion might not hold.
+Snapshots0.v0.bpl(41,5): Error: This assertion might not hold.
 Processing command (at Snapshots0.v0.bpl(8,5)) assert false;
   >>> DoNothingToAssert
-Snapshots0.v0.bpl(8,5): Error BP5001: This assertion might not hold.
+Snapshots0.v0.bpl(8,5): Error: This assertion might not hold.
 Processing command (at Snapshots0.v0.bpl(19,5)) assert false;
   >>> DoNothingToAssert
-Snapshots0.v0.bpl(19,5): Error BP5001: This assertion might not hold.
+Snapshots0.v0.bpl(19,5): Error: This assertion might not hold.
 Processing command (at Snapshots0.v0.bpl(30,5)) assert false;
   >>> DoNothingToAssert
-Snapshots0.v0.bpl(30,5): Error BP5001: This assertion might not hold.
+Snapshots0.v0.bpl(30,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 4 errors
-Snapshots0.v0.bpl(41,5): Error BP5001: This assertion might not hold.
+Snapshots0.v0.bpl(41,5): Error: This assertion might not hold.
 Processing command (at Snapshots0.v1.bpl(19,5)) assert true;
   >>> DoNothingToAssert
 Processing command (at Snapshots0.v1.bpl(30,5)) assert false;
   >>> DoNothingToAssert
-Snapshots0.v1.bpl(30,5): Error BP5001: This assertion might not hold.
+Snapshots0.v1.bpl(30,5): Error: This assertion might not hold.
 Processing command (at Snapshots0.v1.bpl(41,5)) assert true;
   >>> DoNothingToAssert
 
 Boogie program verifier finished with 2 verified, 2 errors
-Snapshots0.v0.bpl(41,5): Error BP5001: This assertion might not hold.
+Snapshots0.v0.bpl(41,5): Error: This assertion might not hold.
 Processing command (at Snapshots0.v2.bpl(19,5)) assert true;
   >>> DoNothingToAssert
 Processing command (at Snapshots0.v2.bpl(30,5)) assert true;
@@ -31,12 +31,12 @@ Processing command (at Snapshots0.v2.bpl(30,5)) assert true;
 Boogie program verifier finished with 2 verified, 1 error
 Processing command (at Snapshots1.v0.bpl(13,5)) assert 1 != 1;
   >>> DoNothingToAssert
-Snapshots1.v0.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots1.v0.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 1 verified, 1 error
 Processing command (at Snapshots1.v1.bpl(13,5)) assert 2 != 2;
   >>> DoNothingToAssert
-Snapshots1.v1.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots1.v1.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 1 verified, 1 error
 Processing call to procedure P2 in implementation P1 (at Snapshots1.v2.bpl(5,5)):
@@ -47,7 +47,7 @@ Processing command (at Snapshots1.v2.bpl(5,5)) assert false;
   >>> DoNothingToAssert
 Processing command (at <unknown location>) a##cached##0 := a##cached##0 && true;
   >>> AssumeNegationOfAssumptionVariable
-Snapshots1.v2.bpl(5,5): Error BP5002: A precondition for this call might not hold.
+Snapshots1.v2.bpl(5,5): Error: A precondition for this call might not hold.
 Snapshots1.v2.bpl(10,3): Related location: This is the precondition that might not hold.
 Processing command (at Snapshots1.v2.bpl(14,5)) assert 2 != 2;
   >>> DoNothingToAssert
@@ -98,7 +98,7 @@ Processing implementation P0 (at Snapshots3.v1.bpl(4,51)):
   >>> added after assuming the current precondition: a##cached##0 := a##cached##0 && false;
 Processing command (at Snapshots3.v1.bpl(2,1)) assert G();
   >>> DoNothingToAssert
-Snapshots3.v1.bpl(6,1): Error BP5003: A postcondition might not hold on this return path.
+Snapshots3.v1.bpl(6,1): Error: A postcondition might not hold on this return path.
 Snapshots3.v1.bpl(2,1): Related location: This is the postcondition that might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
@@ -108,10 +108,10 @@ Processing call to procedure P2 in implementation P1 (at Snapshots4.v1.bpl(14,5)
   >>> added after: a##cached##0 := a##cached##0 && false;
 Processing command (at Snapshots4.v1.bpl(23,5)) assert false;
   >>> DoNothingToAssert
-Snapshots4.v1.bpl(23,5): Error BP5001: This assertion might not hold.
+Snapshots4.v1.bpl(23,5): Error: This assertion might not hold.
 Processing command (at Snapshots4.v1.bpl(28,3)) assert G();
   >>> DoNothingToAssert
-Snapshots4.v1.bpl(33,1): Error BP5003: A postcondition might not hold on this return path.
+Snapshots4.v1.bpl(33,1): Error: A postcondition might not hold on this return path.
 Snapshots4.v1.bpl(28,3): Related location: This is the postcondition that might not hold.
 
 Boogie program verifier finished with 2 verified, 2 errors
@@ -123,7 +123,7 @@ Processing implementation P0 (at Snapshots5.v1.bpl(3,51)):
   >>> added after assuming the current precondition: a##cached##0 := a##cached##0 && false;
 Processing command (at Snapshots5.v1.bpl(5,5)) assert false;
   >>> DoNothingToAssert
-Snapshots5.v1.bpl(5,5): Error BP5001: This assertion might not hold.
+Snapshots5.v1.bpl(5,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots6.v0.bpl(13,5)) assert y == 0;
@@ -138,7 +138,7 @@ Processing command (at <unknown location>) a##cached##0 := a##cached##0 && ##ext
   >>> AssumeNegationOfAssumptionVariable
 Processing command (at Snapshots6.v1.bpl(13,5)) assert y == 0;
   >>> MarkAsPartiallyVerified
-Snapshots6.v1.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots6.v1.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots7.v0.bpl(14,5)) assert y < 0;
@@ -224,7 +224,7 @@ Processing command (at Snapshots11.v0.bpl(7,5)) assert 0 < call0formal#AT#n;
   >>> DoNothingToAssert
 Processing command (at Snapshots11.v0.bpl(9,5)) assert 0 <= x;
   >>> DoNothingToAssert
-Snapshots11.v0.bpl(7,5): Error BP5002: A precondition for this call might not hold.
+Snapshots11.v0.bpl(7,5): Error: A precondition for this call might not hold.
 Snapshots11.v0.bpl(13,3): Related location: This is the precondition that might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
@@ -239,7 +239,7 @@ Processing command (at Snapshots11.v1.bpl(7,5)) assert 0 < call0formal#AT#n;
   >>> RecycleError
 Processing command (at Snapshots11.v1.bpl(9,5)) assert 0 <= x;
   >>> MarkAsPartiallyVerified
-Snapshots11.v0.bpl(7,5): Error BP5002: A precondition for this call might not hold.
+Snapshots11.v0.bpl(7,5): Error: A precondition for this call might not hold.
 Snapshots11.v0.bpl(13,3): Related location: This is the precondition that might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
@@ -251,7 +251,7 @@ Processing call to procedure N in implementation M (at Snapshots12.v1.bpl(5,5)):
   >>> added after: a##cached##0 := a##cached##0 && false;
 Processing command (at Snapshots12.v1.bpl(7,5)) assert false;
   >>> DoNothingToAssert
-Snapshots12.v1.bpl(7,5): Error BP5001: This assertion might not hold.
+Snapshots12.v1.bpl(7,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots13.v0.bpl(7,5)) assert false;
@@ -262,7 +262,7 @@ Processing call to procedure N in implementation M (at Snapshots13.v1.bpl(5,5)):
   >>> added after: a##cached##0 := a##cached##0 && false;
 Processing command (at Snapshots13.v1.bpl(7,5)) assert false;
   >>> DoNothingToAssert
-Snapshots13.v1.bpl(7,5): Error BP5001: This assertion might not hold.
+Snapshots13.v1.bpl(7,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots14.v0.bpl(7,5)) assert false;
@@ -276,7 +276,7 @@ Processing command (at <unknown location>) a##cached##0 := a##cached##0 && ##ext
   >>> AssumeNegationOfAssumptionVariable
 Processing command (at Snapshots14.v1.bpl(7,5)) assert false;
   >>> MarkAsPartiallyVerified
-Snapshots14.v1.bpl(7,5): Error BP5001: This assertion might not hold.
+Snapshots14.v1.bpl(7,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots15.v0.bpl(5,5)) assert true;
@@ -297,7 +297,7 @@ Processing command (at Snapshots15.v1.bpl(9,5)) assert true;
   >>> MarkAsPartiallyVerified
 Processing command (at Snapshots15.v1.bpl(13,5)) assert false;
   >>> MarkAsPartiallyVerified
-Snapshots15.v1.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots15.v1.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots16.v0.bpl(14,5)) assert F(0) == 1;
@@ -306,7 +306,7 @@ Processing command (at Snapshots16.v0.bpl(14,5)) assert F(0) == 1;
 Boogie program verifier finished with 1 verified, 0 errors
 Processing command (at Snapshots16.v1.bpl(14,5)) assert F(0) == 1;
   >>> DoNothingToAssert
-Snapshots16.v1.bpl(14,5): Error BP5001: This assertion might not hold.
+Snapshots16.v1.bpl(14,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots17.v0.bpl(28,5)) assert true;
@@ -333,8 +333,8 @@ Processing command (at Snapshots17.v1.bpl(12,13)) assert true;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots17.v1.bpl(20,13)) assert x == 1;
   >>> MarkAsPartiallyVerified
-Snapshots17.v1.bpl(20,13): Error BP5001: This assertion might not hold.
-Snapshots17.v1.bpl(25,9): Error BP5001: This assertion might not hold.
+Snapshots17.v1.bpl(20,13): Error: This assertion might not hold.
+Snapshots17.v1.bpl(25,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 2 errors
 Processing command (at Snapshots18.v0.bpl(7,9)) assert 0 == 0;
@@ -355,15 +355,15 @@ Processing command (at Snapshots18.v1.bpl(17,9)) assert 1 != 1;
   >>> MarkAsPartiallyVerified
 Processing command (at Snapshots18.v1.bpl(20,5)) assert 2 != 2;
   >>> MarkAsPartiallyVerified
-Snapshots18.v1.bpl(17,9): Error BP5001: This assertion might not hold.
-Snapshots18.v1.bpl(20,5): Error BP5001: This assertion might not hold.
+Snapshots18.v1.bpl(17,9): Error: This assertion might not hold.
+Snapshots18.v1.bpl(20,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 2 errors
 Processing command (at Snapshots19.v0.bpl(5,5)) assert 2 == 2;
   >>> DoNothingToAssert
 Processing command (at Snapshots19.v0.bpl(7,5)) assert 1 != 1;
   >>> DoNothingToAssert
-Snapshots19.v0.bpl(7,5): Error BP5001: This assertion might not hold.
+Snapshots19.v0.bpl(7,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing call to procedure N in implementation M (at Snapshots19.v1.bpl(5,5)):
@@ -376,7 +376,7 @@ Processing command (at Snapshots19.v1.bpl(5,5)) assert 2 == 2;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots19.v1.bpl(7,5)) assert 1 != 1;
   >>> DoNothingToAssert
-Snapshots19.v1.bpl(7,5): Error BP5001: This assertion might not hold.
+Snapshots19.v1.bpl(7,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots20.v0.bpl(9,9)) assert 1 != 1;
@@ -385,7 +385,7 @@ Processing command (at Snapshots20.v0.bpl(13,9)) assert 2 != 2;
   >>> DoNothingToAssert
 Processing command (at Snapshots20.v0.bpl(16,5)) assert 3 != 3;
   >>> DoNothingToAssert
-Snapshots20.v0.bpl(13,9): Error BP5001: This assertion might not hold.
+Snapshots20.v0.bpl(13,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing call to procedure N in implementation M (at Snapshots20.v1.bpl(7,9)):
@@ -397,8 +397,8 @@ Processing command (at Snapshots20.v1.bpl(13,9)) assert 2 != 2;
   >>> RecycleError
 Processing command (at Snapshots20.v1.bpl(16,5)) assert 3 != 3;
   >>> MarkAsPartiallyVerified
-Snapshots20.v1.bpl(9,9): Error BP5001: This assertion might not hold.
-Snapshots20.v0.bpl(13,9): Error BP5001: This assertion might not hold.
+Snapshots20.v1.bpl(9,9): Error: This assertion might not hold.
+Snapshots20.v0.bpl(13,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 2 errors
 Processing command (at Snapshots21.v0.bpl(7,9)) assert 1 != 1;
@@ -407,8 +407,8 @@ Processing command (at Snapshots21.v0.bpl(11,9)) assert 2 != 2;
   >>> DoNothingToAssert
 Processing command (at Snapshots21.v0.bpl(14,5)) assert 3 != 3;
   >>> DoNothingToAssert
-Snapshots21.v0.bpl(7,9): Error BP5001: This assertion might not hold.
-Snapshots21.v0.bpl(11,9): Error BP5001: This assertion might not hold.
+Snapshots21.v0.bpl(7,9): Error: This assertion might not hold.
+Snapshots21.v0.bpl(11,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 2 errors
 Processing command (at Snapshots21.v1.bpl(7,9)) assert 1 == 1;
@@ -417,8 +417,8 @@ Processing command (at Snapshots21.v1.bpl(11,9)) assert 2 != 2;
   >>> RecycleError
 Processing command (at Snapshots21.v1.bpl(14,5)) assert 3 != 3;
   >>> DoNothingToAssert
-Snapshots21.v0.bpl(11,9): Error BP5001: This assertion might not hold.
-Snapshots21.v1.bpl(14,5): Error BP5001: This assertion might not hold.
+Snapshots21.v0.bpl(11,9): Error: This assertion might not hold.
+Snapshots21.v1.bpl(14,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 2 errors
 Processing command (at Snapshots22.v0.bpl(7,9)) assert 1 != 1;
@@ -427,7 +427,7 @@ Processing command (at Snapshots22.v0.bpl(11,9)) assert 2 == 2;
   >>> DoNothingToAssert
 Processing command (at Snapshots22.v0.bpl(14,5)) assert 3 == 3;
   >>> DoNothingToAssert
-Snapshots22.v0.bpl(7,9): Error BP5001: This assertion might not hold.
+Snapshots22.v0.bpl(7,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots22.v1.bpl(7,9)) assert 1 == 1;
@@ -444,10 +444,10 @@ Processing command (at Snapshots23.v0.bpl(11,9)) assert 2 == 2;
   >>> DoNothingToAssert
 Processing command (at Snapshots23.v0.bpl(14,5)) assert 3 == 3;
   >>> DoNothingToAssert
-Snapshots23.v0.bpl(7,9): Error BP5001: This assertion might not hold.
+Snapshots23.v0.bpl(7,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 1 verified, 1 error
-Snapshots23.v0.bpl(7,9): Error BP5001: This assertion might not hold.
+Snapshots23.v0.bpl(7,9): Error: This assertion might not hold.
 Processing command (at Snapshots23.v1.bpl(22,5)) assert 4 == 4;
   >>> DoNothingToAssert
 
@@ -456,7 +456,7 @@ Processing command (at Snapshots23.v2.bpl(8,9)) assert 1 != 1;
   >>> RecycleError
 Processing command (at Snapshots23.v2.bpl(12,9)) assert 2 == 2;
   >>> MarkAsFullyVerified
-Snapshots23.v0.bpl(7,9): Error BP5001: This assertion might not hold.
+Snapshots23.v0.bpl(7,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 1 verified, 1 error
 Processing command (at Snapshots24.v0.bpl(7,9)) assert {:subsumption 0} 1 != 1;
@@ -473,9 +473,9 @@ Processing command (at Snapshots24.v0.bpl(21,9)) assert 5 == 5;
   >>> DoNothingToAssert
 Processing command (at Snapshots24.v0.bpl(24,5)) assert {:subsumption 0} 3 == 3;
   >>> DoNothingToAssert
-Snapshots24.v0.bpl(7,9): Error BP5001: This assertion might not hold.
-Snapshots24.v0.bpl(11,9): Error BP5001: This assertion might not hold.
-Snapshots24.v0.bpl(15,9): Error BP5001: This assertion might not hold.
+Snapshots24.v0.bpl(7,9): Error: This assertion might not hold.
+Snapshots24.v0.bpl(11,9): Error: This assertion might not hold.
+Snapshots24.v0.bpl(15,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 3 errors
 Processing command (at Snapshots24.v1.bpl(7,9)) assert {:subsumption 0} 1 == 1;
@@ -492,49 +492,49 @@ Processing command (at Snapshots24.v1.bpl(21,9)) assert 5 == 5;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots24.v1.bpl(24,5)) assert {:subsumption 0} 3 == 3;
   >>> DoNothingToAssert
-Snapshots24.v0.bpl(15,9): Error BP5001: This assertion might not hold.
+Snapshots24.v0.bpl(15,9): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots25.v0.bpl(12,5)) assert 0 == 0;
   >>> DoNothingToAssert
 Processing command (at Snapshots25.v0.bpl(13,5)) assert x != x;
   >>> DoNothingToAssert
-Snapshots25.v0.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots25.v0.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots25.v1.bpl(12,5)) assert 0 == 0;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots25.v1.bpl(13,5)) assert x != x;
   >>> RecycleError
-Snapshots25.v0.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots25.v0.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots26.v0.bpl(12,5)) assert 0 == 0;
   >>> DoNothingToAssert
 Processing command (at Snapshots26.v0.bpl(13,5)) assert x != x;
   >>> DoNothingToAssert
-Snapshots26.v0.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots26.v0.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots26.v1.bpl(13,5)) assert 0 == 0;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots26.v1.bpl(14,5)) assert x != x;
   >>> RecycleError
-Snapshots26.v0.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots26.v0.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots27.v0.bpl(12,5)) assert 0 == 0;
   >>> DoNothingToAssert
 Processing command (at Snapshots27.v0.bpl(13,5)) assert x != x;
   >>> DoNothingToAssert
-Snapshots27.v0.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots27.v0.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots27.v1.bpl(14,5)) assert 0 == 0;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots27.v1.bpl(15,5)) assert x != x;
   >>> RecycleError
-Snapshots27.v0.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots27.v0.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots28.v0.bpl(13,5)) assert 0 == 0;
@@ -547,7 +547,7 @@ Processing command (at Snapshots28.v1.bpl(14,5)) assert 0 == 0;
   >>> DoNothingToAssert
 Processing command (at Snapshots28.v1.bpl(15,5)) assert x == 0;
   >>> DoNothingToAssert
-Snapshots28.v1.bpl(15,5): Error BP5001: This assertion might not hold.
+Snapshots28.v1.bpl(15,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots30.v0.bpl(5,5)) assert 0 == 0;
@@ -560,7 +560,7 @@ Processing command (at Snapshots30.v0.bpl(5,5)) assert 3 == 3;
   >>> DoNothingToAssert
 Processing command (at Snapshots30.v0.bpl(5,5)) assert 4 == 4;
   >>> DoNothingToAssert
-Snapshots30.v0.bpl(5,5): Error BP5002: A precondition for this call might not hold.
+Snapshots30.v0.bpl(5,5): Error: A precondition for this call might not hold.
 Snapshots30.v0.bpl(11,3): Related location: This is the precondition that might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
@@ -576,7 +576,7 @@ Processing command (at Snapshots30.v1.bpl(5,5)) assert 4 == 4;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots30.v1.bpl(6,5)) assert 5 == 5;
   >>> DoNothingToAssert
-Snapshots30.v0.bpl(5,5): Error BP5002: A precondition for this call might not hold.
+Snapshots30.v0.bpl(5,5): Error: A precondition for this call might not hold.
 Snapshots30.v0.bpl(11,3): Related location: This is the precondition that might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
@@ -591,7 +591,7 @@ Processing command (at <unknown location>) a##cached##0 := a##cached##0 && ##ext
   >>> AssumeNegationOfAssumptionVariable
 Processing command (at Snapshots31.v1.bpl(10,5)) assert 0 < g;
   >>> MarkAsPartiallyVerified
-Snapshots31.v1.bpl(10,5): Error BP5001: This assertion might not hold.
+Snapshots31.v1.bpl(10,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots32.v0.bpl(10,5)) assert 0 < g;
@@ -606,7 +606,7 @@ Processing command (at <unknown location>) a##cached##0 := a##cached##0 && ##ext
   >>> AssumeNegationOfAssumptionVariable
 Processing command (at Snapshots32.v1.bpl(9,5)) assert 0 < g;
   >>> MarkAsPartiallyVerified
-Snapshots32.v1.bpl(9,5): Error BP5001: This assertion might not hold.
+Snapshots32.v1.bpl(9,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots33.v0.bpl(10,5)) assert 0 < g;
@@ -631,7 +631,7 @@ Processing command (at <unknown location>) a##cached##0 := a##cached##0 && ##ext
   >>> AssumeNegationOfAssumptionVariable
 Processing command (at Snapshots34.v1.bpl(5,5)) assert 1 != 1;
   >>> MarkAsPartiallyVerified
-Snapshots34.v1.bpl(5,5): Error BP5001: This assertion might not hold.
+Snapshots34.v1.bpl(5,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots35.v0.bpl(6,5)) assert p;
@@ -645,7 +645,7 @@ Processing command (at <unknown location>) a##cached##0 := a##cached##0 && ##ext
   >>> AssumeNegationOfAssumptionVariable
 Processing command (at Snapshots35.v1.bpl(5,5)) assert p;
   >>> MarkAsPartiallyVerified
-Snapshots35.v1.bpl(5,5): Error BP5001: This assertion might not hold.
+Snapshots35.v1.bpl(5,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots36.v0.bpl(13,5)) assert l[0];
@@ -654,7 +654,7 @@ Processing command (at Snapshots36.v0.bpl(13,5)) assert l[0];
 Boogie program verifier finished with 1 verified, 0 errors
 Processing command (at Snapshots36.v1.bpl(13,5)) assert l[0];
   >>> DoNothingToAssert
-Snapshots36.v1.bpl(13,5): Error BP5001: This assertion might not hold.
+Snapshots36.v1.bpl(13,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots37.v0.bpl(8,5)) assert l[0];
@@ -663,7 +663,7 @@ Processing command (at Snapshots37.v0.bpl(8,5)) assert l[0];
 Boogie program verifier finished with 1 verified, 0 errors
 Processing command (at Snapshots37.v1.bpl(8,5)) assert l[0];
   >>> DoNothingToAssert
-Snapshots37.v1.bpl(8,5): Error BP5001: This assertion might not hold.
+Snapshots37.v1.bpl(8,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots38.v0.bpl(7,5)) assert 0 <= call0formal#AT#n;
@@ -678,7 +678,7 @@ Processing command (at Snapshots38.v1.bpl(8,5)) assert r != 0;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots38.v1.bpl(9,5)) assert 42 <= r;
   >>> DoNothingToAssert
-Snapshots38.v1.bpl(9,5): Error BP5001: This assertion might not hold.
+Snapshots38.v1.bpl(9,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing call to procedure Sum in implementation Callee (at Snapshots38.v2.bpl(7,5)):
@@ -708,7 +708,7 @@ Processing command (at Snapshots39.v1.bpl(8,5)) assert r != 0;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots39.v1.bpl(9,5)) assert r == 42 * 43 div 2;
   >>> DoNothingToAssert
-Snapshots39.v1.bpl(9,5): Error BP5001: This assertion might not hold.
+Snapshots39.v1.bpl(9,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing call to procedure Sum in implementation Callee (at Snapshots39.v2.bpl(7,5)):
@@ -732,7 +732,7 @@ Processing command (at Snapshots40.v0.bpl(8,5)) assert 0 <= call0formal#AT#n;
   >>> DoNothingToAssert
 Processing command (at Snapshots40.v0.bpl(9,5)) assert r != 0;
   >>> DoNothingToAssert
-Snapshots40.v0.bpl(7,5): Error BP5001: This assertion might not hold.
+Snapshots40.v0.bpl(7,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots40.v1.bpl(7,5)) assert b;
@@ -743,8 +743,8 @@ Processing command (at Snapshots40.v1.bpl(9,5)) assert r != 0;
   >>> MarkAsFullyVerified
 Processing command (at Snapshots40.v1.bpl(10,5)) assert r == 42 * 43 div 2;
   >>> DoNothingToAssert
-Snapshots40.v0.bpl(7,5): Error BP5001: This assertion might not hold.
-Snapshots40.v1.bpl(10,5): Error BP5001: This assertion might not hold.
+Snapshots40.v0.bpl(7,5): Error: This assertion might not hold.
+Snapshots40.v1.bpl(10,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 2 errors
 Processing call to procedure Sum in implementation Foo (at Snapshots40.v2.bpl(8,5)):
@@ -762,7 +762,7 @@ Processing command (at Snapshots40.v2.bpl(9,5)) assert r != 0;
   >>> MarkAsPartiallyVerified
 Processing command (at Snapshots40.v2.bpl(10,5)) assert r == 42 * 43 div 2;
   >>> DoNothingToAssert
-Snapshots40.v0.bpl(7,5): Error BP5001: This assertion might not hold.
+Snapshots40.v0.bpl(7,5): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error
 Processing command (at Snapshots41.v0.bpl(3,23)) assert x < 20 || 10 <= x;
@@ -771,16 +771,16 @@ Processing command (at Snapshots41.v0.bpl(4,3)) assert x < 10;
   >>> DoNothingToAssert
 Processing command (at Snapshots41.v0.bpl(5,3)) assert 0 <= call0formal#AT#y;
   >>> DoNothingToAssert
-Snapshots41.v0.bpl(4,3): Error BP5001: This assertion might not hold.
-Snapshots41.v0.bpl(5,3): Error BP5002: A precondition for this call might not hold.
+Snapshots41.v0.bpl(4,3): Error: This assertion might not hold.
+Snapshots41.v0.bpl(5,3): Error: A precondition for this call might not hold.
 Snapshots41.v0.bpl(9,3): Related location: This is the precondition that might not hold.
 Processing command (at Snapshots41.v0.bpl(15,3)) assert 2 <= z;
   >>> DoNothingToAssert
-Snapshots41.v0.bpl(22,3): Error BP5003: A postcondition might not hold on this return path.
+Snapshots41.v0.bpl(22,3): Error: A postcondition might not hold on this return path.
 Snapshots41.v0.bpl(15,3): Related location: This is the postcondition that might not hold.
 Processing command (at Snapshots41.v0.bpl(28,3)) assert u != 53;
   >>> DoNothingToAssert
-Snapshots41.v0.bpl(28,3): Error BP5001: This assertion might not hold.
+Snapshots41.v0.bpl(28,3): Error: This assertion might not hold.
 Processing command (at Snapshots41.v0.bpl(34,3)) assert true;
   >>> DoNothingToAssert
 
@@ -793,18 +793,18 @@ Processing command (at Snapshots41.v1.bpl(7,3)) assert 0 <= call0formal#AT#y;
   >>> RecycleError
 Processing command (at Snapshots41.v1.bpl(8,3)) assert x == 7;
   >>> DoNothingToAssert
-Snapshots41.v1.bpl(6,8): Error BP5001: This assertion might not hold.
-Snapshots41.v1.bpl(7,3): Error BP5002: A precondition for this call might not hold.
+Snapshots41.v1.bpl(6,8): Error: This assertion might not hold.
+Snapshots41.v1.bpl(7,3): Error: A precondition for this call might not hold.
 Snapshots41.v1.bpl(13,10): Related location: This is the precondition that might not hold.
-Snapshots41.v1.bpl(8,3): Error BP5001: This assertion might not hold.
+Snapshots41.v1.bpl(8,3): Error: This assertion might not hold.
 Processing command (at Snapshots41.v1.bpl(27,5)) assert true;
   >>> DoNothingToAssert
 Processing command (at Snapshots41.v1.bpl(21,3)) assert 2 <= z;
   >>> DoNothingToAssert
-Snapshots41.v1.bpl(29,3): Error BP5003: A postcondition might not hold on this return path.
+Snapshots41.v1.bpl(29,3): Error: A postcondition might not hold on this return path.
 Snapshots41.v1.bpl(21,3): Related location: This is the postcondition that might not hold.
 Processing command (at Snapshots41.v1.bpl(35,8)) assert u != 53;
   >>> RecycleError
-Snapshots41.v1.bpl(35,8): Error BP5001: This assertion might not hold.
+Snapshots41.v1.bpl(35,8): Error: This assertion might not hold.
 
 Boogie program verifier finished with 2 verified, 5 errors

--- a/Test/stratifiedinline/bar1.bpl.expect
+++ b/Test/stratifiedinline/bar1.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar1.bpl(24,3): anon0
     Inlined call to procedure foo begins

--- a/Test/stratifiedinline/bar10.bpl.expect
+++ b/Test/stratifiedinline/bar10.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar10.bpl(37,5): anon0
     Inlined call to procedure bar1 begins

--- a/Test/stratifiedinline/bar11.bpl.expect
+++ b/Test/stratifiedinline/bar11.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar11.bpl(28,3): anon0
     Inlined call to procedure foo begins

--- a/Test/stratifiedinline/bar12.bpl.expect
+++ b/Test/stratifiedinline/bar12.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar12.bpl(8,4): anon0
 

--- a/Test/stratifiedinline/bar2.bpl.expect
+++ b/Test/stratifiedinline/bar2.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar2.bpl(20,3): anon0
     Inlined call to procedure foo begins

--- a/Test/stratifiedinline/bar3.bpl.expect
+++ b/Test/stratifiedinline/bar3.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar3.bpl(37,3): anon0
     Inlined call to procedure foo begins

--- a/Test/stratifiedinline/bar7.bpl.expect
+++ b/Test/stratifiedinline/bar7.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar7.bpl(37,5): anon0
     bar7.bpl(39,5): anon4_Then

--- a/Test/stratifiedinline/bar8.bpl.expect
+++ b/Test/stratifiedinline/bar8.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar8.bpl(36,5): anon0
     bar8.bpl(38,5): anon4_Then

--- a/Test/stratifiedinline/bar9.bpl.expect
+++ b/Test/stratifiedinline/bar9.bpl.expect
@@ -1,4 +1,4 @@
-(0,0): Error BP5001: This assertion might not hold.
+(0,0): Error: This assertion might not hold.
 Execution trace:
     bar9.bpl(37,5): anon0
     bar9.bpl(43,5): anon4_Else

--- a/Test/symdiff/foo.bpl.expect
+++ b/Test/symdiff/foo.bpl.expect
@@ -1,3 +1,3 @@
-foo.bpl(17,3): Error BP5001: This assertion might not hold.
+foo.bpl(17,3): Error: This assertion might not hold.
 
 Boogie program verifier finished with 0 verified, 1 error

--- a/Test/test0/Irreducible.bpl.expect
+++ b/Test/test0/Irreducible.bpl.expect
@@ -1,4 +1,4 @@
-Irreducible.bpl(4,11): BP5010: Irreducible flow graphs are unsupported. (encountered in implementation Irreducible).
+Irreducible.bpl(4,11): Irreducible flow graphs are unsupported. (encountered in implementation Irreducible).
 Irreducible.bpl(4,11): Verification inconclusive (Irreducible)
 
 Boogie program verifier finished with 0 verified, 0 errors, 1 inconclusive

--- a/Test/test13/ErrorTraceTestLoopInvViolationBPL.bpl.expect
+++ b/Test/test13/ErrorTraceTestLoopInvViolationBPL.bpl.expect
@@ -1,10 +1,10 @@
-ErrorTraceTestLoopInvViolationBPL.bpl(9,3): Error BP5001: This assertion might not hold.
+ErrorTraceTestLoopInvViolationBPL.bpl(9,3): Error: This assertion might not hold.
 Execution trace:
     ErrorTraceTestLoopInvViolationBPL.bpl(7,5): anon0
-ErrorTraceTestLoopInvViolationBPL.bpl(18,16): Error BP5004: This loop invariant might not hold on entry.
+ErrorTraceTestLoopInvViolationBPL.bpl(18,16): Error: This loop invariant might not hold on entry.
 Execution trace:
     ErrorTraceTestLoopInvViolationBPL.bpl(16,5): anon0
-ErrorTraceTestLoopInvViolationBPL.bpl(29,17): Error BP5005: This loop invariant might not be maintained by the loop.
+ErrorTraceTestLoopInvViolationBPL.bpl(29,17): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     ErrorTraceTestLoopInvViolationBPL.bpl(27,5): anon0
     ErrorTraceTestLoopInvViolationBPL.bpl(29,3): anon2_LoopHead

--- a/Test/test13/ManyErrors.bpl.expect
+++ b/Test/test13/ManyErrors.bpl.expect
@@ -1,40 +1,40 @@
-ManyErrors.bpl(6,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(6,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(6,5): L1
-ManyErrors.bpl(7,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(7,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(7,5): L2
-ManyErrors.bpl(8,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(8,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(8,5): L3
-ManyErrors.bpl(9,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(9,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(9,5): L4
-ManyErrors.bpl(10,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(10,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(10,5): L5
-ManyErrors.bpl(11,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(11,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(11,5): L6
-ManyErrors.bpl(12,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(12,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(12,5): L7
-ManyErrors.bpl(13,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(13,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(13,5): L8
-ManyErrors.bpl(14,9): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(14,9): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(14,5): L9
-ManyErrors.bpl(15,10): Error BP5001: This assertion might not hold.
+ManyErrors.bpl(15,10): Error: This assertion might not hold.
 Execution trace:
     ManyErrors.bpl(5,5): L0
     ManyErrors.bpl(15,5): L10

--- a/Test/test15/CaptureState.bpl.expect
+++ b/Test/test15/CaptureState.bpl.expect
@@ -1,4 +1,4 @@
-CaptureState.bpl(30,1): Error BP5003: A postcondition might not hold on this return path.
+CaptureState.bpl(30,1): Error: A postcondition might not hold on this return path.
 CaptureState.bpl(11,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     CaptureState.bpl(15,3): anon0

--- a/Test/test15/IntInModel.bpl.expect
+++ b/Test/test15/IntInModel.bpl.expect
@@ -1,4 +1,4 @@
-IntInModel.bpl(4,3): Error BP5001: This assertion might not hold.
+IntInModel.bpl(4,3): Error: This assertion might not hold.
 Execution trace:
     IntInModel.bpl(4,3): anon0
 *** MODEL

--- a/Test/test15/InterpretedFunctionTests.bpl.expect
+++ b/Test/test15/InterpretedFunctionTests.bpl.expect
@@ -1,10 +1,10 @@
-InterpretedFunctionTests.bpl(6,3): Error BP5001: This assertion might not hold.
+InterpretedFunctionTests.bpl(6,3): Error: This assertion might not hold.
 Execution trace:
     InterpretedFunctionTests.bpl(4,3): anon0
-InterpretedFunctionTests.bpl(12,3): Error BP5001: This assertion might not hold.
+InterpretedFunctionTests.bpl(12,3): Error: This assertion might not hold.
 Execution trace:
     InterpretedFunctionTests.bpl(10,3): anon0
-InterpretedFunctionTests.bpl(18,3): Error BP5001: This assertion might not hold.
+InterpretedFunctionTests.bpl(18,3): Error: This assertion might not hold.
 Execution trace:
     InterpretedFunctionTests.bpl(16,3): anon0
 

--- a/Test/test15/ModelTest.bpl.expect
+++ b/Test/test15/ModelTest.bpl.expect
@@ -1,4 +1,4 @@
-ModelTest.bpl(9,3): Error BP5001: This assertion might not hold.
+ModelTest.bpl(9,3): Error: This assertion might not hold.
 Execution trace:
     ModelTest.bpl(5,5): anon0
 *** MODEL

--- a/Test/test15/NullInModel.bpl.expect
+++ b/Test/test15/NullInModel.bpl.expect
@@ -1,4 +1,4 @@
-NullInModel.bpl(4,3): Error BP5001: This assertion might not hold.
+NullInModel.bpl(4,3): Error: This assertion might not hold.
 Execution trace:
     NullInModel.bpl(4,3): anon0
 *** MODEL

--- a/Test/test15/trace0.bpl.expect
+++ b/Test/test15/trace0.bpl.expect
@@ -1,4 +1,4 @@
-trace0.bpl(18,1): Error BP5003: A postcondition might not hold on this return path.
+trace0.bpl(18,1): Error: A postcondition might not hold on this return path.
 trace0.bpl(5,1): Related location: This is the postcondition that might not hold.
 Execution trace:
     trace0.bpl(7,5): anon0
@@ -15,7 +15,7 @@ o = 43
 just to show off
 exit of foo
 o = 44
-trace0.bpl(33,1): Error BP5003: A postcondition might not hold on this return path.
+trace0.bpl(33,1): Error: A postcondition might not hold on this return path.
 trace0.bpl(22,1): Related location: This is the postcondition that might not hold.
 Execution trace:
     trace0.bpl(24,5): anon0

--- a/Test/test15/trace1.bpl.expect
+++ b/Test/test15/trace1.bpl.expect
@@ -1,4 +1,4 @@
-trace1.bpl(12,1): Error BP5003: A postcondition might not hold on this return path.
+trace1.bpl(12,1): Error: A postcondition might not hold on this return path.
 trace1.bpl(8,1): Related location: This is the postcondition that might not hold.
 Execution trace:
     trace1.bpl(11,5): anon0

--- a/Test/test16/LoopUnroll.bpl.1.expect
+++ b/Test/test16/LoopUnroll.bpl.1.expect
@@ -1,4 +1,4 @@
-LoopUnroll.bpl(62,5): Error BP5001: This assertion might not hold.
+LoopUnroll.bpl(62,5): Error: This assertion might not hold.
 Execution trace:
     LoopUnroll.bpl(58,5): anon0#1
     LoopUnroll.bpl(61,5): anon2_LoopBody#1

--- a/Test/test16/LoopUnroll.bpl.3.expect
+++ b/Test/test16/LoopUnroll.bpl.3.expect
@@ -1,4 +1,4 @@
-LoopUnroll.bpl(80,5): Error BP5001: This assertion might not hold.
+LoopUnroll.bpl(80,5): Error: This assertion might not hold.
 Execution trace:
     LoopUnroll.bpl(74,5): anon0#3
     LoopUnroll.bpl(77,5): anon2_LoopBody#3

--- a/Test/test2/Arrays.bpl.expect
+++ b/Test/test2/Arrays.bpl.expect
@@ -1,8 +1,8 @@
-Arrays.bpl(50,5): Error BP5003: A postcondition might not hold on this return path.
+Arrays.bpl(50,5): Error: A postcondition might not hold on this return path.
 Arrays.bpl(42,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Arrays.bpl(46,3): start
-Arrays.bpl(131,5): Error BP5003: A postcondition might not hold on this return path.
+Arrays.bpl(131,5): Error: A postcondition might not hold on this return path.
 Arrays.bpl(123,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Arrays.bpl(127,3): start

--- a/Test/test2/AssertVerifiedUnder0.bpl.expect
+++ b/Test/test2/AssertVerifiedUnder0.bpl.expect
@@ -1,10 +1,10 @@
-AssertVerifiedUnder0.bpl(6,5): Error BP5001: This assertion might not hold.
+AssertVerifiedUnder0.bpl(6,5): Error: This assertion might not hold.
 Execution trace:
     AssertVerifiedUnder0.bpl(6,5): anon0
-AssertVerifiedUnder0.bpl(18,5): Error BP5001: This assertion might not hold.
+AssertVerifiedUnder0.bpl(18,5): Error: This assertion might not hold.
 Execution trace:
     AssertVerifiedUnder0.bpl(18,5): anon0
-AssertVerifiedUnder0.bpl(31,5): Error BP5001: This assertion might not hold.
+AssertVerifiedUnder0.bpl(31,5): Error: This assertion might not hold.
 Execution trace:
     AssertVerifiedUnder0.bpl(31,5): anon0
 

--- a/Test/test2/AssumeEnsures.bpl.expect
+++ b/Test/test2/AssumeEnsures.bpl.expect
@@ -1,10 +1,10 @@
-AssumeEnsures.bpl(30,9): Error BP5001: This assertion might not hold.
+AssumeEnsures.bpl(30,9): Error: This assertion might not hold.
 Execution trace:
     AssumeEnsures.bpl(28,5): entry
-AssumeEnsures.bpl(49,9): Error BP5001: This assertion might not hold.
+AssumeEnsures.bpl(49,9): Error: This assertion might not hold.
 Execution trace:
     AssumeEnsures.bpl(48,5): entry
-AssumeEnsures.bpl(64,9): Error BP5001: This assertion might not hold.
+AssumeEnsures.bpl(64,9): Error: This assertion might not hold.
 Execution trace:
     AssumeEnsures.bpl(62,5): entry
 

--- a/Test/test2/AssumptionVariables0.bpl.expect
+++ b/Test/test2/AssumptionVariables0.bpl.expect
@@ -1,10 +1,10 @@
-AssumptionVariables0.bpl(17,5): Error BP5001: This assertion might not hold.
+AssumptionVariables0.bpl(17,5): Error: This assertion might not hold.
 Execution trace:
     AssumptionVariables0.bpl(15,8): anon0
-AssumptionVariables0.bpl(27,5): Error BP5001: This assertion might not hold.
+AssumptionVariables0.bpl(27,5): Error: This assertion might not hold.
 Execution trace:
     AssumptionVariables0.bpl(25,5): anon0
-AssumptionVariables0.bpl(39,5): Error BP5001: This assertion might not hold.
+AssumptionVariables0.bpl(39,5): Error: This assertion might not hold.
 Execution trace:
     AssumptionVariables0.bpl(37,9): anon0
 

--- a/Test/test2/Axioms.bpl.expect
+++ b/Test/test2/Axioms.bpl.expect
@@ -1,4 +1,4 @@
-Axioms.bpl(21,5): Error BP5001: This assertion might not hold.
+Axioms.bpl(21,5): Error: This assertion might not hold.
 Execution trace:
     Axioms.bpl(20,3): start
 

--- a/Test/test2/BadLineNumber.bpl.expect
+++ b/Test/test2/BadLineNumber.bpl.expect
@@ -1,4 +1,4 @@
-BadLineNumber.bpl(15,1): Error BP5003: A postcondition might not hold on this return path.
+BadLineNumber.bpl(15,1): Error: A postcondition might not hold on this return path.
 BadLineNumber.bpl(5,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     BadLineNumber.bpl(9,5): anon0

--- a/Test/test2/Call.bpl.expect
+++ b/Test/test2/Call.bpl.expect
@@ -1,10 +1,10 @@
-Call.bpl(15,5): Error BP5001: This assertion might not hold.
+Call.bpl(15,5): Error: This assertion might not hold.
 Execution trace:
     Call.bpl(11,3): entry
-Call.bpl(48,5): Error BP5001: This assertion might not hold.
+Call.bpl(48,5): Error: This assertion might not hold.
 Execution trace:
     Call.bpl(47,3): start
-Call.bpl(57,5): Error BP5003: A postcondition might not hold on this return path.
+Call.bpl(57,5): Error: A postcondition might not hold on this return path.
 Call.bpl(22,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Call.bpl(55,3): start

--- a/Test/test2/CallVerifiedUnder0.bpl.expect
+++ b/Test/test2/CallVerifiedUnder0.bpl.expect
@@ -1,12 +1,12 @@
-CallVerifiedUnder0.bpl(9,5): Error BP5002: A precondition for this call might not hold.
+CallVerifiedUnder0.bpl(9,5): Error: A precondition for this call might not hold.
 CallVerifiedUnder0.bpl(5,3): Related location: This is the precondition that might not hold.
 Execution trace:
     CallVerifiedUnder0.bpl(9,5): anon0
-CallVerifiedUnder0.bpl(21,5): Error BP5002: A precondition for this call might not hold.
+CallVerifiedUnder0.bpl(21,5): Error: A precondition for this call might not hold.
 CallVerifiedUnder0.bpl(5,3): Related location: This is the precondition that might not hold.
 Execution trace:
     CallVerifiedUnder0.bpl(21,5): anon0
-CallVerifiedUnder0.bpl(34,5): Error BP5002: A precondition for this call might not hold.
+CallVerifiedUnder0.bpl(34,5): Error: A precondition for this call might not hold.
 CallVerifiedUnder0.bpl(5,3): Related location: This is the precondition that might not hold.
 Execution trace:
     CallVerifiedUnder0.bpl(34,5): anon0

--- a/Test/test2/ContractEvaluationOrder.bpl.expect
+++ b/Test/test2/ContractEvaluationOrder.bpl.expect
@@ -1,11 +1,11 @@
-ContractEvaluationOrder.bpl(10,1): Error BP5003: A postcondition might not hold on this return path.
+ContractEvaluationOrder.bpl(10,1): Error: A postcondition might not hold on this return path.
 ContractEvaluationOrder.bpl(5,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     ContractEvaluationOrder.bpl(9,5): anon0
-ContractEvaluationOrder.bpl(17,3): Error BP5001: This assertion might not hold.
+ContractEvaluationOrder.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     ContractEvaluationOrder.bpl(14,5): anon0
-ContractEvaluationOrder.bpl(26,3): Error BP5002: A precondition for this call might not hold.
+ContractEvaluationOrder.bpl(26,3): Error: A precondition for this call might not hold.
 ContractEvaluationOrder.bpl(32,3): Related location: This is the precondition that might not hold.
 Execution trace:
     ContractEvaluationOrder.bpl(25,5): anon0

--- a/Test/test2/CutBackEdge.bpl.expect
+++ b/Test/test2/CutBackEdge.bpl.expect
@@ -1,13 +1,13 @@
-CutBackEdge.bpl(12,5): Error BP5005: This loop invariant might not be maintained by the loop.
+CutBackEdge.bpl(12,5): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     CutBackEdge.bpl(7,3): entry
     CutBackEdge.bpl(11,3): block850
-CutBackEdge.bpl(22,5): Error BP5004: This loop invariant might not hold on entry.
+CutBackEdge.bpl(22,5): Error: This loop invariant might not hold on entry.
 Execution trace:
-CutBackEdge.bpl(28,5): Error BP5001: This assertion might not hold.
+CutBackEdge.bpl(28,5): Error: This assertion might not hold.
 Execution trace:
     CutBackEdge.bpl(27,3): L
-CutBackEdge.bpl(40,5): Error BP5004: This loop invariant might not hold on entry.
+CutBackEdge.bpl(40,5): Error: This loop invariant might not hold on entry.
 Execution trace:
 
 Boogie program verifier finished with 1 verified, 4 errors

--- a/Test/test2/Ensures.bpl.expect
+++ b/Test/test2/Ensures.bpl.expect
@@ -1,20 +1,20 @@
-Ensures.bpl(32,5): Error BP5003: A postcondition might not hold on this return path.
+Ensures.bpl(32,5): Error: A postcondition might not hold on this return path.
 Ensures.bpl(21,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Ensures.bpl(30,3): start
-Ensures.bpl(37,5): Error BP5003: A postcondition might not hold on this return path.
+Ensures.bpl(37,5): Error: A postcondition might not hold on this return path.
 Ensures.bpl(21,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Ensures.bpl(36,3): start
-Ensures.bpl(43,5): Error BP5003: A postcondition might not hold on this return path.
+Ensures.bpl(43,5): Error: A postcondition might not hold on this return path.
 Ensures.bpl(21,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Ensures.bpl(41,3): start
-Ensures.bpl(49,5): Error BP5003: A postcondition might not hold on this return path.
+Ensures.bpl(49,5): Error: A postcondition might not hold on this return path.
 Ensures.bpl(21,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Ensures.bpl(47,3): start
-Ensures.bpl(74,5): Error BP5003: A postcondition might not hold on this return path.
+Ensures.bpl(74,5): Error: A postcondition might not hold on this return path.
 Ensures.bpl(21,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Ensures.bpl(72,3): start

--- a/Test/test2/FormulaTerm.bpl.expect
+++ b/Test/test2/FormulaTerm.bpl.expect
@@ -1,4 +1,4 @@
-FormulaTerm.bpl(12,3): Error BP5003: A postcondition might not hold on this return path.
+FormulaTerm.bpl(12,3): Error: A postcondition might not hold on this return path.
 FormulaTerm.bpl(6,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     FormulaTerm.bpl(10,1): start

--- a/Test/test2/FormulaTerm2.bpl.expect
+++ b/Test/test2/FormulaTerm2.bpl.expect
@@ -1,7 +1,7 @@
-FormulaTerm2.bpl(41,5): Error BP5001: This assertion might not hold.
+FormulaTerm2.bpl(41,5): Error: This assertion might not hold.
 Execution trace:
     FormulaTerm2.bpl(38,3): start
-FormulaTerm2.bpl(49,5): Error BP5001: This assertion might not hold.
+FormulaTerm2.bpl(49,5): Error: This assertion might not hold.
 Execution trace:
     FormulaTerm2.bpl(47,3): start
 

--- a/Test/test2/FreeCall.bpl.expect
+++ b/Test/test2/FreeCall.bpl.expect
@@ -1,16 +1,16 @@
-FreeCall.bpl(39,5): Error BP5002: A precondition for this call might not hold.
+FreeCall.bpl(39,5): Error: A precondition for this call might not hold.
 FreeCall.bpl(10,3): Related location: This is the precondition that might not hold.
 Execution trace:
     FreeCall.bpl(39,5): anon0
-FreeCall.bpl(44,5): Error BP5002: A precondition for this call might not hold.
+FreeCall.bpl(44,5): Error: A precondition for this call might not hold.
 FreeCall.bpl(8,3): Related location: This is the precondition that might not hold.
 Execution trace:
     FreeCall.bpl(44,5): anon0
-FreeCall.bpl(61,5): Error BP5002: A precondition for this call might not hold.
+FreeCall.bpl(61,5): Error: A precondition for this call might not hold.
 FreeCall.bpl(18,3): Related location: This is the precondition that might not hold.
 Execution trace:
     FreeCall.bpl(61,5): anon0
-FreeCall.bpl(68,5): Error BP5002: A precondition for this call might not hold.
+FreeCall.bpl(68,5): Error: A precondition for this call might not hold.
 FreeCall.bpl(16,3): Related location: This is the precondition that might not hold.
 Execution trace:
     FreeCall.bpl(68,5): anon0

--- a/Test/test2/IfThenElse1.bpl.expect
+++ b/Test/test2/IfThenElse1.bpl.expect
@@ -1,7 +1,7 @@
-IfThenElse1.bpl(28,3): Error BP5001: This assertion might not hold.
+IfThenElse1.bpl(28,3): Error: This assertion might not hold.
 Execution trace:
     IfThenElse1.bpl(28,3): anon0
-IfThenElse1.bpl(35,3): Error BP5001: This assertion might not hold.
+IfThenElse1.bpl(35,3): Error: This assertion might not hold.
 Execution trace:
     IfThenElse1.bpl(35,3): anon0
 

--- a/Test/test2/Implies.bpl.expect
+++ b/Test/test2/Implies.bpl.expect
@@ -1,25 +1,25 @@
-Implies.bpl(14,3): Error BP5001: This assertion might not hold.
+Implies.bpl(14,3): Error: This assertion might not hold.
 Execution trace:
     Implies.bpl(13,3): anon0
-Implies.bpl(17,3): Error BP5001: This assertion might not hold.
+Implies.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     Implies.bpl(13,3): anon0
-Implies.bpl(21,3): Error BP5001: This assertion might not hold.
+Implies.bpl(21,3): Error: This assertion might not hold.
 Execution trace:
     Implies.bpl(21,3): anon0
-Implies.bpl(26,3): Error BP5001: This assertion might not hold.
+Implies.bpl(26,3): Error: This assertion might not hold.
 Execution trace:
     Implies.bpl(26,3): anon0
-Implies.bpl(27,3): Error BP5001: This assertion might not hold.
+Implies.bpl(27,3): Error: This assertion might not hold.
 Execution trace:
     Implies.bpl(26,3): anon0
-Implies.bpl(31,3): Error BP5001: This assertion might not hold.
+Implies.bpl(31,3): Error: This assertion might not hold.
 Execution trace:
     Implies.bpl(31,3): anon0
-Implies.bpl(36,3): Error BP5001: This assertion might not hold.
+Implies.bpl(36,3): Error: This assertion might not hold.
 Execution trace:
     Implies.bpl(36,3): anon0
-Implies.bpl(37,3): Error BP5001: This assertion might not hold.
+Implies.bpl(37,3): Error: This assertion might not hold.
 Execution trace:
     Implies.bpl(36,3): anon0
 

--- a/Test/test2/InvariantVerifiedUnder0.bpl.expect
+++ b/Test/test2/InvariantVerifiedUnder0.bpl.expect
@@ -1,22 +1,22 @@
-InvariantVerifiedUnder0.bpl(7,7): Error BP5001: This assertion might not hold.
+InvariantVerifiedUnder0.bpl(7,7): Error: This assertion might not hold.
 Execution trace:
     InvariantVerifiedUnder0.bpl(6,5): anon0
-InvariantVerifiedUnder0.bpl(23,7): Error BP5004: This loop invariant might not hold on entry.
+InvariantVerifiedUnder0.bpl(23,7): Error: This loop invariant might not hold on entry.
 Execution trace:
     InvariantVerifiedUnder0.bpl(22,5): anon0
-InvariantVerifiedUnder0.bpl(24,7): Error BP5004: This loop invariant might not hold on entry.
+InvariantVerifiedUnder0.bpl(24,7): Error: This loop invariant might not hold on entry.
 Execution trace:
     InvariantVerifiedUnder0.bpl(22,5): anon0
-InvariantVerifiedUnder0.bpl(34,7): Error BP5004: This loop invariant might not hold on entry.
+InvariantVerifiedUnder0.bpl(34,7): Error: This loop invariant might not hold on entry.
 Execution trace:
     InvariantVerifiedUnder0.bpl(32,5): anon0
-InvariantVerifiedUnder0.bpl(41,7): Error BP5004: This loop invariant might not hold on entry.
+InvariantVerifiedUnder0.bpl(41,7): Error: This loop invariant might not hold on entry.
 Execution trace:
     InvariantVerifiedUnder0.bpl(40,5): anon0
-InvariantVerifiedUnder0.bpl(42,7): Error BP5004: This loop invariant might not hold on entry.
+InvariantVerifiedUnder0.bpl(42,7): Error: This loop invariant might not hold on entry.
 Execution trace:
     InvariantVerifiedUnder0.bpl(40,5): anon0
-InvariantVerifiedUnder0.bpl(51,7): Error BP5004: This loop invariant might not hold on entry.
+InvariantVerifiedUnder0.bpl(51,7): Error: This loop invariant might not hold on entry.
 Execution trace:
     InvariantVerifiedUnder0.bpl(50,5): anon0
 

--- a/Test/test2/Lambda.bpl.expect
+++ b/Test/test2/Lambda.bpl.expect
@@ -1,7 +1,7 @@
-Lambda.bpl(41,3): Error BP5001: This assertion might not hold.
+Lambda.bpl(41,3): Error: This assertion might not hold.
 Execution trace:
     Lambda.bpl(40,5): anon0
-Lambda.bpl(42,3): Error BP5001: This assertion might not hold.
+Lambda.bpl(42,3): Error: This assertion might not hold.
 Execution trace:
     Lambda.bpl(40,5): anon0
 

--- a/Test/test2/LambdaExt.bpl.expect
+++ b/Test/test2/LambdaExt.bpl.expect
@@ -1,99 +1,99 @@
-LambdaExt.bpl(11,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(11,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(7,7): anon0
-LambdaExt.bpl(27,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(27,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(18,5): anon0
-LambdaExt.bpl(31,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(31,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(18,5): anon0
-LambdaExt.bpl(35,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(35,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(35,3): anon0
-LambdaExt.bpl(82,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(82,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(77,5): anon0
     LambdaExt.bpl(82,5): anon3_Else
-LambdaExt.bpl(100,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(100,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(95,5): anon0
     LambdaExt.bpl(100,5): anon3_Else
-LambdaExt.bpl(118,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(118,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(113,5): anon0
     LambdaExt.bpl(118,5): anon3_Else
-LambdaExt.bpl(130,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(130,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(126,5): anon0
-LambdaExt.bpl(137,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(137,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(135,5): anon0
-LambdaExt.bpl(139,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(139,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(135,5): anon0
-LambdaExt.bpl(141,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(141,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(135,5): anon0
-LambdaExt.bpl(152,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(152,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(147,5): anon0
     LambdaExt.bpl(152,5): anon3_Else
-LambdaExt.bpl(171,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(171,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(171,3): anon0
-LambdaExt.bpl(181,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(181,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(181,3): anon0
 
 Boogie program verifier finished with 5 verified, 14 errors
-LambdaExt.bpl(11,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(11,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(7,7): anon0
-LambdaExt.bpl(27,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(27,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(18,5): anon0
-LambdaExt.bpl(31,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(31,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(18,5): anon0
-LambdaExt.bpl(35,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(35,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(35,3): anon0
-LambdaExt.bpl(82,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(82,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(77,5): anon0
     LambdaExt.bpl(82,5): anon3_Else
-LambdaExt.bpl(100,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(100,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(95,5): anon0
     LambdaExt.bpl(100,5): anon3_Else
-LambdaExt.bpl(116,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(116,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(113,5): anon0
     LambdaExt.bpl(116,5): anon3_Then
-LambdaExt.bpl(118,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(118,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(113,5): anon0
     LambdaExt.bpl(118,5): anon3_Else
-LambdaExt.bpl(130,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(130,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(126,5): anon0
-LambdaExt.bpl(137,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(137,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(135,5): anon0
-LambdaExt.bpl(139,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(139,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(135,5): anon0
-LambdaExt.bpl(141,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(141,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(135,5): anon0
-LambdaExt.bpl(152,5): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(152,5): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(147,5): anon0
     LambdaExt.bpl(152,5): anon3_Else
-LambdaExt.bpl(171,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(171,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(171,3): anon0
-LambdaExt.bpl(181,3): Error BP5001: This assertion might not hold.
+LambdaExt.bpl(181,3): Error: This assertion might not hold.
 Execution trace:
     LambdaExt.bpl(181,3): anon0
 

--- a/Test/test2/LambdaLifting.bpl.expect
+++ b/Test/test2/LambdaLifting.bpl.expect
@@ -1,13 +1,13 @@
-LambdaLifting.bpl(14,2): Error BP5001: This assertion might not hold.
+LambdaLifting.bpl(14,2): Error: This assertion might not hold.
 Execution trace:
     LambdaLifting.bpl(8,4): anon0
-LambdaLifting.bpl(24,2): Error BP5001: This assertion might not hold.
+LambdaLifting.bpl(24,2): Error: This assertion might not hold.
 Execution trace:
     LambdaLifting.bpl(22,4): anon0
-LambdaLifting.bpl(32,2): Error BP5001: This assertion might not hold.
+LambdaLifting.bpl(32,2): Error: This assertion might not hold.
 Execution trace:
     LambdaLifting.bpl(30,4): anon0
-LambdaLifting.bpl(51,2): Error BP5001: This assertion might not hold.
+LambdaLifting.bpl(51,2): Error: This assertion might not hold.
 Execution trace:
     LambdaLifting.bpl(47,4): anon0
 

--- a/Test/test2/LambdaOldExpressions.bpl.expect
+++ b/Test/test2/LambdaOldExpressions.bpl.expect
@@ -1,4 +1,4 @@
-LambdaOldExpressions.bpl(29,1): Error BP5003: A postcondition might not hold on this return path.
+LambdaOldExpressions.bpl(29,1): Error: A postcondition might not hold on this return path.
 LambdaOldExpressions.bpl(23,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     LambdaOldExpressions.bpl(27,7): anon0

--- a/Test/test2/LambdaPoly.bpl.expect
+++ b/Test/test2/LambdaPoly.bpl.expect
@@ -1,12 +1,12 @@
-LambdaPoly.bpl(30,5): Error BP5001: This assertion might not hold.
+LambdaPoly.bpl(30,5): Error: This assertion might not hold.
 Execution trace:
     LambdaPoly.bpl(26,5): anon0
     LambdaPoly.bpl(29,5): anon4_Then
-LambdaPoly.bpl(33,5): Error BP5001: This assertion might not hold.
+LambdaPoly.bpl(33,5): Error: This assertion might not hold.
 Execution trace:
     LambdaPoly.bpl(26,5): anon0
     LambdaPoly.bpl(32,5): anon5_Then
-LambdaPoly.bpl(38,5): Error BP5001: This assertion might not hold.
+LambdaPoly.bpl(38,5): Error: This assertion might not hold.
 Execution trace:
     LambdaPoly.bpl(26,5): anon0
     LambdaPoly.bpl(36,5): anon5_Else

--- a/Test/test2/LoopInvAssume.bpl.expect
+++ b/Test/test2/LoopInvAssume.bpl.expect
@@ -1,4 +1,4 @@
-LoopInvAssume.bpl(20,7): Error BP5001: This assertion might not hold.
+LoopInvAssume.bpl(20,7): Error: This assertion might not hold.
 Execution trace:
     LoopInvAssume.bpl(10,4): entry
     LoopInvAssume.bpl(18,4): exit

--- a/Test/test2/NeverPattern.bpl.expect
+++ b/Test/test2/NeverPattern.bpl.expect
@@ -1,10 +1,10 @@
-NeverPattern.bpl(18,3): Error BP5001: This assertion might not hold.
+NeverPattern.bpl(18,3): Error: This assertion might not hold.
 Execution trace:
     NeverPattern.bpl(17,3): anon0
-NeverPattern.bpl(24,3): Error BP5001: This assertion might not hold.
+NeverPattern.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     NeverPattern.bpl(23,3): anon0
-NeverPattern.bpl(30,3): Error BP5001: This assertion might not hold.
+NeverPattern.bpl(30,3): Error: This assertion might not hold.
 Execution trace:
     NeverPattern.bpl(29,3): anon0
 

--- a/Test/test2/NullaryMaps.bpl.expect
+++ b/Test/test2/NullaryMaps.bpl.expect
@@ -1,10 +1,10 @@
-NullaryMaps.bpl(30,3): Error BP5001: This assertion might not hold.
+NullaryMaps.bpl(30,3): Error: This assertion might not hold.
 Execution trace:
     NullaryMaps.bpl(30,3): anon0
-NullaryMaps.bpl(32,3): Error BP5001: This assertion might not hold.
+NullaryMaps.bpl(32,3): Error: This assertion might not hold.
 Execution trace:
     NullaryMaps.bpl(30,3): anon0
-NullaryMaps.bpl(38,3): Error BP5001: This assertion might not hold.
+NullaryMaps.bpl(38,3): Error: This assertion might not hold.
 Execution trace:
     NullaryMaps.bpl(38,3): anon0
 

--- a/Test/test2/Old.bpl.expect
+++ b/Test/test2/Old.bpl.expect
@@ -1,4 +1,4 @@
-Old.bpl(31,5): Error BP5003: A postcondition might not hold on this return path.
+Old.bpl(31,5): Error: A postcondition might not hold on this return path.
 Old.bpl(28,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Old.bpl(30,3): start

--- a/Test/test2/Passification.bpl.expect
+++ b/Test/test2/Passification.bpl.expect
@@ -1,17 +1,17 @@
-Passification.bpl(46,3): Error BP5003: A postcondition might not hold on this return path.
+Passification.bpl(46,3): Error: A postcondition might not hold on this return path.
 Passification.bpl(38,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Passification.bpl(41,1): A
-Passification.bpl(118,3): Error BP5001: This assertion might not hold.
+Passification.bpl(118,3): Error: This assertion might not hold.
 Execution trace:
     Passification.bpl(108,1): L0
     Passification.bpl(113,1): L1
     Passification.bpl(117,1): L2
-Passification.bpl(153,3): Error BP5001: This assertion might not hold.
+Passification.bpl(153,3): Error: This assertion might not hold.
 Execution trace:
     Passification.bpl(146,1): L0
     Passification.bpl(152,1): L2
-Passification.bpl(167,3): Error BP5001: This assertion might not hold.
+Passification.bpl(167,3): Error: This assertion might not hold.
 Execution trace:
     Passification.bpl(160,1): L0
     Passification.bpl(163,1): L1

--- a/Test/test2/Quantifiers.bpl.expect
+++ b/Test/test2/Quantifiers.bpl.expect
@@ -1,19 +1,19 @@
-Quantifiers.bpl(22,5): Error BP5001: This assertion might not hold.
+Quantifiers.bpl(22,5): Error: This assertion might not hold.
 Execution trace:
     Quantifiers.bpl(21,3): start
-Quantifiers.bpl(45,5): Error BP5001: This assertion might not hold.
+Quantifiers.bpl(45,5): Error: This assertion might not hold.
 Execution trace:
     Quantifiers.bpl(44,3): start
-Quantifiers.bpl(67,5): Error BP5001: This assertion might not hold.
+Quantifiers.bpl(67,5): Error: This assertion might not hold.
 Execution trace:
     Quantifiers.bpl(66,3): start
-Quantifiers.bpl(75,5): Error BP5001: This assertion might not hold.
+Quantifiers.bpl(75,5): Error: This assertion might not hold.
 Execution trace:
     Quantifiers.bpl(73,3): start
-Quantifiers.bpl(127,5): Error BP5001: This assertion might not hold.
+Quantifiers.bpl(127,5): Error: This assertion might not hold.
 Execution trace:
     Quantifiers.bpl(126,3): start
-Quantifiers.bpl(152,5): Error BP5001: This assertion might not hold.
+Quantifiers.bpl(152,5): Error: This assertion might not hold.
 Execution trace:
     Quantifiers.bpl(151,3): start
 

--- a/Test/test2/Rlimitouts0.bpl.expect
+++ b/Test/test2/Rlimitouts0.bpl.expect
@@ -1,4 +1,4 @@
-Rlimitouts0.bpl(29,5): Error BP5003: A postcondition might not hold on this return path.
+Rlimitouts0.bpl(29,5): Error: A postcondition might not hold on this return path.
 Rlimitouts0.bpl(14,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Rlimitouts0.bpl(18,7): anon0
@@ -6,14 +6,14 @@ Execution trace:
     Rlimitouts0.bpl(20,5): anon4_LoopDone
     Rlimitouts0.bpl(29,5): anon5_LoopHead
     Rlimitouts0.bpl(29,5): anon5_LoopDone
-Rlimitouts0.bpl(31,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Rlimitouts0.bpl(31,7): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Rlimitouts0.bpl(18,7): anon0
     Rlimitouts0.bpl(20,5): anon4_LoopHead
     Rlimitouts0.bpl(20,5): anon4_LoopDone
     Rlimitouts0.bpl(29,5): anon5_LoopHead
     Rlimitouts0.bpl(33,11): anon5_LoopBody
-Rlimitouts0.bpl(58,5): Error BP5003: A postcondition might not hold on this return path.
+Rlimitouts0.bpl(58,5): Error: A postcondition might not hold on this return path.
 Rlimitouts0.bpl(41,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Rlimitouts0.bpl(47,7): anon0
@@ -21,14 +21,14 @@ Execution trace:
     Rlimitouts0.bpl(49,5): anon4_LoopDone
     Rlimitouts0.bpl(58,5): anon5_LoopHead
     Rlimitouts0.bpl(58,5): anon5_LoopDone
-Rlimitouts0.bpl(60,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Rlimitouts0.bpl(60,7): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Rlimitouts0.bpl(47,7): anon0
     Rlimitouts0.bpl(49,5): anon4_LoopHead
     Rlimitouts0.bpl(49,5): anon4_LoopDone
     Rlimitouts0.bpl(58,5): anon5_LoopHead
     Rlimitouts0.bpl(62,11): anon5_LoopBody
-Rlimitouts0.bpl(87,5): Error BP5003: A postcondition might not hold on this return path.
+Rlimitouts0.bpl(87,5): Error: A postcondition might not hold on this return path.
 Rlimitouts0.bpl(70,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Rlimitouts0.bpl(76,7): anon0
@@ -36,7 +36,7 @@ Execution trace:
     Rlimitouts0.bpl(78,5): anon4_LoopDone
     Rlimitouts0.bpl(87,5): anon5_LoopHead
     Rlimitouts0.bpl(87,5): anon5_LoopDone
-Rlimitouts0.bpl(89,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Rlimitouts0.bpl(89,7): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Rlimitouts0.bpl(76,7): anon0
     Rlimitouts0.bpl(78,5): anon4_LoopHead

--- a/Test/test2/SelectiveChecking.bpl.expect
+++ b/Test/test2/SelectiveChecking.bpl.expect
@@ -1,15 +1,15 @@
-SelectiveChecking.bpl(19,3): Error BP5001: This assertion might not hold.
+SelectiveChecking.bpl(19,3): Error: This assertion might not hold.
 Execution trace:
     SelectiveChecking.bpl(17,3): anon0
-SelectiveChecking.bpl(32,3): Error BP5001: This assertion might not hold.
+SelectiveChecking.bpl(32,3): Error: This assertion might not hold.
 Execution trace:
     SelectiveChecking.bpl(26,3): anon0
     SelectiveChecking.bpl(29,5): anon3_Then
     SelectiveChecking.bpl(32,3): anon2
-SelectiveChecking.bpl(39,3): Error BP5001: This assertion might not hold.
+SelectiveChecking.bpl(39,3): Error: This assertion might not hold.
 Execution trace:
     SelectiveChecking.bpl(39,3): anon0
-SelectiveChecking.bpl(41,3): Error BP5001: This assertion might not hold.
+SelectiveChecking.bpl(41,3): Error: This assertion might not hold.
 Execution trace:
     SelectiveChecking.bpl(39,3): anon0
 

--- a/Test/test2/Structured.bpl.expect
+++ b/Test/test2/Structured.bpl.expect
@@ -1,4 +1,4 @@
-Structured.bpl(254,14): Error BP5003: A postcondition might not hold on this return path.
+Structured.bpl(254,14): Error: A postcondition might not hold on this return path.
 Structured.bpl(245,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Structured.bpl(246,5): anon0
@@ -6,17 +6,17 @@ Execution trace:
     Structured.bpl(249,7): anon7_LoopBody
     Structured.bpl(250,11): anon8_Then
     Structured.bpl(254,14): anon9_Then
-Structured.bpl(305,3): Error BP5001: This assertion might not hold.
+Structured.bpl(305,3): Error: This assertion might not hold.
 Execution trace:
     Structured.bpl(301,5): anon0
     Structured.bpl(302,3): anon3_Else
     Structured.bpl(305,3): anon2
-Structured.bpl(313,7): Error BP5001: This assertion might not hold.
+Structured.bpl(313,7): Error: This assertion might not hold.
 Execution trace:
     Structured.bpl(310,3): anon0
     Structured.bpl(310,3): anon1_Then
     Structured.bpl(311,5): A
-Structured.bpl(356,3): Error BP5005: This loop invariant might not be maintained by the loop.
+Structured.bpl(356,3): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Structured.bpl(354,5): anon0
     Structured.bpl(355,3): anon4_LoopHead

--- a/Test/test2/Timeouts0.bpl.expect
+++ b/Test/test2/Timeouts0.bpl.expect
@@ -1,4 +1,4 @@
-Timeouts0.bpl(26,5): Error BP5003: A postcondition might not hold on this return path.
+Timeouts0.bpl(26,5): Error: A postcondition might not hold on this return path.
 Timeouts0.bpl(11,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Timeouts0.bpl(15,7): anon0
@@ -6,14 +6,14 @@ Execution trace:
     Timeouts0.bpl(17,5): anon4_LoopDone
     Timeouts0.bpl(26,5): anon5_LoopHead
     Timeouts0.bpl(26,5): anon5_LoopDone
-Timeouts0.bpl(28,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Timeouts0.bpl(28,7): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Timeouts0.bpl(15,7): anon0
     Timeouts0.bpl(17,5): anon4_LoopHead
     Timeouts0.bpl(17,5): anon4_LoopDone
     Timeouts0.bpl(26,5): anon5_LoopHead
     Timeouts0.bpl(30,11): anon5_LoopBody
-Timeouts0.bpl(55,5): Error BP5003: A postcondition might not hold on this return path.
+Timeouts0.bpl(55,5): Error: A postcondition might not hold on this return path.
 Timeouts0.bpl(38,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Timeouts0.bpl(44,7): anon0
@@ -21,14 +21,14 @@ Execution trace:
     Timeouts0.bpl(46,5): anon4_LoopDone
     Timeouts0.bpl(55,5): anon5_LoopHead
     Timeouts0.bpl(55,5): anon5_LoopDone
-Timeouts0.bpl(57,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Timeouts0.bpl(57,7): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Timeouts0.bpl(44,7): anon0
     Timeouts0.bpl(46,5): anon4_LoopHead
     Timeouts0.bpl(46,5): anon4_LoopDone
     Timeouts0.bpl(55,5): anon5_LoopHead
     Timeouts0.bpl(59,11): anon5_LoopBody
-Timeouts0.bpl(84,5): Error BP5003: A postcondition might not hold on this return path.
+Timeouts0.bpl(84,5): Error: A postcondition might not hold on this return path.
 Timeouts0.bpl(67,3): Related location: This is the postcondition that might not hold.
 Execution trace:
     Timeouts0.bpl(73,7): anon0
@@ -36,7 +36,7 @@ Execution trace:
     Timeouts0.bpl(75,5): anon4_LoopDone
     Timeouts0.bpl(84,5): anon5_LoopHead
     Timeouts0.bpl(84,5): anon5_LoopDone
-Timeouts0.bpl(86,7): Error BP5005: This loop invariant might not be maintained by the loop.
+Timeouts0.bpl(86,7): Error: This loop invariant might not be maintained by the loop.
 Execution trace:
     Timeouts0.bpl(73,7): anon0
     Timeouts0.bpl(75,5): anon4_LoopHead

--- a/Test/test2/TypeEncodingM.bpl.expect
+++ b/Test/test2/TypeEncodingM.bpl.expect
@@ -1,4 +1,4 @@
-TypeEncodingM.bpl(26,3): Error BP5001: This assertion might not hold.
+TypeEncodingM.bpl(26,3): Error: This assertion might not hold.
 Execution trace:
     TypeEncodingM.bpl(13,9): anon0
 

--- a/Test/test2/UpdateExpr.bpl.expect
+++ b/Test/test2/UpdateExpr.bpl.expect
@@ -1,16 +1,16 @@
-UpdateExpr.bpl(16,3): Error BP5001: This assertion might not hold.
+UpdateExpr.bpl(16,3): Error: This assertion might not hold.
 Execution trace:
     UpdateExpr.bpl(16,3): anon0
-UpdateExpr.bpl(21,3): Error BP5001: This assertion might not hold.
+UpdateExpr.bpl(21,3): Error: This assertion might not hold.
 Execution trace:
     UpdateExpr.bpl(21,3): anon0
-UpdateExpr.bpl(34,3): Error BP5001: This assertion might not hold.
+UpdateExpr.bpl(34,3): Error: This assertion might not hold.
 Execution trace:
     UpdateExpr.bpl(34,3): anon0
-UpdateExpr.bpl(40,3): Error BP5001: This assertion might not hold.
+UpdateExpr.bpl(40,3): Error: This assertion might not hold.
 Execution trace:
     UpdateExpr.bpl(40,3): anon0
-UpdateExpr.bpl(54,3): Error BP5001: This assertion might not hold.
+UpdateExpr.bpl(54,3): Error: This assertion might not hold.
 Execution trace:
     UpdateExpr.bpl(53,5): anon0
 

--- a/Test/test2/Where.bpl.expect
+++ b/Test/test2/Where.bpl.expect
@@ -1,34 +1,34 @@
-Where.bpl(10,3): Error BP5001: This assertion might not hold.
+Where.bpl(10,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(8,3): anon0
-Where.bpl(24,3): Error BP5001: This assertion might not hold.
+Where.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(18,5): anon0
-Where.bpl(34,3): Error BP5001: This assertion might not hold.
+Where.bpl(34,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(32,3): anon0
-Where.bpl(46,3): Error BP5001: This assertion might not hold.
+Where.bpl(46,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(42,5): anon0
-Where.bpl(59,3): Error BP5001: This assertion might not hold.
+Where.bpl(59,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(54,3): anon0
-Where.bpl(113,3): Error BP5001: This assertion might not hold.
+Where.bpl(113,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(104,5): anon0
     Where.bpl(106,3): anon3_LoopHead
     Where.bpl(106,3): anon3_LoopDone
-Where.bpl(130,3): Error BP5001: This assertion might not hold.
+Where.bpl(130,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(123,5): anon0
     Where.bpl(124,3): anon3_LoopHead
     Where.bpl(124,3): anon3_LoopDone
-Where.bpl(147,3): Error BP5001: This assertion might not hold.
+Where.bpl(147,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(140,5): anon0
     Where.bpl(141,3): anon3_LoopHead
     Where.bpl(141,3): anon3_LoopDone
-Where.bpl(164,3): Error BP5001: This assertion might not hold.
+Where.bpl(164,3): Error: This assertion might not hold.
 Execution trace:
     Where.bpl(157,5): anon0
     Where.bpl(158,3): anon3_LoopHead

--- a/Test/test2/shadow1.bpl.expect
+++ b/Test/test2/shadow1.bpl.expect
@@ -1,4 +1,4 @@
-shadow1.bpl(10,3): Error BP5001: This assertion might not hold.
+shadow1.bpl(10,3): Error: This assertion might not hold.
 Execution trace:
     shadow1.bpl(9,3): anon0
 

--- a/Test/test21/BooleanQuantification.bpl.a.expect
+++ b/Test/test21/BooleanQuantification.bpl.a.expect
@@ -1,7 +1,7 @@
-BooleanQuantification.bpl(23,3): Error BP5001: This assertion might not hold.
+BooleanQuantification.bpl(23,3): Error: This assertion might not hold.
 Execution trace:
     BooleanQuantification.bpl(22,3): anon0
-BooleanQuantification.bpl(35,3): Error BP5001: This assertion might not hold.
+BooleanQuantification.bpl(35,3): Error: This assertion might not hold.
 Execution trace:
     BooleanQuantification.bpl(33,3): anon0
 

--- a/Test/test21/BooleanQuantification.bpl.p.expect
+++ b/Test/test21/BooleanQuantification.bpl.p.expect
@@ -1,7 +1,7 @@
-BooleanQuantification.bpl(23,3): Error BP5001: This assertion might not hold.
+BooleanQuantification.bpl(23,3): Error: This assertion might not hold.
 Execution trace:
     BooleanQuantification.bpl(22,3): anon0
-BooleanQuantification.bpl(35,3): Error BP5001: This assertion might not hold.
+BooleanQuantification.bpl(35,3): Error: This assertion might not hold.
 Execution trace:
     BooleanQuantification.bpl(33,3): anon0
 

--- a/Test/test21/BooleanQuantification2.bpl.a.expect
+++ b/Test/test21/BooleanQuantification2.bpl.a.expect
@@ -1,4 +1,4 @@
-BooleanQuantification2.bpl(17,3): Error BP5001: This assertion might not hold.
+BooleanQuantification2.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     BooleanQuantification2.bpl(14,3): anon0
 

--- a/Test/test21/BooleanQuantification2.bpl.p.expect
+++ b/Test/test21/BooleanQuantification2.bpl.p.expect
@@ -1,4 +1,4 @@
-BooleanQuantification2.bpl(17,3): Error BP5001: This assertion might not hold.
+BooleanQuantification2.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     BooleanQuantification2.bpl(14,3): anon0
 

--- a/Test/test21/Boxing.bpl.a.expect
+++ b/Test/test21/Boxing.bpl.a.expect
@@ -1,4 +1,4 @@
-Boxing.bpl(24,3): Error BP5001: This assertion might not hold.
+Boxing.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     Boxing.bpl(19,6): anon0
 

--- a/Test/test21/Boxing.bpl.p.expect
+++ b/Test/test21/Boxing.bpl.p.expect
@@ -1,4 +1,4 @@
-Boxing.bpl(24,3): Error BP5001: This assertion might not hold.
+Boxing.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     Boxing.bpl(19,6): anon0
 

--- a/Test/test21/Casts.bpl.a.expect
+++ b/Test/test21/Casts.bpl.a.expect
@@ -1,4 +1,4 @@
-Casts.bpl(14,3): Error BP5001: This assertion might not hold.
+Casts.bpl(14,3): Error: This assertion might not hold.
 Execution trace:
     Casts.bpl(10,3): anon0
 

--- a/Test/test21/Casts.bpl.p.expect
+++ b/Test/test21/Casts.bpl.p.expect
@@ -1,4 +1,4 @@
-Casts.bpl(14,3): Error BP5001: This assertion might not hold.
+Casts.bpl(14,3): Error: This assertion might not hold.
 Execution trace:
     Casts.bpl(10,3): anon0
 

--- a/Test/test21/Coercions2.bpl.a.expect
+++ b/Test/test21/Coercions2.bpl.a.expect
@@ -1,5 +1,5 @@
 Coercions2.bpl(16,23): Warning: type parameter a is ambiguous, instantiating to int
-Coercions2.bpl(27,3): Error BP5001: This assertion might not hold.
+Coercions2.bpl(27,3): Error: This assertion might not hold.
 Execution trace:
     Coercions2.bpl(22,3): anon0
 

--- a/Test/test21/Coercions2.bpl.p.expect
+++ b/Test/test21/Coercions2.bpl.p.expect
@@ -1,5 +1,5 @@
 Coercions2.bpl(16,23): Warning: type parameter a is ambiguous, instantiating to int
-Coercions2.bpl(27,3): Error BP5001: This assertion might not hold.
+Coercions2.bpl(27,3): Error: This assertion might not hold.
 Execution trace:
     Coercions2.bpl(22,3): anon0
 

--- a/Test/test21/Colors.bpl.a.expect
+++ b/Test/test21/Colors.bpl.a.expect
@@ -1,7 +1,7 @@
-Colors.bpl(17,3): Error BP5001: This assertion might not hold.
+Colors.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     Colors.bpl(16,3): anon0
-Colors.bpl(24,3): Error BP5001: This assertion might not hold.
+Colors.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     Colors.bpl(23,3): anon0
 

--- a/Test/test21/Colors.bpl.p.expect
+++ b/Test/test21/Colors.bpl.p.expect
@@ -1,7 +1,7 @@
-Colors.bpl(17,3): Error BP5001: This assertion might not hold.
+Colors.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     Colors.bpl(16,3): anon0
-Colors.bpl(24,3): Error BP5001: This assertion might not hold.
+Colors.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     Colors.bpl(23,3): anon0
 

--- a/Test/test21/DisjointDomains.bpl.a.expect
+++ b/Test/test21/DisjointDomains.bpl.a.expect
@@ -1,10 +1,10 @@
-DisjointDomains.bpl(18,5): Error BP5001: This assertion might not hold.
+DisjointDomains.bpl(18,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains.bpl(15,3): start
-DisjointDomains.bpl(25,5): Error BP5001: This assertion might not hold.
+DisjointDomains.bpl(25,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains.bpl(24,3): start
-DisjointDomains.bpl(31,5): Error BP5001: This assertion might not hold.
+DisjointDomains.bpl(31,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains.bpl(30,3): start
 

--- a/Test/test21/DisjointDomains.bpl.p.expect
+++ b/Test/test21/DisjointDomains.bpl.p.expect
@@ -1,10 +1,10 @@
-DisjointDomains.bpl(18,5): Error BP5001: This assertion might not hold.
+DisjointDomains.bpl(18,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains.bpl(15,3): start
-DisjointDomains.bpl(25,5): Error BP5001: This assertion might not hold.
+DisjointDomains.bpl(25,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains.bpl(24,3): start
-DisjointDomains.bpl(31,5): Error BP5001: This assertion might not hold.
+DisjointDomains.bpl(31,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains.bpl(30,3): start
 

--- a/Test/test21/DisjointDomains2.bpl.a.expect
+++ b/Test/test21/DisjointDomains2.bpl.a.expect
@@ -1,19 +1,19 @@
-DisjointDomains2.bpl(15,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(15,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(13,3): start
-DisjointDomains2.bpl(22,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(22,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(20,3): start
-DisjointDomains2.bpl(36,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(36,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(34,3): start
-DisjointDomains2.bpl(43,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(43,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(41,3): start
-DisjointDomains2.bpl(53,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(53,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(49,3): start
-DisjointDomains2.bpl(67,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(67,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(62,3): start
 

--- a/Test/test21/DisjointDomains2.bpl.p.expect
+++ b/Test/test21/DisjointDomains2.bpl.p.expect
@@ -1,19 +1,19 @@
-DisjointDomains2.bpl(15,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(15,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(13,3): start
-DisjointDomains2.bpl(22,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(22,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(20,3): start
-DisjointDomains2.bpl(36,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(36,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(34,3): start
-DisjointDomains2.bpl(43,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(43,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(41,3): start
-DisjointDomains2.bpl(53,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(53,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(49,3): start
-DisjointDomains2.bpl(67,5): Error BP5001: This assertion might not hold.
+DisjointDomains2.bpl(67,5): Error: This assertion might not hold.
 Execution trace:
     DisjointDomains2.bpl(62,3): start
 

--- a/Test/test21/EmptyList.bpl.a.expect
+++ b/Test/test21/EmptyList.bpl.a.expect
@@ -1,5 +1,5 @@
 EmptyList.bpl(50,9): Warning: type parameter a is ambiguous, instantiating to List int
-EmptyList.bpl(46,3): Error BP5001: This assertion might not hold.
+EmptyList.bpl(46,3): Error: This assertion might not hold.
 Execution trace:
     EmptyList.bpl(30,5): anon0
 

--- a/Test/test21/EmptyList.bpl.p.expect
+++ b/Test/test21/EmptyList.bpl.p.expect
@@ -1,5 +1,5 @@
 EmptyList.bpl(50,9): Warning: type parameter a is ambiguous, instantiating to List int
-EmptyList.bpl(46,3): Error BP5001: This assertion might not hold.
+EmptyList.bpl(46,3): Error: This assertion might not hold.
 Execution trace:
     EmptyList.bpl(30,5): anon0
 

--- a/Test/test21/EmptySetBug.bpl.a.expect
+++ b/Test/test21/EmptySetBug.bpl.a.expect
@@ -1,4 +1,4 @@
-EmptySetBug.bpl(33,3): Error BP5001: This assertion might not hold.
+EmptySetBug.bpl(33,3): Error: This assertion might not hold.
 Execution trace:
     EmptySetBug.bpl(29,5): anon0
 

--- a/Test/test21/EmptySetBug.bpl.p.expect
+++ b/Test/test21/EmptySetBug.bpl.p.expect
@@ -1,4 +1,4 @@
-EmptySetBug.bpl(33,3): Error BP5001: This assertion might not hold.
+EmptySetBug.bpl(33,3): Error: This assertion might not hold.
 Execution trace:
     EmptySetBug.bpl(29,5): anon0
 

--- a/Test/test21/Flattening.bpl.a.expect
+++ b/Test/test21/Flattening.bpl.a.expect
@@ -1,4 +1,4 @@
-Flattening.bpl(16,3): Error BP5001: This assertion might not hold.
+Flattening.bpl(16,3): Error: This assertion might not hold.
 Execution trace:
     Flattening.bpl(16,3): anon0
 

--- a/Test/test21/Flattening.bpl.p.expect
+++ b/Test/test21/Flattening.bpl.p.expect
@@ -1,4 +1,4 @@
-Flattening.bpl(16,3): Error BP5001: This assertion might not hold.
+Flattening.bpl(16,3): Error: This assertion might not hold.
 Execution trace:
     Flattening.bpl(16,3): anon0
 

--- a/Test/test21/FunAxioms.bpl.a.expect
+++ b/Test/test21/FunAxioms.bpl.a.expect
@@ -1,4 +1,4 @@
-FunAxioms.bpl(34,3): Error BP5001: This assertion might not hold.
+FunAxioms.bpl(34,3): Error: This assertion might not hold.
 Execution trace:
     FunAxioms.bpl(22,3): anon0
 

--- a/Test/test21/FunAxioms.bpl.p.expect
+++ b/Test/test21/FunAxioms.bpl.p.expect
@@ -1,4 +1,4 @@
-FunAxioms.bpl(34,3): Error BP5001: This assertion might not hold.
+FunAxioms.bpl(34,3): Error: This assertion might not hold.
 Execution trace:
     FunAxioms.bpl(22,3): anon0
 

--- a/Test/test21/FunAxioms2.bpl.a.expect
+++ b/Test/test21/FunAxioms2.bpl.a.expect
@@ -1,4 +1,4 @@
-FunAxioms2.bpl(24,3): Error BP5001: This assertion might not hold.
+FunAxioms2.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     FunAxioms2.bpl(20,5): anon0
 

--- a/Test/test21/FunAxioms2.bpl.p.expect
+++ b/Test/test21/FunAxioms2.bpl.p.expect
@@ -1,4 +1,4 @@
-FunAxioms2.bpl(24,3): Error BP5001: This assertion might not hold.
+FunAxioms2.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     FunAxioms2.bpl(20,5): anon0
 

--- a/Test/test21/HeapAbstraction.bpl.a.expect
+++ b/Test/test21/HeapAbstraction.bpl.a.expect
@@ -1,4 +1,4 @@
-HeapAbstraction.bpl(19,3): Error BP5001: This assertion might not hold.
+HeapAbstraction.bpl(19,3): Error: This assertion might not hold.
 Execution trace:
     HeapAbstraction.bpl(18,3): anon0
 

--- a/Test/test21/HeapAbstraction.bpl.p.expect
+++ b/Test/test21/HeapAbstraction.bpl.p.expect
@@ -1,4 +1,4 @@
-HeapAbstraction.bpl(19,3): Error BP5001: This assertion might not hold.
+HeapAbstraction.bpl(19,3): Error: This assertion might not hold.
 Execution trace:
     HeapAbstraction.bpl(18,3): anon0
 

--- a/Test/test21/HeapAxiom.bpl.a.expect
+++ b/Test/test21/HeapAxiom.bpl.a.expect
@@ -1,4 +1,4 @@
-HeapAxiom.bpl(28,3): Error BP5001: This assertion might not hold.
+HeapAxiom.bpl(28,3): Error: This assertion might not hold.
 Execution trace:
     HeapAxiom.bpl(17,3): anon0
 

--- a/Test/test21/HeapAxiom.bpl.p.expect
+++ b/Test/test21/HeapAxiom.bpl.p.expect
@@ -1,4 +1,4 @@
-HeapAxiom.bpl(28,3): Error BP5001: This assertion might not hold.
+HeapAxiom.bpl(28,3): Error: This assertion might not hold.
 Execution trace:
     HeapAxiom.bpl(17,3): anon0
 

--- a/Test/test21/InterestingExamples1.bpl.a.expect
+++ b/Test/test21/InterestingExamples1.bpl.a.expect
@@ -1,4 +1,4 @@
-InterestingExamples1.bpl(26,3): Error BP5001: This assertion might not hold.
+InterestingExamples1.bpl(26,3): Error: This assertion might not hold.
 Execution trace:
     InterestingExamples1.bpl(17,5): anon0
 

--- a/Test/test21/InterestingExamples1.bpl.p.expect
+++ b/Test/test21/InterestingExamples1.bpl.p.expect
@@ -1,4 +1,4 @@
-InterestingExamples1.bpl(26,3): Error BP5001: This assertion might not hold.
+InterestingExamples1.bpl(26,3): Error: This assertion might not hold.
 Execution trace:
     InterestingExamples1.bpl(17,5): anon0
 

--- a/Test/test21/InterestingExamples3.bpl.a.expect
+++ b/Test/test21/InterestingExamples3.bpl.a.expect
@@ -1,4 +1,4 @@
-InterestingExamples3.bpl(19,2): Error BP5001: This assertion might not hold.
+InterestingExamples3.bpl(19,2): Error: This assertion might not hold.
 Execution trace:
     InterestingExamples3.bpl(17,2): anon0
 

--- a/Test/test21/InterestingExamples3.bpl.p.expect
+++ b/Test/test21/InterestingExamples3.bpl.p.expect
@@ -1,4 +1,4 @@
-InterestingExamples3.bpl(19,2): Error BP5001: This assertion might not hold.
+InterestingExamples3.bpl(19,2): Error: This assertion might not hold.
 Execution trace:
     InterestingExamples3.bpl(17,2): anon0
 

--- a/Test/test21/InterestingExamples4.bpl.a.expect
+++ b/Test/test21/InterestingExamples4.bpl.a.expect
@@ -1,7 +1,7 @@
-InterestingExamples4.bpl(40,3): Error BP5001: This assertion might not hold.
+InterestingExamples4.bpl(40,3): Error: This assertion might not hold.
 Execution trace:
     InterestingExamples4.bpl(40,3): anon0
-InterestingExamples4.bpl(43,3): Error BP5001: This assertion might not hold.
+InterestingExamples4.bpl(43,3): Error: This assertion might not hold.
 Execution trace:
     InterestingExamples4.bpl(40,3): anon0
 

--- a/Test/test21/InterestingExamples4.bpl.p.expect
+++ b/Test/test21/InterestingExamples4.bpl.p.expect
@@ -1,4 +1,4 @@
-InterestingExamples4.bpl(43,3): Error BP5001: This assertion might not hold.
+InterestingExamples4.bpl(43,3): Error: This assertion might not hold.
 Execution trace:
     InterestingExamples4.bpl(40,3): anon0
 

--- a/Test/test21/LargeLiterals0.bpl.a.expect
+++ b/Test/test21/LargeLiterals0.bpl.a.expect
@@ -1,4 +1,4 @@
-LargeLiterals0.bpl(22,3): Error BP5001: This assertion might not hold.
+LargeLiterals0.bpl(22,3): Error: This assertion might not hold.
 Execution trace:
     LargeLiterals0.bpl(11,5): anon0
 

--- a/Test/test21/LargeLiterals0.bpl.p.expect
+++ b/Test/test21/LargeLiterals0.bpl.p.expect
@@ -1,4 +1,4 @@
-LargeLiterals0.bpl(22,3): Error BP5001: This assertion might not hold.
+LargeLiterals0.bpl(22,3): Error: This assertion might not hold.
 Execution trace:
     LargeLiterals0.bpl(11,5): anon0
 

--- a/Test/test21/MapAxiomsConsistency.bpl.a.expect
+++ b/Test/test21/MapAxiomsConsistency.bpl.a.expect
@@ -1,4 +1,4 @@
-MapAxiomsConsistency.bpl(98,5): Error BP5001: This assertion might not hold.
+MapAxiomsConsistency.bpl(98,5): Error: This assertion might not hold.
 Execution trace:
     MapAxiomsConsistency.bpl(83,13): anon0
 

--- a/Test/test21/MapAxiomsConsistency.bpl.p.expect
+++ b/Test/test21/MapAxiomsConsistency.bpl.p.expect
@@ -1,4 +1,4 @@
-MapAxiomsConsistency.bpl(98,5): Error BP5001: This assertion might not hold.
+MapAxiomsConsistency.bpl(98,5): Error: This assertion might not hold.
 Execution trace:
     MapAxiomsConsistency.bpl(83,13): anon0
 

--- a/Test/test21/MapOutputTypeParams.bpl.a.expect
+++ b/Test/test21/MapOutputTypeParams.bpl.a.expect
@@ -1,11 +1,11 @@
 MapOutputTypeParams.bpl(33,3): Warning: type parameter a is ambiguous, instantiating to int
-MapOutputTypeParams.bpl(17,3): Error BP5001: This assertion might not hold.
+MapOutputTypeParams.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     MapOutputTypeParams.bpl(11,9): anon0
-MapOutputTypeParams.bpl(28,3): Error BP5001: This assertion might not hold.
+MapOutputTypeParams.bpl(28,3): Error: This assertion might not hold.
 Execution trace:
     MapOutputTypeParams.bpl(23,9): anon0
-MapOutputTypeParams.bpl(36,3): Error BP5001: This assertion might not hold.
+MapOutputTypeParams.bpl(36,3): Error: This assertion might not hold.
 Execution trace:
     MapOutputTypeParams.bpl(32,8): anon0
 

--- a/Test/test21/MapOutputTypeParams.bpl.p.expect
+++ b/Test/test21/MapOutputTypeParams.bpl.p.expect
@@ -1,11 +1,11 @@
 MapOutputTypeParams.bpl(33,3): Warning: type parameter a is ambiguous, instantiating to int
-MapOutputTypeParams.bpl(17,3): Error BP5001: This assertion might not hold.
+MapOutputTypeParams.bpl(17,3): Error: This assertion might not hold.
 Execution trace:
     MapOutputTypeParams.bpl(11,9): anon0
-MapOutputTypeParams.bpl(28,3): Error BP5001: This assertion might not hold.
+MapOutputTypeParams.bpl(28,3): Error: This assertion might not hold.
 Execution trace:
     MapOutputTypeParams.bpl(23,9): anon0
-MapOutputTypeParams.bpl(36,3): Error BP5001: This assertion might not hold.
+MapOutputTypeParams.bpl(36,3): Error: This assertion might not hold.
 Execution trace:
     MapOutputTypeParams.bpl(32,8): anon0
 

--- a/Test/test21/Maps0.bpl.a.expect
+++ b/Test/test21/Maps0.bpl.a.expect
@@ -1,10 +1,10 @@
-Maps0.bpl(27,3): Error BP5001: This assertion might not hold.
+Maps0.bpl(27,3): Error: This assertion might not hold.
 Execution trace:
     Maps0.bpl(18,3): anon0
-Maps0.bpl(36,3): Error BP5001: This assertion might not hold.
+Maps0.bpl(36,3): Error: This assertion might not hold.
 Execution trace:
     Maps0.bpl(36,3): anon0
-Maps0.bpl(57,3): Error BP5001: This assertion might not hold.
+Maps0.bpl(57,3): Error: This assertion might not hold.
 Execution trace:
     Maps0.bpl(45,9): anon0
 

--- a/Test/test21/Maps0.bpl.p.expect
+++ b/Test/test21/Maps0.bpl.p.expect
@@ -1,10 +1,10 @@
-Maps0.bpl(27,3): Error BP5001: This assertion might not hold.
+Maps0.bpl(27,3): Error: This assertion might not hold.
 Execution trace:
     Maps0.bpl(18,3): anon0
-Maps0.bpl(36,3): Error BP5001: This assertion might not hold.
+Maps0.bpl(36,3): Error: This assertion might not hold.
 Execution trace:
     Maps0.bpl(36,3): anon0
-Maps0.bpl(57,3): Error BP5001: This assertion might not hold.
+Maps0.bpl(57,3): Error: This assertion might not hold.
 Execution trace:
     Maps0.bpl(45,9): anon0
 

--- a/Test/test21/Maps1.bpl.a.expect
+++ b/Test/test21/Maps1.bpl.a.expect
@@ -1,4 +1,4 @@
-Maps1.bpl(35,3): Error BP5001: This assertion might not hold.
+Maps1.bpl(35,3): Error: This assertion might not hold.
 Execution trace:
     Maps1.bpl(23,3): anon0
 

--- a/Test/test21/Maps1.bpl.p.expect
+++ b/Test/test21/Maps1.bpl.p.expect
@@ -1,4 +1,4 @@
-Maps1.bpl(35,3): Error BP5001: This assertion might not hold.
+Maps1.bpl(35,3): Error: This assertion might not hold.
 Execution trace:
     Maps1.bpl(23,3): anon0
 

--- a/Test/test21/Orderings.bpl.a.expect
+++ b/Test/test21/Orderings.bpl.a.expect
@@ -1,4 +1,4 @@
-Orderings.bpl(18,3): Error BP5001: This assertion might not hold.
+Orderings.bpl(18,3): Error: This assertion might not hold.
 Execution trace:
     Orderings.bpl(13,3): anon0
 

--- a/Test/test21/Orderings.bpl.p.expect
+++ b/Test/test21/Orderings.bpl.p.expect
@@ -1,4 +1,4 @@
-Orderings.bpl(18,3): Error BP5001: This assertion might not hold.
+Orderings.bpl(18,3): Error: This assertion might not hold.
 Execution trace:
     Orderings.bpl(13,3): anon0
 

--- a/Test/test21/Orderings2.bpl.a.expect
+++ b/Test/test21/Orderings2.bpl.a.expect
@@ -1,4 +1,4 @@
-Orderings2.bpl(21,3): Error BP5001: This assertion might not hold.
+Orderings2.bpl(21,3): Error: This assertion might not hold.
 Execution trace:
     Orderings2.bpl(16,3): anon0
 

--- a/Test/test21/Orderings2.bpl.p.expect
+++ b/Test/test21/Orderings2.bpl.p.expect
@@ -1,4 +1,4 @@
-Orderings2.bpl(21,3): Error BP5001: This assertion might not hold.
+Orderings2.bpl(21,3): Error: This assertion might not hold.
 Execution trace:
     Orderings2.bpl(16,3): anon0
 

--- a/Test/test21/Orderings3.bpl.a.expect
+++ b/Test/test21/Orderings3.bpl.a.expect
@@ -1,10 +1,10 @@
-Orderings3.bpl(33,3): Error BP5001: This assertion might not hold.
+Orderings3.bpl(33,3): Error: This assertion might not hold.
 Execution trace:
     Orderings3.bpl(19,3): anon0
-Orderings3.bpl(38,3): Error BP5001: This assertion might not hold.
+Orderings3.bpl(38,3): Error: This assertion might not hold.
 Execution trace:
     Orderings3.bpl(38,3): anon0
-Orderings3.bpl(40,3): Error BP5001: This assertion might not hold.
+Orderings3.bpl(40,3): Error: This assertion might not hold.
 Execution trace:
     Orderings3.bpl(38,3): anon0
 

--- a/Test/test21/Orderings3.bpl.p.expect
+++ b/Test/test21/Orderings3.bpl.p.expect
@@ -1,10 +1,10 @@
-Orderings3.bpl(33,3): Error BP5001: This assertion might not hold.
+Orderings3.bpl(33,3): Error: This assertion might not hold.
 Execution trace:
     Orderings3.bpl(19,3): anon0
-Orderings3.bpl(38,3): Error BP5001: This assertion might not hold.
+Orderings3.bpl(38,3): Error: This assertion might not hold.
 Execution trace:
     Orderings3.bpl(38,3): anon0
-Orderings3.bpl(40,3): Error BP5001: This assertion might not hold.
+Orderings3.bpl(40,3): Error: This assertion might not hold.
 Execution trace:
     Orderings3.bpl(38,3): anon0
 

--- a/Test/test21/Orderings4.bpl.a.expect
+++ b/Test/test21/Orderings4.bpl.a.expect
@@ -1,4 +1,4 @@
-Orderings4.bpl(14,3): Error BP5001: This assertion might not hold.
+Orderings4.bpl(14,3): Error: This assertion might not hold.
 Execution trace:
     Orderings4.bpl(13,3): anon0
 

--- a/Test/test21/Orderings4.bpl.p.expect
+++ b/Test/test21/Orderings4.bpl.p.expect
@@ -1,4 +1,4 @@
-Orderings4.bpl(14,3): Error BP5001: This assertion might not hold.
+Orderings4.bpl(14,3): Error: This assertion might not hold.
 Execution trace:
     Orderings4.bpl(13,3): anon0
 

--- a/Test/test21/ParallelAssignment.bpl.a.expect
+++ b/Test/test21/ParallelAssignment.bpl.a.expect
@@ -1,10 +1,10 @@
-ParallelAssignment.bpl(30,3): Error BP5001: This assertion might not hold.
+ParallelAssignment.bpl(30,3): Error: This assertion might not hold.
 Execution trace:
     ParallelAssignment.bpl(19,5): anon0
-ParallelAssignment.bpl(39,3): Error BP5001: This assertion might not hold.
+ParallelAssignment.bpl(39,3): Error: This assertion might not hold.
 Execution trace:
     ParallelAssignment.bpl(19,5): anon0
-ParallelAssignment.bpl(58,3): Error BP5001: This assertion might not hold.
+ParallelAssignment.bpl(58,3): Error: This assertion might not hold.
 Execution trace:
     ParallelAssignment.bpl(44,11): anon0
 

--- a/Test/test21/ParallelAssignment.bpl.p.expect
+++ b/Test/test21/ParallelAssignment.bpl.p.expect
@@ -1,10 +1,10 @@
-ParallelAssignment.bpl(30,3): Error BP5001: This assertion might not hold.
+ParallelAssignment.bpl(30,3): Error: This assertion might not hold.
 Execution trace:
     ParallelAssignment.bpl(19,5): anon0
-ParallelAssignment.bpl(39,3): Error BP5001: This assertion might not hold.
+ParallelAssignment.bpl(39,3): Error: This assertion might not hold.
 Execution trace:
     ParallelAssignment.bpl(19,5): anon0
-ParallelAssignment.bpl(58,3): Error BP5001: This assertion might not hold.
+ParallelAssignment.bpl(58,3): Error: This assertion might not hold.
 Execution trace:
     ParallelAssignment.bpl(44,11): anon0
 

--- a/Test/test21/PolyList.bpl.a.expect
+++ b/Test/test21/PolyList.bpl.a.expect
@@ -1,7 +1,7 @@
-PolyList.bpl(46,3): Error BP5001: This assertion might not hold.
+PolyList.bpl(46,3): Error: This assertion might not hold.
 Execution trace:
     PolyList.bpl(31,7): anon0
-PolyList.bpl(64,3): Error BP5001: This assertion might not hold.
+PolyList.bpl(64,3): Error: This assertion might not hold.
 Execution trace:
     PolyList.bpl(53,7): anon0
 

--- a/Test/test21/PolyList.bpl.p.expect
+++ b/Test/test21/PolyList.bpl.p.expect
@@ -1,7 +1,7 @@
-PolyList.bpl(46,3): Error BP5001: This assertion might not hold.
+PolyList.bpl(46,3): Error: This assertion might not hold.
 Execution trace:
     PolyList.bpl(31,7): anon0
-PolyList.bpl(64,3): Error BP5001: This assertion might not hold.
+PolyList.bpl(64,3): Error: This assertion might not hold.
 Execution trace:
     PolyList.bpl(53,7): anon0
 

--- a/Test/test21/Real.bpl.a.expect
+++ b/Test/test21/Real.bpl.a.expect
@@ -1,8 +1,8 @@
-Real.bpl(30,5): Error BP5001: This assertion might not hold.
+Real.bpl(30,5): Error: This assertion might not hold.
 Execution trace:
     Real.bpl(27,5): anon0
     Real.bpl(30,5): anon3_Then
-Real.bpl(45,5): Error BP5001: This assertion might not hold.
+Real.bpl(45,5): Error: This assertion might not hold.
 Execution trace:
     Real.bpl(38,3): anon0
     Real.bpl(45,5): anon3_Else

--- a/Test/test21/Real.bpl.p.expect
+++ b/Test/test21/Real.bpl.p.expect
@@ -1,8 +1,8 @@
-Real.bpl(30,5): Error BP5001: This assertion might not hold.
+Real.bpl(30,5): Error: This assertion might not hold.
 Execution trace:
     Real.bpl(27,5): anon0
     Real.bpl(30,5): anon3_Then
-Real.bpl(45,5): Error BP5001: This assertion might not hold.
+Real.bpl(45,5): Error: This assertion might not hold.
 Execution trace:
     Real.bpl(38,3): anon0
     Real.bpl(45,5): anon3_Else

--- a/Test/test21/Triggers0.bpl.a.expect
+++ b/Test/test21/Triggers0.bpl.a.expect
@@ -1,7 +1,7 @@
-Triggers0.bpl(43,3): Error BP5001: This assertion might not hold.
+Triggers0.bpl(43,3): Error: This assertion might not hold.
 Execution trace:
     Triggers0.bpl(43,3): anon0
-Triggers0.bpl(47,3): Error BP5001: This assertion might not hold.
+Triggers0.bpl(47,3): Error: This assertion might not hold.
 Execution trace:
     Triggers0.bpl(43,3): anon0
 

--- a/Test/test21/Triggers0.bpl.p.expect
+++ b/Test/test21/Triggers0.bpl.p.expect
@@ -1,7 +1,7 @@
-Triggers0.bpl(43,3): Error BP5001: This assertion might not hold.
+Triggers0.bpl(43,3): Error: This assertion might not hold.
 Execution trace:
     Triggers0.bpl(43,3): anon0
-Triggers0.bpl(47,3): Error BP5001: This assertion might not hold.
+Triggers0.bpl(47,3): Error: This assertion might not hold.
 Execution trace:
     Triggers0.bpl(43,3): anon0
 

--- a/Test/test21/Triggers1.bpl.a.expect
+++ b/Test/test21/Triggers1.bpl.a.expect
@@ -1,4 +1,4 @@
-Triggers1.bpl(20,3): Error BP5001: This assertion might not hold.
+Triggers1.bpl(20,3): Error: This assertion might not hold.
 Execution trace:
     Triggers1.bpl(16,3): anon0
 

--- a/Test/test21/Triggers1.bpl.p.expect
+++ b/Test/test21/Triggers1.bpl.p.expect
@@ -1,4 +1,4 @@
-Triggers1.bpl(20,3): Error BP5001: This assertion might not hold.
+Triggers1.bpl(20,3): Error: This assertion might not hold.
 Execution trace:
     Triggers1.bpl(16,3): anon0
 


### PR DESCRIPTION
**Context**

Boogie outputs the following error codes alongside error messages:

`BP5001` failed assertion
`BP5002` failed precondition
`BP5003` failed postcondition
`BP5004` failed loop invariant initialization
`BP5005` failed loop invariant maintenance
`BP5010` anything causing a `VCGenException`

So an error message might look like this:
```
bla1.bpl(2097,5): Error BP5001: This assertion might not hold.
Execution trace:
    bla1.bpl(751,3): start#1
    ...
```

**The problem**

These error codes look odd when tools encode their own checks but use Boogie's error reporting with custom error messages.

Dafny example:
```
Inc.dfy(318,17): Error BP5001: cannot prove termination; try supplying a decreases clause
```

CIVL example:
```
left-mover.bpl(19,32): Error BP5001: Commutativity check between init and inc failed
```

**This PR**

This PR drops error codes. They do not seem particularly helpful to Boogie users. It's just the 6 above; nothing for parsing, type checking, etc. And there is no documentation.

**Other options**

Two other options could be:

1. Introduce a configuration flag that disables error codes. Clients that don't like error codes can disable them.
2. Add the possibility to attach error codes to `Requires`, `Ensures`, and `AssertCmd` (anything else?). Clients can either put a custom error code or disable (by setting to `null`).

**Let's vote**

@RustanLeino @shazqadeer @zvonimir @akashlal @alexanderjsummers @gauravpartha 
Do you want to keep error codes? In which form?
Does this affect your tools?