### PR TITLE
Bump version number to 2.9.6

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.9.5</Version>
+    <Version>2.9.6</Version>
     <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>


### PR DESCRIPTION
Releasing a new version to include this bug fix: https://github.com/boogie-org/boogie/commit/5a5a476a5138c86dca2cea018fad0cea2cfa8395

Locally tested this version against Dafny's regression tests.