### PR TITLE
Explicitly remove any finite rlimits when resetting the prover state.

### DIFF
--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -612,6 +612,7 @@ namespace Microsoft.Boogie.SMTLib
       {
         this.gen = gen;
         SendThisVC("(reset)");
+        SendThisVC("(set-option :" + Z3.RlimitOption + " 0)");
 
         if (0 < common.Length)
         {
@@ -633,6 +634,7 @@ namespace Microsoft.Boogie.SMTLib
       {
         this.gen = gen;
         SendThisVC("(reset)");
+        SendThisVC("(set-option :" + Z3.RlimitOption + " 0)");
         Namer.Reset();
         common.Clear();
         SetupAxiomBuilder(gen);

--- a/Test/test2/git-issue-366.bpl
+++ b/Test/test2/git-issue-366.bpl
@@ -1,0 +1,17 @@
+// RUN: %boogie -rlimit:5 /proverOpt:O:smt.qi.eager_threshold=100 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function f(i:int, j:int) returns (int)
+{
+    if i == 0 then 0 else f(i - 1, i * j + 1) + f(i - 1, 2 * i * j)
+}
+
+procedure test0(x:int)
+{
+    assert(x - x == 0);
+}
+
+procedure {:rlimit 100000000} test1()
+{
+    assert(f(13,5) == 0);
+}

--- a/Test/test2/git-issue-366.bpl.expect
+++ b/Test/test2/git-issue-366.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 2 verified, 0 errors


### PR DESCRIPTION
This addresses Issue #366.