### PR TITLE
Improve parsing of output of get-model

### DIFF
--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1734,7 +1734,7 @@ namespace Microsoft.Boogie.SMTLib
           HandleProverError("Expecting only one model but got many");
 
         string modelStr = null;
-        if (resp.Name == "model" && resp.ArgCount >= 1)
+        if (resp.ArgCount >= 1)
         {
           var converter = new SMTErrorModelConverter(resp, this);
           modelStr = converter.Convert();


### PR DESCRIPTION
Do not rely on get-model output to start as (model ...). The SMTLIB standard doesn't include the 'model' as part of the output.

More context in #370 .