### PR TITLE
Enable turning off skolemid

### DIFF
--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -205,6 +205,20 @@ namespace Microsoft.Boogie
       /// If there is one argument and it is a non-negative integer, then set "arg" to that number and return "true".
       /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
       /// </summary>
+      public bool GetNumericArgument(ref bool arg)
+      {
+        int intArg = 0;
+        var result = GetNumericArgument(ref intArg, x => x < 2);
+        if (result) {
+          arg = intArg != 0;
+        }
+        return result;
+      }
+      
+      /// <summary>
+      /// If there is one argument and it is a non-negative integer, then set "arg" to that number and return "true".
+      /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
+      /// </summary>
       public bool GetNumericArgument(ref int arg)
       {
         //modifies nextIndex, encounteredErrors, Console.Error.*;
@@ -543,8 +557,16 @@ namespace Microsoft.Boogie
     public int VerifySnapshots = -1;
     public bool VerifySeparately = false;
     public string PrintFile = null;
-    public bool EmitSkolemIdAndQId = true;
-    
+
+    /**
+     * Whether to emit {:qid}, {:skolemid} and set-info :boogie-vc-id
+     */
+    public bool EmitDebugInformation
+    {
+      get => emitDebugInformation;
+      set => emitDebugInformation = value;
+    }
+
     public int PrintUnstructured {
       get => printUnstructured;
       set => printUnstructured = value;
@@ -995,6 +1017,7 @@ namespace Microsoft.Boogie
     private bool printWithUniqueAstIds = false;
     private int printUnstructured = 0;
     private bool printDesugarings = false;
+    private bool emitDebugInformation = true;
 
     public class ConcurrentHoudiniOptions
     {
@@ -1657,6 +1680,10 @@ namespace Microsoft.Boogie
         case "kInductionDepth":
           ps.GetNumericArgument(ref KInductionDepth);
           return true;
+        
+        case "emitDebugInformation":
+          ps.GetNumericArgument(ref emitDebugInformation);
+          return true;
 
         default:
           bool optionValue = false;
@@ -2172,6 +2199,10 @@ namespace Microsoft.Boogie
 
   /useBaseNameForFileName : When parsing use basename of file for tokens instead
                             of the path supplied on the command line
+
+  /emitDebugInformation:<n>
+                0 - do not emit debug information
+                1 (default) - emit the debug information :qid, :skolemid and set-info :boogie-vc-id
 
   ---- Inference options -----------------------------------------------------
 

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -543,7 +543,8 @@ namespace Microsoft.Boogie
     public int VerifySnapshots = -1;
     public bool VerifySeparately = false;
     public string PrintFile = null;
-
+    public bool EmitSkolimIdAndQId = true;
+    
     public int PrintUnstructured {
       get => printUnstructured;
       set => printUnstructured = value;

--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -543,7 +543,7 @@ namespace Microsoft.Boogie
     public int VerifySnapshots = -1;
     public bool VerifySeparately = false;
     public string PrintFile = null;
-    public bool EmitSkolimIdAndQId = true;
+    public bool EmitSkolemIdAndQId = true;
     
     public int PrintUnstructured {
       get => printUnstructured;

--- a/Source/Core/SMTLibOptions.cs
+++ b/Source/Core/SMTLibOptions.cs
@@ -20,5 +20,6 @@ namespace Microsoft.Boogie
     bool SIBoolControlVC { get; }
     bool RestartProverPerVC { get; }
     bool Trace { get; }
+    bool EmitDebugInformation { get; }
   }
 }

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Boogie.SMTLib
         if (hasAttrs)
         {
           wr.Write("\n");
-          if (info.qid != null)
+          if (info.qid != null && CommandLineOptions.Clo.EmitSkolimIdAndQId)
           {
             wr.Write(" :qid {0}\n", SMTLibNamer.QuoteId(info.qid));
           }
@@ -469,7 +469,7 @@ namespace Microsoft.Boogie.SMTLib
             wr.Write(" :weight {0}\n", weight);
           }
 
-          if (info.uniqueId != -1)
+          if (info.uniqueId != -1 && CommandLineOptions.Clo.EmitSkolimIdAndQId)
           {
             wr.Write(" :skolemid |{0}|\n", info.uniqueId);
           }

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Boogie.SMTLib
         if (hasAttrs)
         {
           wr.Write("\n");
-          if (info.qid != null && CommandLineOptions.Clo.EmitSkolimIdAndQId)
+          if (info.qid != null && CommandLineOptions.Clo.EmitSkolemIdAndQId)
           {
             wr.Write(" :qid {0}\n", SMTLibNamer.QuoteId(info.qid));
           }
@@ -469,7 +469,7 @@ namespace Microsoft.Boogie.SMTLib
             wr.Write(" :weight {0}\n", weight);
           }
 
-          if (info.uniqueId != -1 && CommandLineOptions.Clo.EmitSkolimIdAndQId)
+          if (info.uniqueId != -1 && CommandLineOptions.Clo.EmitSkolemIdAndQId)
           {
             wr.Write(" :skolemid |{0}|\n", info.uniqueId);
           }

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Boogie.SMTLib
         if (hasAttrs)
         {
           wr.Write("\n");
-          if (info.qid != null && CommandLineOptions.Clo.EmitSkolemIdAndQId)
+          if (info.qid != null && LibOptions.EmitDebugInformation)
           {
             wr.Write(" :qid {0}\n", SMTLibNamer.QuoteId(info.qid));
           }
@@ -469,7 +469,7 @@ namespace Microsoft.Boogie.SMTLib
             wr.Write(" :weight {0}\n", weight);
           }
 
-          if (info.uniqueId != -1 && CommandLineOptions.Clo.EmitSkolemIdAndQId)
+          if (info.uniqueId != -1 && LibOptions.EmitDebugInformation)
           {
             wr.Write(" :skolemid |{0}|\n", info.uniqueId);
           }

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -572,7 +572,10 @@ namespace Microsoft.Boogie.SMTLib
       PossiblyRestart();
 
       SendThisVC("(push 1)");
-      SendThisVC("(set-info :boogie-vc-id " + SMTLibNamer.QuoteId(descriptiveName) + ")");
+      if (this.libOptions.EmitDebugInformation) {
+        SendThisVC("(set-info :boogie-vc-id " + SMTLibNamer.QuoteId(descriptiveName) + ")");
+      }
+
       if (options.Solver == SolverKind.Z3)
       {
         SendThisVC("(set-option :" + Z3.TimeoutOption + " " + options.TimeLimit + ")");

--- a/Source/UnitTests/ExecutionEngineTests/ProofIsolation.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ProofIsolation.cs
@@ -12,7 +12,7 @@ namespace ExecutionEngineTests
   public class ProofIsolation
   {
     [Test()]
-    public void TurnOffEmitSkolemIdAndQId()
+    public void TurnOffEmitDebugInformation()
     {
       var procedure = @"
 procedure M(x: int) 
@@ -28,14 +28,16 @@ procedure M(x: int)
       var proverLog1 = GetProverLogForProgram(procedure).ToList();
       Assert.True(proverLog1[0].Contains("skolemid"));
       Assert.True(proverLog1[0].Contains("qid"));
+      Assert.True(proverLog1[0].Contains(":boogie-vc-id"));
       
       CommandLineOptions.Install(new CommandLineOptions());
       CommandLineOptions.Clo.Parse(new string[]{});
-      CommandLineOptions.Clo.EmitSkolemIdAndQId = false;
+      CommandLineOptions.Clo.EmitDebugInformation = false;
       ExecutionEngine.printer = new ConsolePrinter();
       var proverLog2 = GetProverLogForProgram(procedure).ToList();
       Assert.True(!proverLog2[0].Contains("skolemid"));
       Assert.True(!proverLog2[0].Contains("qid"));
+      Assert.True(!proverLog2[0].Contains(":boogie-vc-id"));
     }
 
     [Test()]

--- a/Source/UnitTests/ExecutionEngineTests/ProofIsolation.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ProofIsolation.cs
@@ -12,7 +12,7 @@ namespace ExecutionEngineTests
   public class ProofIsolation
   {
     [Test()]
-    public void TurnOffEmitSkolimIdAndQId()
+    public void TurnOffEmitSkolemIdAndQId()
     {
       var procedure = @"
 procedure M(x: int) 
@@ -31,7 +31,7 @@ procedure M(x: int)
       
       CommandLineOptions.Install(new CommandLineOptions());
       CommandLineOptions.Clo.Parse(new string[]{});
-      CommandLineOptions.Clo.EmitSkolimIdAndQId = false;
+      CommandLineOptions.Clo.EmitSkolemIdAndQId = false;
       ExecutionEngine.printer = new ConsolePrinter();
       var proverLog2 = GetProverLogForProgram(procedure).ToList();
       Assert.True(!proverLog2[0].Contains("skolemid"));


### PR DESCRIPTION
To prevent verification behavior from changing unexpectedly, it can help not to emit skolemid and qid, since these contain an incrementally assigned number and a source code location, respectively, that can easily change for the entire SMT program when small changes occur in the input Boogie program.

Related Dafny issue: https://github.com/dafny-lang/dafny/issues/1585

### Testing

- Add a tests that inspects whether the solver logs contain the right information when `EmitDebugInformation` is either turned on or off.
- Manually tried the `/emitDebugInformation:1` and `/emitDebugInformation:0` command line options.