### PR TITLE
Clarify release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To push a new version to nuget, perform the following steps:
 
 - Update the version (e.g., x.y.z) in `Source/Directory.Build.props` and commit the change locally
 - `git tag vx.y.z`
-- `git push origin vx.y.z` where `origin` denotes the remote on the github.com
+- `git push origin master vx.y.z` where `origin` denotes the remote on github.com
 
 The [CI workflow](.github/workflows/test.yml) will build and push the packages.
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ See the [Unit test documentation](Source/UnitTests/README.md)
 The current version of Boogie is noted in a [build property](Source/Directory.Build.props).
 To push a new version to nuget, perform the following steps:
 
-- Update the version (e.g., x.y.z) and commit the change
-- git tag vx.y.z
-- git push --tags
+- Update the version (e.g., x.y.z) in `Source/Directory.Build.props` and commit the change locally
+- `git tag vx.y.z`
+- `git push origin vx.y.z` where `origin` denotes the remote on the github.com
 
 The [CI workflow](.github/workflows/test.yml) will build and push the packages.
 


### PR DESCRIPTION
The `git push --tags` command is discouraged, since it will push _all_ tags on the local machine. For example, this fails for me, which leaves everything in a state I don't understand.