### PR TITLE
Fixed bug and proof

### DIFF
--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -125,7 +125,10 @@ function {:inline} Vec_Swap<T>(v: Vec T, i: int, j: int): Vec T {
 }
 
 function {:inline} Vec_Remove<T>(v: Vec T): Vec T {
-    Vec(contents#Vec(v)[len#Vec(v)-1 := Default()], if (0 < len#Vec(v)) then len#Vec(v) - 1 else 0)
+    (
+        var cond, new_len := 0 < len#Vec(v), len#Vec(v) - 1;
+        Vec(contents#Vec(v)[new_len := if (cond) then Default() else contents#Vec(v)[new_len]], if (cond) then new_len else len#Vec(v))
+    )
 }
 
 // extensionality lemma to be used explicitly by the programmer

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -986,6 +986,11 @@ namespace Microsoft.Boogie
       return monomorphizationDuplicator.VisitExpr(node);
     }
 
+    public override Expr VisitNAryExpr(NAryExpr node)
+    {
+      return monomorphizationDuplicator.VisitExpr(node);
+    }
+
     public override Expr VisitIdentifierExpr(IdentifierExpr node)
     {
       return monomorphizationDuplicator.VisitExpr(node);

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -203,6 +203,8 @@ namespace Microsoft.Boogie
           visitor.Visit(node.TypeParameters[t]);
         });
       }
+
+      Visit(node.Type);
       return base.VisitNAryExpr(node);
     }
 
@@ -275,6 +277,24 @@ namespace Microsoft.Boogie
       LinqExtender.Map(node.Proc.TypeParameters, node.TypeParameters)
         .Iter(x => typeVariableDependencyGraph.AddEdge(x.Key, x.Value));
       return base.VisitImplementation(node);
+    }
+
+    public override Absy Visit(Absy node)
+    {
+      if (node is ICarriesAttributes attrNode && attrNode.Attributes != null)
+      {
+        VisitQKeyValue(attrNode.Attributes);
+      }
+      return base.Visit(node);
+    }
+    
+    public override Type VisitTypeProxy(TypeProxy node)
+    {
+      if (node.ProxyFor == null)
+      {
+        isMonomorphizable = false;
+      }
+      return node;
     }
   }
   

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -294,6 +294,10 @@ namespace Microsoft.Boogie
       {
         isMonomorphizable = false;
       }
+      else
+      {
+        Visit(TypeProxy.FollowProxy(node));
+      }
       return node;
     }
   }

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -692,6 +692,11 @@ namespace Microsoft.Boogie
         return (Type) Visit(node);
       }
 
+      public override Type VisitTypeProxy(TypeProxy node)
+      {
+        return VisitType(TypeProxy.FollowProxy(node));
+      }
+
       public override Expr VisitExpr(Expr node)
       {
         node = base.VisitExpr(node);

--- a/Test/civl/GC.bpl
+++ b/Test/civl/GC.bpl
@@ -258,10 +258,10 @@ requires {:layer 100} (forall x: idx :: rootAddr(x) ==> rootAbs[x] == Int(0));
 
 procedure {:yields} {:layer 100}
 {:yield_requires "Yield_Initialize_100", tid, mutatorTids}
-{:yield_requires "Yield_InitVars99", mutatorTids, MapConst(false), old(rootScanBarrier)}
+{:yield_requires "Yield_InitVars99", mutatorTids, MapConst(false) : [int]bool, old(rootScanBarrier)}
 {:yield_ensures "Yield_Iso"}
 {:yield_ensures "Yield_RootScanBarrierInv"}
-{:yield_ensures "Yield_InitVars99", mutatorTids, MapConst(false), numMutators}
+{:yield_ensures "Yield_InitVars99", mutatorTids, MapConst(false) : [int]bool, numMutators}
 Initialize({:linear_in "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 requires {:layer 97,98,99} gcAndMutatorTids(tid, mutatorTids);
 {

--- a/Test/civl/generic-call-arg.bpl
+++ b/Test/civl/generic-call-arg.bpl
@@ -1,0 +1,11 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+// A call to a polymorphic function (in an attribute) whose type arguments cannot be resolved
+// must be detected and reported as error
+
+procedure
+{:layer 1}
+{:yield_requires "A", MapConst(false)}
+B();
+
+procedure {:yield_invariant} {:layer 1} A(x: [int]bool);

--- a/Test/civl/generic-call-arg.bpl.expect
+++ b/Test/civl/generic-call-arg.bpl.expect
@@ -1,0 +1,1 @@
+Unable to monomorphize input program: unhandled polymorphic features detected

--- a/Test/inst/vector-generic.bpl
+++ b/Test/inst/vector-generic.bpl
@@ -225,7 +225,7 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
         i := i + 1;
         assume {:add_to_pool "Slice", i} true;
         call x := Vec_Ext(Vec_Slice(B, 0, i), Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1)));
-        assume {:add_to_pool "Slice", 0, x + j, x - j, x, x + 1, x - 1} true;
+        assume {:add_to_pool "Concat", x} {:add_to_pool "Slice", 0, x, x - j} true;
         call y := Vec_Ext(Vec_Slice(B, i + 1, Vec_Len(B)), Vec_Slice(A, i + 1, Vec_Len(A)));
         assume {:add_to_pool "Slice", y, y + 1} true;
         assert {:split_here} true;
@@ -234,7 +234,7 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
     e := Vec_Nth(B, Vec_Len(A) - 1);
     B := Vec_Remove(B);
     call z := Vec_Ext(B, Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A))));
-    assume {:add_to_pool "Slice", z, j, j + 1, j - 1} true;
+    assume {:add_to_pool "Concat", z} {:add_to_pool "Slice", z, z - j} true;
 }
 
 procedure swap_remove<Element>(A: Vec Element, j: int) returns (B: Vec Element)

--- a/Test/inst/vector.bpl
+++ b/Test/inst/vector.bpl
@@ -196,11 +196,11 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
         call B, i := Ex8(A, j, B, i);
         assert {:split_here} true;
     }
+    assert {:split_here} true;
     e := Vec_Nth(B, Vec_Len(A) - 1);
     B := Vec_Remove(B);
     call z := Vec_Ext(B, Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A))));
     assume {:add_to_pool "Slice", z, j, j + 1, j - 1} true;
-    assert {:split_here} true;
 }
 
 // "real" vector procedures start here
@@ -227,16 +227,16 @@ ensures B == Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A)));
         i := i + 1;
         assume {:add_to_pool "Slice", i} true;
         call x := Vec_Ext(Vec_Slice(B, 0, i), Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, i + 1)));
-        assume {:add_to_pool "Concat", x} {:add_to_pool "Slice", 0, x + j, x - j, x, x + 1, x - 1} true;
+        assume {:add_to_pool "Concat", x} {:add_to_pool "Slice", 0, x, x - j} true;
         call y := Vec_Ext(Vec_Slice(B, i + 1, Vec_Len(B)), Vec_Slice(A, i + 1, Vec_Len(A)));
         assume {:add_to_pool "Slice", y, y + 1} true;
         assert {:split_here} true;
     }
+    assert {:split_here} true;
     e := Vec_Nth(B, Vec_Len(A) - 1);
     B := Vec_Remove(B);
     call z := Vec_Ext(B, Vec_Concat(Vec_Slice(A, 0, j), Vec_Slice(A, j + 1, Vec_Len(A))));
-    assume {:add_to_pool "Concat", z} {:add_to_pool "Slice", z, j, j + 1, j - 1} true;
-    assert {:split_here} true;
+    assume {:add_to_pool "Concat", z} {:add_to_pool "Slice", z, z - j} true;
 }
 
 procedure swap_remove(A: Vec Element, j: int) returns (B: Vec Element)

--- a/Test/monomorphize/generic-call-arg.bpl
+++ b/Test/monomorphize/generic-call-arg.bpl
@@ -1,0 +1,9 @@
+// RUN: %boogie -lib "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+// A call to a polymorphic function (in an attribute) whose type arguments cannot be resolved
+// must be detected and reported as error
+
+procedure B()
+{
+    assume {:add_to_pool "A", MapConst(false)} true;
+}

--- a/Test/monomorphize/generic-call-arg.bpl.expect
+++ b/Test/monomorphize/generic-call-arg.bpl.expect
@@ -1,0 +1,1 @@
+Unable to monomorphize input program: unhandled polymorphic features detected


### PR DESCRIPTION
- Further cleanup of vector proof
- Fixed bug where monomorphization was not being done on expressions inside attributes
- The attempt to fix this bug revealed another bug where monomorphization depends on all type arguments being resolved in polymorphic expressions; so added a check for this condition in MonomorphizableChecker