### PR TITLE
always_assume attribute for specs 

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -3675,7 +3675,8 @@ namespace Microsoft.Boogie
 
     public QKeyValue Attributes { get; set; }
 
-    public bool CanAlwaysAssume () {
+    public bool CanAlwaysAssume ()
+    {
       return QKeyValue.FindBoolAttribute(this.Attributes, "alwaysAssume");
     }
 

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -3548,7 +3548,7 @@ namespace Microsoft.Boogie
 
     public bool CanAlwaysAssume()
     {
-      return QKeyValue.FindBoolAttribute(Attributes, "alwaysAssume");
+      return QKeyValue.FindBoolAttribute(Attributes, "always_assume");
     }
 
 
@@ -3677,7 +3677,7 @@ namespace Microsoft.Boogie
 
     public bool CanAlwaysAssume ()
     {
-      return QKeyValue.FindBoolAttribute(this.Attributes, "alwaysAssume");
+      return QKeyValue.FindBoolAttribute(this.Attributes, "always_assume");
     }
 
     public Ensures(IToken token, bool free, Expr /*!*/ condition, string comment, QKeyValue kv)

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -3548,7 +3548,7 @@ namespace Microsoft.Boogie
 
     public bool CanAlwaysAssume()
     {
-      return QKeyValue.FindBoolAttribute(Attributes, "always_assume");
+      return Free && QKeyValue.FindBoolAttribute(Attributes, "always_assume");
     }
 
 
@@ -3677,7 +3677,7 @@ namespace Microsoft.Boogie
 
     public bool CanAlwaysAssume ()
     {
-      return QKeyValue.FindBoolAttribute(this.Attributes, "always_assume");
+      return Free && QKeyValue.FindBoolAttribute(this.Attributes, "always_assume");
     }
 
     public Ensures(IToken token, bool free, Expr /*!*/ condition, string comment, QKeyValue kv)

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -3546,6 +3546,12 @@ namespace Microsoft.Boogie
       get { return QKeyValue.FindStringAttribute(Attributes, "msg"); }
     }
 
+    public bool CanAlwaysAssume()
+    {
+      return QKeyValue.FindBoolAttribute(Attributes, "alwaysAssume");
+    }
+
+
     public Requires(IToken token, bool free, Expr condition, string comment, QKeyValue kv)
       : base(token)
     {
@@ -3668,6 +3674,10 @@ namespace Microsoft.Boogie
     }
 
     public QKeyValue Attributes { get; set; }
+
+    public bool CanAlwaysAssume () {
+      return QKeyValue.FindBoolAttribute(this.Attributes, "alwaysAssume");
+    }
 
     public Ensures(IToken token, bool free, Expr /*!*/ condition, string comment, QKeyValue kv)
       : base(token)

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -3230,15 +3230,7 @@ namespace Microsoft.Boogie
       {
         Requires /*!*/
           req = cce.NonNull(this.Proc.Requires[i]);
-        if (req.CanAlwaysAssume())
-        {
-          // inject free requires as assume statements at the call site
-          AssumeCmd /*!*/
-            a = new AssumeCmd(req.tok, Substituter.Apply(s, req.Condition));
-          Contract.Assert(a != null);
-          newBlockBody.Add(a);
-        }
-        else if (!req.Free && !IsFree)
+        if (!req.Free && !IsFree)
         {
           if (hasWildcard)
           {
@@ -3272,7 +3264,8 @@ namespace Microsoft.Boogie
             newBlockBody.Add(a);
           }
         }
-        else if (CommandLineOptions.Clo.StratifiedInlining > 0)
+        else if ((req.Free && req.CanAlwaysAssume())
+                || CommandLineOptions.Clo.StratifiedInlining > 0)
         {
           // inject free requires as assume statements at the call site
           AssumeCmd /*!*/

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -3264,7 +3264,7 @@ namespace Microsoft.Boogie
             newBlockBody.Add(a);
           }
         }
-        else if ((req.Free && req.CanAlwaysAssume())
+        else if (req.CanAlwaysAssume()
                 || CommandLineOptions.Clo.StratifiedInlining > 0)
         {
           // inject free requires as assume statements at the call site

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -3230,7 +3230,15 @@ namespace Microsoft.Boogie
       {
         Requires /*!*/
           req = cce.NonNull(this.Proc.Requires[i]);
-        if (!req.Free && !IsFree)
+        if (req.CanAlwaysAssume())
+        {
+          // inject free requires as assume statements at the call site
+          AssumeCmd /*!*/
+            a = new AssumeCmd(req.tok, Substituter.Apply(s, req.Condition));
+          Contract.Assert(a != null);
+          newBlockBody.Add(a);
+        }
+        else if (!req.Free && !IsFree)
         {
           if (hasWildcard)
           {

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1689,8 +1689,12 @@ namespace Microsoft.Boogie
   ---- On specs -------------------------------------
 
     {:always_assume}
-      On a requires, this lets the caller assume the pre-condition, instead of proving it.
-      On an ensures, this lets the procedure's implementation assume the post-condition (instead of proving it).
+      On a free requires, it lets the caller assume the pre-condition. Without it,
+      the caller simply skips the free requires.
+      On a free ensures, it lets the procedure's implementation assume the
+      post-condition. Without it, the procedure's implementation
+      ignores the free ensures.
+      Boogie ignores this attribute on non-free specs.
 
   ---- On implementations and procedures -------------------------------------
 

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1690,10 +1690,9 @@ namespace Microsoft.Boogie
 
     {:always_assume}
       On a free requires, it lets the caller assume the pre-condition. Without it,
-      the caller simply skips the free requires.
-      On a free ensures, it lets the procedure's implementation assume the
-      post-condition. Without it, the procedure's implementation
-      ignores the free ensures.
+      the caller simply skips the free requires. On a free ensures,
+      it lets the procedure's implementation assume the post-condition.
+      Without it, the procedure's implementation ignores the free ensures.
       Boogie ignores this attribute on non-free specs.
 
   ---- On implementations and procedures -------------------------------------

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1686,6 +1686,12 @@ namespace Microsoft.Boogie
     {:checksum <string>}
       Attach a checksum to be used for verification result caching.
 
+  ---- On specs -------------------------------------
+
+    {:alwaysAssume}
+      On a requires, this lets the caller assume the pre-condition, instead of proving it.
+      On an ensures, this lets the procedure's implementation assume the post-condition (instead of proving it).
+
   ---- On implementations and procedures -------------------------------------
 
      {:inline N}

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -1688,7 +1688,7 @@ namespace Microsoft.Boogie
 
   ---- On specs -------------------------------------
 
-    {:alwaysAssume}
+    {:always_assume}
       On a requires, this lets the caller assume the pre-condition, instead of proving it.
       On an ensures, this lets the procedure's implementation assume the post-condition (instead of proving it).
 

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -309,11 +309,9 @@ namespace VC
       foreach (Ensures ens in impl.Proc.Ensures)
       {
         Contract.Assert(ens != null);
-        if (ens.CanAlwaysAssume()) {
-          Expr e = Substituter.Apply(formalProcImplSubst, ens.Condition);
-          unifiedExitBlock.Cmds.Add(new AssumeCmd(ens.tok, e));
-        } else if (!ens.Free) {
-          // skip free ensures clauses
+
+        if (!ens.Free)
+        {
           Expr e = Substituter.Apply(formalProcImplSubst, ens.Condition);
           Ensures ensCopy = (Ensures) cce.NonNull(ens.Clone());
           ensCopy.Condition = e;
@@ -324,10 +322,16 @@ namespace VC
           {
             c.Emit(debugWriter, 1);
           }
-        } else {
-          // forget about it
         }
-
+        else if (ens.Free && ens.CanAlwaysAssume())
+        {
+          Expr e = Substituter.Apply(formalProcImplSubst, ens.Condition);
+          unifiedExitBlock.Cmds.Add(new AssumeCmd(ens.tok, e));
+        }
+        else
+        {
+          // skip free ensures if it doesn't have the :always_assume attr
+        }
       }
 
       if (debugWriter != null)

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -323,7 +323,7 @@ namespace VC
             c.Emit(debugWriter, 1);
           }
         }
-        else if (ens.Free && ens.CanAlwaysAssume())
+        else if (ens.CanAlwaysAssume())
         {
           Expr e = Substituter.Apply(formalProcImplSubst, ens.Condition);
           unifiedExitBlock.Cmds.Add(new AssumeCmd(ens.tok, e));

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -309,8 +309,10 @@ namespace VC
       foreach (Ensures ens in impl.Proc.Ensures)
       {
         Contract.Assert(ens != null);
-        if (!ens.Free)
-        {
+        if (ens.CanAlwaysAssume()) {
+          Expr e = Substituter.Apply(formalProcImplSubst, ens.Condition);
+          unifiedExitBlock.Cmds.Add(new AssumeCmd(ens.tok, e));
+        } else if (!ens.Free) {
           // skip free ensures clauses
           Expr e = Substituter.Apply(formalProcImplSubst, ens.Condition);
           Ensures ensCopy = (Ensures) cce.NonNull(ens.Clone());
@@ -322,7 +324,10 @@ namespace VC
           {
             c.Emit(debugWriter, 1);
           }
+        } else {
+          // forget about it
         }
+
       }
 
       if (debugWriter != null)

--- a/Test/test0/AlwaysAssume.bpl
+++ b/Test/test0/AlwaysAssume.bpl
@@ -1,0 +1,24 @@
+// RUN: %boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure reqDef()
+  free requires false;
+  requires false;  // fails
+  free requires {:alwaysAssume} false;
+  requires false;
+{
+}
+
+procedure testReq()
+  ensures false;
+{
+  call reqDef();
+}
+
+procedure ensDef()
+  free ensures false;
+  ensures false;  // fails
+  free ensures {:alwaysAssume} false;
+  ensures false;
+{
+}

--- a/Test/test0/AlwaysAssume.bpl.expect
+++ b/Test/test0/AlwaysAssume.bpl.expect
@@ -1,0 +1,10 @@
+AlwaysAssume.bpl(15,3): Error: A precondition for this call might not hold.
+AlwaysAssume.bpl(6,3): Related location: This is the precondition that might not hold.
+Execution trace:
+    AlwaysAssume.bpl(15,3): anon0
+AlwaysAssume.bpl(24,1): Error: A postcondition might not hold on this return path.
+AlwaysAssume.bpl(20,3): Related location: This is the postcondition that might not hold.
+Execution trace:
+    AlwaysAssume.bpl(24,1): anon0
+
+Boogie program verifier finished with 1 verified, 2 errors


### PR DESCRIPTION
feat: `always_assume` attribute on `requires` and `ensures`.  On a requires, this lets the caller assume the pre-condition, instead of proving it. On an ensures, this lets the procedure's implementation assume the post-condition (instead of proving it).