### PR TITLE
fix race condition in augmented trace printing code

### DIFF
--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1727,17 +1727,7 @@ namespace Microsoft.Boogie
             if (CommandLineOptions.Clo.EnhancedErrorMessages == 1 && error.AugmentedTrace != null && error.AugmentedTrace.Count > 0)
             {
               errorInfo.Out.WriteLine("Augmented execution trace:");
-              foreach (var elem in error.AugmentedTrace)
-              {
-                if (elem is IdentifierExpr identifierExpr)
-                {
-                  errorInfo.Out.Write(error.GetModelValue(identifierExpr.Decl));
-                }
-                else
-                {
-                  errorInfo.Out.Write(elem);
-                }
-              }
+              error.AugmentedTrace.Iter(elem => errorInfo.Out.Write(elem));
             }
             if (CommandLineOptions.Clo.PrintErrorModel >= 1 && error.Model != null)
             {

--- a/Source/VCGeneration/Couterexample.cs
+++ b/Source/VCGeneration/Couterexample.cs
@@ -88,11 +88,13 @@ namespace Microsoft.Boogie
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
       this.Trace = trace;
-      this.AugmentedTrace = augmentedTrace;
       this.Model = model;
       this.MvInfo = mvInfo;
       this.Context = context;
       this.calleeCounterexamples = new Dictionary<TraceLocation, CalleeCounterexampleInfo>();
+      // the call to instance method GetModelValue in the following code requires the fields Model and Context to be initialized
+      this.AugmentedTrace = augmentedTrace
+        .Select(elem => elem is IdentifierExpr identifierExpr ? GetModelValue(identifierExpr.Decl) : elem).ToList();
     }
 
     // Create a shallow copy of the counterexample


### PR DESCRIPTION
By the time, ProcessErrors is called the checker that processed the implementation may have already been re-purposed for a different implementation.  Therefore it is not safe to examine the prover context inside ProcessErrors.  So I moved the computation of the AugmentedTrace to the  constructor of the counterexample rather than ProcessErrors.