### PR TITLE
Allow not normalising the top level declaration order

### DIFF
--- a/Source/Core/CommandLineOptions.cs
+++ b/Source/Core/CommandLineOptions.cs
@@ -671,6 +671,12 @@ namespace Microsoft.Boogie
       get => normalizeNames;
       set => normalizeNames = value;
     }
+    
+    public bool NormalizeDeclarationOrder
+    {
+      get => normalizeDeclarationOrder;
+      set => normalizeDeclarationOrder = value;
+    }
 
     public bool ImmediatelyAcceptCommands => StratifiedInlining > 0 || ContractInfer;
 
@@ -1076,6 +1082,7 @@ namespace Microsoft.Boogie
     private bool printDesugarings = false;
     private bool emitDebugInformation = true;
     private bool normalizeNames;
+    private bool normalizeDeclarationOrder = true;
 
     public class ConcurrentHoudiniOptions
     {
@@ -1761,6 +1768,10 @@ namespace Microsoft.Boogie
         case "normalizeNames":
           ps.GetNumericArgument(ref normalizeNames);
           return true;
+        
+        case "normalizeDeclarationOrder":
+          ps.GetNumericArgument(ref normalizeNames);
+          return true;
 
         default:
           bool optionValue = false;
@@ -2291,9 +2302,15 @@ namespace Microsoft.Boogie
 
   /normalizeNames:<n>
                 0 (default) - Keep Boogie program names when generating SMT commands
-                1 (default) - Normalize Boogie program names when generating SMT commands. 
+                1 - Normalize Boogie program names when generating SMT commands. 
                   This keeps SMT solver input, and thus output, 
                   constant when renaming declarations in the input program.
+
+  /normalizeDeclarationOrder:<n>
+                0 - Keep order of top-level declarations when generating SMT commands.
+                1 (default) - Normalize order of top-level declarations when generating SMT commands.
+                  This keeps SMT solver input, and thus output, 
+                  constant when reordering declarations in the input program.
 
   ---- Inference options -----------------------------------------------------
 

--- a/Source/UnitTests/ExecutionEngineTests/ProofIsolation.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ProofIsolation.cs
@@ -53,6 +53,13 @@ procedure M(p: Person)
       var proverLog1 = GetProverLogForProgram(procedure1);
       var proverLog2 = GetProverLogForProgram(procedure2);
       Assert.AreEqual(proverLog1, proverLog2);
+      
+      CommandLineOptions.Clo.NormalizeDeclarationOrder = false;
+      var proverLog3 = GetProverLogForProgram(procedure2);
+      Assert.AreNotEqual(proverLog1, proverLog3);
+      
+      // Set this option back to its default
+      CommandLineOptions.Clo.NormalizeDeclarationOrder = true;
     }
     
     [Test()]
@@ -302,6 +309,7 @@ procedure M2(x: int, coloredBarrel: Barrel2 RGBColor2)
       Directory.CreateDirectory(directory);
       var temp1 = directory + "/proverLog";
       CommandLineOptions.Clo.ProverLogFilePath = temp1;
+      CommandLineOptions.Clo.ProverOptions.Add("SOLVER=noop");
       var success1 = ExecutionEngine.ProcessProgram(program1, "1");
       foreach (var proverFile in Directory.GetFiles(directory)) {
         yield return File.ReadAllText(proverFile);

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -201,7 +201,8 @@ namespace Microsoft.Boogie
       {
         var decls = s == null ? prog.TopLevelDeclarations : s.TopLevelDeclarations;
         // By ordering the declarations based on content and naming them based on order, the solver input stays content under reordering and renaming.
-        var orderedByContentHash = decls.OrderBy(d => d.ContentHash);
+        var orderedByContentHash = CommandLineOptions.Clo.NormalizeDeclarationOrder 
+          ? decls.OrderBy(d => d.ContentHash) : decls;
         foreach (Declaration decl in orderedByContentHash) {
           Contract.Assert(decl != null);
           if (decl is TypeCtorDecl typeDecl)

--- a/Source/VCGeneration/Prune/Prune.cs
+++ b/Source/VCGeneration/Prune/Prune.cs
@@ -64,11 +64,10 @@ namespace Microsoft.Boogie
       BlocksVisitor blocksNode = new BlocksVisitor(blocks);
       blocksNode.Blocks.ForEach(blk => blocksNode.Visit(blk));
 
-      var reachableDeclarations = GraphAlgorithms.FindReachableNodesInGraphWithMergeNodes(program.DeclarationDependencies, blocksNode.outgoing).ToHashSet();
-      var liveDeclarations = program.TopLevelDeclarations.Where(d =>
-        d is not Constant && d is not Axiom && d is not Function || reachableDeclarations.Contains(d)).ToList();
-      var pruned = program.TopLevelDeclarations.Except(liveDeclarations).ToList();
-      return liveDeclarations;
+      var keepRoots = program.TopLevelDeclarations.Where(d => QKeyValue.FindBoolAttribute(d.Attributes, "keep"));
+      var reachableDeclarations = GraphAlgorithms.FindReachableNodesInGraphWithMergeNodes(program.DeclarationDependencies, blocksNode.outgoing.Concat(keepRoots).ToHashSet()).ToHashSet();
+      return program.TopLevelDeclarations.Where(d => 
+        d is not Constant && d is not Axiom && d is not Function || reachableDeclarations.Contains(d));
     }
   }
 }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -128,15 +128,27 @@ namespace VC
         this.parent = par;
         this.impl = impl;
         Interlocked.Increment(ref currentId);
-        
+
+        PrintTopLevelDeclarationsForPruning(impl, "before");        
         TopLevelDeclarations = Prune.GetLiveDeclarations(par.program, blocks).ToList();
-        
-        if (CommandLineOptions.Clo.PrintPrunedFile != null) {
-          var t = new TokenTextWriter(CommandLineOptions.Clo.PrintPrunedFile + "-" + Util.EscapeFilename(impl.Name),  false, CommandLineOptions.Clo.PrettyPrint);
-          foreach (var d in TopLevelDeclarations) {
-            d.Emit(t, 0);
-          }
+        PrintTopLevelDeclarationsForPruning(impl, "after");
+      }
+
+      private void PrintTopLevelDeclarationsForPruning(Implementation implementation, string suffix)
+      {
+        if (!CommandLineOptions.Clo.Prune || CommandLineOptions.Clo.PrintPrunedFile == null)
+        {
+          return;
         }
+
+        using var writer = new TokenTextWriter(
+          $"{CommandLineOptions.Clo.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}", false,
+          CommandLineOptions.Clo.PrettyPrint);
+        foreach (var declaration in TopLevelDeclarations) {
+          declaration.Emit(writer, 0);
+        }
+
+        writer.Close();
       }
 
       public double Cost


### PR DESCRIPTION
### Changes
- Allow not normalising the top level declaration order
- Improve logging of the pruning feature

### Testing
- Add unit test for 'NormalizeDeclarationOrder' option
- Manually try CLI option 'normalizeDeclarationOrder'