### PR TITLE
Allow continuing if rlimit response is invalid

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.11.3</Version>
+    <Version>2.11.4</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1951,7 +1951,20 @@ namespace Microsoft.Boogie.SMTLib
     {
       SendThisVC("(get-info :rlimit)");
       var resp = Process.GetProverResponse();
-      return int.Parse(resp[0].Name);
+      try
+      {
+        return int.Parse(resp[0].Name);
+      }
+      catch
+      {
+        // If anything goes wrong with parsing the response from the solver,
+        // it's better to be able to continue, even with uninformative data.
+        lock (proverWarnings)
+        {
+          proverWarnings.Add("Failed to parse resource count from solver.");
+        }
+        return -1;
+      }
     }
 
     object ParseValueFromProver(SExpr expr)

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1961,7 +1961,7 @@ namespace Microsoft.Boogie.SMTLib
         // it's better to be able to continue, even with uninformative data.
         lock (proverWarnings)
         {
-          proverWarnings.Add("Failed to parse resource count from solver.");
+          proverWarnings.Add($"Failed to parse resource count from solver. Got: {resp.ToString()}");
         }
         return -1;
       }

--- a/Test/prover/mocksolver.sh
+++ b/Test/prover/mocksolver.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+while true ; do
+    read cmd
+    case $cmd in
+      *get-info*name*   ) echo "(:name \"Z3\")" ;;
+      *get-info*rlimit* ) echo "(:rlimit bad)" ;;
+      *check-sat*       ) echo "unsat" ;;
+      *                 ) continue ;;
+    esac
+done

--- a/Test/prover/rlimit-parse.bpl
+++ b/Test/prover/rlimit-parse.bpl
@@ -1,0 +1,7 @@
+// RUN: %boogie /trace /proverOpt:PROVER_PATH=mocksolver.sh "%s" > "%t"
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+// CHECK: resource count: -1
+
+procedure P(x: int, y: int) {
+  assert x*y == y*x;
+}


### PR DESCRIPTION
Previously, the code to get the resource count from Z3 could crash if Z3's response was badly-formed. Now it will continue with a dummy value of -1.