### PR TITLE
[Civl] Fixes in attribute propagation during transition relation computation

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -375,7 +375,8 @@ namespace Microsoft.Boogie
       foreach (Variable x in action.impl.LocVars)
       {
         Variable xCopy = new LocalVariable(Token.NoToken,
-          new TypedIdent(Token.NoToken, prefix + x.Name, x.TypedIdent.Type));
+          new TypedIdent(Token.NoToken, prefix + x.Name, x.TypedIdent.Type),
+          (QKeyValue) x.Attributes?.Clone());
         subst[x] = Expr.Ident(xCopy);
         localsCopy.Add(xCopy);
       }

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -375,8 +375,7 @@ namespace Microsoft.Boogie
       foreach (Variable x in action.impl.LocVars)
       {
         Variable xCopy = new LocalVariable(Token.NoToken,
-          new TypedIdent(Token.NoToken, prefix + x.Name, x.TypedIdent.Type),
-          (QKeyValue) x.Attributes?.Clone());
+          new TypedIdent(Token.NoToken, prefix + x.Name, x.TypedIdent.Type), x.Attributes);
         subst[x] = Expr.Ident(xCopy);
         localsCopy.Add(xCopy);
       }

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Boogie
       {
         int id = varCopies[v].Count;
         var copyVar = trc.civlTypeChecker.LocalVariable(string.Format(copierFormat, v.Name, id), v.TypedIdent.Type);
-        copyVar.Attributes = (QKeyValue) v.Attributes?.Clone();
+        copyVar.Attributes = v.Attributes;
         varCopies[v].Add(copyVar);
         copyToOriginalVar[copyVar] = v;
       }
@@ -475,7 +475,7 @@ namespace Microsoft.Boogie
         var substMap = remainingVars.ToDictionary(v => copyToOriginalVar[v], v => existsVarMap[v]);
         existsVarMap.Iter(kv =>
         {
-          kv.Value.Attributes = (QKeyValue) copyToOriginalVar[kv.Key].Attributes?.Clone();
+          kv.Value.Attributes = copyToOriginalVar[kv.Key].Attributes;
         });
         pathExprs = SubstitutionHelper.Apply(existsVarMap, pathExprs).ToList();
       }

--- a/Test/civl/inductive-sequentialization/NBuyer.bpl
+++ b/Test/civl/inductive-sequentialization/NBuyer.bpl
@@ -140,7 +140,7 @@ modifies QuoteCH, RemCH, DecCH, contribution;
   else if (*)
   {
     assume
-      {:add_to_pool "INV3", k, k+1}
+      {:add_to_pool "INV3", 1, k, k+1}
       1 <= k && k < n && 0 <= sum(contribution, 1, k) && sum(contribution, 1, k) <= price;
     QuoteCH := (lambda i:int :: (lambda q:int :: if buyerID(i) && i > k && q == price then 1 else 0));
     RemCH := (lambda i:int :: (lambda r:int :: if i == k+1 && r == price - sum(contribution, 1, k) then 1 else 0));

--- a/Test/civl/inductive-sequentialization/paxos/PaxosAbstractions.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosAbstractions.bpl
@@ -24,9 +24,9 @@ procedure {:IS_abstraction}{:layer 2} A_Propose'(r: Round, {:linear_in "perm"} p
 returns ({:pending_async "A_Vote", "A_Conclude"} PAs:[PA]int)
 modifies voteInfo, pendingAsyncs;
 {
-  var maxRound: int;
+  var {:pool "Round"} maxRound: int;
   var maxValue: Value;
-  var ns: NodeSet;
+  var {:pool "NodeSet"} ns: NodeSet;
 
   assert Round(r);
   assert pendingAsyncs[A_Propose(r, ps)] > 0;
@@ -42,6 +42,10 @@ modifies voteInfo, pendingAsyncs;
     {:add_to_pool "Node", 0}
     ps[ConcludePerm(r)];
   /**************************************************************************/
+
+  assume
+    {:add_to_pool "NodeSet", ns}
+    true;
 
   if (*) {
     assume IsSubset(ns, joinedNodes[r]) && IsQuorum(ns);
@@ -63,7 +67,7 @@ modifies voteInfo, pendingAsyncs;
 procedure {:IS_abstraction}{:layer 2} A_Conclude'(r: Round, v: Value, {:linear_in "perm"} p: Permission)
 modifies decision, pendingAsyncs;
 {
-  var q:NodeSet;
+  var q: NodeSet;
 
   assert Round(r);
   assert pendingAsyncs[A_Conclude(r, v, p)] > 0;

--- a/Test/civl/inductive-sequentialization/paxos/PaxosActions.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosActions.bpl
@@ -16,14 +16,18 @@ procedure {:atomic}{:layer 2} A_Propose(r: Round, {:linear_in "perm"} ps: [Permi
 returns ({:pending_async "A_Vote", "A_Conclude"} PAs:[PA]int)
 modifies voteInfo, pendingAsyncs;
 {
-  var maxRound: int;
+  var {:pool "Round"} maxRound: int;
   var maxValue: Value;
-  var ns: NodeSet;
+  var {:pool "NodeSet"} ns: NodeSet;
 
   assert Round(r);
   assert pendingAsyncs[A_Propose(r, ps)] > 0;
   assert ps == ProposePermissions(r);
   assert is#None(voteInfo[r]);
+
+  assume
+    {:add_to_pool "NodeSet", ns}
+    true;
 
   if (*) {
     assume IsSubset(ns, joinedNodes[r]) && IsQuorum(ns);
@@ -85,6 +89,11 @@ modifies joinedNodes, voteInfo, pendingAsyncs;
   assert is#Some(voteInfo[r]);
   assert value#VoteInfo(t#Some(voteInfo[r])) == v;
   assert !ns#VoteInfo(t#Some(voteInfo[r]))[n];
+
+  assume
+    {:add_to_pool "Round", r, r-1}
+    {:add_to_pool "Node", n}
+    true;
 
   if (*) {
     assume (forall r': Round :: Round(r') && joinedNodes[r'][n] ==> r' <= r);

--- a/Test/civl/inductive-sequentialization/paxos/PaxosImpl.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosImpl.bpl
@@ -2,7 +2,7 @@ procedure {:atomic}{:layer 2} A_Paxos({:linear_in "perm"} rs: [Round]bool)
 returns ({:pending_async "A_StartRound"} PAs:[PA]int)
 modifies pendingAsyncs;
 {
-  var numRounds: int;
+  var {:pool "NumRounds"} numRounds: int;
   assert
     {:add_to_pool "Round", 0, numRounds}
     Init(rs, joinedNodes, voteInfo, decision, pendingAsyncs);

--- a/Test/civl/inductive-sequentialization/paxos/PaxosSeq.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosSeq.bpl
@@ -18,7 +18,7 @@ A_Paxos({:linear_in "perm"} rs: [Round]bool)
 returns ({:pending_async "A_StartRound"} PAs:[PA]int)
 modifies pendingAsyncs;
 {
-  var numRounds: int;
+  var {:pool "NumRounds"} numRounds: int;
   assert
     {:add_to_pool "Round", 0, numRounds}
     Init(rs, joinedNodes, voteInfo, decision, pendingAsyncs);


### PR DESCRIPTION
- propagate attributes on variables throughout transition relation computation
- add more pool hints to the paxos proof