### PR TITLE
Fix inconsistency implementation of Vec library

### DIFF
--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -95,8 +95,15 @@ function {:inline} Vec_Slice<T>(v: Vec T, i: int, j: int): Vec T {
            )
     )
 }
+
 /*
-// Monomorphization currently crashes with the following version of Vec_Slice
+// The current implementation of pool-based quantifier instantiation will 
+// not collect a lambda instance if the instance refers to a let-bound 
+// variable as in the alternative definition of Vec_Slice below.
+// This limitation is pervasive and may apply also to quantifiers that
+// occur in the definition of let-bound variables.
+// The solution is to detect that certain let-bindings are interfering 
+// with quantifier instantiation and inline them.
 function {:inline} Vec_Slice<T>(v: Vec T, i: int, j: int): Vec T {
     (
         var cond := 0 <= i && i < j && j <= len#Vec(v);
@@ -109,6 +116,7 @@ function {:inline} Vec_Slice<T>(v: Vec T, i: int, j: int): Vec T {
     )
 }
 */
+
 function {:inline} Vec_Swap<T>(v: Vec T, i: int, j: int): Vec T {
     (
         var cond := 0 <= i && i < len#Vec(v) && 0 <= j && j < len#Vec(v);

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -709,7 +709,9 @@ namespace Microsoft.Boogie
         {
           return new IdentifierExpr(node.tok, boundVarSubst[node.Decl], node.Immutable);
         }
-        return base.VisitIdentifierExpr(node);
+        var identifierExpr = base.VisitIdentifierExpr(node);
+        identifierExpr.Type = VisitType(identifierExpr.Type);
+        return identifierExpr;
       }
 
       public override BinderExpr VisitBinderExpr(BinderExpr node)
@@ -764,6 +766,7 @@ namespace Microsoft.Boogie
         }
 
         var expr = (LetExpr) base.VisitLetExpr(node);
+        expr.Type = VisitType(expr.Type);
         expr.Dummies = node.Dummies.Select(x => oldToNew[x]).ToList<Variable>();
         foreach (var x in node.Dummies)
         {

--- a/Source/VCExpr/QuantifierInstantiationEngine.cs
+++ b/Source/VCExpr/QuantifierInstantiationEngine.cs
@@ -682,14 +682,12 @@ namespace Microsoft.Boogie.VCExprAST
     {
       var lambdaInstanceCollector = new LambdaInstanceCollector(qiEngine);
       lambdaInstanceCollector.Traverse(vcExpr, true);
-      var lambdaFunctionToInstances = new Dictionary<Function, HashSet<List<VCExpr>>>();
+      var lambdaFunctionToInstances =
+        lambdaInstanceCollector.lambdaFunctions.ToDictionary(
+          x => x, x => new HashSet<List<VCExpr>>(new ListComparer<VCExpr>()));
       foreach (var instance in lambdaInstanceCollector.instances)
       {
         var function = (instance.Op as VCExprBoogieFunctionOp).Func;
-        if (!lambdaFunctionToInstances.ContainsKey(function))
-        {
-          lambdaFunctionToInstances[function] = new HashSet<List<VCExpr>>(new ListComparer<VCExpr>());
-        }
         lambdaFunctionToInstances[function].Add(instance.UniformArguments.ToList());
       }
       return lambdaFunctionToInstances;
@@ -698,11 +696,13 @@ namespace Microsoft.Boogie.VCExprAST
     private LambdaInstanceCollector(QuantifierInstantiationEngine qiEngine)
     {
       this.qiEngine = qiEngine;
+      this.lambdaFunctions = new HashSet<Function>();
       this.instances = new HashSet<VCExprNAry>();
       this.instancesOnStack = new Stack<VCExprNAry>();
     }
 
     private QuantifierInstantiationEngine qiEngine;
+    private HashSet<Function> lambdaFunctions;
     private HashSet<VCExprNAry> instances;
     private Stack<VCExprNAry> instancesOnStack;
 
@@ -718,6 +718,7 @@ namespace Microsoft.Boogie.VCExprAST
         var function = functionOp.Func;
         if (function.OriginalLambdaExprAsString != null && qiEngine.BindLambdaFunction(function))
         {
+          lambdaFunctions.Add(function);
           instances.Add(node);
           instancesOnStack.Push(node);
           var retVal = base.Visit(node, arg);

--- a/Test/inst/vector-generic.bpl
+++ b/Test/inst/vector-generic.bpl
@@ -52,6 +52,7 @@ requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == B;
 
 procedure Ex5<Element>(A: Vec Element, B: Vec Element, i: int, e: Element)
 requires 0 <= i && i < Vec_Len(A);
+requires Vec_Len(A) == Vec_Len(B);
 requires Vec_Nth(A, i) == Vec_Nth(B, Vec_Len(B) - 1);
 requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_Slice(B, 0, Vec_Len(B) - 1);
 {
@@ -66,6 +67,7 @@ requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_
 
 procedure Ex6a<Element>(A: Vec Element, B: Vec Element, i: int, e: Element)
 requires 0 <= i && i < Vec_Len(A);
+requires Vec_Len(A) == Vec_Len(B);
 requires Vec_Nth(A, i) == Vec_Nth(B, Vec_Len(B) - 1);
 requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_Slice(B, 0, Vec_Len(B) - 1);
 {
@@ -79,6 +81,7 @@ requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_
 
 procedure Ex6b<Element>(A: Vec Element, B: Vec Element, i: int, e: Element)
 requires 0 <= i && i < Vec_Len(A);
+requires Vec_Len(A) == Vec_Len(B);
 requires Vec_Nth(A, i) == Vec_Nth(B, Vec_Len(B) - 1);
 requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_Slice(B, 0, Vec_Len(B) - 1);
 {
@@ -154,6 +157,7 @@ ensures i' == i + 1;
 ensures Vec_Nth(B', i') == Vec_Nth(A, j);
 ensures Vec_Slice(B', 0, i') == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i' + 1));
 ensures Vec_Slice(B', i' + 1, Vec_Len(B')) == Vec_Slice(A, i' + 1, Vec_Len(A));
+ensures Vec_Len(B) == Vec_Len(B');
 {
     var x, y: int;
 
@@ -179,20 +183,22 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
 
     B := A;
     i := j;
+    assert {:split_here} true;
     while (i < Vec_Len(A) - 1)
     invariant j <= i && i <= Vec_Len(A) - 1;
+    invariant Vec_Len(A) == Vec_Len(B);
     invariant Vec_Nth(B, i) == Vec_Nth(A, j);
     invariant Vec_Slice(B, 0, i) == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1));
     invariant Vec_Slice(B, i + 1, Vec_Len(B)) == Vec_Slice(A, i + 1, Vec_Len(A));
     {
-        assert {:split_here} true;
         call B, i := Ex8(A, j, B, i);
+        assert {:split_here} true;
     }
+    assert {:split_here} true;
     e := Vec_Nth(B, Vec_Len(A) - 1);
     B := Vec_Remove(B);
     call z := Vec_Ext(B, Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A))));
     assume {:add_to_pool "Slice", z, j, j + 1, j - 1} true;
-    assert {:split_here} true;
 }
 
 // "real" vector procedures start here
@@ -206,36 +212,37 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
 
     B := A;
     i := j;
+    assert {:split_here} true;
     while (i < Vec_Len(A) - 1)
     invariant j <= i && i <= Vec_Len(A) - 1;
+    invariant Vec_Len(A) == Vec_Len(B);
     invariant Vec_Nth(B, i) == Vec_Nth(A, j);
     invariant Vec_Slice(B, 0, i) == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1));
     invariant Vec_Slice(B, i + 1, Vec_Len(B)) == Vec_Slice(A, i + 1, Vec_Len(A));
     {
-        assert {:split_here} true;
         assume {:add_to_pool "Slice", i, j} true;
-
         B := Vec_Swap(B, i, i + 1);
         i := i + 1;
-
         assume {:add_to_pool "Slice", i} true;
         call x := Vec_Ext(Vec_Slice(B, 0, i), Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1)));
         assume {:add_to_pool "Slice", 0, x + j, x - j, x, x + 1, x - 1} true;
         call y := Vec_Ext(Vec_Slice(B, i + 1, Vec_Len(B)), Vec_Slice(A, i + 1, Vec_Len(A)));
         assume {:add_to_pool "Slice", y, y + 1} true;
+        assert {:split_here} true;
     }
+    assert {:split_here} true;
     e := Vec_Nth(B, Vec_Len(A) - 1);
     B := Vec_Remove(B);
     call z := Vec_Ext(B, Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A))));
     assume {:add_to_pool "Slice", z, j, j + 1, j - 1} true;
-    assert {:split_here} true;
 }
 
 procedure swap_remove<Element>(A: Vec Element, j: int) returns (B: Vec Element)
 requires 0 <= j && j < Vec_Len(A);
 ensures Vec_Slice(B, 0, j) == Vec_Slice(A, 0, j);
 ensures Vec_Slice(B, j+1, Vec_Len(B)) == Vec_Slice(A, j+1, Vec_Len(B));
-ensures Vec_Nth(B, j) == Vec_Nth(A, Vec_Len(A) - 1);
+ensures Vec_Len(B) == Vec_Len(A) - 1;
+ensures j < Vec_Len(B) ==> Vec_Nth(B, j) == Vec_Nth(A, Vec_Len(A) - 1);
 {
     var last_idx: int;
 
@@ -283,7 +290,9 @@ ensures C == Vec_Concat(A, B);
 
     C := A;
     call R := reverse(B);
+    assert {:split_here} true;
     while (0 < Vec_Len(R))
+    invariant Vec_Len(R) <= Vec_Len(B);
     invariant (forall {:pool "L"} x: int :: {:skolem_add_to_pool "L", 0, x + 1}
     0 <= x && x < Vec_Len(R) ==> Vec_Nth(B, x + Vec_Len(B) - Vec_Len(R)) == Vec_Nth(R, Vec_Len(R) - 1 - x));
     invariant C == Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R)));
@@ -294,7 +303,9 @@ ensures C == Vec_Concat(A, B);
         assert Vec_Len(C) == Vec_Len(Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R))));
         call y := Vec_Ext(C, Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R))));
         assume {:add_to_pool "Slice", y, y - Vec_Len(A)} true;
+        assert {:split_here} true;
     }
+    assert {:split_here} true;
 }
 
 procedure contains<Element>(A: Vec Element, e: Element) returns (found: bool)

--- a/Test/inst/vector-generic.bpl
+++ b/Test/inst/vector-generic.bpl
@@ -300,9 +300,8 @@ ensures C == Vec_Concat(A, B);
         e := Vec_Nth(R, Vec_Len(R) - 1);
         C := Vec_Append(C, e);
         R := Vec_Remove(R);
-        assert Vec_Len(C) == Vec_Len(Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R))));
         call y := Vec_Ext(C, Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R))));
-        assume {:add_to_pool "Slice", y, y - Vec_Len(A)} true;
+        assume {:add_to_pool "Concat", y} {:add_to_pool "Slice", y - Vec_Len(A)} true;
         assert {:split_here} true;
     }
     assert {:split_here} true;

--- a/Test/inst/vector.bpl
+++ b/Test/inst/vector.bpl
@@ -54,6 +54,7 @@ requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == B;
 
 procedure Ex5(A: Vec Element, B: Vec Element, i: int, e: Element)
 requires 0 <= i && i < Vec_Len(A);
+requires Vec_Len(A) == Vec_Len(B);
 requires Vec_Nth(A, i) == Vec_Nth(B, Vec_Len(B) - 1);
 requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_Slice(B, 0, Vec_Len(B) - 1);
 {
@@ -68,6 +69,7 @@ requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_
 
 procedure Ex6a(A: Vec Element, B: Vec Element, i: int, e: Element)
 requires 0 <= i && i < Vec_Len(A);
+requires Vec_Len(A) == Vec_Len(B);
 requires Vec_Nth(A, i) == Vec_Nth(B, Vec_Len(B) - 1);
 requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_Slice(B, 0, Vec_Len(B) - 1);
 {
@@ -81,6 +83,7 @@ requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_
 
 procedure Ex6b(A: Vec Element, B: Vec Element, i: int, e: Element)
 requires 0 <= i && i < Vec_Len(A);
+requires Vec_Len(A) == Vec_Len(B);
 requires Vec_Nth(A, i) == Vec_Nth(B, Vec_Len(B) - 1);
 requires Vec_Concat(Vec_Slice(A, 0, i), Vec_Slice(A, i + 1, Vec_Len(A))) == Vec_Slice(B, 0, Vec_Len(B) - 1);
 {
@@ -156,6 +159,7 @@ ensures i' == i + 1;
 ensures Vec_Nth(B', i') == Vec_Nth(A, j);
 ensures Vec_Slice(B', 0, i') == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i' + 1));
 ensures Vec_Slice(B', i' + 1, Vec_Len(B')) == Vec_Slice(A, i' + 1, Vec_Len(A));
+ensures Vec_Len(B) == Vec_Len(B');
 {
     var x, y: int;
 
@@ -181,14 +185,16 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
 
     B := A;
     i := j;
+    assert {:split_here} true;
     while (i < Vec_Len(A) - 1)
     invariant j <= i && i <= Vec_Len(A) - 1;
+    invariant Vec_Len(A) == Vec_Len(B);
     invariant Vec_Nth(B, i) == Vec_Nth(A, j);
     invariant Vec_Slice(B, 0, i) == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1));
     invariant Vec_Slice(B, i + 1, Vec_Len(B)) == Vec_Slice(A, i + 1, Vec_Len(A));
     {
-        assert {:split_here} true;
         call B, i := Ex8(A, j, B, i);
+        assert {:split_here} true;
     }
     e := Vec_Nth(B, Vec_Len(A) - 1);
     B := Vec_Remove(B);
@@ -208,23 +214,23 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
 
     B := A;
     i := j;
+    assert {:split_here} true;
     while (i < Vec_Len(A) - 1)
     invariant j <= i && i <= Vec_Len(A) - 1;
+    invariant Vec_Len(A) == Vec_Len(B);
     invariant Vec_Nth(B, i) == Vec_Nth(A, j);
     invariant Vec_Slice(B, 0, i) == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1));
     invariant Vec_Slice(B, i + 1, Vec_Len(B)) == Vec_Slice(A, i + 1, Vec_Len(A));
     {
-        assert {:split_here} true;
         assume {:add_to_pool "Slice", i, j} true;
-
         B := Vec_Swap(B, i, i + 1);
         i := i + 1;
-
         assume {:add_to_pool "Slice", i} true;
         call x := Vec_Ext(Vec_Slice(B, 0, i), Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1)));
         assume {:add_to_pool "Slice", 0, x + j, x - j, x, x + 1, x - 1} true;
         call y := Vec_Ext(Vec_Slice(B, i + 1, Vec_Len(B)), Vec_Slice(A, i + 1, Vec_Len(A)));
         assume {:add_to_pool "Slice", y, y + 1} true;
+        assert {:split_here} true;
     }
     e := Vec_Nth(B, Vec_Len(A) - 1);
     B := Vec_Remove(B);
@@ -237,7 +243,8 @@ procedure swap_remove(A: Vec Element, j: int) returns (B: Vec Element)
 requires 0 <= j && j < Vec_Len(A);
 ensures Vec_Slice(B, 0, j) == Vec_Slice(A, 0, j);
 ensures Vec_Slice(B, j+1, Vec_Len(B)) == Vec_Slice(A, j+1, Vec_Len(B));
-ensures Vec_Nth(B, j) == Vec_Nth(A, Vec_Len(A) - 1);
+ensures Vec_Len(B) == Vec_Len(A) - 1;
+ensures j < Vec_Len(B) ==> Vec_Nth(B, j) == Vec_Nth(A, Vec_Len(A) - 1);
 {
     var last_idx: int;
 
@@ -285,7 +292,9 @@ ensures C == Vec_Concat(A, B);
 
     C := A;
     call R := reverse(B);
+    assert {:split_here} true;
     while (0 < Vec_Len(R))
+    invariant Vec_Len(R) <= Vec_Len(B);
     invariant (forall {:pool "L"} x: int :: {:skolem_add_to_pool "L", 0, x + 1}
     0 <= x && x < Vec_Len(R) ==> Vec_Nth(B, x + Vec_Len(B) - Vec_Len(R)) == Vec_Nth(R, Vec_Len(R) - 1 - x));
     invariant C == Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R)));
@@ -296,7 +305,9 @@ ensures C == Vec_Concat(A, B);
         assert Vec_Len(C) == Vec_Len(Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R))));
         call y := Vec_Ext(C, Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R))));
         assume {:add_to_pool "Slice", y, y - Vec_Len(A)} true;
+        assert {:split_here} true;
     }
+    assert {:split_here} true;
 }
 
 procedure contains(A: Vec Element, e: Element) returns (found: bool)

--- a/Test/inst/vector.bpl
+++ b/Test/inst/vector.bpl
@@ -227,7 +227,7 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
         i := i + 1;
         assume {:add_to_pool "Slice", i} true;
         call x := Vec_Ext(Vec_Slice(B, 0, i), Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1)));
-        assume {:add_to_pool "Slice", 0, x + j, x - j, x, x + 1, x - 1} true;
+        assume {:add_to_pool "Concat", x} {:add_to_pool "Slice", 0, x + j, x - j, x, x + 1, x - 1} true;
         call y := Vec_Ext(Vec_Slice(B, i + 1, Vec_Len(B)), Vec_Slice(A, i + 1, Vec_Len(A)));
         assume {:add_to_pool "Slice", y, y + 1} true;
         assert {:split_here} true;
@@ -235,7 +235,7 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
     e := Vec_Nth(B, Vec_Len(A) - 1);
     B := Vec_Remove(B);
     call z := Vec_Ext(B, Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A))));
-    assume {:add_to_pool "Slice", z, j, j + 1, j - 1} true;
+    assume {:add_to_pool "Concat", z} {:add_to_pool "Slice", z, j, j + 1, j - 1} true;
     assert {:split_here} true;
 }
 
@@ -302,9 +302,8 @@ ensures C == Vec_Concat(A, B);
         e := Vec_Nth(R, Vec_Len(R) - 1);
         C := Vec_Append(C, e);
         R := Vec_Remove(R);
-        assert Vec_Len(C) == Vec_Len(Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R))));
         call y := Vec_Ext(C, Vec_Concat(A, Vec_Slice(B, 0, Vec_Len(B) - Vec_Len(R))));
-        assume {:add_to_pool "Slice", y, y - Vec_Len(A)} true;
+        assume {:add_to_pool "Concat", y} {:add_to_pool "Slice", y - Vec_Len(A)} true;
         assert {:split_here} true;
     }
     assert {:split_here} true;


### PR DESCRIPTION
- @cbarrettfb detected an inconsistency in the implementation of the Vec library.  This PR fixes the problem by rewriting the buggy definitions of vector operations in LibraryDefinitions.bpl
- While doing this work, some bugs were discovered in monomorphization and pool-based QI; they were fixed.