### PR TITLE
fix: Cancellation tokens to cancel and restart checkers

### DIFF
--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1210,19 +1210,20 @@ namespace Microsoft.Boogie
 
           try {
             var cancellationToken = RequestIdToCancellationTokenSource[requestId].Token;
-            verificationResult.Outcome = vcgen.VerifyImplementation(impl, out verificationResult.Errors, requestId, cancellationToken);
-            if (CommandLineOptions.Clo.ExtractLoops && verificationResult.Errors != null)
-            {
+            verificationResult.Outcome =
+              vcgen.VerifyImplementation(impl, out verificationResult.Errors, requestId, cancellationToken);
+            if (CommandLineOptions.Clo.ExtractLoops && verificationResult.Errors != null) {
               var vcg = vcgen as VCGen;
-              if (vcg != null)
-              {
-                for (int i = 0; i < verificationResult.Errors.Count; i++)
-                {
+              if (vcg != null) {
+                for (int i = 0; i < verificationResult.Errors.Count; i++) {
                   verificationResult.Errors[i] = vcg.extractLoopTrace(verificationResult.Errors[i], impl.Name,
                     program, extractLoopMappingInfo);
                 }
               }
             }
+          }
+          catch (OperationCanceledException) {
+            
           }
           catch (VCGenException e)
           {

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1054,6 +1054,7 @@ namespace Microsoft.Boogie
 
           if (e is OperationCanceledException)
           {
+            outcome = PipelineOutcome.Cancelled;
             return true;
           }
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -204,6 +204,7 @@ namespace Microsoft.Boogie
     TypeCheckingError,
     ResolvedAndTypeChecked,
     FatalError,
+    Cancelled,
     VerificationCompleted
   }
 
@@ -1148,7 +1149,7 @@ namespace Microsoft.Boogie
       {
         if (RequestIdToCancellationTokenSource.IsEmpty)
         {
-          checkerPool.Dispose();
+          checkerPool?.Dispose();
           checkerPool = null;
         }
       }

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1207,9 +1207,9 @@ namespace Microsoft.Boogie
             CommandLineOptions.Clo.XmlSink.WriteStartMethod(impl.Name, verificationResult.Start);
           }
 
-          try
-          {
-            verificationResult.Outcome = vcgen.VerifyImplementation(impl, out verificationResult.Errors, requestId);
+          try {
+            var cancellationToken = RequestIdToCancellationTokenSource[requestId].Token;
+            verificationResult.Outcome = vcgen.VerifyImplementation(impl, out verificationResult.Errors, requestId, cancellationToken);
             if (CommandLineOptions.Clo.ExtractLoops && verificationResult.Errors != null)
             {
               var vcg = vcgen as VCGen;

--- a/Source/Houdini/Checker.cs
+++ b/Source/Houdini/Checker.cs
@@ -5,6 +5,7 @@ using Microsoft.Boogie.VCExprAST;
 using Microsoft.BaseTypes;
 using VC;
 using System.Linq;
+using System.Threading;
 
 namespace Microsoft.Boogie.Houdini
 {
@@ -256,7 +257,7 @@ namespace Microsoft.Boogie.Houdini
 
       VCExpr vc = proverInterface.VCExprGen.Implies(BuildAxiom(proverInterface, assignment), conjecture);
       proverInterface.BeginCheck(descriptiveName, vc, handler);
-      ProverInterface.Outcome proverOutcome = proverInterface.CheckOutcome(handler, errorLimit);
+      ProverInterface.Outcome proverOutcome = proverInterface.CheckOutcome(handler, errorLimit, CancellationToken.None).Result;
 
       double queryTime = (DateTime.UtcNow - now).TotalSeconds;
       stats.proverTime += queryTime;
@@ -388,8 +389,8 @@ namespace Microsoft.Boogie.Houdini
       do
       {
         hardAssumptions.Add(controlExprNoop);
-        outcome = proverInterface.CheckAssumptions(hardAssumptions, softAssumptions, out var unsatisfiedSoftAssumptions,
-          handler);
+        (outcome, var unsatisfiedSoftAssumptions) = proverInterface.CheckAssumptions(hardAssumptions, softAssumptions, 
+          handler, CancellationToken.None).Result;
         hardAssumptions.RemoveAt(hardAssumptions.Count - 1);
 
         if (outcome == ProverInterface.Outcome.TimeOut || outcome == ProverInterface.Outcome.OutOfMemory ||
@@ -423,9 +424,8 @@ namespace Microsoft.Boogie.Houdini
           hardAssumptions.Add(softAssumptions[i]);
         }
 
-        var unsatisfiedSoftAssumptions2 = new List<int>();
-        outcome = proverInterface.CheckAssumptions(hardAssumptions, softAssumptions2, out unsatisfiedSoftAssumptions2,
-          handler);
+        (outcome, var unsatisfiedSoftAssumptions2) = proverInterface.CheckAssumptions(hardAssumptions, softAssumptions2, 
+          handler, CancellationToken.None).Result;
 
         if (outcome == ProverInterface.Outcome.TimeOut || outcome == ProverInterface.Outcome.OutOfMemory ||
             outcome == ProverInterface.Outcome.OutOfResource || outcome == ProverInterface.Outcome.Undetermined)
@@ -506,7 +506,7 @@ namespace Microsoft.Boogie.Houdini
         assumptionExprs.Add(exprTranslator.LookupVariable(v));
       }
 
-      ProverInterface.Outcome tmp = proverInterface.CheckAssumptions(assumptionExprs, out var unsatCore, handler);
+      (ProverInterface.Outcome tmp, var unsatCore) = proverInterface.CheckAssumptions(assumptionExprs, handler, CancellationToken.None).Result;
       System.Diagnostics.Debug.Assert(tmp == ProverInterface.Outcome.Valid);
       unsatCoreSet = new HashSet<Variable>();
       foreach (int i in unsatCore)

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Boogie.SMTLib;
 
@@ -34,7 +35,7 @@ class NoopSolver : SMTLibSolver
     }
   }
 
-  public override SExpr GetProverResponse()
+  public override async Task<SExpr> GetProverResponse()
   {
     var result = response;
     response = null;

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Boogie.SMTLib;
@@ -35,11 +36,11 @@ class NoopSolver : SMTLibSolver
     }
   }
 
-  public override async Task<SExpr> GetProverResponse()
+  public override Task<SExpr> GetProverResponse(CancellationToken cancellationToken)
   {
     var result = response;
     response = null;
-    return result;
+    return Task.FromResult(result);
   }
 
   public override void NewProblem(string descriptiveName)

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -36,7 +36,7 @@ class NoopSolver : SMTLibSolver
     }
   }
 
-  public override Task<SExpr> GetProverResponse(CancellationToken cancellationToken)
+  public override Task<SExpr> GetProverResponse()
   {
     var result = response;
     response = null;

--- a/Source/Provers/SMTLib/SMTLib.csproj
+++ b/Source/Provers/SMTLib/SMTLib.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\..\VCGeneration\VCGeneration.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
 
@@ -58,6 +57,7 @@ namespace Microsoft.Boogie.SMTLib
         prover.StartInfo = psi;
         prover.ErrorDataReceived += prover_ErrorDataReceived;
         prover.OutputDataReceived += prover_OutputDataReceived;
+        prover.Exited += prover_Exited;
         prover.Start();
         toProver = prover.StandardInput;
         prover.BeginErrorReadLine();
@@ -67,6 +67,17 @@ namespace Microsoft.Boogie.SMTLib
       {
         throw new ProverException(string.Format("Unable to start the process {0}: {1}", psi.FileName, e.Message));
       }
+    }
+
+    private void prover_Exited(object sender, EventArgs e)
+    {
+      lock (this) {
+        if (outputReceivers.TryDequeue(out var source)) {
+          source.SetResult(null);
+        }
+      }
+
+      DisposeProver();
     }
 
     [NoDefaultContract] // important, since we have no idea what state the object might be in when this handler is invoked
@@ -114,71 +125,61 @@ namespace Microsoft.Boogie.SMTLib
       toProver.WriteLine(cmd);
     }
 
-    internal Inspector Inspector
+    internal Inspector Inspector => inspector;
+
+    public override async Task<SExpr> GetProverResponse()
     {
-      get { return inspector; }
-    }
+      await toProver.FlushAsync();
 
-    public override Task<SExpr> GetProverResponse(CancellationToken cancellationToken)
-    {
-      return Task.Factory.StartNew(GetProverResponseSync, cancellationToken);
-    }
+      while (true) {
+        var exprs = await ParseSExprs(true).ToListAsync();
+        Contract.Assert(exprs.Count <= 1);
+        if (exprs.Count == 0) {
+          return null;
+        }
 
-    private SExpr GetProverResponseSync()
-    {
-      toProver.Flush();
-
-      lock (this) {
-        while (true) {
-          var exprs = ParseSExprs(true).ToArray();
-          Contract.Assert(exprs.Length <= 1);
-          if (exprs.Length == 0) {
-            return null;
-          }
-
-          var resp = exprs[0];
-          if (resp.Name == "error") {
-            if (resp.Arguments.Length == 1 && resp.Arguments[0].IsId) {
-              if (resp.Arguments[0].Name.Contains("max. resource limit exceeded")) {
-                return resp;
-              } else {
-                HandleError(resp.Arguments[0].Name);
-                return null;
-              }
+        var resp = exprs[0];
+        if (resp.Name == "error") {
+          if (resp.Arguments.Length == 1 && resp.Arguments[0].IsId) {
+            if (resp.Arguments[0].Name.Contains("max. resource limit exceeded")) {
+              return resp;
             } else {
-              HandleError(resp.ToString());
+              HandleError(resp.Arguments[0].Name);
               return null;
             }
-          } else if (resp.Name == "progress") {
-            if (inspector != null) {
-              var sb = new StringBuilder();
-              foreach (var a in resp.Arguments) {
-                if (a.Name == "labels") {
-                  sb.Append("STATS LABELS");
-                  foreach (var x in a.Arguments) {
-                    sb.Append(" ").Append(x.Name);
-                  }
-                } else if (a.Name.StartsWith(":")) {
-                  sb.Append("STATS NAMED_VALUES ").Append(a.Name);
-                  foreach (var x in a.Arguments) {
-                    sb.Append(" ").Append(x.Name);
-                  }
-                } else {
-                  continue;
-                }
-
-                inspector.StatsLine(sb.ToString());
-                sb.Clear();
-              }
-            }
-          } else if (resp.Name == "unsupported") {
-            // Skip -- this may be a benign "unsupported" from a previous command.
-            // Of course, this is suboptimal.  We should really be using
-            // print-success to identify the errant command and determine whether
-            // the response is benign.
           } else {
-            return resp;
+            HandleError(resp.ToString());
+            return null;
           }
+        } else if (resp.Name == "progress") {
+          if (inspector != null) {
+            var sb = new StringBuilder();
+            foreach (var a in resp.Arguments) {
+              if (a.Name == "labels") {
+                sb.Append("STATS LABELS");
+                foreach (var x in a.Arguments) {
+                  sb.Append(" ").Append(x.Name);
+                }
+              } else if (a.Name.StartsWith(":")) {
+                sb.Append("STATS NAMED_VALUES ").Append(a.Name);
+                foreach (var x in a.Arguments) {
+                  sb.Append(" ").Append(x.Name);
+                }
+              } else {
+                continue;
+              }
+
+              inspector.StatsLine(sb.ToString());
+              sb.Clear();
+            }
+          }
+        } else if (resp.Name == "unsupported") {
+          // Skip -- this may be a benign "unsupported" from a previous command.
+          // Of course, this is suboptimal.  We should really be using
+          // print-success to identify the errant command and determine whether
+          // the response is benign.
+        } else {
+          return resp;
         }
       }
     }
@@ -212,7 +213,6 @@ namespace Microsoft.Boogie.SMTLib
     }
 
     public override event Action<string> ErrorHandler;
-    int errorCnt;
 
     protected override void HandleError(string msg)
     {
@@ -229,13 +229,13 @@ namespace Microsoft.Boogie.SMTLib
     int linePos;
     string currLine;
 
-    char SkipWs()
+    async Task<char> SkipWs()
     {
       while (true)
       {
         if (currLine == null)
         {
-          currLine = ReadProver();
+          currLine = await ReadProver();
           if (currLine == null)
           {
             return '\0';
@@ -265,13 +265,13 @@ namespace Microsoft.Boogie.SMTLib
       linePos++;
     }
 
-    string ParseId()
+    async Task<string> ParseId()
     {
       var sb = new StringBuilder();
 
-      var beg = SkipWs();
+      var begin = await SkipWs();
 
-      var quoted = beg == '"' || beg == '|';
+      var quoted = begin == '"' || begin == '|';
       if (quoted)
       {
         Shift();
@@ -286,7 +286,7 @@ namespace Microsoft.Boogie.SMTLib
             do
             {
               sb.Append("\n");
-              currLine = ReadProver();
+              currLine = await ReadProver();
             } while (currLine == "");
             if (currLine == null)
             {
@@ -302,7 +302,7 @@ namespace Microsoft.Boogie.SMTLib
         }
 
         var c = currLine[linePos++];
-        if (quoted && c == beg)
+        if (quoted && c == begin)
         {
           break;
         }
@@ -331,11 +331,11 @@ namespace Microsoft.Boogie.SMTLib
       HandleError("Error parsing prover output: " + msg);
     }
 
-    IEnumerable<SExpr> ParseSExprs(bool top)
+    async IAsyncEnumerable<SExpr> ParseSExprs(bool top)
     {
       while (true)
       {
-        var c = SkipWs();
+        var c = await SkipWs();
         if (c == '\0')
         {
           break;
@@ -356,7 +356,7 @@ namespace Microsoft.Boogie.SMTLib
         if (c == '(')
         {
           Shift();
-          c = SkipWs();
+          c = await SkipWs();
           if (c == '\0')
           {
             ParseError("expecting something after '('");
@@ -368,12 +368,12 @@ namespace Microsoft.Boogie.SMTLib
           }
           else
           {
-            id = ParseId();
+            id = await ParseId();
           }
 
-          var args = ParseSExprs(false).ToArray();
+          var args = await ParseSExprs(false).ToListAsync();
 
-          c = SkipWs();
+          c = await SkipWs();
           if (c == ')')
           {
             Shift();
@@ -387,7 +387,7 @@ namespace Microsoft.Boogie.SMTLib
         }
         else
         {
-          id = ParseId();
+          id = await ParseId();
           yield return new SExpr(id);
         }
 
@@ -402,39 +402,18 @@ namespace Microsoft.Boogie.SMTLib
 
     #region handling input from the prover
 
-    string ReadProver()
+    private readonly Queue<TaskCompletionSource<string>> outputReceivers = new();
+    
+    Task<string> ReadProver()
     {
-      string error = null;
-      while (true)
-      {
-        if (error != null)
-        {
-          HandleError(error);
-          errorCnt++;
-          error = null;
+      lock (this) {
+        if (proverOutput.TryDequeue(out var result)) {
+          return Task.FromResult(result);
         }
 
-        while (proverOutput.Count == 0 && proverErrors.Count == 0 && !prover.HasExited)
-        {
-          Monitor.Wait(this, 100);
-        }
-
-        if (proverErrors.Count > 0)
-        {
-          error = proverErrors.Dequeue();
-          continue;
-        }
-
-        if (proverOutput.Count > 0)
-        {
-          return proverOutput.Dequeue();
-        }
-
-        if (prover.HasExited)
-        {
-          DisposeProver();
-          return null;
-        }
+        var taskCompletionSource = new TaskCompletionSource<string>();
+        outputReceivers.Enqueue(taskCompletionSource);
+        return taskCompletionSource.Task;
       }
     }
 
@@ -449,35 +428,39 @@ namespace Microsoft.Boogie.SMTLib
 
     void prover_OutputDataReceived(object sender, DataReceivedEventArgs e)
     {
-      lock (this)
-      {
-        if (e.Data != null)
+        if (e.Data == null)
         {
-          if (options.Verbosity >= 2 || (options.Verbosity >= 1 && !e.Data.StartsWith("(:name ")))
-          {
-            Console.WriteLine("[SMT-OUT-{0}] {1}", smtProcessId, e.Data);
-          }
-
-          proverOutput.Enqueue(e.Data);
-          Monitor.Pulse(this);
+          return;
         }
-      }
+
+        if (options.Verbosity >= 2 || (options.Verbosity >= 1 && !e.Data.StartsWith("(:name ")))
+        {
+          Console.WriteLine("[SMT-OUT-{0}] {1}", smtProcessId, e.Data);
+        }
+
+        lock (this) {
+          if (outputReceivers.TryDequeue(out var source)) {
+            source.SetResult(e.Data);
+          } else {
+            proverOutput.Enqueue(e.Data);
+          }
+        }
     }
 
     void prover_ErrorDataReceived(object sender, DataReceivedEventArgs e)
     {
-      lock (this)
-      {
-        if (e.Data != null)
+      lock (this) {
+        if (e.Data == null)
         {
-          if (options.Verbosity >= 1)
-          {
-            Console.WriteLine("[SMT-ERR-{0}] {1}", smtProcessId, e.Data);
-          }
-
-          proverErrors.Enqueue(e.Data);
-          Monitor.Pulse(this);
+          return;
         }
+
+        if (options.Verbosity >= 1)
+        {
+          Console.WriteLine("[SMT-ERR-{0}] {1}", smtProcessId, e.Data);
+        }
+
+        HandleError(e.Data);
       }
     }
 

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Diagnostics.Contracts;
+using System.Threading.Tasks;
 
 namespace Microsoft.Boogie.SMTLib
 {
@@ -118,7 +119,7 @@ namespace Microsoft.Boogie.SMTLib
       get { return inspector; }
     }
 
-    public override SExpr GetProverResponse()
+    public override async Task<SExpr> GetProverResponse()
     {
       toProver.Flush();
 

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -819,7 +819,7 @@ namespace Microsoft.Boogie.SMTLib
               {
                 UsedNamedAssumes = new HashSet<string>();
                 SendThisVC("(get-unsat-core)");
-                var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
+                var resp = await Process.GetProverResponse(cancellationToken);
                 if (resp.Name != "")
                 {
                   UsedNamedAssumes.Add(resp.Name);
@@ -1066,7 +1066,7 @@ namespace Microsoft.Boogie.SMTLib
       var path = new List<string>();
       while (true)
       {
-        var response = await Process.GetProverResponse().WaitAsync(cancellationToken);
+        var response = await Process.GetProverResponse(cancellationToken);
         if (response == null)
         {
           break;
@@ -1529,7 +1529,7 @@ namespace Microsoft.Boogie.SMTLib
       Model theModel = null;
       while (true)
       {
-        var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
+        var resp = await Process.GetProverResponse(cancellationToken);
         if (resp == null || Process.IsPong(resp))
         {
           break;
@@ -1604,7 +1604,7 @@ namespace Microsoft.Boogie.SMTLib
 
       while (true)
       {
-        var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
+        var resp = await Process.GetProverResponse(cancellationToken);
         if (resp == null || Process.IsPong(resp))
         {
           break;
@@ -1651,7 +1651,7 @@ namespace Microsoft.Boogie.SMTLib
         Process.Ping();
         while (true)
         {
-          var resp = await Process.GetProverResponse();
+          var resp = await Process.GetProverResponse(cancellationToken);
           if (resp == null || Process.IsPong(resp))
           {
             break;
@@ -1903,7 +1903,7 @@ namespace Microsoft.Boogie.SMTLib
     public override List<string> UnsatCore()
     {
       SendThisVC("(get-unsat-core)");
-      var resp = Process.GetProverResponse().ToString();
+      var resp = Process.GetProverResponse(CancellationToken.None).ToString();
       if (resp == "" || resp == "()")
       {
         return null;
@@ -1960,7 +1960,7 @@ namespace Microsoft.Boogie.SMTLib
     public override async Task<int> GetRCount() 
     {
       SendThisVC("(get-info :rlimit)");
-      var resp = await Process.GetProverResponse();
+      var resp = await Process.GetProverResponse(CancellationToken.None);
       try
       {
         return int.Parse(resp[0].Name);
@@ -2142,7 +2142,7 @@ namespace Microsoft.Boogie.SMTLib
     {
       string vcString = VCExpr2String(expr, 1);
       SendThisVC("(get-value (" + vcString + "))");
-      var resp = await Process.GetProverResponse();
+      var resp = await Process.GetProverResponse(CancellationToken.None);
       if (resp == null)
       {
         throw new VCExprEvaluationException();
@@ -2273,7 +2273,7 @@ namespace Microsoft.Boogie.SMTLib
 
       Contract.Assert(usingUnsatCore, "SMTLib prover not setup for computing unsat cores");
       SendThisVC("(get-unsat-core)");
-      var resp = await Process.GetProverResponse();
+      var resp = await Process.GetProverResponse(cancellationToken);
       var unsatCore = new List<int>();
       if (resp.Name != "")
       {
@@ -2296,7 +2296,7 @@ namespace Microsoft.Boogie.SMTLib
       DeclCollector.Push();
     }
 
-    public virtual async Task<(Outcome, List<int>)> CheckAssumptions(List<VCExpr> hardAssumptions, List<VCExpr> softAssumptions,
+    public override async Task<(Outcome, List<int>)> CheckAssumptions(List<VCExpr> hardAssumptions, List<VCExpr> softAssumptions,
       ErrorHandler handler, CancellationToken cancellationToken)
     {
 
@@ -2367,7 +2367,7 @@ namespace Microsoft.Boogie.SMTLib
         {
           SendThisVC("(get-value (" + relaxVar + "))");
           FlushLogFile();
-          var resp = await Process.GetProverResponse();
+          var resp = await Process.GetProverResponse(cancellationToken);
           if (resp == null)
           {
             break;

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -99,6 +99,11 @@ namespace Microsoft.Boogie.SMTLib
       SendThisVC(string.Format("(assert (! {0} :named {1}))", vcString, name));
     }
 
+    public override Task GoBackToIdle()
+    {
+      return Process.PingPong();
+    }
+
     private void SetupAxiomBuilder(VCExpressionGenerator gen)
     {
       switch (libOptions.TypeEncodingMethod)

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -824,7 +824,7 @@ namespace Microsoft.Boogie.SMTLib
               {
                 UsedNamedAssumes = new HashSet<string>();
                 SendThisVC("(get-unsat-core)");
-                var resp = await Process.GetProverResponse(cancellationToken);
+                var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
                 if (resp.Name != "")
                 {
                   UsedNamedAssumes.Add(resp.Name);
@@ -1071,7 +1071,7 @@ namespace Microsoft.Boogie.SMTLib
       var path = new List<string>();
       while (true)
       {
-        var response = await Process.GetProverResponse(cancellationToken);
+        var response = await Process.GetProverResponse().WaitAsync(cancellationToken);
         if (response == null)
         {
           break;
@@ -1534,7 +1534,7 @@ namespace Microsoft.Boogie.SMTLib
       Model theModel = null;
       while (true)
       {
-        var resp = await Process.GetProverResponse(cancellationToken);
+        var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
         if (resp == null || Process.IsPong(resp))
         {
           break;
@@ -1609,7 +1609,7 @@ namespace Microsoft.Boogie.SMTLib
 
       while (true)
       {
-        var resp = await Process.GetProverResponse(cancellationToken);
+        var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
         if (resp == null || Process.IsPong(resp))
         {
           break;
@@ -1656,7 +1656,7 @@ namespace Microsoft.Boogie.SMTLib
         Process.Ping();
         while (true)
         {
-          var resp = await Process.GetProverResponse(cancellationToken);
+          var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
           if (resp == null || Process.IsPong(resp))
           {
             break;
@@ -1908,7 +1908,7 @@ namespace Microsoft.Boogie.SMTLib
     public override List<string> UnsatCore()
     {
       SendThisVC("(get-unsat-core)");
-      var resp = Process.GetProverResponse(CancellationToken.None).ToString();
+      var resp = Process.GetProverResponse().ToString();
       if (resp == "" || resp == "()")
       {
         return null;
@@ -1965,7 +1965,7 @@ namespace Microsoft.Boogie.SMTLib
     public override async Task<int> GetRCount() 
     {
       SendThisVC("(get-info :rlimit)");
-      var resp = await Process.GetProverResponse(CancellationToken.None);
+      var resp = await Process.GetProverResponse();
       try
       {
         return int.Parse(resp[0].Name);
@@ -2147,7 +2147,7 @@ namespace Microsoft.Boogie.SMTLib
     {
       string vcString = VCExpr2String(expr, 1);
       SendThisVC("(get-value (" + vcString + "))");
-      var resp = await Process.GetProverResponse(CancellationToken.None);
+      var resp = await Process.GetProverResponse();
       if (resp == null)
       {
         throw new VCExprEvaluationException();
@@ -2278,7 +2278,7 @@ namespace Microsoft.Boogie.SMTLib
 
       Contract.Assert(usingUnsatCore, "SMTLib prover not setup for computing unsat cores");
       SendThisVC("(get-unsat-core)");
-      var resp = await Process.GetProverResponse(cancellationToken);
+      var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
       var unsatCore = new List<int>();
       if (resp.Name != "")
       {
@@ -2372,7 +2372,7 @@ namespace Microsoft.Boogie.SMTLib
         {
           SendThisVC("(get-value (" + relaxVar + "))");
           FlushLogFile();
-          var resp = await Process.GetProverResponse(cancellationToken);
+          var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
           if (resp == null)
           {
             break;

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -69,23 +69,18 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    private static ScopedNamer GetNamer(SMTLibOptions libOptions, ProverOptions options)
+    private static ScopedNamer GetNamer(SMTLibOptions libOptions, ProverOptions options, ScopedNamer namer = null)
     {
       return (RandomSeed: options.RandomSeed, libOptions.NormalizeNames) switch
       {
-        (null, true) => new NormalizeNamer(),
-        (null, false) => new KeepOriginalNamer(),
-        _ => new RandomiseNamer(new Random(options.RandomSeed.Value))
+        (null, true) => NormalizeNamer.Create(namer),
+        (null, false) => KeepOriginalNamer.Create(namer),
+        _ => RandomiseNamer.Create(new Random(options.RandomSeed.Value), namer)
       };
     }
 
     private ScopedNamer ResetNamer(ScopedNamer namer) {
-      return (RandomSeed: options.RandomSeed, libOptions.NormalizeNames) switch
-      {
-        (null, true) => new NormalizeNamer(namer), 
-        (null, false) => new KeepOriginalNamer(namer),
-        _ => new RandomiseNamer(namer, new Random(options.RandomSeed.Value))
-      }; 
+      return GetNamer(libOptions, options, namer);
     }
 
     public override void AssertNamed(VCExpr vc, bool polarity, string name)

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Boogie.SMTLib;
 
@@ -7,7 +8,7 @@ public abstract class SMTLibSolver
   public abstract event Action<string> ErrorHandler;
   public abstract void Close();
   public abstract void Send(string cmd);
-  public abstract SExpr GetProverResponse();
+  public abstract Task<SExpr> GetProverResponse();
   public abstract void NewProblem(string descriptiveName);
 
   protected abstract void HandleError(string msg);
@@ -17,12 +18,12 @@ public abstract class SMTLibSolver
     Send("(get-info :name)");
   }
 
-  public void PingPong()
+  public async Task PingPong()
   {
     Ping();
     while (true)
     {
-      var sx = GetProverResponse();
+      var sx = await GetProverResponse();
       if (sx == null)
       {
         throw new ProverDiedException();
@@ -48,7 +49,7 @@ public abstract class SMTLibSolver
   {
     try
     {
-      PingPong();
+      PingPong().Wait();
     }
     catch (ProverDiedException e)
     {

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Boogie.SMTLib;
@@ -8,7 +9,7 @@ public abstract class SMTLibSolver
   public abstract event Action<string> ErrorHandler;
   public abstract void Close();
   public abstract void Send(string cmd);
-  public abstract Task<SExpr> GetProverResponse();
+  public abstract Task<SExpr> GetProverResponse(CancellationToken cancellationToken);
   public abstract void NewProblem(string descriptiveName);
 
   protected abstract void HandleError(string msg);
@@ -23,7 +24,7 @@ public abstract class SMTLibSolver
     Ping();
     while (true)
     {
-      var sx = await GetProverResponse();
+      var sx = await GetProverResponse(CancellationToken.None);
       if (sx == null)
       {
         throw new ProverDiedException();

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -9,7 +9,7 @@ public abstract class SMTLibSolver
   public abstract event Action<string> ErrorHandler;
   public abstract void Close();
   public abstract void Send(string cmd);
-  public abstract Task<SExpr> GetProverResponse(CancellationToken cancellationToken);
+  public abstract Task<SExpr> GetProverResponse();
   public abstract void NewProblem(string descriptiveName);
 
   protected abstract void HandleError(string msg);
@@ -24,7 +24,7 @@ public abstract class SMTLibSolver
     Ping();
     while (true)
     {
-      var sx = await GetProverResponse(CancellationToken.None);
+      var sx = await GetProverResponse();
       if (sx == null)
       {
         throw new ProverDiedException();

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -12,12 +12,13 @@ namespace ExecutionEngineTests
     public Program GetProgram(string code) {
       var options = CommandLineOptions.FromArguments();
       CommandLineOptions.Install(options);
-      int errorCount = Parser.Parse(code, "1", out Program program,
+      var bplFileName = "1";
+      int errorCount = Parser.Parse(code, bplFileName, out Program program,
         CommandLineOptions.Clo.UseBaseNameForFileName);
       Assert.AreEqual(0, errorCount);
 
       ExecutionEngine.printer = new ConsolePrinter();
-      PipelineOutcome oc = ExecutionEngine.ResolveAndTypecheck(program, "bla", out _);
+      ExecutionEngine.ResolveAndTypecheck(program, bplFileName, out _);
       ExecutionEngine.EliminateDeadVariables(program);
       ExecutionEngine.CollectModSets(program);
       ExecutionEngine.CoalesceBlocks(program);
@@ -26,7 +27,7 @@ namespace ExecutionEngineTests
     }
     
     [Test]
-    public async Task BoogieCorrectlyCancelsProvers() {
+    public async Task InferAndVerifyCanBeCancelledWhileWaitingForProver() {
       var infiniteProgram = GetProgram(slow);
       var terminatingProgram = GetProgram(fast);
       

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -101,14 +101,6 @@ procedure easy() ensures 1 + 1 == 0; {
 
   procedure proof()
   {
-    var ##m#0: int;
-    var ##n#0: int;
-
-    ##m#0 := LitInt(5);
-    ##n#0 := LitInt(5);
-    assert {:subsumption 0} ##m#0 >= LitInt(0);
-    assert {:subsumption 0} ##n#0 >= LitInt(0);
-    assume Ack#canCall(LitInt(5), LitInt(5));
     assume Ack#canCall(LitInt(5), LitInt(5));
     assert LitInt(Ack($LS($LS($LZ)), LitInt(5), LitInt(5))) == LitInt(0);
   }

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace ExecutionEngineTests
 {
   [TestFixture]
-  public class SolverVerificationCancellationTest
+  public class CancellationTests
   {
     public Program GetProgram(string code) {
       var options = CommandLineOptions.FromArguments();

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -35,7 +35,7 @@ namespace ExecutionEngineTests
 
       var requestId = ExecutionEngine.FreshRequestId();
       var outcomeTask = Task.Run(() => ExecutionEngine.InferAndVerify(infiniteProgram, new PipelineStatistics(), requestId, null, requestId));
-      await Task.Delay(2000);
+      await Task.Delay(1000);
       ExecutionEngine.CancelRequest(requestId);
       var outcome = await outcomeTask;
       Assert.AreEqual(PipelineOutcome.Cancelled, outcome);

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Boogie;
+using NUnit.Framework;
+
+namespace ExecutionEngineTests
+{
+  [TestFixture]
+  public class SolverVerificationCancellationTest
+  {
+    public Program GetProgram(string code) {
+      var options = CommandLineOptions.FromArguments();
+      CommandLineOptions.Install(options);
+      int errorCount = Parser.Parse(code, "1", out Program program,
+        CommandLineOptions.Clo.UseBaseNameForFileName);
+      Assert.AreEqual(0, errorCount);
+
+      ExecutionEngine.printer = new ConsolePrinter();
+      PipelineOutcome oc = ExecutionEngine.ResolveAndTypecheck(program, "bla", out _);
+      ExecutionEngine.EliminateDeadVariables(program);
+      ExecutionEngine.CollectModSets(program);
+      ExecutionEngine.CoalesceBlocks(program);
+      ExecutionEngine.Inline(program);
+      return program;
+    }
+    
+    [Test]
+    public async Task BoogieCorrectlyCancelsProvers() {
+      var infiniteProgram = GetProgram(slow);
+      var terminatingProgram = GetProgram(fast);
+      
+      // We limit the number of checkers to 1.
+      CommandLineOptions.Clo.VcsCores = 1;
+
+      var requestId = ExecutionEngine.FreshRequestId();
+      var outcomeTask = Task.Run(() => ExecutionEngine.InferAndVerify(infiniteProgram, new PipelineStatistics(), requestId, null, requestId));
+      await Task.Delay(2000);
+      ExecutionEngine.CancelRequest(requestId);
+      var outcome = await outcomeTask;
+      Assert.AreEqual(PipelineOutcome.Cancelled, outcome);
+      var requestId2 = ExecutionEngine.FreshRequestId();
+      var outcome2 = ExecutionEngine.InferAndVerify(terminatingProgram, new PipelineStatistics(), requestId2, null, requestId2);
+      Assert.AreEqual(PipelineOutcome.VerificationCompleted, outcome2);
+    }
+
+    private string fast = @"
+procedure easy() ensures 1 + 1 == 0; {
+}
+";
+
+    string slow = @"
+  type LayerType;
+  function {:identity} LitInt(x: int) : int;
+  axiom (forall x: int :: {:identity} { LitInt(x): int } LitInt(x): int == x);
+  const $LZ: LayerType;
+  function $LS(LayerType) : LayerType;
+
+  function Ack($ly: LayerType, m#0: int, n#0: int) : int;
+  function Ack#canCall(m#0: int, n#0: int) : bool;
+  axiom (forall $ly: LayerType, m#0: int, n#0: int :: 
+    { Ack($LS($ly), m#0, n#0) } 
+    Ack($LS($ly), m#0, n#0)
+       == Ack($ly, m#0, n#0));
+  axiom (forall $ly: LayerType, m#0: int, n#0: int :: 
+      { Ack($LS($ly), m#0, n#0) } 
+      Ack#canCall(m#0, n#0)
+           || (m#0 >= LitInt(0) && n#0 >= LitInt(0))
+         ==> (m#0 != LitInt(0)
+             ==> (n#0 == LitInt(0) ==> Ack#canCall(m#0 - 1, LitInt(1)))
+               && (n#0 != LitInt(0)
+                 ==> Ack#canCall(m#0, n#0 - 1)
+                   && Ack#canCall(m#0 - 1, Ack($ly, m#0, n#0 - 1))))
+           && Ack($LS($ly), m#0, n#0)
+             == (if m#0 == LitInt(0)
+               then n#0 + 1
+               else (if n#0 == LitInt(0)
+                 then Ack($ly, m#0 - 1, LitInt(1))
+                 else Ack($ly, m#0 - 1, Ack($ly, m#0, n#0 - 1)))));
+  axiom (forall $ly: LayerType, m#0: int, n#0: int :: 
+      {:weight 3} { Ack($LS($ly), LitInt(m#0), LitInt(n#0)) } 
+      Ack#canCall(LitInt(m#0), LitInt(n#0))
+           || (LitInt(m#0) >= LitInt(0)
+             && LitInt(n#0) >= LitInt(0))
+         ==> (LitInt(m#0) != LitInt(0)
+             ==> (LitInt(n#0) == LitInt(0)
+                 ==> Ack#canCall(LitInt(m#0 - 1), LitInt(1)))
+               && (LitInt(n#0) != LitInt(0)
+                 ==> Ack#canCall(LitInt(m#0), LitInt(n#0 - 1))
+                   && Ack#canCall(LitInt(m#0 - 1), 
+                    LitInt(Ack($LS($ly), LitInt(m#0), LitInt(n#0 - 1))))))
+           && Ack($LS($ly), LitInt(m#0), LitInt(n#0))
+             == (if LitInt(m#0) == LitInt(0)
+               then n#0 + 1
+               else (if LitInt(n#0) == LitInt(0)
+                 then Ack($LS($ly), LitInt(m#0 - 1), LitInt(1))
+                 else Ack($LS($ly), 
+                  LitInt(m#0 - 1), 
+                  LitInt(Ack($LS($ly), LitInt(m#0), LitInt(n#0 - 1)))))));
+
+  procedure proof()
+  {
+    var ##m#0: int;
+    var ##n#0: int;
+
+    ##m#0 := LitInt(5);
+    ##n#0 := LitInt(5);
+    assert {:subsumption 0} ##m#0 >= LitInt(0);
+    assert {:subsumption 0} ##n#0 >= LitInt(0);
+    assume Ack#canCall(LitInt(5), LitInt(5));
+    assume Ack#canCall(LitInt(5), LitInt(5));
+    assert LitInt(Ack($LS($LS($LZ)), LitInt(5), LitInt(5))) == LitInt(0);
+  }
+  ";
+  }
+}

--- a/Source/VCExpr/KeepOriginalNamer.cs
+++ b/Source/VCExpr/KeepOriginalNamer.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Boogie.VCExprAST
     public KeepOriginalNamer(ScopedNamer namer) : base(namer)
     {
     }
+
+    public static KeepOriginalNamer Create(ScopedNamer namer = null) {
+      return namer != null ? new KeepOriginalNamer(namer) : new KeepOriginalNamer();
+    }
     
     public override UniqueNamer Clone()
     {

--- a/Source/VCExpr/NormalizeNamer.cs
+++ b/Source/VCExpr/NormalizeNamer.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Boogie.VCExprAST
     {
     }
 
+    public static NormalizeNamer Create(ScopedNamer namer = null) {
+      return namer != null ? new NormalizeNamer(namer) : new NormalizeNamer();
+    }
+
     protected override string GetModifiedName(string uniqueInherentName)
     {
       return "$generated";

--- a/Source/VCExpr/RandomiseNamer.cs
+++ b/Source/VCExpr/RandomiseNamer.cs
@@ -16,6 +16,10 @@ public class RandomiseNamer : ScopedNamer
   {
     this.random = random;
   }
+
+  public static RandomiseNamer Create(Random random, ScopedNamer namer = null) {
+    return namer != null ? new RandomiseNamer(namer, random) : new RandomiseNamer(random);
+  }
   
   private RandomiseNamer(RandomiseNamer namer) : base(namer)
   {

--- a/Source/VCExpr/ScopedNamer.cs
+++ b/Source/VCExpr/ScopedNamer.cs
@@ -52,17 +52,6 @@ namespace Microsoft.Boogie.VCExprAST
       globalNewToOldName = new(namer.globalNewToOldName);
     }
 
-    public virtual void Reset()
-    {
-      GlobalNames.Clear();
-      LocalNames.Clear();
-      LocalNames.Add(new Dictionary<Object /*!*/, string /*!*/>());
-      UsedNames.Clear();
-      CurrentCounters.Clear();
-      GlobalPlusLocalNames.Clear();
-      globalNewToOldName.Clear();
-    }
-
     [ContractInvariantMethod]
     private void GlobalNamesInvariantMethod()
     {

--- a/Source/VCExpr/UniqueNamer.cs
+++ b/Source/VCExpr/UniqueNamer.cs
@@ -5,8 +5,6 @@ namespace Microsoft.Boogie.VCExprAST
   public interface UniqueNamer
   {
     string Lookup(Object thingie);
-    
-    void Reset();
 
     string GetName(Object thing, string name);
     void PopScope();

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Boogie
       Contract.Requires(IsBusy);
 
       status = CheckerStatus.Idle;
-      var becameIdle = false; //thmProver.GoBackToIdle().Wait(TimeSpan.FromMilliseconds(100));
+      var becameIdle = thmProver.GoBackToIdle().Wait(TimeSpan.FromMilliseconds(100));
       if (becameIdle) {
         pool.AddChecker(this);
       } else {

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -61,7 +61,13 @@ namespace Microsoft.Boogie
       Contract.Requires(IsBusy);
 
       status = CheckerStatus.Idle;
-      pool.AddChecker(this);
+      var becameIdle = thmProver.GoBackToIdle().Wait(TimeSpan.FromMilliseconds(100));
+      if (becameIdle) {
+        pool.AddChecker(this);
+      } else {
+        pool.CheckerDied();
+        Close();
+      }
     }
 
     public Task ProverTask { get; set; }
@@ -404,6 +410,11 @@ namespace Microsoft.Boogie
 
         throw new NotImplementedException();
       }
+    }
+
+    public override Task GoBackToIdle()
+    {
+      throw new NotImplementedException();
     }
 
     public override void BeginCheck(string descriptiveName, VCExpr vc, ErrorHandler handler)

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -304,9 +304,12 @@ namespace Microsoft.Boogie
 
     private async Task WaitForOutput(object dummy, CancellationToken cancellationToken)
     {
-      try
-      {
-        outcome = await thmProver.CheckOutcome(cce.NonNull(handler), CommandLineOptions.Clo.ErrorLimit, cancellationToken);
+      try {
+        outcome = await thmProver.CheckOutcome(cce.NonNull(handler), CommandLineOptions.Clo.ErrorLimit,
+          cancellationToken);
+      }
+      catch (OperationCanceledException) {
+        throw;
       }
       catch (UnexpectedProverOutputException e)
       {

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Boogie
       Contract.Requires(IsBusy);
 
       status = CheckerStatus.Idle;
-      var becameIdle = thmProver.GoBackToIdle().Wait(TimeSpan.FromMilliseconds(100));
+      var becameIdle = false; //thmProver.GoBackToIdle().Wait(TimeSpan.FromMilliseconds(100));
       if (becameIdle) {
         pool.AddChecker(this);
       } else {

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Boogie
       this.gen = prover.VCExprGen;
     }
 
-    public void Retarget(Program prog, ProverContext ctx, Split s)
+    public void Retarget(Program prog, ProverContext ctx, Split split)
     {
       lock (this)
       {
@@ -199,7 +199,7 @@ namespace Microsoft.Boogie
         handler = default;
         TheoremProver.FullReset(gen);
         ctx.Reset();
-        Setup(prog, ctx, s);
+        Setup(prog, ctx, split);
       }
     }
 

--- a/Source/VCGeneration/CheckerPool.cs
+++ b/Source/VCGeneration/CheckerPool.cs
@@ -6,18 +6,13 @@ using System.Threading.Tasks;
 using Microsoft.Boogie;
 
 namespace VC
-{  
-  public record CheckerWaiter(
-    TaskCompletionSource<Checker> checkerSource,
-    ConditionGeneration vcgen,
-    Split split = null);
-  
+{
   public class CheckerPool
   {
     private readonly CommandLineOptions options;
 
     private readonly Stack<Checker> availableCheckers = new();
-    private readonly Queue<CheckerWaiter> checkerWaiters = new();
+    private readonly Queue<TaskCompletionSource<Checker>> checkerWaiters = new();
     private int notCreatedCheckers;
     private bool disposed;
     
@@ -49,9 +44,13 @@ namespace VC
 
         Interlocked.Increment(ref notCreatedCheckers);
         var source = new TaskCompletionSource<Checker>();
-        var checkerWaiter = new CheckerWaiter(source, vcgen, split);
-        checkerWaiters.Enqueue(checkerWaiter);
-        return source.Task;
+        checkerWaiters.Enqueue(source);
+        return source.Task.ContinueWith(t =>
+        {
+          PrepareChecker(vcgen.program, split, t.Result);
+          Contract.Assert(t.Result != null);
+          return t.Result;
+        });
       }
       
     }
@@ -77,11 +76,6 @@ namespace VC
           checker.Close();
         }
         availableCheckers.Clear();
-
-        // Notify all checker waiters that they shouldn't wait anymore.
-        foreach (var waiter in checkerWaiters) {
-          waiter.checkerSource.TrySetException(new Exception("CheckerPool was disposed"));
-        }
         disposed = true;
       }
     }
@@ -110,8 +104,7 @@ namespace VC
       lock(this)
       {
         if (checkerWaiters.TryDequeue(out var waiter)) {
-          PrepareChecker(waiter.vcgen.program, waiter.split, checker);
-          if (waiter.checkerSource.TrySetResult(checker)) {
+          if (waiter.TrySetResult(checker)) {
             return;
           }
         }
@@ -122,20 +115,7 @@ namespace VC
 
     public void CheckerDied()
     {
-      if (disposed) {
-        return;
-      }
-      lock(this)
-      {
-        if (checkerWaiters.TryDequeue(out var waiter)) {
-          var checker = CreateNewChecker(waiter.vcgen, waiter.split);
-          if (waiter.checkerSource.TrySetResult(checker)) {
-            return;
-          }
-        }
-
-        Interlocked.Increment(ref notCreatedCheckers);
-      }
+      Interlocked.Increment(ref notCreatedCheckers);
     }
   }
 }

--- a/Source/VCGeneration/CheckerPool.cs
+++ b/Source/VCGeneration/CheckerPool.cs
@@ -35,7 +35,7 @@ namespace VC
           return Task.FromResult(result);
         }
 
-        if (notCreatedCheckers >= 0) {
+        if (notCreatedCheckers > 0) {
           notCreatedCheckers--;
           var checker = CreateNewChecker();
           PrepareChecker(vcgen.program, split, checker);

--- a/Source/VCGeneration/CheckerPool.cs
+++ b/Source/VCGeneration/CheckerPool.cs
@@ -35,15 +35,14 @@ namespace VC
           return Task.FromResult(result);
         }
 
-        int afterDec = Interlocked.Decrement(ref notCreatedCheckers);
-        if (afterDec >= 0) {
+        if (notCreatedCheckers >= 0) {
+          notCreatedCheckers--;
           var checker = CreateNewChecker();
           PrepareChecker(vcgen.program, split, checker);
           Contract.Assert(checker != null);
           return Task.FromResult(checker);
         }
 
-        Interlocked.Increment(ref notCreatedCheckers);
         var source = new TaskCompletionSource<Checker>();
         checkerWaiters.Enqueue(source);
         return source.Task.ContinueWith(t =>
@@ -118,7 +117,7 @@ namespace VC
         if (checkerWaiters.TryDequeue(out var waiter)) {
           waiter.SetResult(CreateNewChecker());
         } else {
-          Interlocked.Increment(ref notCreatedCheckers);
+          notCreatedCheckers++;
         }
       }
     }

--- a/Source/VCGeneration/CheckerPool.cs
+++ b/Source/VCGeneration/CheckerPool.cs
@@ -58,13 +58,12 @@ namespace VC
 
     private Checker CreateNewChecker()
     {
-      // TODO use this log variable.
       var log = options.ProverLogFilePath;
       if (log != null && !log.Contains("@PROC@") && availableCheckers.Count > 0) {
         log = log + "." + availableCheckers.Count;
       } 
 
-      return new Checker(this, options.ProverLogFilePath, options.ProverLogFileAppend);
+      return new Checker(this, log, options.ProverLogFileAppend);
     }
 
     public void Dispose()

--- a/Source/VCGeneration/CheckerPool.cs
+++ b/Source/VCGeneration/CheckerPool.cs
@@ -112,5 +112,10 @@ namespace VC
         availableCheckers.Push(checker);
       }
     }
+
+    public void CheckerDied()
+    {
+      Interlocked.Increment(ref notCreatedCheckers);
+    }
   }
 }

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -22,7 +22,7 @@ namespace VC
   [ContractClassFor(typeof(ConditionGeneration))]
   public abstract class ConditionGenerationContracts : ConditionGeneration
   {
-    public override Outcome VerifyImplementation(Implementation impl, VerifierCallback callback)
+    public override Outcome VerifyImplementation(Implementation impl, VerifierCallback callback, CancellationToken cancellationToken)
     {
       Contract.Requires(impl != null);
       Contract.Requires(callback != null);
@@ -115,7 +115,7 @@ namespace VC
     /// </summary>
     /// <param name="impl"></param>
     public Outcome VerifyImplementation(Implementation impl, out List<Counterexample> /*?*/ errors,
-      string requestId = null)
+      string requestId, CancellationToken cancellationToken)
     {
       Contract.Requires(impl != null);
 
@@ -127,7 +127,7 @@ namespace VC
 
       CounterexampleCollector collector = new CounterexampleCollector();
       collector.RequestId = requestId;
-      Outcome outcome = VerifyImplementation(impl, collector);
+      Outcome outcome = VerifyImplementation(impl, collector, cancellationToken);
       if (outcome == Outcome.Errors || outcome == Outcome.TimedOut || outcome == Outcome.OutOfMemory ||
           outcome == Outcome.OutOfResource)
       {
@@ -142,7 +142,7 @@ namespace VC
       return outcome;
     }
 
-    public abstract Outcome VerifyImplementation(Implementation impl, VerifierCallback callback);
+    public abstract Outcome VerifyImplementation(Implementation impl, VerifierCallback callback, CancellationToken cancellationToken);
 
     /////////////////////////////////// Common Methods and Classes //////////////////////////////////////////
 

--- a/Source/VCGeneration/ProverInterface.cs
+++ b/Source/VCGeneration/ProverInterface.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Boogie.VCExprAST;
 
 namespace Microsoft.Boogie;
@@ -156,12 +158,7 @@ public abstract class ProverInterface
   public abstract void BeginCheck(string descriptiveName, VCExpr vc, ErrorHandler handler);
 
   [NoDefaultContract]
-  public abstract Outcome CheckOutcome(ErrorHandler handler, int errorLimit);
-
-  public virtual string[] CalculatePath(int controlFlowConstant)
-  {
-    throw new System.NotImplementedException();
-  }
+  public abstract Task<Outcome> CheckOutcome(ErrorHandler handler, int errorLimit, CancellationToken cancellationToken);
 
   public virtual void LogComment(string comment)
   {
@@ -236,18 +233,20 @@ public abstract class ProverInterface
   }
 
   // (check-sat + get-unsat-core + checkOutcome)
-  public virtual Outcome CheckAssumptions(List<VCExpr> assumptions, out List<int> unsatCore, ErrorHandler handler)
+  public virtual Task<(Outcome, List<int>)> CheckAssumptions(List<VCExpr> assumptions, ErrorHandler handler,
+    CancellationToken cancellationToken)
   {
     throw new NotImplementedException();
   }
 
-  public virtual Outcome CheckAssumptions(List<VCExpr> hardAssumptions, List<VCExpr> softAssumptions,
-    out List<int> unsatisfiedSoftAssumptions, ErrorHandler handler)
+  public virtual Task<(Outcome, List<int>)> CheckAssumptions(List<VCExpr> hardAssumptions, List<VCExpr> softAssumptions,
+    ErrorHandler handler, CancellationToken cancellationToken)
   {
     throw new NotImplementedException();
   }
 
-  public virtual Outcome CheckOutcomeCore(ErrorHandler handler, int taskID = -1)
+  public virtual Task<Outcome> CheckOutcomeCore(ErrorHandler handler,
+    CancellationToken cancellationToken, int taskID = -1)
   {
     throw new NotImplementedException();
   }
@@ -267,7 +266,7 @@ public abstract class ProverInterface
   {
   }
 
-  public virtual int GetRCount()
+  public virtual Task<int> GetRCount()
   {
     throw new NotImplementedException();
   }
@@ -285,7 +284,7 @@ public abstract class ProverInterface
   {
   }
 
-  public virtual object Evaluate(VCExpr expr)
+  public virtual Task<object> Evaluate(VCExpr expr)
   {
     throw new NotImplementedException();
   }

--- a/Source/VCGeneration/ProverInterface.cs
+++ b/Source/VCGeneration/ProverInterface.cs
@@ -294,4 +294,6 @@ public abstract class ProverInterface
   {
     throw new NotImplementedException();
   }
+
+  public abstract Task GoBackToIdle();
 }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1299,7 +1299,7 @@ namespace VC
           DumpDot(splitNum);
         }
 
-        totalResourceCount += checker.ProverResourceCount;
+        totalResourceCount += checker.GetProverResourceCount().Result;
 
         proverFailed = false;
 
@@ -1350,7 +1350,7 @@ namespace VC
       /// <summary>
       /// As a side effect, updates "this.parent.CumulativeAssertionCount".
       /// </summary>
-      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, uint timeout, uint rlimit)
+      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, uint timeout, uint rlimit, CancellationToken cancellationToken)
       {
         Contract.Requires(checker != null);
         Contract.Requires(callback != null);
@@ -1396,7 +1396,7 @@ namespace VC
             desc += "_split" + no;
           }
 
-          checker.BeginCheck(desc, vc, reporter, timeout, rlimit);
+          checker.BeginCheck(desc, vc, reporter, timeout, rlimit, cancellationToken);
         }
       }
 

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -99,6 +99,7 @@ namespace VC
       var checker = await split.parent.CheckerPool.FindCheckerFor(split.parent, split);
 
       try {
+        cancellationToken.ThrowIfCancellationRequested();
         StartCheck(split, checker, cancellationToken);
         await split.ProverTask;
         await ProcessResult(split, cancellationToken);

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -99,8 +99,8 @@ namespace VC
       var checker = await split.parent.CheckerPool.FindCheckerFor(split.parent, split);
 
       try {
-        StartCheck(split, checker);
-        await split.ProverTask.WaitAsync(cancellationToken);
+        StartCheck(split, checker, cancellationToken);
+        await split.ProverTask;
         await ProcessResult(split, cancellationToken);
       }
       finally {
@@ -108,7 +108,7 @@ namespace VC
       }
     }
 
-    private void StartCheck(Split split, Checker checker)
+    private void StartCheck(Split split, Checker checker, CancellationToken cancellationToken)
     {
       int currentSplitNumber = DoSplitting ? Interlocked.Increment(ref splitNumber) - 1 : -1;
       if (options.Trace && DoSplitting) {
@@ -126,7 +126,7 @@ namespace VC
       var timeout = KeepGoing && split.LastChance ? options.VcsFinalAssertTimeout :
         KeepGoing ? options.VcsKeepGoingTimeout :
         implementation.TimeLimit;
-      split.BeginCheck(checker, callback, mvInfo, currentSplitNumber, timeout, implementation.ResourceLimit);
+      split.BeginCheck(checker, callback, mvInfo, currentSplitNumber, timeout, implementation.ResourceLimit, cancellationToken);
     }
 
     private async Task ProcessResult(Split split, CancellationToken cancellationToken)

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -805,7 +805,7 @@ namespace VC
       }
     }
 
-    public override Outcome VerifyImplementation(Implementation impl, VerifierCallback callback)
+    public override Outcome VerifyImplementation(Implementation impl, VerifierCallback callback, CancellationToken cancellationToken)
     {
       Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
 
@@ -867,7 +867,7 @@ namespace VC
       }
 
       var worker = new SplitAndVerifyWorker(CommandLineOptions.Clo, this, impl, gotoCmdOrigins, callback, mvInfo, outcome);
-      outcome = worker.WorkUntilDone().Result;
+      outcome = worker.WorkUntilDone(cancellationToken).Result;
       ResourceCount = worker.ResourceCount;
       
       if (outcome == Outcome.Correct && smoke_tester != null)

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -351,7 +351,7 @@ namespace VC
             }
 
             ch.BeginCheck(cce.NonNull(impl.Name + "_smoke" + id++), vc, new ErrorHandler(absyIds, this.callback),
-              CommandLineOptions.Clo.SmokeTimeout, CommandLineOptions.Clo.ResourceLimit);
+              CommandLineOptions.Clo.SmokeTimeout, CommandLineOptions.Clo.ResourceLimit, CancellationToken.None);
           }
 
           ch.ProverTask.Wait();


### PR DESCRIPTION
This PR enables Boogie's execution engine to effectively kill verification on demand, and recycle killed checkers/SMTLib processes

## Changes

- Enable cancellation while waiting for input from the solver
- Only recycle a `Checker` if its associated prover is responsive
- Return a `PipelineOutcome.Cancelled` outcome if a request was cancelled.

## Issues it fixes
This PR should be able to fix the following bugs:
https://github.com/dafny-lang/ide-vscode/issues/119
https://github.com/dafny-lang/ide-vscode/issues/114
https://github.com/dafny-lang/ide-vscode/issues/96

## How it has been tested

1. Add a unit test `InferAndVerifyCanBeCancelledWhileWaitingForProver`

2. Dafny tests
https://github.com/dafny-lang/dafny/pull/1771
It takes a program which is hard to verify, and two changes that makes it easy to verify and then a parse error.
Without this PR, the test fails and loops indefinitely on the first program.
With this PR, the tests succeeds and all the changes are taken into account.
