### PR TITLE
add quotes and extension to OutputCheck command

### DIFF
--- a/Test/test2/RandomSeed.bpl
+++ b/Test/test2/RandomSeed.bpl
@@ -1,5 +1,5 @@
-// RUN: %boogie -proverOpt:O:smt.random_seed=55 -proverLog:%t "%s"
-// RUN: %OutputCheck --file-to-check "%t" "%s"
+// RUN: %boogie -proverOpt:O:smt.random_seed=55 -proverLog:"%t.smt2" "%s"
+// RUN: %OutputCheck --file-to-check "%t.smt2" "%s"
 // CHECK-L: (set-info :boogie-vc-id WithRandomSeed0)
 // CHECK-L: (set-option :smt.random_seed 100)
 // CHECK-L: (set-option :smt.random_seed 55)

--- a/Test/test2/Rlimitouts0.bpl
+++ b/Test/test2/Rlimitouts0.bpl
@@ -1,5 +1,5 @@
-// RUN: %boogie -rlimit:800 -proverLog:%t "%s"
-// RUN: %OutputCheck --file-to-check "%t" "%s"
+// RUN: %boogie -rlimit:800 -proverLog:"%t.smt2" "%s"
+// RUN: %OutputCheck --file-to-check "%t.smt2" "%s"
 // CHECK-L: (set-option :timeout 0)
 // CHECK-L: (set-option :rlimit 800000)
 // CHECK-L: (set-option :timeout 0)

--- a/Test/test2/Timeouts0.bpl
+++ b/Test/test2/Timeouts0.bpl
@@ -1,7 +1,7 @@
 // RUN: %boogie -timeLimit:4 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-// RUN: %boogie -timeLimit:4 -proverLog:%t "%s"
-// RUN: %OutputCheck --file-to-check "%t" "%s"
+// RUN: %boogie -timeLimit:4 -proverLog:"%t.smt2" "%s"
+// RUN: %OutputCheck --file-to-check "%t.smt2" "%s"
 // CHECK-L: (set-option :timeout 4000)
 // CHECK-L: (set-option :timeout 8000)
 // CHECK-L: (set-option :timeout 2000)


### PR DESCRIPTION
Currently, three tests crash if Boogie's path contains spaces. The reason is because the `proverLog` filename parameter is not enclosed with quotes in the OutputCheck command. A sufficient fix would be to just enclose the parameter with quotes, but I also added the extension ".smt2" to be consistent with similar tests such as https://github.com/boogie-org/boogie/blob/20cae5c1b9be3be082c963540b41b3db35c24ce4/Test/functiondefine/fundef.bpl#L1