### PR TITLE
Fix ModelParser error for not setting the else path

### DIFF
--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -298,7 +298,10 @@ namespace Microsoft.Boogie
 
               if (tuple0 == "else")
               {
-                if (fn != null && !(resultName is string && ((string)resultName) == "#unspecified") && fn.Else == null)
+                if (fn.Else != null) {
+                  BadModel("multipe else cases");
+                }
+                if (!(resultName is string && ((string) resultName) == "#unspecified"))
                 {
                   fn.Else = GetElt(resultName);
                 }

--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -268,15 +268,6 @@ namespace Microsoft.Boogie
               if (tuplePenultimate != "->")
                 BadModel("invalid function tuple definition");
               var resultName = tuple[tuple.Count - 1];
-              if (tuple0 == "else")
-              {
-                if (fn != null && !(resultName is string && ((string) resultName) == "#unspecified") && fn.Else == null)
-                {
-                  fn.Else = GetElt(resultName);
-                }
-
-                continue;
-              }
 
               if (fn == null)
               {
@@ -303,6 +294,15 @@ namespace Microsoft.Boogie
                 {
                   fn = currModel.MkFunc(funName, arity);
                 }
+              }
+
+              if (tuple0 == "else")
+              {
+                if (fn != null && !(resultName is string && ((string)resultName) == "#unspecified") && fn.Else == null)
+                {
+                  fn.Else = GetElt(resultName);
+                }
+                continue;
               }
 
               var args = new Model.Element[fn.Arity];

--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Boogie
               if (tuple0 == "else")
               {
                 if (fn.Else != null) {
-                  BadModel("multipe else cases");
+                  BadModel("multiple else cases");
                 }
                 if (!(resultName is string && ((string) resultName) == "#unspecified"))
                 {


### PR DESCRIPTION
The ModelParser does not populate the else path for the boogie functions that only have an else path such as the following:
`$Is -> {`
`  else -> true`
`}`
This is because `fn` is not created at the time the else path is parsing, and as a result, else path will not be set.
Moving the else path check after the `if (fn == null)` block will fix the issue and else path will be set.