### PR TITLE
Ignore empty assignments when parsing models

### DIFF
--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -312,6 +312,12 @@ namespace Microsoft.Boogie
             fn.SetConstant(GetElt(lastWord));
           }
         }
+        else if (words.Count == 2 && words[1] is string && ((string)words[1]) == "->")
+        {
+          // This line says that words[0] has no value in the model.
+          // Ignore this line.
+          continue;
+        }
         else
         {
           BadModel("unidentified line");


### PR DESCRIPTION
PR https://github.com/boogie-org/boogie/pull/298 changed the printing of models so that a constant `x` for which the solver does not supply a value is printed as

```
  x -> 
```

The present PR changes the model parser in a corresponding way, so that lines like the above are parsed and then ignored (rather than throwing an "unidentified line" exception).