### PR TITLE
Add checking for inline and define attributes on functions

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -3189,8 +3189,6 @@ namespace Microsoft.Boogie
       otherDefinitionAxioms.Add(axiom);
     }
 
-    public bool doingExpansion;
-
     private bool neverTrigger;
     private bool neverTriggerComputed;
 

--- a/Source/Core/FunctionDependencyChecker.cs
+++ b/Source/Core/FunctionDependencyChecker.cs
@@ -1,0 +1,110 @@
+using System.Linq;
+using Microsoft.Boogie.GraphUtil;
+
+namespace Microsoft.Boogie
+{
+    public class FunctionDependencyChecker : StandardVisitor
+    {
+        public static bool Check(Program program)
+        {
+            var checkingContext = new CheckingContext(null);
+            var functionDependencyChecker = new FunctionDependencyChecker();
+            program.TopLevelDeclarations.OfType<Function>().Iter(function =>
+            {
+                var expr = QKeyValue.FindExprAttribute(function.Attributes, "inline");
+                if (expr != null && expr.Type != Type.Bool)
+                {
+                    checkingContext.Error(function.tok, "Parameter to :inline attribute on a function must be Boolean");
+                }
+                if (QKeyValue.FindBoolAttribute(function.Attributes, "inline") &&
+                    QKeyValue.FindBoolAttribute(function.Attributes, "define"))
+                {
+                    checkingContext.Error(function.tok, "A function may not have both :inline and :define attributes");
+                }
+                if (QKeyValue.FindBoolAttribute(function.Attributes, "inline") &&
+                    function.Body == null)
+                {
+                    checkingContext.Error(function.tok, "Inlined function must have a body");
+                }
+            });
+            if (checkingContext.ErrorCount > 0)
+            {
+                return false;
+            }
+            program.TopLevelDeclarations.OfType<Function>()
+                .Iter(function => functionDependencyChecker.VisitFunction(function));
+            var functionDependencyGraph = functionDependencyChecker.functionDependencyGraph;
+            var selfLoops = functionDependencyGraph.Edges.SelectMany(edge =>
+                edge.Item1 == edge.Item2 ? new[] {edge.Item1} : Enumerable.Empty<Function>()).ToHashSet();
+            var sccs = new StronglyConnectedComponents<Function>(
+                functionDependencyGraph.Nodes,
+                functionDependencyGraph.Predecessors,
+                functionDependencyGraph.Successors);
+            sccs.Compute();
+            sccs.Iter(scc =>
+            {
+                if (scc.Count > 1 ||
+                    scc.Count == 1 && selfLoops.Contains(scc.First()))
+                {
+                    var errorMsg = "Call cycle detected among functions";
+                    var first = true;
+                    var token = Token.NoToken;
+                    scc.Iter(function =>
+                    {
+                        if (first)
+                        {
+                            first = false;
+                            errorMsg += ": ";
+                            token = function.tok;
+                        }
+                        else
+                        {
+                            errorMsg += ", ";
+                        }
+                        errorMsg += function.Name;
+                    });
+                    checkingContext.Error(token, errorMsg);
+                }
+            });
+            return checkingContext.ErrorCount == 0;
+        }
+
+        private Graph<Function> functionDependencyGraph;
+        private Function enclosingFunction;
+        
+        private FunctionDependencyChecker()
+        {
+            functionDependencyGraph = new Graph<Function>();
+        }
+
+        public override Function VisitFunction(Function node)
+        {
+            if (QKeyValue.FindBoolAttribute(node.Attributes, "inline"))
+            {
+                this.enclosingFunction = node;
+                base.Visit(node.Body);
+                this.enclosingFunction = null;
+            }
+            else if (QKeyValue.FindBoolAttribute(node.Attributes, "define"))
+            {
+                this.enclosingFunction = node;
+                base.Visit(node.DefinitionBody.Args[1]);
+                this.enclosingFunction = null;
+            }
+            return node;
+        }
+
+        public override Expr VisitNAryExpr(NAryExpr node)
+        {
+            if (node.Fun is FunctionCall functionCall)
+            {
+                if (QKeyValue.FindBoolAttribute(functionCall.Func.Attributes, "inline") ||
+                    QKeyValue.FindBoolAttribute(functionCall.Func.Attributes, "define"))
+                {
+                    functionDependencyGraph.AddEdge(enclosingFunction, functionCall.Func);
+                }
+            }
+            return base.VisitNAryExpr(node);
+        }
+    }
+}

--- a/Source/Core/FunctionDependencyChecker.cs
+++ b/Source/Core/FunctionDependencyChecker.cs
@@ -24,7 +24,12 @@ namespace Microsoft.Boogie
                 if (QKeyValue.FindBoolAttribute(function.Attributes, "inline") &&
                     function.Body == null)
                 {
-                    checkingContext.Error(function.tok, "Inlined function must have a body");
+                    checkingContext.Error(function.tok, "Function with :inline attribute must have a body");
+                }
+                if (QKeyValue.FindBoolAttribute(function.Attributes, "define") &&
+                    function.DefinitionBody == null)
+                {
+                    checkingContext.Error(function.tok, "Function with :define attribute must have a body");
                 }
             });
             if (checkingContext.ErrorCount > 0)

--- a/Source/Core/ResolutionContext.cs
+++ b/Source/Core/ResolutionContext.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Boogie
     /// If both "a" and "b" have an ":extern" attribute, returns either one.
     /// If one of "a" and "b" has an ":extern" attribute, returns that one.
     /// If neither of "a" and "b" has an ":extern" attribute, returns null.
-    /// If a non-value value is returned, this method also adds the ":ignore"
+    /// If a non-null value is returned, this method also adds the ":ignore"
     /// attribute to the declaration NOT returned.
     /// </summary>
     T SelectNonExtern<T>(T a, T b) where T : Declaration 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -726,6 +726,11 @@ namespace Microsoft.Boogie
         return PipelineOutcome.Done;
       }
 
+      if (!FunctionDependencyChecker.Check(program))
+      {
+        return PipelineOutcome.TypeCheckingError;
+      }
+      
       errorCount = program.Typecheck();
       if (errorCount != 0)
       {

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -340,17 +340,9 @@ namespace Microsoft.Boogie.SMTLib
         {
           if (ctx.DefinedFunctions.ContainsKey(fdep) && !definitionAdded.Contains(fdep))
           {
-            if (!dependenciesComputed.Contains(fdep))
-            {
-              // Handle dependencies first
-              functionDefs.Push(fdep);
-              hasDependencies = true;
-            }
-            else
-            {
-              HandleProverError(
-                "Function definition cycle detected: " + f.ToString() + " depends on " + fdep.ToString());
-            }
+            // Handle dependencies first
+            functionDefs.Push(fdep);
+            hasDependencies = true;
           }
         }
 

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -1530,12 +1530,6 @@ namespace Microsoft.Boogie.VCExprAST
 
       lock (app.Func)
       {
-        if (app.Func.doingExpansion)
-        {
-          System.Console.WriteLine("*** detected expansion loop on {0}", app.Func);
-          return null;
-        }
-
         var exp = app.Func.Body;
         if (exp == null)
           return null;
@@ -1548,7 +1542,6 @@ namespace Microsoft.Boogie.VCExprAST
         {
           BaseTranslator.PushFormalsScope();
           BaseTranslator.PushBoundVariableScope();
-          app.Func.doingExpansion = true;
 
           // first bind the formals to VCExpr variables, which are later
           // substituted with the actual parameters
@@ -1563,7 +1556,6 @@ namespace Microsoft.Boogie.VCExprAST
         {
           BaseTranslator.PopFormalsScope();
           BaseTranslator.PopBoundVariableScope();
-          app.Func.doingExpansion = false;
         }
 
         // substitute the formals with the actual parameters in the body

--- a/Test/civl/array-insert.bpl
+++ b/Test/civl/array-insert.bpl
@@ -10,7 +10,7 @@ var {:layer 0,2} A:[int]int;
 var {:layer 0,2} count:int;
 var {:layer 0,2} lock:Tid;
 
-function {:inline 1} sorted (A:[int]int, count:int) : bool
+function {:inline} sorted (A:[int]int, count:int) : bool
 { (forall i:int, j:int :: 0 <= i && i <= j && j < count ==> A[i] <= A[j]) }
 
 procedure {:atomic}{:layer 2} INSERT ({:linear "tid"} tid:Tid, v:int)
@@ -132,4 +132,3 @@ procedure {:yields}{:layer 0}{:refines "READ_COUNT"} read_count ({:linear "tid"}
 procedure {:yields}{:layer 0}{:refines "WRITE_COUNT"} write_count ({:linear "tid"} tid:Tid, c:int);
 procedure {:yields}{:layer 0}{:refines "ACQUIRE"} acquire ({:linear "tid"} tid:Tid);
 procedure {:yields}{:layer 0}{:refines "RELEASE"} release ({:linear "tid"} tid:Tid);
-

--- a/Test/civl/async/leader.bpl
+++ b/Test/civl/async/leader.bpl
@@ -130,10 +130,10 @@ procedure {:yields}{:layer 0}{:refines "read_init_val_atomic"} read_init_val (pi
 // ###########################################################################
 // Linear permissions
 
-function {:inline 1} all_perms () : [Perm]bool { (lambda p:Perm :: is_pid(s#Perm(p)) && is_pid(r#Perm(p))) }
-function {:inline 1} s_perms_eq (s:Pid) : [Perm]bool { (lambda p:Perm :: s#Perm(p) == s && is_pid(r#Perm(p))) }
-function {:inline 1} s_perms_geq (s:Pid) : [Perm]bool { (lambda p:Perm :: is_pid(s#Perm(p)) && is_pid(r#Perm(p)) && s#Perm(p) >= s) }
-function {:inline 1} s_r_perms_geq (s:Pid, r:Pid) : [Perm]bool { (lambda p:Perm :: s#Perm(p) == s && is_pid(r#Perm(p)) && r#Perm(p) >= r) }
+function {:inline} all_perms () : [Perm]bool { (lambda p:Perm :: is_pid(s#Perm(p)) && is_pid(r#Perm(p))) }
+function {:inline} s_perms_eq (s:Pid) : [Perm]bool { (lambda p:Perm :: s#Perm(p) == s && is_pid(r#Perm(p))) }
+function {:inline} s_perms_geq (s:Pid) : [Perm]bool { (lambda p:Perm :: is_pid(s#Perm(p)) && is_pid(r#Perm(p)) && s#Perm(p) >= s) }
+function {:inline} s_r_perms_geq (s:Pid, r:Pid) : [Perm]bool { (lambda p:Perm :: s#Perm(p) == s && is_pid(r#Perm(p)) && r#Perm(p) >= r) }
 
 procedure {:yields}{:layer 1}{:both} split_perms_sender (s:Pid, {:linear_in "Perm"} perms_in:[Perm]bool) returns ({:linear "Perm"} perms_out_1:[Perm]bool, {:linear "Perm"} perms_out_2:[Perm]bool);
 requires {:layer 1} perms_in == s_perms_geq(s);

--- a/Test/civl/podelski/x_perm.bpl
+++ b/Test/civl/podelski/x_perm.bpl
@@ -43,10 +43,10 @@ procedure {:yield_invariant}{:layer 1} Inv_incdec (b:B);
 requires As[bToA(b)];
 
 // Definitions and facts about cardinality
-function {:inline} cardAs (As:[A]bool) : int;
+function cardAs (As:[A]bool) : int;
 axiom (forall As:[A]bool :: cardAs(As) >= 0);
 
-function {:inline} cardBs (Bs:[B]bool) : int;
+function cardBs (Bs:[B]bool) : int;
 axiom (forall Bs:[B]bool :: cardBs(Bs) >= 0);
 
 procedure {:lemma} Lemma_add_to_A (a: A, As: [A]bool);

--- a/Test/civl/seqlock.bpl
+++ b/Test/civl/seqlock.bpl
@@ -11,8 +11,8 @@ var {:layer 0,2} seq:int;
 var {:layer 0,3} x:int;
 var {:layer 0,3} y:int;
 
-function {:inline 1} isEven (x:int) : bool { x mod 2 == 0 }
-function {:inline 1} isOdd (x:int) : bool { x mod 2 != 0 }
+function {:inline} isEven (x:int) : bool { x mod 2 == 0 }
+function {:inline} isOdd (x:int) : bool { x mod 2 != 0 }
 
 // =============================================================================
 // Implementation of atomic read and write operations (to variables x and y)

--- a/Test/functiondefine/fundef10.bpl
+++ b/Test/functiondefine/fundef10.bpl
@@ -1,0 +1,17 @@
+// RUN: %boogie  "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:define} foo(x:int) returns(int)
+  { foo2(x) + 1 }
+function {:inline} foo2(x:int) returns(int)
+  { foo(x) + 2 }
+
+procedure test(x:int) returns (r:int)
+  ensures r > 0;
+{
+  if (foo(x) > 0) {
+    r := foo2(x);
+  } else {
+    r := 1;
+  }
+}

--- a/Test/functiondefine/fundef10.bpl.expect
+++ b/Test/functiondefine/fundef10.bpl.expect
@@ -1,0 +1,1 @@
+fundef10.bpl(4,19): Error: Call cycle detected among functions: foo, foo2

--- a/Test/functiondefine/fundef11.bpl
+++ b/Test/functiondefine/fundef11.bpl
@@ -1,0 +1,19 @@
+// RUN: %boogie  "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:define} foo(x:int) returns(int)
+  { foo1(x) + 1 }
+function foo1(x:int) returns(int)
+  { foo2(x) }
+function {:inline} foo2(x:int) returns(int)
+  { foo(x) + 2 }
+
+procedure test(x:int) returns (r:int)
+  ensures r > 0;
+{
+  if (foo(x) > 0) {
+    r := foo2(x);
+  } else {
+    r := 1;
+  }
+}

--- a/Test/functiondefine/fundef11.bpl.expect
+++ b/Test/functiondefine/fundef11.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/functiondefine/fundef12.bpl
+++ b/Test/functiondefine/fundef12.bpl
@@ -1,0 +1,6 @@
+// RUN: %boogie  "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function {:inline} foo(x:int) returns(int);
+
+function {:define} bar(x:int) returns(int);

--- a/Test/functiondefine/fundef12.bpl.expect
+++ b/Test/functiondefine/fundef12.bpl.expect
@@ -1,0 +1,2 @@
+fundef12.bpl(4,19): Error: Function with :inline attribute must have a body
+fundef12.bpl(6,19): Error: Function with :define attribute must have a body

--- a/Test/functiondefine/fundef9.bpl
+++ b/Test/functiondefine/fundef9.bpl
@@ -1,6 +1,6 @@
-// RUN: %boogie "%s" | %OutputCheck "%s"
+// RUN: %boogie  "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
 
-// CHECK-L: Prover error: Function definition cycle detected: foo depends on foo2
 function {:define} foo(x:int) returns(int)
   { foo2(x) + 1 }
 function {:define} foo2(x:int) returns(int)
@@ -15,5 +15,3 @@ procedure test(x:int) returns (r:int)
     r := 1;
   }
 }
-
-// CHECK-L: Boogie program verifier finished with 0 verified, 0 errors, 1 inconclusive

--- a/Test/functiondefine/fundef9.bpl.expect
+++ b/Test/functiondefine/fundef9.bpl.expect
@@ -1,0 +1,1 @@
+fundef9.bpl(4,19): Error: Call cycle detected among functions: foo, foo2

--- a/Test/inline/expansion3.bpl.expect
+++ b/Test/inline/expansion3.bpl.expect
@@ -1,5 +1,1 @@
-*** detected expansion loop on foo3
-*** detected expansion loop on foo3
-*** detected expansion loop on foo3
-
-Boogie program verifier finished with 1 verified, 0 errors
+expansion3.bpl(3,24): Error: Call cycle detected among functions: foo3

--- a/Test/monomorphize/issue-358.bpl
+++ b/Test/monomorphize/issue-358.bpl
@@ -5,7 +5,7 @@
 type {:datatype} Cell _;
 function {:constructor} Mk<T>(x: T): Cell T;
 
-function {:inline} foo<T>(): Cell T;
+function foo<T>(): Cell T;
 
 type Cell_int = Cell int;
 type Cell_bool = Cell bool;

--- a/Test/monomorphize/monomorphize5.bpl
+++ b/Test/monomorphize/monomorphize5.bpl
@@ -5,7 +5,7 @@
 type {:datatype} Cell _;
 function {:constructor} Mk<T>(x: T): Cell T;
 
-function {:inline} foo<T>(): Cell T;
+function foo<T>(): Cell T;
 
 procedure p() {
   var x: Cell int;

--- a/Test/monomorphize/monomorphize5.bpl.expect
+++ b/Test/monomorphize/monomorphize5.bpl.expect
@@ -2,6 +2,6 @@ monomorphize5.bpl(21,3): Error: This assertion might not hold.
 Execution trace:
     monomorphize5.bpl(19,5): anon0
 Augmented execution trace:
-x=(Mk_34 1)
+x=(Mk_33 1)
 
 Boogie program verifier finished with 1 verified, 1 error

--- a/Test/monomorphize/monomorphize6.bpl
+++ b/Test/monomorphize/monomorphize6.bpl
@@ -8,7 +8,7 @@ function {:constructor} Cell<T>(x: T): Cell T;
 type {:datatype} OtherCell _;
 function {:constructor} OtherCell<T>(x: T): OtherCell T;
 
-function {:inline} foo<T>(): Cell T;
+function foo<T>(): Cell T;
 
 procedure p() {
   var x: Cell (OtherCell int);

--- a/Test/monomorphize/monomorphize6.bpl.expect
+++ b/Test/monomorphize/monomorphize6.bpl.expect
@@ -2,6 +2,6 @@ monomorphize6.bpl(24,3): Error: This assertion might not hold.
 Execution trace:
     monomorphize6.bpl(22,5): anon0
 Augmented execution trace:
-x=(Cell_183 (OtherCell_47 1))
+x=(Cell_182 (OtherCell_46 1))
 
 Boogie program verifier finished with 1 verified, 1 error


### PR DESCRIPTION
This PR tightens the type checking of function declarations with respect to attributes and how they call each other.

1. :inline attribute must have no parameter or a Boolean parameter
2. :inline attribute on a function requires function to have a body
3. function call graph projected onto functions with :inline or :define attribute must be acyclic