### PR TITLE
fix: Model parsing of states

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.8.25</Version>
+    <Version>2.8.26</Version>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -223,6 +223,11 @@ namespace Microsoft.Boogie
             {
               cs.AddBinding((string) tuple[0], GetElt(tuple[2]));
             }
+            else if (tuple.Count == 2 && tuple[1] is string && ((string)tuple[1]) == "->")
+            {
+              // This line says that words[0] has no value in the model.
+              // Ignore this line.
+            }
             else
             {
               BadModel("invalid state tuple definition");
@@ -316,7 +321,6 @@ namespace Microsoft.Boogie
         {
           // This line says that words[0] has no value in the model.
           // Ignore this line.
-          continue;
         }
         else
         {


### PR DESCRIPTION
This PR contains the changes from Boogie v2.8.25 that had once made it v2.8.26. Version 2.8.26 was released on NuGet, but was subsequently lost.