### PR TITLE
Add example that asynchronously sums the numbers from 1 to n

### DIFF
--- a/Test/civl/inductive-sequentialization/Gauss.bpl
+++ b/Test/civl/inductive-sequentialization/Gauss.bpl
@@ -1,0 +1,58 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,2} x:int;
+
+type {:pending_async}{:datatype} PA;
+function {:constructor} ADD(i: int) : PA;
+
+////////////////////////////////////////////////////////////////////////////////
+
+function trigger(i: int) : bool { true }
+
+procedure {:atomic}{:layer 1}
+{:IS "MAIN'","INV"}{:elim "ADD"}
+SUM (n: int)
+returns ({:pending_async "ADD"} PAs:[PA]int)
+modifies x;
+{
+  assert n >= 0;
+  assert trigger(0); // base hint
+  PAs := (lambda pa: PA :: if is#ADD(pa) && 1 <= i#ADD(pa) && i#ADD(pa) <= n then 1 else 0);
+}
+
+procedure {:atomic}{:layer 2}
+MAIN' (n: int)
+modifies x;
+{
+  assert n >= 0;
+  x := x + ((n * (n+1)) div 2);
+}
+
+procedure {:IS_invariant}{:layer 1}
+INV (n: int)
+returns ({:pending_async "ADD"} PAs:[PA]int, {:choice} choice:PA)
+modifies x;
+{
+  var i: int;
+
+  assert n >= 0;
+  
+  assume 0 <= i && i <= n;
+  x := x + (i * (i+1)) div 2;
+  PAs := (lambda pa: PA :: if is#ADD(pa) && i < i#ADD(pa) && i#ADD(pa) <= n then 1 else 0);
+  choice := ADD(i+1);
+
+  assume trigger(i);                // the pattern we hope Z3 to put as a trigger
+  assume trigger(i+1);              // step hint
+  assume i < n ==> PAs[ADD(n)] > 0; // conclusion hint
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+procedure {:left}{:layer 1}
+ADD (i: int)
+modifies x;
+{
+  x := x + i;
+}

--- a/Test/civl/inductive-sequentialization/Gauss.bpl
+++ b/Test/civl/inductive-sequentialization/Gauss.bpl
@@ -26,7 +26,7 @@ MAIN' (n: int)
 modifies x;
 {
   assert n >= 0;
-  x := x + ((n * (n+1)) div 2);
+  x := x + (n * (n+1)) div 2;
 }
 
 procedure {:IS_invariant}{:layer 1}

--- a/Test/civl/inductive-sequentialization/Gauss.bpl.expect
+++ b/Test/civl/inductive-sequentialization/Gauss.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 8 verified, 0 errors

--- a/Test/test2/Gauss.bpl
+++ b/Test/test2/Gauss.bpl
@@ -1,0 +1,19 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure sum(n: int) returns (s: int)
+requires n >= 0;
+ensures s == (n * (n + 1)) div 2;
+{
+  var i: int;
+
+  i := 0;
+  s := 0;
+  while (i < n)
+  invariant 0 <= i && i <= n;
+  invariant s == (i * (i + 1)) div 2;
+  {
+    i := i + 1;
+    s := s + i;
+  }
+}

--- a/Test/test2/Gauss.bpl.expect
+++ b/Test/test2/Gauss.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
This is a simple example to illustrate inductive sequentialization.

It creates `n` asynchronous `ADD(i)` operations (`i` between `1` and `n`), each adding `i` to the global variable `x`. Instead of considering all interleavings, inductive sequentialization allows us to only consider `ADD(1); ADD(2); ...; ADD(n)`. Thus we can use the identity `1 + 2 + ... + n = (n * (n+1)) / 2` (which Gauss allegedly figured out as a child) in the invariant.

Because nonlinear invariants are so much fun, also a sequential version of the example is added.