### PR TITLE
Invoking yices-smt2 as Yices2 binary

### DIFF
--- a/Source/Provers/SMTLib/SMTLibProverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibProverOptions.cs
@@ -128,25 +128,33 @@ namespace Microsoft.Boogie.SMTLib
     {
       base.PostParse();
 
+      string SolverBinaryName = null;
       switch (Solver)
       {
         case SolverKind.Z3:
           Z3.SetDefaultOptions(this);
           SolverArguments.Add("-smt2 -in");
+          SolverBinaryName = Solver.ToString().ToLower();
           break;
         case SolverKind.CVC4:
           SolverArguments.Add(
             "--lang=smt --no-strict-parsing --no-condense-function-values --incremental --produce-models");
           if (Logic == null) Logic = "ALL_SUPPORTED";
+          SolverBinaryName = Solver.ToString().ToLower();
           break;
         case SolverKind.YICES2:
           SolverArguments.Add("--incremental");
           if (Logic == null) Logic = "ALL";
+          SolverBinaryName = "yices-smt2";
           break;
+        default:
+          Contract.Assert(false);
+          throw new cce.UnreachableException();
       }
 
-      if (ProverName == null)
-        ProverName = Solver.ToString().ToLower();
+      if (ProverName == null) {
+        ProverName = SolverBinaryName;
+      }
     }
 
     public override string Help


### PR DESCRIPTION
This is the right binary to be invoking. The current implementation
is invoking yices2, which does not exist when Yices2 is installed.

Fixes #374