### PR TITLE
Add tests for parallel processing

### DIFF
--- a/Test/aitest0/Intervals.bpl
+++ b/Test/aitest0/Intervals.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie -infer:j "%s" > "%t"
+// RUN: %parallel-boogie -infer:j "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 const N: int;
 axiom 0 <= N;

--- a/Test/aitest0/Intervals.bpl.expect
+++ b/Test/aitest0/Intervals.bpl.expect
@@ -1,57 +1,13 @@
 Intervals.bpl(64,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(59,5): anon0
-    Intervals.bpl(60,3): anon3_LoopHead
-    Intervals.bpl(60,3): anon3_LoopDone
 Intervals.bpl(75,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(70,5): anon0
-    Intervals.bpl(71,3): anon3_LoopHead
-    Intervals.bpl(71,3): anon3_LoopDone
 Intervals.bpl(94,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(89,5): anon0
-    Intervals.bpl(90,3): loop_head
-    Intervals.bpl(93,3): after_loop
 Intervals.bpl(140,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(135,5): anon0
-    Intervals.bpl(136,3): anon3_LoopHead
-    Intervals.bpl(136,3): anon3_LoopDone
 Intervals.bpl(151,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(146,5): anon0
-    Intervals.bpl(147,3): anon3_LoopHead
-    Intervals.bpl(147,3): anon3_LoopDone
 Intervals.bpl(202,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(192,8): anon0
-    Intervals.bpl(193,3): anon4_LoopHead
-    Intervals.bpl(193,3): anon4_LoopDone
 Intervals.bpl(240,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(235,5): anon0
-    Intervals.bpl(236,3): anon3_LoopHead
-    Intervals.bpl(236,3): anon3_LoopDone
 Intervals.bpl(252,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(246,8): anon0
-    Intervals.bpl(247,3): anon3_LoopHead
-    Intervals.bpl(247,3): anon3_LoopDone
 Intervals.bpl(263,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(258,5): anon0
-    Intervals.bpl(259,3): anon3_LoopHead
-    Intervals.bpl(259,3): anon3_LoopDone
 Intervals.bpl(285,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(280,5): anon0
-    Intervals.bpl(281,3): anon3_LoopHead
-    Intervals.bpl(281,3): anon3_LoopDone
 Intervals.bpl(307,3): Error: This assertion might not hold.
-Execution trace:
-    Intervals.bpl(302,5): anon0
-    Intervals.bpl(303,3): anon3_LoopHead
-    Intervals.bpl(303,3): anon3_LoopDone
 
 Boogie program verifier finished with 17 verified, 11 errors

--- a/Test/aitest9/TestIntervals.bpl
+++ b/Test/aitest9/TestIntervals.bpl
@@ -1,4 +1,4 @@
-// RUN: %boogie "%s" -infer:j > "%t"
+// RUN: %parallel-boogie "%s" -infer:j > "%t"
 // RUN: %diff "%s.expect" "%t"
 procedure P()
 {

--- a/Test/aitest9/TestIntervals.bpl.expect
+++ b/Test/aitest9/TestIntervals.bpl.expect
@@ -1,20 +1,5 @@
 TestIntervals.bpl(25,3): Error: This assertion might not hold.
-Execution trace:
-    TestIntervals.bpl(7,5): anon0
-    TestIntervals.bpl(8,3): anon9_LoopHead
-    TestIntervals.bpl(14,14): anon10_Then
-    TestIntervals.bpl(15,14): anon11_Then
-    TestIntervals.bpl(16,3): anon12_Else
-    TestIntervals.bpl(19,5): anon8
 TestIntervals.bpl(70,3): Error: This assertion might not hold.
-Execution trace:
-    TestIntervals.bpl(62,3): anon0
-    TestIntervals.bpl(67,3): anon3_LoopHead
-    TestIntervals.bpl(67,3): anon3_LoopDone
 TestIntervals.bpl(71,3): Error: This assertion might not hold.
-Execution trace:
-    TestIntervals.bpl(62,3): anon0
-    TestIntervals.bpl(67,3): anon3_LoopHead
-    TestIntervals.bpl(67,3): anon3_LoopDone
 
 Boogie program verifier finished with 2 verified, 3 errors

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -104,6 +104,7 @@ if len(boogieParams) > 0:
 lit_config.note('Using Boogie: {}'.format(boogieExecutable))
 
 config.substitutions.append(('%boogie', boogieExecutable))
+config.substitutions.append(('%parallel-boogie', boogieExecutable + ' /vcsCores:2 /errorTrace:0'))
 
 # Add diff tool substitution
 if os.name == 'posix':


### PR DESCRIPTION
Let some of the Boogie tests in the suite use multiple processors to enable testing the parallel processing features.

We turn off error tracing for these tests since there are multiple valid error traces for a single verification error, and which trace is shown by Boogie can depend on the order in which Boogie verifies the program which depends on the amount of threads used.