### PR TITLE
Convert time and resource limits to uint, and ensure we safely multiply them

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.Contracts;
+using Microsoft.BaseTypes;
 using Microsoft.Boogie.GraphUtil;
 using Set = Microsoft.Boogie.GSet<object>;
 
@@ -1591,6 +1592,27 @@ namespace Microsoft.Boogie
       return false;
     }
 
+    public bool CheckUIntAttribute(string name, ref uint result)
+    {
+      Contract.Requires(name != null);
+      Expr expr = FindExprAttribute(name);
+      if (expr != null)
+      {
+        if (expr is LiteralExpr && ((LiteralExpr) expr).isBigNum)
+        {
+          BigNum big = ((LiteralExpr) expr).asBigNum;
+          if (big.IsNegative) {
+            return false;
+          }
+
+          result = (uint)big.ToIntSafe;
+          return true;
+        }
+      }
+
+      return false;
+    }
+
     public void AddAttribute(string name, params object[] vals)
     {
       Contract.Requires(name != null);
@@ -1798,12 +1820,12 @@ namespace Microsoft.Boogie
       }
     }
 
-    public int TimeLimit
+    public uint TimeLimit
     {
       get
       {
-        int tl = CommandLineOptions.Clo.TimeLimit;
-        CheckIntAttribute("timeLimit", ref tl);
+        uint tl = CommandLineOptions.Clo.TimeLimit;
+        CheckUIntAttribute("timeLimit", ref tl);
         if (tl < 0)
         {
           tl = CommandLineOptions.Clo.TimeLimit;
@@ -1812,12 +1834,12 @@ namespace Microsoft.Boogie
       }
     }
 
-    public int ResourceLimit
+    public uint ResourceLimit
     {
       get
       {
-        int rl = CommandLineOptions.Clo.ResourceLimit;
-        CheckIntAttribute("rlimit", ref rl);
+        uint rl = CommandLineOptions.Clo.ResourceLimit;
+        CheckUIntAttribute("rlimit", ref rl);
         if (rl < 0)
         {
           rl = CommandLineOptions.Clo.ResourceLimit;

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -211,6 +211,37 @@ namespace Microsoft.Boogie
         return GetNumericArgument(ref arg, a => 0 <= a);
       }
 
+      public bool GetUnsignedNumericArgument(ref uint arg, Predicate<uint> filter)
+      {
+        if (this.ConfirmArgumentCount(1))
+        {
+          try
+          {
+            Contract.Assume(args[i] != null);
+            Contract.Assert(args[i] is string); // needed to prove args[i].IsPeerConsistent
+            uint d = Convert.ToUInt32(this.args[this.i]);
+            if (filter == null || filter(d))
+            {
+              arg = d;
+              return true;
+            }
+          }
+          catch (System.FormatException)
+          {
+          }
+          catch (System.OverflowException)
+          {
+          }
+        }
+        else
+        {
+          return false;
+        }
+
+        Error("Invalid argument \"{0}\" to option {1}", args[this.i], this.s);
+        return false;
+      }
+
       /// <summary>
       /// If there is one argument and the filtering predicate holds, then set "arg" to that number and return "true".
       /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
@@ -656,7 +687,7 @@ namespace Microsoft.Boogie
     public bool UseArrayTheory = false;
     public bool RunDiagnosticsOnTimeout = false;
     public bool TraceDiagnosticsOnTimeout = false;
-    public int TimeLimitPerAssertionInPercent = 10;
+    public uint TimeLimitPerAssertionInPercent = 10;
     public bool SIBoolControlVC = false;
     public bool ExpandLambdas = true; // not useful from command line, only to be set to false programatically
     public bool DoModSetAnalysis = false;
@@ -693,9 +724,9 @@ namespace Microsoft.Boogie
       }
     }
 
-    public int TimeLimit = 0; // 0 means no limit
-    public int ResourceLimit = 0; // default to 0
-    public int SmokeTimeout = 10; // default to 10s
+    public uint TimeLimit = 0; // 0 means no limit
+    public uint ResourceLimit = 0; // default to 0
+    public uint SmokeTimeout = 10; // default to 10s
     public int ErrorLimit = 5; // 0 means attempt to falsify each assertion in a desugared implementation 
     public bool RestartProverPerVC = false;
 
@@ -706,8 +737,8 @@ namespace Microsoft.Boogie
     public double VcsPathSplitMult = 0.5; // 0.5-always, 2-rarely do path splitting
     public int VcsMaxSplits = 1;
     public int VcsMaxKeepGoingSplits = 1;
-    public int VcsFinalAssertTimeout = 30;
-    public int VcsKeepGoingTimeout = 1;
+    public uint VcsFinalAssertTimeout = 30;
+    public uint VcsKeepGoingTimeout = 1;
     public int VcsCores = 1;
     public bool VcsDumpSplits = false;
 
@@ -1398,11 +1429,11 @@ namespace Microsoft.Boogie
           return true;
 
         case "vcsFinalAssertTimeout":
-          ps.GetNumericArgument(ref VcsFinalAssertTimeout);
+          ps.GetUnsignedNumericArgument(ref VcsFinalAssertTimeout, null);
           return true;
 
         case "vcsKeepGoingTimeout":
-          ps.GetNumericArgument(ref VcsKeepGoingTimeout);
+          ps.GetUnsignedNumericArgument(ref VcsKeepGoingTimeout, null);
           return true;
 
         case "vcsCores":
@@ -1426,19 +1457,19 @@ namespace Microsoft.Boogie
           return true;
 
         case "timeLimit":
-          ps.GetNumericArgument(ref TimeLimit);
+          ps.GetUnsignedNumericArgument(ref TimeLimit, null);
           return true;
 
         case "rlimit":
-          ps.GetNumericArgument(ref ResourceLimit);
+          ps.GetUnsignedNumericArgument(ref ResourceLimit, null);
           return true;
 
         case "timeLimitPerAssertionInPercent":
-          ps.GetNumericArgument(ref TimeLimitPerAssertionInPercent, a => 0 < a);
+          ps.GetUnsignedNumericArgument(ref TimeLimitPerAssertionInPercent, a => 0 < a);
           return true;
 
         case "smokeTimeout":
-          ps.GetNumericArgument(ref SmokeTimeout);
+          ps.GetUnsignedNumericArgument(ref SmokeTimeout, null);
           return true;
 
         case "errorLimit":

--- a/Source/Core/ProverUtil.cs
+++ b/Source/Core/ProverUtil.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Boogie
 
     // Say (DBG_WAS_VALID) or (DBG_WAS_INVALID) after query
     public bool ForceLogStatus = false;
-    public int TimeLimit = 0;
-    public int ResourceLimit = 0;
+    public uint TimeLimit = 0;
+    public uint ResourceLimit = 0;
     public int? RandomSeed = null;
     public int MemoryLimit = 0;
     public int Verbosity = 0;
@@ -56,7 +56,7 @@ namespace Microsoft.Boogie
              ParseBool(opt, "FORCE_LOG_STATUS", ref ForceLogStatus) ||
              ParseInt(opt, "MEMORY_LIMIT", ref MemoryLimit) ||
              ParseInt(opt, "VERBOSITY", ref Verbosity) ||
-             ParseInt(opt, "TIME_LIMIT", ref TimeLimit);
+             ParseUInt(opt, "TIME_LIMIT", ref TimeLimit);
     }
 
     public virtual string Help
@@ -76,7 +76,7 @@ LOG_FILE=<string>         Log input for the theorem prover. The string @PROC@ in
 APPEND_LOG_FILE=<bool>    Append, rather than overwrite the log file.
 MEMORY_LIMIT=<int>        Memory limit of the prover in megabytes.
 VERBOSITY=<int>           The higher, the more verbose.
-TIME_LIMIT=<int>          Time limit per verification condition in milliseconds.
+TIME_LIMIT=<uint>          Time limit per verification condition in milliseconds.
 
 The generic options may or may not be used by the prover plugin.
 ";
@@ -246,6 +246,28 @@ The generic options may or may not be used by the prover plugin.
         else
         {
           ReportError("Invalid integer option \"" + opt + "\"");
+        }
+      }
+
+      return false;
+    }
+
+    protected virtual bool ParseUInt(string opt, string name, ref uint field)
+    {
+      Contract.Requires(name != null);
+      Contract.Requires(opt != null);
+      string tmp = null;
+      uint t2;
+      if (ParseString(opt, name, ref tmp))
+      {
+        if (uint.TryParse(cce.NonNull(tmp), out t2))
+        {
+          field = t2;
+          return true;
+        }
+        else
+        {
+          ReportError("Invalid unsigned integer option \"" + opt + "\"");
         }
       }
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1448,7 +1448,7 @@ namespace Microsoft.Boogie
 
 
     private static void ProcessOutcome(VC.VCGen.Outcome outcome, List<Counterexample> errors, string timeIndication,
-      PipelineStatistics stats, TextWriter tw, int timeLimit, ErrorReporterDelegate er = null, string implName = null,
+      PipelineStatistics stats, TextWriter tw, uint timeLimit, ErrorReporterDelegate er = null, string implName = null,
       IToken implTok = null, string requestId = null, string msgIfVerifies = null, bool wasCached = false)
     {
       Contract.Requires(stats != null);
@@ -1462,7 +1462,7 @@ namespace Microsoft.Boogie
 
 
     private static void ReportOutcome(VC.VCGen.Outcome outcome, ErrorReporterDelegate er, string implName,
-      IToken implTok, string requestId, string msgIfVerifies, TextWriter tw, int timeLimit, List<Counterexample> errors)
+      IToken implTok, string requestId, string msgIfVerifies, TextWriter tw, uint timeLimit, List<Counterexample> errors)
     {
       ErrorInformation errorInfo = null;
 

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -855,7 +855,7 @@ namespace Microsoft.Boogie.SMTLib
               var timedOut = new SortedSet<int>();
               int frac = 2;
               int queries = 0;
-              int timeLimitPerAssertion = 0 < options.TimeLimit
+              uint timeLimitPerAssertion = 0 < options.TimeLimit
                 ? (options.TimeLimit / 100) * CommandLineOptions.Clo.TimeLimitPerAssertionInPercent
                 : 1000;
               while (true)
@@ -1019,10 +1019,10 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    private Outcome CheckSplit(SortedSet<int> split, ref bool popLater, int timeLimit, int timeLimitPerAssertion,
+    private Outcome CheckSplit(SortedSet<int> split, ref bool popLater, uint timeLimit, uint timeLimitPerAssertion,
       ref int queries)
     {
-      var tla = timeLimitPerAssertion * split.Count;
+      uint tla = (uint)(timeLimitPerAssertion * split.Count);
 
       if (popLater)
       {
@@ -1031,7 +1031,7 @@ namespace Microsoft.Boogie.SMTLib
 
       SendThisVC("(push 1)");
       // FIXME: Gross. Timeout should be set in one place! This is also Z3 specific!
-      int newTimeout = (0 < tla && tla < timeLimit) ? tla : timeLimit;
+      uint newTimeout = (0 < tla && tla < timeLimit) ? tla : timeLimit;
       if (newTimeout > 0)
       {
         SendThisVC(string.Format("(set-option :{0} {1})", Z3.TimeoutOption, newTimeout));
@@ -1874,12 +1874,12 @@ namespace Microsoft.Boogie.SMTLib
       SendThisVC("(check-sat)");
     }
 
-    public override void SetTimeout(int ms)
+    public override void SetTimeout(uint ms)
     {
       options.TimeLimit = ms;
     }
 
-    public override void SetRlimit(int limit)
+    public override void SetRlimit(uint limit)
     {
       options.ResourceLimit = limit;
     }

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -14,6 +14,21 @@ namespace Microsoft.Boogie
     Closed
   }
 
+  public class Util
+  {
+    public static uint SafeMult(uint a, uint b) {
+      uint result = UInt32.MaxValue;
+      try {
+        checked {
+          result = a * b;
+        }
+      } catch (OverflowException) { }
+
+      return result;
+    }
+  }
+
+
   /// <summary>
   /// Interface to the theorem prover specialized to Boogie.
   ///
@@ -200,14 +215,14 @@ namespace Microsoft.Boogie
       Setup(prog, ctx);
     }
 
-    private void SetTimeout(int timeout)
+    private void SetTimeout(uint timeout)
     {
-      TheoremProver.SetTimeout(timeout * 1000);
+      TheoremProver.SetTimeout(Util.SafeMult(timeout, 1000));
     }
 
-    private void SetRlimit(int rlimit)
+    private void SetRlimit(uint rlimit)
     {
-      TheoremProver.SetRlimit(rlimit * 1000);
+      TheoremProver.SetRlimit(Util.SafeMult(rlimit, 1000));
     }
 
     private void SetRandomSeed(int? randomSeed)
@@ -350,7 +365,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, int timeout, int rlimit, int? randomSeed)
+    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, uint timeout, uint rlimit, int? randomSeed)
     {
       Contract.Requires(descriptiveName != null);
       Contract.Requires(vc != null);
@@ -400,7 +415,7 @@ namespace Microsoft.Boogie
 
   public abstract class ProverInterface
   {
-    public static ProverInterface CreateProver(Program prog, string /*?*/ logFilePath, bool appendLogFile, int timeout,
+    public static ProverInterface CreateProver(Program prog, string /*?*/ logFilePath, bool appendLogFile, uint timeout,
       int taskID = -1)
     {
       Contract.Requires(prog != null);
@@ -416,7 +431,7 @@ namespace Microsoft.Boogie
 
       if (timeout > 0)
       {
-        options.TimeLimit = timeout * 1000;
+        options.TimeLimit = Util.SafeMult(timeout, 1000);
       }
 
       if (taskID >= 0)
@@ -650,11 +665,11 @@ namespace Microsoft.Boogie
     }
 
     // Set theorem prover timeout for the next "check-sat"
-    public virtual void SetTimeout(int ms)
+    public virtual void SetTimeout(uint ms)
     {
     }
 
-    public virtual void SetRlimit(int limit)
+    public virtual void SetRlimit(uint limit)
     {
     }
 

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1129,7 +1129,7 @@ namespace VC
       /// <summary>
       /// As a side effect, updates "this.parent.CumulativeAssertionCount".
       /// </summary>
-      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, int timeout, int rlimit)
+      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, uint timeout, uint rlimit)
       {
         Contract.Requires(checker != null);
         Contract.Requires(callback != null);


### PR DESCRIPTION
This PR systematically converts time and resource limits into `uint` (instead of `int`),  since a negative time limit is perplexing.  It also makes use of a `SafeMult` routine that multiplies two `uint` values and returns  `UInt32.MaxValue` if the multiplication overflows.

Closes #393 