### PR TITLE
Default arity value for functions with a single else path

### DIFF
--- a/Source/Model/Model.cs
+++ b/Source/Model/Model.cs
@@ -659,16 +659,24 @@ namespace Microsoft.Boogie
     public Func MkFunc(string name, int arity)
     {
       Func res;
+      Element elseBranch = null;
       if (functionsByName.TryGetValue(name, out res))
       {
-        if (res.Arity != arity)
-          throw new ArgumentException(string.Format(
-            "function '{0}' previously created with arity {1}, now trying to recreate with arity {2}", name, res.Arity,
-            arity));
-        return res;
+        if (res.Arity != arity) {
+          if (res.apps.Count > 0) {
+            throw new ArgumentException(string.Format(
+              "function '{0}' previously created with arity {1}, now trying to recreate with arity {2}", name, res.Arity,
+              arity));
+          }
+          elseBranch = res.Else;
+          functions.Remove(res);
+          functionsByName.Remove(res.Name);
+        } else 
+          return res;
       }
 
       res = new Func(this, name, arity);
+      res.Else = elseBranch;
       functionsByName.Add(name, res);
       functions.Add(res);
       return res;

--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -298,9 +298,6 @@ namespace Microsoft.Boogie
 
               if (tuple0 == "else")
               {
-                if (fn.Else != null) {
-                  BadModel("multiple else cases");
-                }
                 if (!(resultName is string && ((string) resultName) == "#unspecified"))
                 {
                   fn.Else = GetElt(resultName);

--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -310,7 +310,8 @@ namespace Microsoft.Boogie
                 continue;
               }
 
-              var args = new Model.Element[fn.Arity];
+              fn.Arity = tuple.Count - 2;
+              var args = new Model.Element[fn.Arity ?? 1]; // arity cannot be null here
               for (int i = 0; i < fn.Arity; ++i)
                 args[i] = GetElt(tuple[i]);
               fn.AddApp(GetElt(resultName), args);

--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Boogie
               if (tuple.Count == 1)
               {
                 if (fn == null)
-                  fn = currModel.MkFunc(funName, 1);
+                  fn = currModel.MkFunc(funName, null);
                 if (tuple0 == "}")
                   break;
                 if (fn.Else == null)
@@ -271,23 +271,25 @@ namespace Microsoft.Boogie
 
               if (fn == null)
               {
-                var arity = tuple.Count - 2;
+                int? arity = tuple0 == "else" ? null : tuple.Count - 2;
+                // TODO: arity can be null here meaning that the renaming below
+                // is not safe and can lead to name clashes
                 if (Regex.IsMatch(funName, "^MapType[0-9]*Select$"))
                 {
-                  funName = string.Format("[{0}]", arity);
-                  if (!selectFunctions.TryGetValue(arity, out fn))
+                  funName = string.Format("[{0}]", arity ?? 1);
+                  if (!selectFunctions.TryGetValue(arity ?? 1, out fn))
                   {
                     fn = currModel.MkFunc(funName, arity);
-                    selectFunctions.Add(arity, fn);
+                    selectFunctions.Add(arity ?? 1, fn);
                   }
                 }
                 else if (Regex.IsMatch(funName, "^MapType[0-9]*Store$"))
                 {
-                  funName = string.Format("[{0}:=]", arity);
-                  if (!storeFunctions.TryGetValue(arity, out fn))
+                  funName = string.Format("[{0}:=]", arity ?? 1);
+                  if (!storeFunctions.TryGetValue(arity ?? 1, out fn))
                   {
                     fn = currModel.MkFunc(funName, arity);
-                    storeFunctions.Add(arity, fn);
+                    storeFunctions.Add(arity ?? 1, fn);
                   }
                 }
                 else

--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -298,6 +298,9 @@ namespace Microsoft.Boogie
 
               if (tuple0 == "else")
               {
+                if (fn.Else != null) {
+                  BadModel("multiple else cases");
+                }
                 if (!(resultName is string && ((string) resultName) == "#unspecified"))
                 {
                   fn.Else = GetElt(resultName);

--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Boogie
               }
 
               fn.Arity = tuple.Count - 2;
-              var args = new Model.Element[fn.Arity ?? 1]; // arity cannot be null here
+              var args = new Model.Element[(int) fn.Arity]; 
               for (int i = 0; i < fn.Arity; ++i)
                 args[i] = GetElt(tuple[i]);
               fn.AddApp(GetElt(resultName), args);


### PR DESCRIPTION
This issue is closely related to #408 and concerns cases when a function only has an else path, which are numerous when translating Dafny to Boogie and using the `/proverOpt:O:model.completion=true` command line argument.

When a function only has an else path, its arity is currently set to 1 by default, even if the actual arity is different. This is a problem for two reasons: 

- arity is supposed to be immutable, so any attempt to use such a function later on will lead to a failure. In particular, [DafnyServer](https://github.com/dafny-lang/dafny/blob/master/Source/DafnyServer/boogie/DafnyProvider.cs) has a call to `MkFunc("Seq#Index", 2)` which fails if the original model only had the else branch for this function. I propose a fix (first commit) that allows MkFunc to change the arity of the function if no function applications were previously recorded.
- the names of `MapType1Store`, `MapType2Select`, etc. depend on their arity. When these function only have an else path, their names clash and this leads to "multiple else cases" exceptions. Incidentally, their names can also clash with Dafny's `[2]` function. The long-term fix would be to stop renaming these function but this can potentially lead to significant consequences downstream so I propose to remove the "multiple else cases" exception instead (second commit). This will at least stop the parser failing when processing a model generated from Dafny code with `/proverOpt:O:model.completion=true` and should not introduce any issues that were not already present.