### PR TITLE
Major bug fix in monomorphization

### DIFF
--- a/Test/monomorphize/monomorphize7.bpl
+++ b/Test/monomorphize/monomorphize7.bpl
@@ -1,0 +1,45 @@
+// RUN: %boogie -lib "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:inline} $Box(x: $Value): $Value {
+    x
+}
+function {:inline} $Box_int(x: int): $Value {
+    $Integer(x)
+}
+function {:inline} $Box_bool(x: bool): $Value {
+    $Boolean(x)
+}
+function {:inline} $Box_addr(x: int): $Value {
+    $Address(x)
+}
+function {:inline} $Box_vec(x: Vec $Value): $Value {
+    $Vector(x)
+}
+
+function {:inline} $Unbox(x: $Value): $Value {
+    x
+}
+function {:inline} $Unbox_int(x: $Value): int {
+    i#$Integer(x)
+}
+function {:inline} $Unbox_bool(x: $Value): bool {
+    b#$Boolean(x)
+}
+function {:inline} $Unbox_addr(x: $Value): int {
+    a#$Address(x)
+}
+function {:inline} $Unbox_vec(x: $Value): Vec $Value {
+    v#$Vector(x)
+}
+
+type {:datatype} $Value;
+function {:constructor} $Boolean(b: bool): $Value;
+function {:constructor} $Integer(i: int): $Value;
+function {:constructor} $Address(a: int): $Value;
+function {:constructor} $Vector(v: Vec $Value): $Value;
+function {:constructor} $Error(): $Value;
+
+procedure p() {
+    assert $Unbox_vec($Box_vec(Vec_Empty())) == Vec_Empty();
+}

--- a/Test/monomorphize/monomorphize7.bpl.expect
+++ b/Test/monomorphize/monomorphize7.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
This PR reorganizes the monomorphization code and fixes a bug.

Bug:  A call to a  non-generic function that uses an instantiation of a generic type in its signature was not being rewritten properly.  The same problem occurred even for calls to constructors/selectors/memberships of a non-generic datatype that uses an instantiation of a generic type.

Code reorganization: ExprMonomorphizationVisitor is now made a private class of MonomorphizationVisitor to allow it to access private fields of MonomorphizationVisitor.