### PR TITLE
feat: Ability to kill verification

### DIFF
--- a/Source/Core/ProverUtil.cs
+++ b/Source/Core/ProverUtil.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using System.Diagnostics.Contracts;
+using System.Threading;
 
 namespace Microsoft.Boogie
 {
@@ -301,7 +302,8 @@ The generic options may or may not be used by the prover plugin.
   {
     // Really returns ProverInterface.
     //public abstract object! SpawnProver(ProverOptions! options, object! ctxt);
-    public abstract object SpawnProver(SMTLibOptions libOptions, ProverOptions options, object ctxt);
+    public abstract object SpawnProver(SMTLibOptions libOptions, ProverOptions options, object ctxt,
+      CancellationToken cancellationToken);
 
     // Really returns ProverContext
     public abstract object /*!*/ NewProverContext(ProverOptions /*!*/ options);

--- a/Source/Houdini/Checker.cs
+++ b/Source/Houdini/Checker.cs
@@ -5,6 +5,7 @@ using Microsoft.Boogie.VCExprAST;
 using Microsoft.BaseTypes;
 using VC;
 using System.Linq;
+using System.Threading;
 
 namespace Microsoft.Boogie.Houdini
 {
@@ -243,7 +244,7 @@ namespace Microsoft.Boogie.Houdini
     }
 
     public ProverInterface.Outcome Verify(ProverInterface proverInterface, Dictionary<Variable, bool> assignment,
-      out List<Counterexample> errors, int errorLimit)
+      out List<Counterexample> errors, int errorLimit, CancellationToken cancellationToken)
     {
       collector.examples.Clear();
 

--- a/Source/Houdini/ConcurrentHoudini.cs
+++ b/Source/Houdini/ConcurrentHoudini.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using System.Threading;
 
 namespace Microsoft.Boogie.Houdini
 {
@@ -25,7 +26,7 @@ namespace Microsoft.Boogie.Houdini
       this.program = program;
       this.cexTraceFile = cexTraceFile;
       this.taskID = taskId;
-      Initialize(program, stats);
+      Initialize(program, stats, CancellationToken.None);
     }
 
     static ConcurrentHoudini()

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -31,7 +31,7 @@ namespace VC
     }
 
     public ConditionGenerationContracts(Program p, CheckerPool checkerPool)
-      : base(p, checkerPool)
+      : base(p, checkerPool, CancellationToken.None)
     {
     }
   }
@@ -100,11 +100,14 @@ namespace VC
     public Program program;
     public CheckerPool CheckerPool { get; }
 
-    public ConditionGeneration(Program p, CheckerPool checkerPool)
+    public CancellationToken CancellationToken { get; }
+    
+    public ConditionGeneration(Program p, CheckerPool checkerPool, CancellationToken cancellationToken)
     {
       Contract.Requires(p != null && checkerPool != null);
       program = p;
       CheckerPool = checkerPool;
+      CancellationToken = cancellationToken;
     }
 
     /// <summary>

--- a/Source/VCGeneration/ProverInterface.cs
+++ b/Source/VCGeneration/ProverInterface.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Threading;
 using Microsoft.Boogie.VCExprAST;
 
 namespace Microsoft.Boogie;
 
 public abstract class ProverInterface
 {
-  public static ProverInterface CreateProver(Program prog, string /*?*/ logFilePath, bool appendLogFile, uint timeout,
+  public static ProverInterface CreateProver(Program prog, string /*?*/ logFilePath, bool appendLogFile, uint timeout, CancellationToken cancellationToken,
     int taskID = -1)
   {
     Contract.Requires(prog != null);
@@ -83,7 +84,7 @@ public abstract class ProverInterface
       }
     }
 
-    return (ProverInterface) CommandLineOptions.Clo.TheProverFactory.SpawnProver(CommandLineOptions.Clo, options, ctx);
+    return (ProverInterface) CommandLineOptions.Clo.TheProverFactory.SpawnProver(CommandLineOptions.Clo, options, ctx, cancellationToken);
   }
 
   public enum Outcome
@@ -94,6 +95,7 @@ public abstract class ProverInterface
     OutOfMemory,
     OutOfResource,
     Undetermined,
+    Canceled,
     Bounded
   }
 

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1350,7 +1350,8 @@ namespace VC
       /// <summary>
       /// As a side effect, updates "this.parent.CumulativeAssertionCount".
       /// </summary>
-      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, uint timeout, uint rlimit)
+      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, uint timeout,
+        uint rlimit, CancellationToken vcGenCancellationToken)
       {
         Contract.Requires(checker != null);
         Contract.Requires(callback != null);
@@ -1367,7 +1368,7 @@ namespace VC
 
           ProverContext ctx = checker.TheoremProver.Context;
           Boogie2VCExprTranslator bet = ctx.BoogieExprTranslator;
-          var cc = new VCGen.CodeExprConversionClosure(absyIds, ctx);
+          var cc = new VCGen.CodeExprConversionClosure(absyIds, ctx, vcGenCancellationToken);
           bet.SetCodeExprConverter(cc.CodeExprToVerificationCondition);
 
           var exprGen = ctx.ExprGen;
@@ -1396,7 +1397,7 @@ namespace VC
             desc += "_split" + no;
           }
 
-          checker.BeginCheck(desc, vc, reporter, timeout, rlimit);
+          checker.BeginCheck(desc, vc, reporter, timeout, rlimit, vcGenCancellationToken);
         }
       }
 

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -12,6 +12,7 @@ namespace VC
   class SplitAndVerifyWorker
   {
     private readonly CommandLineOptions options;
+    private readonly VCGen vcGen;
     private readonly VerifierCallback callback;
     private readonly ModelViewInfo mvInfo;
     private readonly Implementation implementation;
@@ -38,6 +39,7 @@ namespace VC
       Outcome outcome)
     {
       this.options = options;
+      this.vcGen = vcGen;
       this.callback = callback;
       this.mvInfo = mvInfo;
       this.implementation = implementation;
@@ -127,7 +129,7 @@ namespace VC
       var timeout = KeepGoing && split.LastChance ? options.VcsFinalAssertTimeout :
         KeepGoing ? options.VcsKeepGoingTimeout :
         implementation.TimeLimit;
-      split.BeginCheck(checker, callback, mvInfo, currentSplitNumber, timeout, implementation.ResourceLimit);
+      split.BeginCheck(checker, callback, mvInfo, currentSplitNumber, timeout, implementation.ResourceLimit, vcGen.CancellationToken);
     }
 
     private async Task ProcessResult(Split split)


### PR DESCRIPTION
This PR enables Boogie's execution engine to kill verification on demand.

**Changes**
This PR adds cancellation token checks inside the loop that listens to the prover's output.
It enables `ExecutionEngine.CancelRequest(requestId), which triggers the `CancellationTokenSource` to cancel, to abruptly kills the while loop where the SMTLibProcess waits for the Z3 process's output. (because Z3 can actually loop forever or for very long in some cases, especially when there is no timeout)

This alone should be able to fix the following bugs:
https://github.com/dafny-lang/ide-vscode/issues/119
https://github.com/dafny-lang/ide-vscode/issues/114
https://github.com/dafny-lang/ide-vscode/issues/96
