### PR TITLE
Remove :captureState dependence on model.compact

### DIFF
--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1879,8 +1879,6 @@ namespace Microsoft.Boogie
        shows the values of variables at each {:captureState ...} point in
        the counterexample trace. The argument 's' is to be a string, and it
        will be printed as part of /mv's output.
-       Note, the use of :captureState and /mv have not been implemented for
-       use with procedure inlining.
 
   ---- CIVL ------------------------------------------------------------------
 

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1873,8 +1873,14 @@ namespace Microsoft.Boogie
        used in conjunction with /enhancedErrorMessages:n command-line option.
 
      {:captureState s}
-       Indicates that state must be captured under the name s.  Must be used
-       together with /mv:<string> command-line option.
+       When this attribute is applied to assume commands, it causes the 
+       /mv:<string> command-line option to group each counterexample model
+       into a sequence of states. In particular, this sequence of states
+       shows the values of variables at each {:captureState ...} point in
+       the counterexample trace. The argument 's' is to be a string, and it
+       will be printed as part of /mv's output.
+       Note, the use of :captureState and /mv have not been implemented for
+       use with procedure inlining.
 
   ---- CIVL ------------------------------------------------------------------
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1787,7 +1787,7 @@ namespace Microsoft.Boogie
 
           if (CommandLineOptions.Clo.ModelViewFile != null)
           {
-            error.PrintModel(errorInfo.Model);
+            error.PrintModel(errorInfo.Model, error);
           }
 
           printer.WriteErrorInformation(errorInfo, tw);

--- a/Source/VCGeneration/ModelViewInfo.cs
+++ b/Source/VCGeneration/ModelViewInfo.cs
@@ -11,6 +11,8 @@ namespace VC
     public readonly List<Variable> AllVariables = new List<Variable>();
     public readonly List<Mapping> CapturePoints = new List<Mapping>();
 
+    public readonly Dictionary<Block, List<(AssumeCmd, Mapping)>> BlockToCapturePointIndex = new Dictionary<Block, List<(AssumeCmd, Mapping)>>();
+
     public static readonly Function MVState_FunctionDef = new Function(Token.NoToken, "$mv_state",
       new List<Variable>
       {

--- a/Test/test15/CaptureInlineUnroll.bpl
+++ b/Test/test15/CaptureInlineUnroll.bpl
@@ -1,0 +1,42 @@
+// RUN: %boogie "%s" /mv:- /loopUnroll:2 /inline:none > "%t"
+// RUN: %boogie "%s" /mv:- /loopUnroll:3 >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure LoopUnroll(n: int)
+{
+  var i: int;
+
+  assume {:captureState "procedure entry"} true;
+  i := 0;
+  while (i < n) {
+    assume {:captureState "loop entry"} true;
+    assert i != 2;  // error (with /loopUnroll:3 or higher)
+    i := i + 1;
+  }
+  assume {:captureState "after loop"} true;
+}
+
+procedure Caller()
+{
+  var u: int;
+
+  u := 0;
+  assume {:captureState "0 calls"} true;
+
+  call u := Increment(u);
+  assume {:captureState "1 call"} true;
+
+  u := u + 3;
+  call u := Increment(u);
+  assume {:captureState "2 calls"} true;
+
+  assert u == 8;  // error
+}
+
+procedure {:inline 10} Increment(x: int) returns (y: int)
+{
+  assume {:captureState "Increment entry"} true;
+  y := x + 1;
+  assert y == 2;
+  assume {:captureState "Increment exit"} true;
+}

--- a/Test/test15/CaptureInlineUnroll.bpl.expect
+++ b/Test/test15/CaptureInlineUnroll.bpl.expect
@@ -1,0 +1,171 @@
+CaptureInlineUnroll.bpl(33,3): Error: This assertion might not hold.
+Execution trace:
+    CaptureInlineUnroll.bpl(23,5): anon0#2
+*** MODEL
+$mv_state_const -> 5
+call1formal@y@0 -> (- 3)
+call1formal@y@0@@0 -> 4
+u -> 
+u@0 -> 0
+$mv_state -> {
+  5 0 -> true
+  5 1 -> true
+  5 2 -> true
+  else -> true
+}
+ControlFlow -> {
+  0 0 -> 322
+  0 180 -> (- 412)
+  0 322 -> 180
+  else -> (- 412)
+}
+tickleBool -> {
+  false -> true
+  true -> true
+  else -> true
+}
+*** STATE <initial>
+  u -> 
+*** END_STATE
+*** STATE 0 calls$renamed$Caller$0
+  u -> 0
+*** END_STATE
+*** STATE 1 call$renamed$Caller$1
+  u -> (- 3)
+*** END_STATE
+*** STATE 2 calls$renamed$Caller$2
+  u -> 4
+*** END_STATE
+*** END_MODEL
+CaptureInlineUnroll.bpl(40,3): Error: This assertion might not hold.
+Execution trace:
+    CaptureInlineUnroll.bpl(38,3): anon0#2
+*** MODEL
+$mv_state_const -> 4
+x -> 2
+y -> 
+y@0 -> 3
+$mv_state -> {
+  4 0 -> true
+  else -> true
+}
+ControlFlow -> {
+  0 0 -> 422
+  0 188 -> (- 444)
+  0 422 -> 188
+  else -> (- 444)
+}
+tickleBool -> {
+  false -> true
+  true -> true
+  else -> true
+}
+*** STATE <initial>
+  x -> 2
+  y -> 
+*** END_STATE
+*** STATE Increment entry$renamed$Increment$0
+*** END_STATE
+*** END_MODEL
+
+Boogie program verifier finished with 1 verified, 2 errors
+CaptureInlineUnroll.bpl(13,5): Error: This assertion might not hold.
+Execution trace:
+    CaptureInlineUnroll.bpl(9,3): anon0#3
+    CaptureInlineUnroll.bpl(12,5): anon3_LoopBody#3
+    CaptureInlineUnroll.bpl(12,5): anon3_LoopBody#2
+    CaptureInlineUnroll.bpl(12,5): anon3_LoopBody#1
+*** MODEL
+$mv_state_const -> 5
+i -> 
+i@0 -> 1
+i@1 -> 2
+i@2 -> 0
+i@3 -> 0
+n -> 3
+$mv_state -> {
+  5 0 -> true
+  5 1 -> true
+  5 2 -> true
+  5 3 -> true
+  else -> true
+}
+ControlFlow -> {
+  0 0 -> 429
+  0 360 -> (- 531)
+  0 364 -> 360
+  0 368 -> 364
+  0 372 -> 368
+  0 429 -> 372
+  else -> (- 531)
+}
+tickleBool -> {
+  false -> true
+  true -> true
+  else -> true
+}
+*** STATE <initial>
+  i -> 
+  n -> 3
+*** END_STATE
+*** STATE procedure entry$renamed$LoopUnroll$0
+*** END_STATE
+*** STATE loop entry$renamed$LoopUnroll$1
+  i -> 0
+*** END_STATE
+*** STATE loop entry$renamed$LoopUnroll$2
+  i -> 1
+*** END_STATE
+*** STATE loop entry$renamed$LoopUnroll$3
+  i -> 2
+*** END_STATE
+*** END_MODEL
+CaptureInlineUnroll.bpl(40,3): Error: This assertion might not hold.
+Execution trace:
+    CaptureInlineUnroll.bpl(23,5): anon0#3
+    CaptureInlineUnroll.bpl(38,3): inline$Increment$0$anon0#3
+*** MODEL
+$mv_state_const -> 2
+inline$Increment$0$x -> 
+inline$Increment$0$y -> 
+inline$Increment$0$y@0 -> 
+inline$Increment$0$y@1 -> 1
+inline$Increment$1$x -> 
+inline$Increment$1$y -> 
+inline$Increment$1$y@1 -> 0
+u -> 
+u@0 -> 0
+$mv_state -> {
+  2 0 -> true
+  2 1 -> true
+  else -> true
+}
+ControlFlow -> {
+  0 0 -> 585
+  0 396 -> (- 635)
+  0 400 -> 396
+  0 585 -> 400
+  else -> (- 635)
+}
+tickleBool -> {
+  false -> true
+  true -> true
+  else -> true
+}
+*** STATE <initial>
+  inline$Increment$0$x -> 
+  inline$Increment$0$y -> 
+  inline$Increment$1$x -> 
+  inline$Increment$1$y -> 
+  u -> 
+*** END_STATE
+*** STATE 0 calls$renamed$Caller$0
+  u -> 0
+*** END_STATE
+*** STATE Increment entry$renamed$Caller$1
+  inline$Increment$0$x -> 0
+  inline$Increment$0$y -> 
+*** END_STATE
+*** END_MODEL
+
+Boogie program verifier finished with 0 verified, 2 errors

--- a/Test/test15/MoreCapturedStates.bpl
+++ b/Test/test15/MoreCapturedStates.bpl
@@ -1,0 +1,86 @@
+// RUN: %boogie "%s" -mv:"%t".model > "%t"
+// RUN: grep STATE "%t".model >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure Abs(x: int) returns (y: int)
+  ensures y >= 0;
+{
+  assume {:captureState "structure.dfyl(3,0): initial state"} true;  // SHOWS IN MODEL
+  goto LabelA, LabelB;
+
+  LabelA:
+  assume {:captureState "structure.dfyl(5,2): then branch"} true;
+  assume 0 <= x;
+  y := x;
+  goto Done;
+
+  LabelB:
+  assume {:captureState "structure.dfyl(5,2): else branch"} true;  // SHOWS IN MODEL
+  assume x < 0;
+  y := x;  // error: should be -x
+  goto LabelC;
+
+  LabelC:
+  assume {:captureState "structure.dfyl(6,2): y is x"} true;  // SHOWS IN MODEL
+  y := y + 2;
+  y := y + 3;
+  assume {:captureState "structure.dfyl(8,2): y is 5 more than x"} true;  // SHOWS IN MODEL
+  assume {:captureState "structure.dfyl(9,2): no change to y"} true;  // SHOWS IN MODEL
+  y := y - 5;
+  goto Done;
+
+  Done:
+  assume {:captureState "structure.dfy(10,0): done"} true;  // SHOWS IN MODEL
+}
+
+procedure BadCall(x: int) returns (y: int)
+{
+  var r: int;
+
+  assume {:captureState "structure.dfyl(100,0): initial state"} true;  // SHOWS IN MODEL
+  r := 0;
+  goto LabelA, LabelB;
+
+  LabelA:
+  assume {:captureState "structure.dfyl(101,2): then branch"} true;
+  assume x < 50;
+  goto Done;
+
+  LabelB:
+  assume {:captureState "structure.dfyl(102,2): else branch"} true;  // SHOWS IN MODEL
+  assume 0 <= x;
+  y := x;
+  call r := Callee(y);  // error
+  y := 200;
+  assume {:captureState "structure.dfyl(103,2): shortly after call"} true;
+  goto Done;
+
+  Done:
+  assume {:captureState "structure.dfy(110,0): done"} true;
+}
+procedure Callee(x: int) returns (ret: int);
+  requires x < 20;
+
+procedure BadAssert(x: int) returns (y: int)
+  requires x <= 10;
+{
+  assume {:captureState "structure.dfyl(200,0): initial state"} true;  // SHOWS IN MODEL for both errors
+  y := x;
+  goto LabelA;
+
+  LabelA:
+  assume {:captureState "structure.dfyl(201,2): then branch"} true;  // SHOWS IN MODEL for both errors
+  assert y < 1000;
+  assume {:captureState "structure.dfyl(202,2): then branch"} true;  // SHOWS IN MODEL for both errors
+  assert y < 100;
+  assume {:captureState "structure.dfyl(203,2): then branch"} true;  // SHOWS IN MODEL for both errors
+  assert y < 20;
+  assume {:captureState "structure.dfyl(204,2): then branch"} true;  // SHOWS IN MODEL for both errors
+  assert y < 8;
+  assume {:captureState "structure.dfyl(205,2): then branch"} true;  // SHOWS IN MODEL for second error
+  assert y < 12;
+  assume {:captureState "structure.dfyl(206,2): then branch"} true;  // SHOWS IN MODEL for second error
+  assert y < 9;
+  assume {:captureState "structure.dfyl(207,2): then branch"} true;  // SHOWS IN MODEL for second error
+  assert y < 4;
+}

--- a/Test/test15/MoreCapturedStates.bpl.expect
+++ b/Test/test15/MoreCapturedStates.bpl.expect
@@ -1,0 +1,69 @@
+MoreCapturedStates.bpl(34,1): Error: A postcondition might not hold on this return path.
+MoreCapturedStates.bpl(6,3): Related location: This is the postcondition that might not hold.
+Execution trace:
+    MoreCapturedStates.bpl(8,3): anon0
+    MoreCapturedStates.bpl(17,3): LabelB
+    MoreCapturedStates.bpl(32,3): Done
+MoreCapturedStates.bpl(53,3): Error: A precondition for this call might not hold.
+MoreCapturedStates.bpl(62,3): Related location: This is the precondition that might not hold.
+Execution trace:
+    MoreCapturedStates.bpl(40,3): anon0
+    MoreCapturedStates.bpl(49,3): LabelB
+MoreCapturedStates.bpl(79,3): Error: This assertion might not hold.
+Execution trace:
+    MoreCapturedStates.bpl(67,3): anon0
+MoreCapturedStates.bpl(85,3): Error: This assertion might not hold.
+Execution trace:
+    MoreCapturedStates.bpl(67,3): anon0
+
+Boogie program verifier finished with 0 verified, 4 errors
+*** STATE <initial>
+*** END_STATE
+*** STATE structure.dfyl(3,0): initial state
+*** END_STATE
+*** STATE structure.dfyl(5,2): else branch
+*** END_STATE
+*** STATE structure.dfyl(6,2): y is x
+*** END_STATE
+*** STATE structure.dfyl(8,2): y is 5 more than x
+*** END_STATE
+*** STATE structure.dfyl(9,2): no change to y
+*** END_STATE
+*** STATE structure.dfy(10,0): done
+*** END_STATE
+*** STATE <initial>
+*** END_STATE
+*** STATE structure.dfyl(100,0): initial state
+*** END_STATE
+*** STATE structure.dfyl(102,2): else branch
+*** END_STATE
+*** STATE <initial>
+*** END_STATE
+*** STATE structure.dfyl(200,0): initial state
+*** END_STATE
+*** STATE structure.dfyl(201,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(202,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(203,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(204,2): then branch
+*** END_STATE
+*** STATE <initial>
+*** END_STATE
+*** STATE structure.dfyl(200,0): initial state
+*** END_STATE
+*** STATE structure.dfyl(201,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(202,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(203,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(204,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(205,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(206,2): then branch
+*** END_STATE
+*** STATE structure.dfyl(207,2): then branch
+*** END_STATE


### PR DESCRIPTION
This PR reimplements the `:captureState` behavior (for default VC generation) in a way that does not depend on disabling model compression in Z3. Since the option to turn off model compression depends on the Z3 version, this PR lets the functionality be used with a variety of Z3 versions.

## Background and purpose

The `{:captureState "any string"}` attribute can be placed on `assume` statements (typically, on `assume true;` statements). If such a statement is along the trace to an error, Boogie will harvest the SMT solver's counterexample model to reconstruct values for all variables in that "captured" state. This information can be printed out using the `-mv` switch, which will list the sequence of captured states, each one described with the user-specified `"any string"`.

This feature is being used by the [VS Code plug-in for Dafny](https://github.com/dafny-lang/language-server-csharp), since the Boogie programs that Dafny emits contain such `:captureState` attributes. This feature was originally designed and used by the now-deprecated Boogie Verification Debugger.

## Problem

The encoding that made `:captureState` work uses a function `$mv_state`, which it arranges to be set to `true` along the error trace. The idea was that these points of being `true` would show up in Z3's model. However, since the points of interest are all `true` and there is never a reason for the SMT solver to pick a model with a value `false`, the model-compression feature of Z3 would just say that `$mv_state` is `true` everywhere, which is of no use to the `:captureState` mechanism.

To get the `$mv_state` encoding to work, model compression must be disabled in the SMT solver. In Z3, model compression was introduced in v4.8.1, and along with it an option `model_compress` that would turn model compression off. This was still supported in Z3 v.4.8.5 (and maybe slightly later, I don't know). This global Z3 option `model_compress` was being phased out, its replacement being named `model.compact`. (I'm saying "replacement", but I'm not actually sure if `model.compact` is supposed to do the same thing as `model_compress` did.)

From my experiments, Z3 v4.8.5 responds as expected to `model_compress`. Apparently, this version also accepts the existence of a `model.compact` option, but ignores whatever it's set to. In Z3 v4.8.8, any use of `model_compress` gives an error, but `model.compact` seems to work satisfactorily. The upshot of this is that if you are using `:captureState`, then:

* With Z3 v4.8.5, you (or Boogie) should set `model_compress=false`. It's okay if you also set `model.compact=false`, since that seems not to do anything.
* With Z3 v4.8.8, you _must not_ set `model_compress_false`, since that will give an error. Instead, you should set `model.compact=false`.

Boogie's test suite currently seems to expect Z3 v4.8.8, so Boogie is currently setting `model.compact=false` (and _not_ doing anything with the deprecated `model_compress`). This makes tests like `test15/CaptureState.bpl` work.

Dafny uses (the current Boogie and) Z3 v4.8.5. This means that Boogie supplies `model.compact=false`, which doesn't do anything with Z3 v4.8.5, which means that Dafny's use of `:captureState` doesn't work. (At present, it is not feasible to upgrade Dafny to use a newer version of Z3.)

## Possible solution

A quick solution would be for Dafny (and, in particular, the VS Code plug-in for Dafny to supply the Z3 option `model_compress=false`. This would work as long as the Z3 version used is v4.8.5. However, this would mean one cannot experimentally try Dafny with a newer version of Z3, since the use of `model_compress` would then cause an error.

## The solution

This PR provides a different solution, which is to use Boogie's (somewhat new) `ControlFlow` encoding to figure out which `:captureState` attributes lie along the error trace. This is, after all, how Boogie computes error traces. Since `ControlFlow` uses an integer function that points out successor blocks in the error trace, it is not sensitive to model compression in the way that `$mv_state` was.

While Boogie's test suite is currently geared for Z3 v4.8.8, I've manually successfully tested this PR on the new `Test/test15/MoreCapturedStates.bpl` with both Z3 v4.8.5 and v4.8.8.

## Limitations

I did not remove the `$mv_state` encoding, so those functions are still being generated into the SMT formula. The reason I didn't is that FixedpointVC.cs and StratifiedVC.cs still make use of it. I couldn't tell how these use `$mv_state`, and didn't notice tests that prove that behavior. Therefore, I left that code unchanged. (If this functionality is not needed or can be replaced, then `$mv_state` and `$mv_state_const` can be removed from the encoding, and also `ModelViewInfo.CapturePoints` in ModelViewInfo.cs.)
