### PR TITLE
Remove multiple else cases exceptions

### DIFF
--- a/Source/Model/ModelParser.cs
+++ b/Source/Model/ModelParser.cs
@@ -298,10 +298,7 @@ namespace Microsoft.Boogie
 
               if (tuple0 == "else")
               {
-                if (fn.Else != null) {
-                  BadModel("multiple else cases");
-                }
-                if (!(resultName is string && ((string) resultName) == "#unspecified"))
+                if ((fn.Else == null) && (!(resultName is string && ((string) resultName) == "#unspecified")))
                 {
                   fn.Else = GetElt(resultName);
                 }


### PR DESCRIPTION
This is a continuation of #414 (thank you for all the help with it!) made into a separate PR as requested. The short description is that I propose to remove the "Multiple Else Cases" exception because it makes the model parser fail on a relatively large set of models. The full explanation is below:

The current version of the [ModelParser](https://github.com/boogie-org/boogie/blob/master/Source/Model/ModelParser.cs) renames any function matching the `^MapType[0-9]*Select$` and `^MapType[0-9]*Store$` regex patterns. The new name assigned to such a function depends on its arity. When a function has no application, its arity is computed from the else branch as if the latter were an application. The result is that the arity is set `1` (or `null` if #414 is adopted). Combined with the renaming, this leads to a name clash when two or more such functions only have an else branch. A name clash leads to a “Multiple else cases” exception down the road (because an else branch is assigned more than once). 

 It is not clear to me if one can stop the renaming without breaking the code that might depend on it. Neither is it clear how to compute the true arity when there is only the else branch. As such, I can’t think of an immediate way to avoid the name clash. The fix proposed here is, therefore, to remove the recently introduced “Multiple else cases” exception. Once removed, it will stop the parser from failing to process models generated with the `/proverOpt:O:model.completion=true` command line argument from certain Boogie programs (most notably almost all programs translated from Dafny to Boogie). This command line argument is critical to implementing a feature I am working on for Dafny.

Guide for reproducing the error in question:

1) Download [this file](https://gist.github.com/Dargones/b57d253ad74b8b23b3d06373557cc878). It is generated by Dafny but it is a syntactically valid Boogie program (which fails verification). I am afraid I can't immediately reduce this to a simpler example as I don't fully understand what the MapType.. functions are used for or why they are being renamed. The source Dafny code is this: 
`method a() {assert false;}`
2) Run the following to generate a model for the failing assertion.:
`boogie /proverOpt:O:model.completion=true /printModel:1 /printModelToFile:model.txt test.bpl`
3) Attempt to parse the model. The easiest way to do this is to insert the following line at the top of BoogieDriver's Main, compile boogie, and run it passing the path to `model.txt` as argument:
`Model.ParseModels(new StreamReader(args[0]));`

Thank you!