### PR TITLE
Move Vec to LibraryDefinitions

### DIFF
--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -39,6 +39,7 @@ function {:constructor} Vec<T>(contents: [int]T, len: int): Vec T;
 
 const Identity: [int]int;
 axiom (forall x: int :: Identity[x] == x);
+
 function {:inline} AtLeast(x: int): [int]bool
 {
   MapLe(MapConst(x), Identity)
@@ -46,6 +47,7 @@ function {:inline} AtLeast(x: int): [int]bool
 function {:inline} Range(from: int, n: int): [int]bool {
   MapDiff(AtLeast(from), AtLeast(from + n))
 }
+
 axiom {:ctor "Vec"} (forall<T> x: Vec T :: {len#Vec(x)}{contents#Vec(x)} MapIte(Range(0, len#Vec(x)), MapConst(Default()), contents#Vec(x)) == MapConst(Default()));
 axiom {:ctor "Vec"} (forall<T> x: Vec T :: {len#Vec(x)} len#Vec(x) >= 0);
 

--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -31,3 +31,41 @@ function {:inline} Id<T>(t: T): T
 {
   t
 }
+
+function Default<T>(): T;
+
+type {:datatype} Vec _;
+function {:constructor} Vec<T>(contents: [int]T, len: int): Vec T;
+
+const Identity: [int]int;
+axiom (forall x: int :: Identity[x] == x);
+function {:inline} AtLeast(x: int): [int]bool
+{
+  MapLe(MapConst(x), Identity)
+}
+function {:inline} Range(from: int, n: int): [int]bool {
+  MapDiff(AtLeast(from), AtLeast(from + n))
+}
+axiom {:ctor "Vec"} (forall<T> x: Vec T :: {len#Vec(x)}{contents#Vec(x)} MapIte(Range(0, len#Vec(x)), MapConst(Default()), contents#Vec(x)) == MapConst(Default()));
+axiom {:ctor "Vec"} (forall<T> x: Vec T :: {len#Vec(x)} len#Vec(x) >= 0);
+
+function {:inline} Vec_Empty<T>(): Vec T
+{
+  Vec(MapConst(Default()), 0)
+}
+function {:inline} Vec_Append<T>(v: Vec T, x: T) : Vec T
+{
+  Vec(contents#Vec(v)[len#Vec(v) := x], len#Vec(v) + 1)
+}
+function {:inline} Vec_Update<T>(v: Vec T, i: int, x: T) : Vec T
+{
+  if (0 <= i && i < len#Vec(v)) then Vec(contents#Vec(v)[i := x], len#Vec(v)) else v
+}
+function {:inline} Vec_Nth<T>(v: Vec T, i: int): T
+{
+  contents#Vec(v)[i]
+}
+function {:inline} Vec_Len<T>(v: Vec T): int
+{
+  len#Vec(v)
+}

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -666,12 +666,12 @@ namespace Microsoft.Boogie
         if (program.TopLevelDeclarations.Any(d => d.HasCivlAttribute()))
         {
           CommandLineOptions.Clo.UseLibrary = true;
-          CommandLineOptions.Clo.UseArrayTheory = true;
-          CommandLineOptions.Clo.Monomorphize = true;
         }
 
         if (CommandLineOptions.Clo.UseLibrary)
         {
+          CommandLineOptions.Clo.UseArrayTheory = true;
+          CommandLineOptions.Clo.Monomorphize = true;
           var library = Parser.ParseLibraryDefinitions();
           program.AddTopLevelDeclarations(library.TopLevelDeclarations);
         }
@@ -752,7 +752,13 @@ namespace Microsoft.Boogie
       else if (CommandLineOptions.Clo.UseArrayTheory)
       {
         Console.WriteLine(
-          "Option /useArrayTheory only supported for monomorphic programs and polymorphism is detected in input program");
+          "Option /useArrayTheory only supported for monomorphic programs, polymorphism is detected in input program, try using -monomorphize");
+        return PipelineOutcome.FatalError;
+      } 
+      else if (program.TopLevelDeclarations.OfType<DatatypeTypeCtorDecl>().Any())
+      {
+        Console.WriteLine(
+          "Datatypes only supported for monomorphic programs, polymorphism is detected in input program, try using -monomorphize");
         return PipelineOutcome.FatalError;
       }
 

--- a/Test/monomorphize/vector.bpl
+++ b/Test/monomorphize/vector.bpl
@@ -1,84 +1,47 @@
-// RUN: %boogie -useArrayTheory -lib -monomorphize "%s" > "%t"
+// RUN: %boogie -lib "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-
-type {:datatype} Vec _;
-function {:constructor} Vec<T>(contents: [int]T, len: int): Vec T;
-function Default<T>(): T;
-
-const Identity: [int]int;
-axiom (forall x: int :: Identity[x] == x);
-function {:inline} AtLeast(x: int): [int]bool
-{
-  MapLe(MapConst(x), Identity)
-}
-function {:inline} Range(from: int, n: int): [int]bool {
-  MapDiff(AtLeast(from), AtLeast(from + n))
-}
-axiom {:ctor "Vec"} (forall<T> x: Vec T :: {len#Vec(x)}{contents#Vec(x)} MapIte(Range(0, len#Vec(x)), MapConst(Default()), contents#Vec(x)) == MapConst(Default()));
-axiom {:ctor "Vec"} (forall<T> x: Vec T :: {len#Vec(x)} len#Vec(x) >= 0);
-
-function {:inline} Empty<T>(): Vec T
-{
-  Vec(MapConst(Default()), 0)
-}
-function {:inline} Append<T>(v: Vec T, x: T) : Vec T
-{
-  Vec(contents#Vec(v)[len#Vec(v) := x], len#Vec(v) + 1)
-}
-function {:inline} Update<T>(v: Vec T, i: int, x: T) : Vec T
-{
-  if (0 <= i && i < len#Vec(v)) then Vec(contents#Vec(v)[i := x], len#Vec(v)) else v
-}
-function {:inline} Nth<T>(v: Vec T, i: int): T
-{
-  contents#Vec(v)[i]
-}
-function {:inline} Len<T>(v: Vec T): int
-{
-  len#Vec(v)
-}
 
 procedure test0()
 {
   var s: Vec int;
 
-  s := Append(Empty(), 0);
-  s := Append(s, 1);
-  s := Append(s, 2);
-  assert Len(s) == 3;
-  assert Nth(s, 1) == 1;
-  s := Update(s, 1, 3);
-  assert Nth(s, 0) == 0;
-  assert Nth(s, 1) == 3;
-  assert Len(s) == 3;
+  s := Vec_Append(Vec_Empty(), 0);
+  s := Vec_Append(s, 1);
+  s := Vec_Append(s, 2);
+  assert Vec_Len(s) == 3;
+  assert Vec_Nth(s, 1) == 1;
+  s := Vec_Update(s, 1, 3);
+  assert Vec_Nth(s, 0) == 0;
+  assert Vec_Nth(s, 1) == 3;
+  assert Vec_Len(s) == 3;
 }
 
 procedure test1(s: Vec int, x: int)
-requires 0 <= x && x < Len(s);
-requires (forall i: int :: 0 <= i && i < Len(s) ==> Nth(s, i) == 0);
-ensures Nth(s, x) == 0;
+requires 0 <= x && x < Vec_Len(s);
+requires (forall i: int :: 0 <= i && i < Vec_Len(s) ==> Vec_Nth(s, i) == 0);
+ensures Vec_Nth(s, x) == 0;
 {
 }
 
 procedure test2(s: Vec int, x: int, y: int)
-requires 0 <= x && x <= y && y < Len(s);
-requires (forall i, j: int :: 0 <= i && i <= j && j < Len(s) ==> Nth(s, i) <= Nth(s, j));
-ensures Nth(s, x) <= Nth(s, y);
+requires 0 <= x && x <= y && y < Vec_Len(s);
+requires (forall i, j: int :: 0 <= i && i <= j && j < Vec_Len(s) ==> Vec_Nth(s, i) <= Vec_Nth(s, j));
+ensures Vec_Nth(s, x) <= Vec_Nth(s, y);
 {
 }
 
 procedure lookup(s: Vec int, x: int) returns (b: bool)
-ensures b == (exists i: int :: 0 <= i && i < Len(s) && x == Nth(s, i));
+ensures b == (exists i: int :: 0 <= i && i < Vec_Len(s) && x == Vec_Nth(s, i));
 {
   var i: int;
 
   b := false;
   i := 0;
-  while (i < Len(s))
-  invariant (forall u: int :: 0 <= u && u < i ==> x != Nth(s, u));
+  while (i < Vec_Len(s))
+  invariant (forall u: int :: 0 <= u && u < i ==> x != Vec_Nth(s, u));
   invariant 0 <= i;
   {
-    if (Nth(s, i) == x) {
+    if (Vec_Nth(s, i) == x) {
       b := true;
       return;
     }
@@ -87,57 +50,57 @@ ensures b == (exists i: int :: 0 <= i && i < Len(s) && x == Nth(s, i));
 }
 
 procedure equality(s: Vec int, s': Vec int)
-requires Len(s) == Len(s');
-requires (forall i: int :: 0 <= i && i < Len(s) ==> Nth(s, i) == Nth(s', i));
+requires Vec_Len(s) == Vec_Len(s');
+requires (forall i: int :: 0 <= i && i < Vec_Len(s) ==> Vec_Nth(s, i) == Vec_Nth(s', i));
 ensures s == s';
 {
 }
 
 procedure update(s: Vec int, pos: int, val: int) returns (s': Vec int)
-requires 0 <= pos && pos < Len(s);
-requires Nth(s, pos) == val;
+requires 0 <= pos && pos < Vec_Len(s);
+requires Vec_Nth(s, pos) == val;
 ensures s' == s;
 {
-  s' := Update(s, pos, val);
+  s' := Vec_Update(s, pos, val);
 }
 
 procedure sorted_update(s: Vec int, pos: int, val: int) returns (s': Vec int)
-requires (forall i, j: int :: 0 <= i && i <= j && j < Len(s) ==> Nth(s, i) <= Nth(s, j));
-requires 0 <= pos && pos < Len(s);
-requires (forall i: int:: 0 <= i && i < pos ==> Nth(s, i) <= val);
-requires (forall i: int :: pos < i && i < Len(s) ==> val <= Nth(s, i));
-ensures (forall i, j: int :: 0 <= i && i <= j && j < Len(s') ==> Nth(s', i) <= Nth(s', j));
+requires (forall i, j: int :: 0 <= i && i <= j && j < Vec_Len(s) ==> Vec_Nth(s, i) <= Vec_Nth(s, j));
+requires 0 <= pos && pos < Vec_Len(s);
+requires (forall i: int:: 0 <= i && i < pos ==> Vec_Nth(s, i) <= val);
+requires (forall i: int :: pos < i && i < Vec_Len(s) ==> val <= Vec_Nth(s, i));
+ensures (forall i, j: int :: 0 <= i && i <= j && j < Vec_Len(s') ==> Vec_Nth(s', i) <= Vec_Nth(s', j));
 {
-  s' := Update(s, pos, val);
+  s' := Vec_Update(s, pos, val);
 }
 
 procedure sorted_insert(s: Vec int, x: int) returns (s': Vec int)
-requires (forall i, j: int :: 0 <= i && i <= j && j < Len(s) ==> Nth(s, i) <= Nth(s, j));
-ensures (forall i, j: int :: 0 <= i && i <= j && j < Len(s') ==> Nth(s', i) <= Nth(s', j));
+requires (forall i, j: int :: 0 <= i && i <= j && j < Vec_Len(s) ==> Vec_Nth(s, i) <= Vec_Nth(s, j));
+ensures (forall i, j: int :: 0 <= i && i <= j && j < Vec_Len(s') ==> Vec_Nth(s', i) <= Vec_Nth(s', j));
 {
   var pos: int;
   var val: int;
 
   pos := 0;
-  while (pos < Len(s) && Nth(s, pos) <= x)
+  while (pos < Vec_Len(s) && Vec_Nth(s, pos) <= x)
   invariant 0 <= pos;
-  invariant (forall i: int:: 0 <= i && i < pos ==> Nth(s, i) <= x);
+  invariant (forall i: int:: 0 <= i && i < pos ==> Vec_Nth(s, i) <= x);
   {
     pos := pos + 1;
   }
 
   val := x;
   s' := s;
-  while (pos < Len(s'))
+  while (pos < Vec_Len(s'))
   invariant 0 <= pos;
-  invariant (forall i: int:: 0 <= i && i < pos ==> Nth(s', i) <= val);
-  invariant (forall i, j: int :: 0 <= i && i <= j && j < Len(s') ==> Nth(s', i) <= Nth(s', j));
-  invariant (forall i: int :: pos <= i && i < Len(s') ==> val <= Nth(s', i));
+  invariant (forall i: int:: 0 <= i && i < pos ==> Vec_Nth(s', i) <= val);
+  invariant (forall i, j: int :: 0 <= i && i <= j && j < Vec_Len(s') ==> Vec_Nth(s', i) <= Vec_Nth(s', j));
+  invariant (forall i: int :: pos <= i && i < Vec_Len(s') ==> val <= Vec_Nth(s', i));
   {
-    s', val := Update(s', pos, val), Nth(s', pos); // swap s'[pos] and val
+    s', val := Vec_Update(s', pos, val), Vec_Nth(s', pos); // swap s'[pos] and val
     pos := pos + 1;
   }
-  s' := Append(s', val);
+  s' := Vec_Append(s', val);
 }
 
 type {:datatype} Value;
@@ -145,13 +108,13 @@ function {:constructor} Integer(i: int): Value;
 function {:constructor} Vector(v: Vec Value): Value;
 
 procedure test3(val: Value) returns (val': Value)
-requires is#Vector(val) && Len(v#Vector(val)) == 1 && Nth(v#Vector(val), 0) == Integer(0);
+requires is#Vector(val) && Vec_Len(v#Vector(val)) == 1 && Vec_Nth(v#Vector(val), 0) == Integer(0);
 ensures val == val';
 {
   var s: Vec Value;
 
-  s := Empty();
-  s := Append(s, Integer(0));
+  s := Vec_Empty();
+  s := Vec_Append(s, Integer(0));
   val' := Vector(s);
 }
 
@@ -159,7 +122,7 @@ function has_zero(val: Value): (bool)
 {
   if (is#Integer(val))
   then val == Integer(0)
-  else (exists i: int :: 0 <= i && i < Len(v#Vector(val)) && has_zero(Nth(v#Vector(val), i)))
+  else (exists i: int :: 0 <= i && i < Vec_Len(v#Vector(val)) && has_zero(Vec_Nth(v#Vector(val), i)))
 }
 
 procedure traverse(val: Value) returns (b: bool)
@@ -175,16 +138,16 @@ ensures b == has_zero(val);
   }
   s := v#Vector(val);
   i := 0;
-  while (i < Len(s))
+  while (i < Vec_Len(s))
   invariant !b;
   invariant 0 <= i;
-  invariant (forall j: int :: 0 <= j && j < i ==> !has_zero(Nth(s, j)));
+  invariant (forall j: int :: 0 <= j && j < i ==> !has_zero(Vec_Nth(s, j)));
   {
-    call b := traverse(Nth(s, i));
+    call b := traverse(Vec_Nth(s, i));
     if (b) {
         return;
     }
-    assert !has_zero(Nth(s, i));
+    assert !has_zero(Vec_Nth(s, i));
     i := i + 1;
   }
 }


### PR DESCRIPTION
This PR does the following:

- Moves native Vec (finite vectors) into LibraryDefinitions.bpl
- Automatically turn on /useArrayTheory and /monomorphize when /lib is used
- Improve error reporting when polymorphism combined with datatypes

Closes #353 .