### PR TITLE
Add splits to xml

### DIFF
--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Boogie
     public void WriteStartSplit(int splitNum, DateTime startTime)
     {
       Contract.Requires(splitNum > 0);
+      Contract.Requires(startTime != null);
       Contract.Requires(IsOpen);
       //modifies this.*;
       Contract.Ensures(IsOpen);
@@ -128,6 +129,7 @@ namespace Microsoft.Boogie
     public void WriteEndSplit(string outcome, TimeSpan elapsed)
     {
       Contract.Requires(outcome != null);
+      Contract.Requires(elapsed != null);
       Contract.Requires(IsOpen);
       //modifies this.*;
       Contract.Ensures(IsOpen);

--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -112,7 +112,6 @@ namespace Microsoft.Boogie
     public void WriteStartSplit(int splitNum, DateTime startTime)
     {
       Contract.Requires(splitNum > 0);
-      Contract.Requires(startTime != null);
       Contract.Requires(IsOpen);
       //modifies this.*;
       Contract.Ensures(IsOpen);
@@ -129,7 +128,6 @@ namespace Microsoft.Boogie
     public void WriteEndSplit(string outcome, TimeSpan elapsed)
     {
       Contract.Requires(outcome != null);
-      Contract.Requires(elapsed != null);
       Contract.Requires(IsOpen);
       //modifies this.*;
       Contract.Ensures(IsOpen);

--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -109,6 +109,41 @@ namespace Microsoft.Boogie
       cce.EndExpose();
     }
 
+    public void WriteStartSplit(int splitNum, DateTime startTime)
+    {
+      Contract.Requires(splitNum > 0);
+      Contract.Requires(IsOpen);
+      //modifies this.*;
+      Contract.Ensures(IsOpen);
+      Contract.Assert(wr != null);
+      cce.BeginExpose(this);
+      {
+        wr.WriteStartElement("split");
+        wr.WriteAttributeString("number", splitNum.ToString());
+        wr.WriteAttributeString("startTime", startTime.ToString(DateTimeFormatString));
+      }
+      cce.EndExpose();
+    }
+    
+    public void WriteEndSplit(string outcome, TimeSpan elapsed)
+    {
+      Contract.Requires(outcome != null);
+      Contract.Requires(IsOpen);
+      //modifies this.*;
+      Contract.Ensures(IsOpen);
+      Contract.Assert(wr != null);
+      cce.BeginExpose(this);
+      {
+        wr.WriteStartElement("conclusion");
+        wr.WriteAttributeString("duration", elapsed.TotalSeconds.ToString());
+        wr.WriteAttributeString("outcome", outcome);
+
+        wr.WriteEndElement(); // outcome
+        wr.WriteEndElement(); // split
+      }
+      cce.EndExpose();
+    }
+    
     public void WriteError(string message, IToken errorToken, IToken relatedToken, List<Block> trace)
     {
       Contract.Requires(errorToken != null);

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1412,6 +1412,11 @@ namespace VC
             checker.ProverRunTime.TotalSeconds, outcome);
         }
 
+        if (CommandLineOptions.Clo.XmlSink != null) {
+          CommandLineOptions.Clo.XmlSink.WriteEndSplit(outcome.ToString().ToLowerInvariant(), 
+            TimeSpan.FromSeconds(checker.ProverRunTime.TotalSeconds));
+        }
+
         if (CommandLineOptions.Clo.VcsDumpSplits)
         {
           DumpDot(splitNum);

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -108,6 +108,10 @@ namespace VC
           split.Stats, currentSplitNumber + 1, total, 100 * provenCost / (provenCost + remainingCost));
       }
 
+      if (options.XmlSink != null && DoSplitting) {
+        options.XmlSink.WriteStartSplit(currentSplitNumber + 1, DateTime.UtcNow);
+      }
+
       callback.OnProgress?.Invoke("VCprove", currentSplitNumber, total,
         provenCost / (remainingCost + provenCost));
 

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -1,5 +1,5 @@
 // Can't use %parallel-boogie here yet - see https://github.com/boogie-org/boogie/issues/460
-// RUN: %boogie /proverOpt:PROVER_PATH=/Users/salkeldr/Documents/GitHub/dafny/Binaries/z3/bin/z3 -xml:"%t.xml" "%s"
+// RUN: %boogie -xml:"%t.xml" "%s"
 // RUN: %OutputCheck "%s" --file-to-check="%t.xml"
 // CHECK: \<method name="Example" startTime=".*"\>
 // CHECK:   \<split number="1" startTime=".*"\>

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -1,6 +1,8 @@
 // Can't use %parallel-boogie here yet - see https://github.com/boogie-org/boogie/issues/460
 // RUN: %boogie -xml:"%t.xml" "%s"
-// RUN: %OutputCheck "%s" --file-to-check="%t.xml"
+// Chop off the first line, since OutputCheck expects ASCII and can't handle the byte-order mark
+// RUN: tail -n +2 "%t.xml" > "%t.trimmed.xml"
+// RUN: %OutputCheck "%s" --file-to-check="%t.trimmed.xml"
 // CHECK: \<method name="Example" startTime=".*"\>
 // CHECK:   \<split number="1" startTime=".*"\>
 // CHECK:     \<conclusion duration=".*" outcome="valid" />

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -1,0 +1,19 @@
+// Can't use %parallel-boogie here yet - see https://github.com/boogie-org/boogie/issues/460
+// RUN: %boogie /proverOpt:PROVER_PATH=/Users/salkeldr/Documents/GitHub/dafny/Binaries/z3/bin/z3 -xml:"%t.xml" "%s"
+// RUN: %OutputCheck "%s" --file-to-check="%t.xml"
+// CHECK: \<method name="Example" startTime=".*"\>
+// CHECK:   \<split number="1" startTime=".*"\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" />
+// CHECK:   \</split\>
+// CHECK:   \<split number="2" startTime=".*"\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" />
+// CHECK:   \</split\>
+// CHECK:   \<conclusion endTime=".*" duration=".*" outcome="correct" />
+// CHECK: \</method\>
+
+procedure Example()
+{
+  assert 1 + 1 == 2;
+  assume {:split_here} true;
+  assert 2 + 2 == 4;
+}


### PR DESCRIPTION
This information is currently included in the output of `/trace` but not the XML. Including it there too will enable more programmatic analysis.