### PR TITLE
Don't automatically run StyleCop for any projects referencing Boogie projects

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <!-- Use StyleCop to check for consistent code formatting -->
   <ItemGroup Condition="'$(Configuration)' != 'Release'">
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
   </ItemGroup>
 


### PR DESCRIPTION
I ran into the issue that when referencing Boogie projects, instead of the Boogie NuGet packages, StyleCop was ran on non-Boogie packages. This change resolved that. [More information](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2278).