### PR TITLE
Add .editorconfig file to specify coding style

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -12,7 +12,6 @@ tab_width = 2
 
 # New line preferences
 end_of_line = lf
-max_line_length = 200
 
 #### .NET Coding Conventions ####
 

--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,0 +1,31 @@
+# More options for this file can be found at https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options?view=vs-2019
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 2
+indent_style = space
+tab_width = 2
+
+# New line preferences
+end_of_line = lf
+max_line_length = 200
+
+#### .NET Coding Conventions ####
+
+#### C# Formatting Rules ####
+
+#### Naming rules
+
+dotnet_naming_rule.private_members.symbols  = private_fields
+dotnet_naming_rule.private_members.style    = private
+dotnet_naming_rule.private_members.severity = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.private.capitalization = camel_case
+dotnet_naming_style.private.required_prefix = 


### PR DESCRIPTION
Add a `.editorconfig` file to specify the Boogie coding style.

This file is supported by C# editors such as Visual Studio, Rider and Resharper.

My intent was to pick values for `.editorconfig` that reflect the current coding style in Boogie. However, the coding style in Boogie is not super consistent. I've tried to pick the options that are most popular in Boogie, these tend to be the defaults so the `.editorconfig` file is mostly empty.