### PR TITLE
Add noop prover that always returns unknown.

### DIFF
--- a/Source/Provers/SMTLib/FunctionDependencyCollector.cs
+++ b/Source/Provers/SMTLib/FunctionDependencyCollector.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Microsoft.Boogie.VCExprAST;
+
+namespace Microsoft.Boogie.SMTLib;
+
+public class FunctionDependencyCollector : BoundVarTraversingVCExprVisitor<bool, bool>
+{
+  private List<Function> functionList;
+
+  // not used but required by interface
+  protected override bool StandardResult(VCExpr node, bool arg)
+  {
+    return true;
+  }
+
+  public List<Function> Collect(VCExpr expr)
+  {
+    functionList = new List<Function>();
+    Traverse(expr, true);
+    return functionList;
+  }
+
+  public override bool Visit(VCExprNAry node, bool arg)
+  {
+    VCExprBoogieFunctionOp op = node.Op as VCExprBoogieFunctionOp;
+    if (op != null)
+    {
+      functionList.Add(op.Func);
+    }
+
+    return base.Visit(node, arg);
+  }
+}

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace Microsoft.Boogie.SMTLib;
+
+class NoopSolver : SMTLibSolver
+{
+#pragma warning disable CS0067
+  public override event Action<string> ErrorHandler;
+#pragma warning restore CS0067
+
+  public override void Close()
+  {
+  }
+
+  private SExpr response;
+
+  public override void Send(string cmd)
+  {
+    if (cmd.StartsWith("(get-value")) {
+      response = null;
+    } 
+    else
+    {
+      response = cmd switch
+      {
+        "(get-model)" => null,
+        "(get-info :name)" => new SExpr(":name"),
+        "(check-sat)" => new SExpr("unknown"),
+        "(get-info :reason-unknown)" => new SExpr("incomplete"),
+        "(get-unsat-core)" => new SExpr(""),
+        _ => null
+      };
+    }
+  }
+
+  public override SExpr GetProverResponse()
+  {
+    var result = response;
+    response = null;
+    return result;
+  }
+
+  public override void NewProblem(string descriptiveName)
+  {
+  }
+
+  protected override void HandleError(string msg)
+  {
+    throw new NotSupportedException();
+  }
+}

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Boogie.SMTLib
         TerminateProver();
       }
     }
-    
+
     private void TerminateProver(Int32 timeout = 2000)
     {
       try
@@ -224,7 +224,7 @@ namespace Microsoft.Boogie.SMTLib
       TerminateProver();
       DisposeProver();
     }
-    
+
     public override event Action<string> ErrorHandler;
     int errorCnt;
 

--- a/Source/Provers/SMTLib/SMTLibProverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibProverOptions.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Boogie.SMTLib
             Solver = SolverKind.YICES2;
             break;
           default:
-            ReportError("Invalid SOLVER value; must be 'Z3' or 'CVC5', 'Yices2' or 'noop'");
+            ReportError("Invalid SOLVER value; must be 'Z3' or 'CVC5' or 'Yices2' or 'noop'");
             return false;
         }
 

--- a/Source/Provers/SMTLib/SMTLibProverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibProverOptions.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Boogie.SMTLib
   {
     Z3,
     CVC5,
-    YICES2
+    YICES2,
+    NoOp
   }
 
   public class SMTLibProverOptions : ProverOptions
@@ -87,11 +88,14 @@ namespace Microsoft.Boogie.SMTLib
         return true;
       }
 
-      string SolverStr = null;
-      if (ParseString(opt, "SOLVER", ref SolverStr))
+      string solverStr = null;
+      if (ParseString(opt, "SOLVER", ref solverStr))
       {
-        switch (SolverStr.ToLower())
+        switch (solverStr.ToLower())
         {
+          case "noop":
+            Solver = SolverKind.NoOp;
+            break;
           case "z3":
             Solver = SolverKind.Z3;
             break;
@@ -102,7 +106,7 @@ namespace Microsoft.Boogie.SMTLib
             Solver = SolverKind.YICES2;
             break;
           default:
-            ReportError("Invalid SOLVER value; must be 'Z3' or 'CVC5' or 'Yices2'");
+            ReportError("Invalid SOLVER value; must be 'Z3' or 'CVC5', 'Yices2' or 'noop'");
             return false;
         }
 
@@ -147,6 +151,9 @@ namespace Microsoft.Boogie.SMTLib
 
           SolverBinaryName = "yices-smt2";
           break;
+        case SolverKind.NoOp:
+          ProverName = "noop";
+          break;
         default:
           Contract.Assert(false);
           throw new cce.UnreachableException();
@@ -166,7 +173,8 @@ namespace Microsoft.Boogie.SMTLib
           @"
 SMT-specific options:
 ~~~~~~~~~~~~~~~~~~~~~
-SOLVER=<string>           Use the given SMT solver (z3, cvc5, yices2; default: z3)
+SOLVER=<string>           Use the given SMT solver (z3, cvc5, yices2, noop; default: z3)
+                          The noop solver never does any solving and always returns unknown.
 LOGIC=<string>            Pass (set-logic <string>) to the prover (default: empty, 'ALL' for CVC5)
 USE_WEIGHTS=<bool>        Pass :weight annotations on quantified formulas (default: true)
 VERBOSITY=<int>           1 - print prover output (default: 0)

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -1,0 +1,60 @@
+using System;
+
+namespace Microsoft.Boogie.SMTLib;
+
+public abstract class SMTLibSolver
+{
+  public abstract event Action<string> ErrorHandler;
+  public abstract void Close();
+  public abstract void Send(string cmd);
+  public abstract SExpr GetProverResponse();
+  public abstract void NewProblem(string descriptiveName);
+
+  protected abstract void HandleError(string msg);
+
+  public void Ping()
+  {
+    Send("(get-info :name)");
+  }
+
+  public void PingPong()
+  {
+    Ping();
+    while (true)
+    {
+      var sx = GetProverResponse();
+      if (sx == null)
+      {
+        throw new ProverDiedException();
+      }
+
+      if (IsPong(sx))
+      {
+        return;
+      }
+      else
+      {
+        HandleError("Invalid PING response from the prover: " + sx.ToString());
+      }
+    }
+  }
+
+  public bool IsPong(SExpr sx)
+  {
+    return sx is { Name: ":name" };
+  }
+
+  public ProverDiedException GetExceptionIfProverDied()
+  {
+    try
+    {
+      PingPong();
+    }
+    catch (ProverDiedException e)
+    {
+      return e;
+    }
+
+    return null;
+  }
+}

--- a/Test/pruning/Noop.bpl
+++ b/Test/pruning/Noop.bpl
@@ -1,0 +1,7 @@
+// RUN: %parallel-boogie -proverOpt:SOLVER=noop "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure P(K: int)
+  ensures true;
+{
+}

--- a/Test/pruning/Noop.bpl.expect
+++ b/Test/pruning/Noop.bpl.expect
@@ -1,0 +1,3 @@
+Noop.bpl(4,11): Verification inconclusive (P)
+
+Boogie program verifier finished with 0 verified, 0 errors, 1 inconclusive


### PR DESCRIPTION
### Changes

Add a 'noop' prover that always returns unknown. Useful for getting prover logs quickly without having to wait for a solver

Can be turned on by passing `-proverOpt:SOLVER=noop`. Updated documentation to include this.

### Testing

Added a test that uses the 'noop' solver.