### PR TITLE
feat: Robustness against prover crash on (reset)

### DIFF
--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -125,6 +125,20 @@ namespace Microsoft.Boogie.SMTLib
       return sx != null && sx.Name == ":name";
     }
 
+    public ProverDiedException HasProverDied()
+    {
+      try
+      {
+        PingPong();
+      }
+      catch (ProverDiedException e)
+      {
+        return e;
+      }
+
+      return null;
+    }
+    
     public void PingPong()
     {
       Ping();

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Boogie.SMTLib
       return sx != null && sx.Name == ":name";
     }
 
-    public ProverDiedException HasProverDied()
+    public ProverDiedException GetExceptionIfProverDied()
     {
       try
       {

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -648,7 +648,7 @@ namespace Microsoft.Boogie.SMTLib
     private void RecoverIfProverCrashedAfterReset()
     {
       resetCount += 1;
-      if (Process.HasProverDied() is { } e)
+      if (Process.GetExceptionIfProverDied() is Exception e)
       {
         if (resetCount == 1)
         {

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -129,20 +129,9 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    void SetupProcess(bool forceRestart = false)
+    void SetupProcess()
     {
-      if (Process != null)
-      {
-        if (forceRestart)
-        {
-          Process.Close();
-        }
-        else 
-        {
-          return;
-        }
-      }
-
+      Process?.Close();
       Process = new SMTLibProcess(this.libOptions, this.options);
       Process.ErrorHandler += this.HandleProverError;
     }
@@ -151,7 +140,7 @@ namespace Microsoft.Boogie.SMTLib
     {
       if (Process != null && Process.NeedsRestart)
       {
-        SetupProcess(true);
+        SetupProcess();
         Process.Send(common.ToString());
       }
     }
@@ -655,7 +644,7 @@ namespace Microsoft.Boogie.SMTLib
       if (Process.GetExceptionIfProverDied() is Exception e)
       {
         // We recover the process but don't issue the `(reset)` command that fails.
-        SetupProcess(true);
+        SetupProcess();
       }
     }
 


### PR DESCRIPTION
This PR provides backward compatible support for Z3 4.8.5 on Windows, which sometimes would crash when receiving the `(reset)` command - this happened in the Dafny test suite (https://github.com/dafny-lang/dafny/pull/1540).
This bug was corrected in Z3 4.8.8, but I believe this feature can be our defense-in-depth strategy for dealing with any unexpected Z3 reset crash in the future.

## Changes

- `SMTLibProcessTheoremProver.cs` Added a check right after the `(reset)` command via a `HasProverDied()` command to the prover. If it was not the first (reset) sent, it restarts a new fresh process.
- `SMTLibProcess.cs` Added the method `HasProverDied()` which invokes `PingPong` and returns the exception if one was thrown.
