### PR TITLE
Reduce references to `CoreOptions.Clo` from 204 to 92

### DIFF
--- a/Source/AbsInt/IntervalDomain.cs
+++ b/Source/AbsInt/IntervalDomain.cs
@@ -214,8 +214,8 @@ namespace Microsoft.Boogie.AbstractInterpretation
 
       public Expr ToExpr()
       {
-        if (!V.IsMutable && CommandLineOptions.Clo.InstrumentInfer !=
-          CommandLineOptions.InstrumentationPlaces.Everywhere)
+        if (!V.IsMutable && CoreOptions.Clo.InstrumentInfer !=
+          CoreOptions.InstrumentationPlaces.Everywhere)
         {
           // omit invariants about readonly variables
           return Expr.True;

--- a/Source/AbsInt/NativeLattice.cs
+++ b/Source/AbsInt/NativeLattice.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
       Helpers.ExtraTraceInformation("Starting abstract interpretation");
 
       DateTime start = new DateTime(); // to please compiler's definite assignment rules
-      if (CommandLineOptions.Clo.Trace)
+      if (CoreOptions.Clo.Trace)
       {
         Console.WriteLine();
         Console.WriteLine("Running abstract interpretation...");
@@ -87,11 +87,11 @@ namespace Microsoft.Boogie.AbstractInterpretation
       WidenPoints.Compute(program);
 
       NativeLattice lattice = null;
-      if (CommandLineOptions.Clo.Ai.J_Trivial)
+      if (CoreOptions.Clo.Ai.J_Trivial)
       {
         lattice = new TrivialDomain();
       }
-      else if (CommandLineOptions.Clo.Ai.J_Intervals)
+      else if (CoreOptions.Clo.Ai.J_Intervals)
       {
         lattice = new NativeIntervalDomain();
       }
@@ -100,13 +100,13 @@ namespace Microsoft.Boogie.AbstractInterpretation
       {
         Dictionary<Procedure, Implementation[]> procedureImplementations = ComputeProcImplMap(program);
         ComputeProgramInvariants(program, procedureImplementations, lattice);
-        if (CommandLineOptions.Clo.Ai.DebugStatistics)
+        if (CoreOptions.Clo.Ai.DebugStatistics)
         {
           Console.Error.WriteLine(lattice.DebugStatistics);
         }
       }
 
-      if (CommandLineOptions.Clo.Trace)
+      if (CoreOptions.Clo.Trace)
       {
         DateTime end = DateTime.UtcNow;
         TimeSpan elapsed = end - start;
@@ -180,7 +180,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
       // the additional information.
       var pre = new NativeLattice.Element[impl.Blocks
         .Count]; // set to null if we never compute a join/widen at this block
-      var post = CommandLineOptions.Clo.InstrumentInfer == CommandLineOptions.InstrumentationPlaces.Everywhere
+      var post = CoreOptions.Clo.InstrumentInfer == CoreOptions.InstrumentationPlaces.Everywhere
         ? new NativeLattice.Element[impl.Blocks.Count]
         : null;
       var iterations = new int[impl.Blocks.Count];
@@ -223,7 +223,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
           // no change
           continue;
         }
-        else if (b.widenBlock && CommandLineOptions.Clo.Ai.StepsBeforeWidening <= iterations[id])
+        else if (b.widenBlock && CoreOptions.Clo.Ai.StepsBeforeWidening <= iterations[id])
         {
           e = lattice.Widen(pre[id], e);
           pre[id] = e;
@@ -269,14 +269,14 @@ namespace Microsoft.Boogie.AbstractInterpretation
       foreach (var b in impl.Blocks)
       {
         var element = pre[b.aiId];
-        if (element != null && (b.widenBlock || CommandLineOptions.Clo.InstrumentInfer ==
-          CommandLineOptions.InstrumentationPlaces.Everywhere))
+        if (element != null && (b.widenBlock || CoreOptions.Clo.InstrumentInfer ==
+          CoreOptions.InstrumentationPlaces.Everywhere))
         {
           List<Cmd> newCommands = new List<Cmd>();
           Expr inv = element.ToExpr();
           PredicateCmd cmd;
           var kv = new QKeyValue(Token.NoToken, "inferred", new List<object>(), null);
-          if (CommandLineOptions.Clo.InstrumentWithAsserts)
+          if (CoreOptions.Clo.InstrumentWithAsserts)
           {
             cmd = new AssertCmd(Token.NoToken, inv, kv);
           }
@@ -291,7 +291,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
           {
             inv = post[b.aiId].ToExpr();
             kv = new QKeyValue(Token.NoToken, "inferred", new List<object>(), null);
-            if (CommandLineOptions.Clo.InstrumentWithAsserts)
+            if (CoreOptions.Clo.InstrumentWithAsserts)
             {
               cmd = new AssertCmd(Token.NoToken, inv, kv);
             }

--- a/Source/BoogieDriver/BoogieDriver.cs
+++ b/Source/BoogieDriver/BoogieDriver.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Boogie
       Contract.Requires(cce.NonNullElements(args));
 
 
-      var options = new CommandLineOptionsImpl
+      var options = new CommandLineOptions
       {
         RunningBoogieFromCommandLine = true
       };
       ExecutionEngine.printer = new ConsolePrinter(options);
-      CommandLineOptionsImpl.Install(options);
+      CommandLineOptions.Install(options);
 
       if (!options.Parse(args))
       {
@@ -67,9 +67,9 @@ namespace Microsoft.Boogie
 
       var success = ExecutionEngine.ProcessFiles(options, fileList);
 
-      if (CommandLineOptions.Clo.XmlSink != null)
+      if (CoreOptions.Clo.XmlSink != null)
       {
-        CommandLineOptions.Clo.XmlSink.Close();
+        CoreOptions.Clo.XmlSink.Close();
       }
 
       if (options.Wait)
@@ -81,7 +81,7 @@ namespace Microsoft.Boogie
       return success ? 0 : 1;
     }
 
-    private static List<string> GetFileList(CommandLineOptionsImpl options)
+    private static List<string> GetFileList(CommandLineOptions options)
     {
       List<string> fileList = new List<string>();
       foreach (string file in options.Files)

--- a/Source/BoogieDriver/BoogieDriver.cs
+++ b/Source/BoogieDriver/BoogieDriver.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(cce.NonNullElements(args));
 
-
       var options = new CommandLineOptions
       {
         RunningBoogieFromCommandLine = true
@@ -23,6 +22,7 @@ namespace Microsoft.Boogie
       {
         return 1;
       }
+      using var executionEngine = new ExecutionEngine(options);
       
       if (options.ProcessInfoFlags())
       {
@@ -65,7 +65,7 @@ namespace Microsoft.Boogie
 
       Helpers.ExtraTraceInformation("Becoming sentient");
 
-      var success = ExecutionEngine.ProcessFiles(options, fileList);
+      var success = executionEngine.ProcessFiles(fileList);
 
       if (CoreOptions.Clo.XmlSink != null)
       {

--- a/Source/Concurrency/ConcurrencyOptions.cs
+++ b/Source/Concurrency/ConcurrencyOptions.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.Boogie;
 
-public interface ConcurrencyOptions : CommandLineOptions
+public interface ConcurrencyOptions : CoreOptions
 {
   bool TrustMoverTypes { get; }
   bool TrustInductiveSequentialization { get; }

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Boogie
         {
           int e = rc.ErrorCount;
           d.Resolve(rc);
-          if (CommandLineOptions.Clo.OverlookBoogieTypeErrors && rc.ErrorCount != e && d is Implementation)
+          if (CoreOptions.Clo.OverlookBoogieTypeErrors && rc.ErrorCount != e && d is Implementation)
           {
             // ignore this implementation
             System.Console.WriteLine("Warning: Ignoring implementation {0} because of translation resolution errors",
@@ -813,7 +813,7 @@ namespace Microsoft.Boogie
     /// <returns></returns>
     private HashSet<Block> GetBreakBlocksOfLoop(Block header, Block backEdgeNode, Graph<Block /*!*/> /*!*/ g)
     {
-      Contract.Assert(CommandLineOptions.Clo.DeterministicExtractLoops,
+      Contract.Assert(CoreOptions.Clo.DeterministicExtractLoops,
         "Can only be called with /deterministicExtractLoops option");
       var immSuccBlks = new HashSet<Block>();
       var loopBlocks = g.NaturalLoops(header, backEdgeNode);
@@ -842,7 +842,7 @@ namespace Microsoft.Boogie
 
     private HashSet<Block> GetBlocksInAllNaturalLoops(Block header, Graph<Block /*!*/> /*!*/ g)
     {
-      Contract.Assert(CommandLineOptions.Clo.DeterministicExtractLoops,
+      Contract.Assert(CoreOptions.Clo.DeterministicExtractLoops,
         "Can only be called with /deterministicExtractLoops option");
       var allBlocksInNaturalLoops = new HashSet<Block>();
       foreach (Block /*!*/ source in g.BackEdgeNodes(header))
@@ -882,7 +882,7 @@ namespace Microsoft.Boogie
         AddToFullMap(fullMap, impl.Name, block.Label, block);
       }
 
-      bool detLoopExtract = CommandLineOptions.Clo.DeterministicExtractLoops;
+      bool detLoopExtract = CoreOptions.Clo.DeterministicExtractLoops;
 
       Dictionary<Block /*!*/, List<Variable> /*!*/> /*!*/
         loopHeaderToInputs = new Dictionary<Block /*!*/, List<Variable> /*!*/>();
@@ -1467,7 +1467,7 @@ namespace Microsoft.Boogie
             fullMap[impl.Name] = null;
             procsWithIrreducibleLoops.Add(impl.Name);
 
-            if (CommandLineOptions.Clo.ExtractLoopsUnrollIrreducible)
+            if (CoreOptions.Clo.ExtractLoopsUnrollIrreducible)
             {
               // statically unroll loops in this procedure
 
@@ -1480,7 +1480,7 @@ namespace Microsoft.Boogie
 
               // unroll
               Block start = impl.Blocks[0];
-              impl.Blocks = LoopUnroll.UnrollLoops(start, CommandLineOptions.Clo.RecursionBound, false);
+              impl.Blocks = LoopUnroll.UnrollLoops(start, CoreOptions.Clo.RecursionBound, false);
 
               // Now construct the "map back" information
               // Resulting block label -> original block
@@ -1936,11 +1936,11 @@ namespace Microsoft.Boogie
     {
       get
       {
-        uint tl = CommandLineOptions.Clo.TimeLimit;
+        uint tl = CoreOptions.Clo.TimeLimit;
         CheckUIntAttribute("timeLimit", ref tl);
         if (tl < 0)
         {
-          tl = CommandLineOptions.Clo.TimeLimit;
+          tl = CoreOptions.Clo.TimeLimit;
         }
         return tl;
       }
@@ -1950,11 +1950,11 @@ namespace Microsoft.Boogie
     {
       get
       {
-        uint rl = CommandLineOptions.Clo.ResourceLimit;
+        uint rl = CoreOptions.Clo.ResourceLimit;
         CheckUIntAttribute("rlimit", ref rl);
         if (rl < 0)
         {
-          rl = CommandLineOptions.Clo.ResourceLimit;
+          rl = CoreOptions.Clo.ResourceLimit;
         }
         return rl;
       }
@@ -2388,7 +2388,7 @@ namespace Microsoft.Boogie
         EmitAttributes(stream);
       }
 
-      if (CommandLineOptions.Clo.PrintWithUniqueASTIds && this.TypedIdent.HasName)
+      if (CoreOptions.Clo.PrintWithUniqueASTIds && this.TypedIdent.HasName)
       {
         stream.Write("h{0}^^",
           this.GetHashCode()); // the idea is that this will prepend the name printed by TypedIdent.Emit
@@ -3399,7 +3399,7 @@ namespace Microsoft.Boogie
         stream.Write("{:define} ");
       }
 
-      if (CommandLineOptions.Clo.PrintWithUniqueASTIds)
+      if (CoreOptions.Clo.PrintWithUniqueASTIds)
       {
         stream.Write("h{0}^^{1}", this.GetHashCode(), TokenTextWriter.SanitizeIdentifier(this.Name));
       }
@@ -4228,8 +4228,8 @@ namespace Microsoft.Boogie
           return true;
         }
 
-        if (CommandLineOptions.Clo.ProcedureInlining == CommandLineOptions.Inlining.Assert ||
-            CommandLineOptions.Clo.ProcedureInlining == CommandLineOptions.Inlining.Assume)
+        if (CoreOptions.Clo.ProcedureInlining == CoreOptions.Inlining.Assert ||
+            CoreOptions.Clo.ProcedureInlining == CoreOptions.Inlining.Assume)
         {
           Expr inl = this.FindExprAttribute("inline");
           if (inl == null)
@@ -4243,7 +4243,7 @@ namespace Microsoft.Boogie
           }
         }
 
-        if (CommandLineOptions.Clo.StratifiedInlining > 0)
+        if (CoreOptions.Clo.StratifiedInlining > 0)
         {
           return !QKeyValue.FindBoolAttribute(Attributes, "entrypoint");
         }
@@ -4527,31 +4527,31 @@ namespace Microsoft.Boogie
         v.Emit(stream, level + 1);
       }
 
-      if (this.StructuredStmts != null && !CommandLineOptions.Clo.PrintInstrumented &&
-          !CommandLineOptions.Clo.PrintInlined)
+      if (this.StructuredStmts != null && !CoreOptions.Clo.PrintInstrumented &&
+          !CoreOptions.Clo.PrintInlined)
       {
         if (this.LocVars.Count > 0)
         {
           stream.WriteLine();
         }
 
-        if (CommandLineOptions.Clo.PrintUnstructured < 2)
+        if (CoreOptions.Clo.PrintUnstructured < 2)
         {
-          if (CommandLineOptions.Clo.PrintUnstructured == 1)
+          if (CoreOptions.Clo.PrintUnstructured == 1)
           {
             stream.WriteLine(this, level + 1, "/*** structured program:");
           }
 
           this.StructuredStmts.Emit(stream, level + 1);
-          if (CommandLineOptions.Clo.PrintUnstructured == 1)
+          if (CoreOptions.Clo.PrintUnstructured == 1)
           {
             stream.WriteLine(level + 1, "**** end structured program */");
           }
         }
       }
 
-      if (this.StructuredStmts == null || 1 <= CommandLineOptions.Clo.PrintUnstructured ||
-          CommandLineOptions.Clo.PrintInstrumented || CommandLineOptions.Clo.PrintInlined)
+      if (this.StructuredStmts == null || 1 <= CoreOptions.Clo.PrintUnstructured ||
+          CoreOptions.Clo.PrintInstrumented || CoreOptions.Clo.PrintInlined)
       {
         foreach (Block b in this.Blocks)
         {
@@ -4795,7 +4795,7 @@ namespace Microsoft.Boogie
 
         this.formalMap = map;
 
-        if (CommandLineOptions.Clo.PrintWithUniqueASTIds)
+        if (CoreOptions.Clo.PrintWithUniqueASTIds)
         {
           Console.WriteLine("Implementation.GetImplFormalMap on {0}:", this.Name);
           using TokenTextWriter stream =
@@ -4974,7 +4974,7 @@ namespace Microsoft.Boogie
           reachable.Add(b);
           if (b.TransferCmd is GotoCmd)
           {
-            if (CommandLineOptions.Clo.PruneInfeasibleEdges)
+            if (CoreOptions.Clo.PruneInfeasibleEdges)
             {
               foreach (Cmd /*!*/ s in b.Cmds)
               {

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Boogie
       if (!Anonymous)
       {
         stream.WriteLine(level, "{0}:",
-          CommandLineOptions.Clo.PrintWithUniqueASTIds
+          CoreOptions.Clo.PrintWithUniqueASTIds
             ? String.Format("h{0}^^{1}", this.GetHashCode(), this.LabelName)
             : this.LabelName);
       }
@@ -1331,7 +1331,7 @@ namespace Microsoft.Boogie
         this,
         level,
         "{0}:{1}",
-        CommandLineOptions.Clo.PrintWithUniqueASTIds
+        CoreOptions.Clo.PrintWithUniqueASTIds
           ? String.Format("h{0}^^{1}", this.GetHashCode(), this.Label)
           : this.Label,
         this.widenBlock ? "  // cut point" : "");
@@ -1427,7 +1427,7 @@ namespace Microsoft.Boogie
     public static void ComputeChecksums(Cmd cmd, Implementation impl, ISet<Variable> usedVariables,
       byte[] currentChecksum = null)
     {
-      if (CommandLineOptions.Clo.VerifySnapshots < 2)
+      if (CoreOptions.Clo.VerifySnapshots < 2)
       {
         return;
       }
@@ -1568,7 +1568,7 @@ namespace Microsoft.Boogie
         {
           tc.Error(this, "command assigns to an immutable variable: {0}", v.Name);
         }
-        else if (!CommandLineOptions.Clo.DoModSetAnalysis && v is GlobalVariable)
+        else if (!CoreOptions.Clo.DoModSetAnalysis && v is GlobalVariable)
         {
           if (!tc.Yields && !tc.InFrame(v))
           {
@@ -1730,7 +1730,7 @@ namespace Microsoft.Boogie
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      if (!CommandLineOptions.Clo.DoModSetAnalysis && !tc.Yields)
+      if (!CoreOptions.Clo.DoModSetAnalysis && !tc.Yields)
       {
         tc.Error(this, "enclosing procedure of a yield command must yield");
       }
@@ -2553,7 +2553,7 @@ namespace Microsoft.Boogie
     public override void Emit(TokenTextWriter stream, int level)
     {
       //Contract.Requires(stream != null);
-      if (CommandLineOptions.Clo.PrintDesugarings && !stream.UseForComputingChecksums)
+      if (CoreOptions.Clo.PrintDesugarings && !stream.UseForComputingChecksums)
       {
         stream.WriteLine(this, level, "/*** desugaring:");
         Desugaring.Emit(stream, level);
@@ -2733,7 +2733,7 @@ namespace Microsoft.Boogie
     public override void Typecheck(TypecheckingContext tc)
     {
       TypecheckAttributes(Attributes, tc);
-      if (!CommandLineOptions.Clo.DoModSetAnalysis)
+      if (!CoreOptions.Clo.DoModSetAnalysis)
       {
         if (!tc.Yields)
         {
@@ -3139,7 +3139,7 @@ namespace Microsoft.Boogie
       TypeParameters = SimpleTypeParamInstantiation.From(Proc.TypeParameters,
         actualTypeParams);
 
-      if (!CommandLineOptions.Clo.DoModSetAnalysis && IsAsync)
+      if (!CoreOptions.Clo.DoModSetAnalysis && IsAsync)
       {
         if (!tc.Yields)
         {
@@ -3310,7 +3310,7 @@ namespace Microsoft.Boogie
           }
         }
         else if (req.CanAlwaysAssume()
-                || CommandLineOptions.Clo.StratifiedInlining > 0)
+                || CoreOptions.Clo.StratifiedInlining > 0)
         {
           // inject free requires as assume statements at the call site
           AssumeCmd /*!*/
@@ -4312,7 +4312,7 @@ namespace Microsoft.Boogie
       //Contract.Requires(stream != null);
       Contract.Assume(this.labelNames != null);
       stream.Write(this, level, "goto ");
-      if (CommandLineOptions.Clo.PrintWithUniqueASTIds)
+      if (CoreOptions.Clo.PrintWithUniqueASTIds)
       {
         if (labelTargets == null)
         {

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -1294,7 +1294,7 @@ namespace Microsoft.Boogie
     public override void Emit(TokenTextWriter stream, int contextBindingStrength, bool fragileContext)
     {
       //Contract.Requires(stream != null);
-      if (CommandLineOptions.Clo.PrintWithUniqueASTIds && !stream.UseForComputingChecksums)
+      if (CoreOptions.Clo.PrintWithUniqueASTIds && !stream.UseForComputingChecksums)
       {
         stream.Write("{0}^^", this.Decl == null ? "NoDecl" : "h" + this.Decl.GetHashCode());
       }

--- a/Source/Core/CoreOptions.cs
+++ b/Source/Core/CoreOptions.cs
@@ -6,10 +6,10 @@ namespace Microsoft.Boogie
   /// Boogie command-line options (other tools can subclass this class in order to support a
   /// superset of Boogie's options).
   /// </summary>
-  public interface CommandLineOptions
+  public interface CoreOptions
   {
 
-    public static CommandLineOptions /*!*/ Clo
+    public static CoreOptions /*!*/ Clo
     {
       get;
       set;

--- a/Source/Core/DeadVarElim.cs
+++ b/Source/Core/DeadVarElim.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(program != null);
 
-      if (CommandLineOptions.Clo.Trace)
+      if (CoreOptions.Clo.Trace)
       {
 //          Console.WriteLine();
 //          Console.WriteLine("Running modset analysis ...");
@@ -602,7 +602,7 @@ namespace Microsoft.Boogie
       Microsoft.Boogie.Helpers.ExtraTraceInformation("Starting live variable analysis");
       Graph<Block> dag = Program.GraphFromBlocks(impl.Blocks, false);
       IEnumerable<Block> sortedNodes;
-      if (CommandLineOptions.Clo.ModifyTopologicalSorting)
+      if (CoreOptions.Clo.ModifyTopologicalSorting)
       {
         sortedNodes = dag.TopologicalSort(true);
       }

--- a/Source/Core/Helpers.cs
+++ b/Source/Core/Helpers.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Boogie
     public static void ExtraTraceInformation(string point)
     {
       Contract.Requires(point != null);
-      if (CommandLineOptions.Clo.TraceTimes)
+      if (CoreOptions.Clo.TraceTimes)
       {
         DateTime now = DateTime.UtcNow;
         TimeSpan timeSinceStartUp = now - StartUp;

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Boogie
 
     public override Expr VisitCodeExpr(CodeExpr node)
     {
-      Inliner codeExprInliner = new Inliner(program, inlineCallback, CommandLineOptions.Clo.InlineDepth);
+      Inliner codeExprInliner = new Inliner(program, inlineCallback, CoreOptions.Clo.InlineDepth);
       codeExprInliner.newLocalVars.AddRange(node.LocVars);
       codeExprInliner.inlinedProcLblMap = this.inlinedProcLblMap;
       List<Block> newCodeExprBlocks = codeExprInliner.DoInlineBlocks(node.Blocks, ref inlinedSomething);
@@ -171,7 +171,7 @@ namespace Microsoft.Boogie
       // we need to resolve the new code
       inliner.ResolveImpl(impl);
 
-      if (CommandLineOptions.Clo.PrintInlined)
+      if (CoreOptions.Clo.PrintInlined)
       {
         inliner.EmitImpl(impl);
       }
@@ -182,7 +182,7 @@ namespace Microsoft.Boogie
       Contract.Requires(impl != null);
       Contract.Requires(program != null);
       Contract.Requires(impl.Proc != null);
-      ProcessImplementation(program, impl, new Inliner(program, null, CommandLineOptions.Clo.InlineDepth));
+      ProcessImplementation(program, impl, new Inliner(program, null, CoreOptions.Clo.InlineDepth));
     }
 
     public static void ProcessImplementation(Program program, Implementation impl)
@@ -388,12 +388,12 @@ namespace Microsoft.Boogie
             else if (inline == 0)
             {
               inlinedSomething = true;
-              if (CommandLineOptions.Clo.ProcedureInlining == CommandLineOptions.Inlining.Assert)
+              if (CoreOptions.Clo.ProcedureInlining == CoreOptions.Inlining.Assert)
               {
                 // add assert
                 newCmds.Add(new AssertCmd(callCmd.tok, Expr.False));
               }
-              else if (CommandLineOptions.Clo.ProcedureInlining == CommandLineOptions.Inlining.Assume)
+              else if (CoreOptions.Clo.ProcedureInlining == CoreOptions.Inlining.Assume)
               {
                 // add assume
                 newCmds.Add(new AssumeCmd(callCmd.tok, Expr.False));

--- a/Source/Core/InterProceduralReachabilityGraph.cs
+++ b/Source/Core/InterProceduralReachabilityGraph.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Boogie
     {
       if (ReachabilityGraphSCCsDAG == null)
       {
-        if (CommandLineOptions.Clo.Trace)
+        if (CoreOptions.Clo.Trace)
         {
           Console.WriteLine("Interprocedural reachability: computing SCCs");
         }
@@ -292,7 +292,7 @@ namespace Microsoft.Boogie
           ReachabilityGraphSCCsDAG.AddEdge(BlockToSCC[n], dummy);
         }
 
-        if (CommandLineOptions.Clo.Trace)
+        if (CoreOptions.Clo.Trace)
         {
           Console.WriteLine("Interprocedural reachability: SCCs computed!");
         }

--- a/Source/Core/LambdaHelper.cs
+++ b/Source/Core/LambdaHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Boogie
       program = v.VisitProgram(program);
       axioms = v.lambdaAxioms;
       functions = v.lambdaFunctions;
-      if (CommandLineOptions.Clo.TraceVerify)
+      if (CoreOptions.Clo.TraceVerify)
       {
         Console.WriteLine("Desugaring of lambda expressions produced {0} functions and {1} axioms:", functions.Count,
           axioms.Count);
@@ -121,7 +121,7 @@ namespace Microsoft.Boogie
           return baseResult; // apparently, the base visitor already turned the lambda into something else
         }
 
-        return CommandLineOptions.Clo.FreeVarLambdaLifting ? LiftLambdaFreeVars(lambda) : LiftLambdaMaxHoles(lambda);
+        return CoreOptions.Clo.FreeVarLambdaLifting ? LiftLambdaFreeVars(lambda) : LiftLambdaMaxHoles(lambda);
       }
 
       /// <summary>
@@ -174,7 +174,7 @@ namespace Microsoft.Boogie
           Substituter.SubstitutionFromDictionary(oldSubst),
           lambda.Attributes);
 
-        if (0 < CommandLineOptions.Clo.VerifySnapshots &&
+        if (0 < CoreOptions.Clo.VerifySnapshots &&
             QKeyValue.FindStringAttribute(lambdaAttrs, "checksum") == null)
         {
           // Attach a dummy checksum to avoid issues in the dependency analysis.
@@ -250,14 +250,14 @@ namespace Microsoft.Boogie
 
         if (liftedLambdas.TryGetValue(lambda, out var fcall))
         {
-          if (CommandLineOptions.Clo.TraceVerify)
+          if (CoreOptions.Clo.TraceVerify)
           {
             Console.WriteLine("Old lambda: {0}", lam_str);
           }
         }
         else
         {
-          if (CommandLineOptions.Clo.TraceVerify)
+          if (CoreOptions.Clo.TraceVerify)
           {
             Console.WriteLine("New lambda: {0}", lam_str);
           }

--- a/Source/Core/MaxHolesLambdaLifter.cs
+++ b/Source/Core/MaxHolesLambdaLifter.cs
@@ -346,7 +346,7 @@ namespace Core
 
 
       var lambdaAttrs = _lambda.Attributes;
-      if (0 < CommandLineOptions.Clo.VerifySnapshots && QKeyValue.FindStringAttribute(lambdaAttrs, "checksum") == null)
+      if (0 < CoreOptions.Clo.VerifySnapshots && QKeyValue.FindStringAttribute(lambdaAttrs, "checksum") == null)
       {
         // Attach a dummy checksum to avoid issues in the dependency analysis.
         var checksumAttr = new QKeyValue(_lambda.tok, "checksum", new List<object> {"lambda expression"}, null);
@@ -381,14 +381,14 @@ namespace Core
 
       if (_liftedLambdas.TryGetValue(liftedLambda, out var fcall))
       {
-        if (CommandLineOptions.Clo.TraceVerify)
+        if (CoreOptions.Clo.TraceVerify)
         {
           Console.WriteLine("Old lambda: {0}", lam_str);
         }
       }
       else
       {
-        if (CommandLineOptions.Clo.TraceVerify)
+        if (CoreOptions.Clo.TraceVerify)
         {
           Console.WriteLine("New lambda: {0}", lam_str);
         }

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -628,7 +628,7 @@ namespace Microsoft.Boogie
 
       private static bool IsInlined(Implementation impl)
       {
-        if (CommandLineOptions.Clo.ProcedureInlining == CommandLineOptions.Inlining.None)
+        if (CoreOptions.Clo.ProcedureInlining == CoreOptions.Inlining.None)
         {
           return false;
         }

--- a/Source/Core/VariableDependenceAnalyser.cs
+++ b/Source/Core/VariableDependenceAnalyser.cs
@@ -265,21 +265,21 @@ namespace Microsoft.Boogie
        * 
        */
 
-      if (CommandLineOptions.Clo.Trace)
+      if (CoreOptions.Clo.Trace)
       {
         Console.WriteLine("Variable dependence analysis: Initialising");
       }
 
       Initialise();
 
-      if (CommandLineOptions.Clo.Trace)
+      if (CoreOptions.Clo.Trace)
       {
         Console.WriteLine("Variable dependence analysis: Computing control dependence info");
       }
 
       BlockToControllingBlocks = ComputeGlobalControlDependences();
 
-      if (CommandLineOptions.Clo.Trace)
+      if (CoreOptions.Clo.Trace)
       {
         Console.WriteLine("Variable dependence analysis: Computing control dependence variables");
       }
@@ -287,7 +287,7 @@ namespace Microsoft.Boogie
       ControllingBlockToVariables = ComputeControllingVariables(BlockToControllingBlocks);
       foreach (var Impl in prog.NonInlinedImplementations())
       {
-        if (CommandLineOptions.Clo.Trace)
+        if (CoreOptions.Clo.Trace)
         {
           Console.WriteLine("Variable dependence analysis: Analysing " + Impl.Name);
         }
@@ -384,7 +384,7 @@ namespace Microsoft.Boogie
     {
       foreach (var n in vs)
       {
-        if (CommandLineOptions.Clo.DebugStagedHoudini)
+        if (CoreOptions.Clo.DebugStagedHoudini)
         {
           Console.WriteLine("Adding dependence " + v + " -> " + n + ", reason: " + reason + "(" + tok.line + ":" +
                             tok.col + ")");
@@ -471,14 +471,14 @@ namespace Microsoft.Boogie
     private void MakeIgnoreList()
     {
       IgnoredVariables = new HashSet<VariableDescriptor>();
-      if (CommandLineOptions.Clo.VariableDependenceIgnore == null)
+      if (CoreOptions.Clo.VariableDependenceIgnore == null)
       {
         return;
       }
 
       try
       {
-        var file = System.IO.File.OpenText(CommandLineOptions.Clo.VariableDependenceIgnore);
+        var file = System.IO.File.OpenText(CoreOptions.Clo.VariableDependenceIgnore);
         while (!file.EndOfStream)
         {
           string line = file.ReadLine();
@@ -507,7 +507,7 @@ namespace Microsoft.Boogie
       catch (System.IO.IOException e)
       {
         Console.Error.WriteLine("Error reading from ignored variables file " +
-                                CommandLineOptions.Clo.VariableDependenceIgnore + ": " + e);
+                                CoreOptions.Clo.VariableDependenceIgnore + ": " + e);
       }
     }
 
@@ -654,7 +654,7 @@ namespace Microsoft.Boogie
     {
       if (DependsOnSCCsDAG == null)
       {
-        if (CommandLineOptions.Clo.Trace)
+        if (CoreOptions.Clo.Trace)
         {
           Console.WriteLine("Variable dependence: computing SCCs");
         }
@@ -690,7 +690,7 @@ namespace Microsoft.Boogie
           DependsOnSCCsDAG.AddEdge(VariableDescriptorToSCC[n], dummy);
         }
 
-        if (CommandLineOptions.Clo.Trace)
+        if (CoreOptions.Clo.Trace)
         {
           Console.WriteLine("Variable dependence: SCCs computed!");
         }

--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Boogie
         wr = XmlWriter.Create(filename, settings);
         wr.WriteStartDocument();
         wr.WriteStartElement("boogie");
-        wr.WriteAttributeString("version", CommandLineOptions.Clo.VersionNumber);
+        wr.WriteAttributeString("version", CoreOptions.Clo.VersionNumber);
         wr.WriteAttributeString("commandLine", Environment.CommandLine);
       }
       cce.EndExpose();

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -627,31 +627,31 @@ namespace Microsoft.Boogie
   /// Boogie command-line options (other tools can subclass this class in order to support a
   /// superset of Boogie's options).
   /// </summary>
-  public class CommandLineOptionsImpl : CommandLineOptionEngine, ExecutionEngineOptions
+  public class CommandLineOptions : CommandLineOptionEngine, ExecutionEngineOptions
   {
-    public static CommandLineOptionsImpl FromArguments(params string[] arguments)
+    public static CommandLineOptions FromArguments(params string[] arguments)
     {
-      var result = new CommandLineOptionsImpl();
+      var result = new CommandLineOptions();
       result.Parse(arguments);
       return result;
     }
     
-    public CommandLineOptionsImpl()
+    public CommandLineOptions()
       : base("Boogie", "Boogie program verifier")
     {
     }
 
-    protected CommandLineOptionsImpl(string toolName, string descriptiveName)
+    protected CommandLineOptions(string toolName, string descriptiveName)
       : base(toolName, descriptiveName)
     {
       Contract.Requires(toolName != null);
       Contract.Requires(descriptiveName != null);
     }
 
-    public static void Install(CommandLineOptions options)
+    public static void Install(CoreOptions options)
     {
       Contract.Requires(options != null);
-      CommandLineOptions.Clo = options;
+      CoreOptions.Clo = options;
     }
 
     // Flags and arguments
@@ -771,7 +771,7 @@ namespace Microsoft.Boogie
      */
     public bool Prune { get; set; }
 
-    public CommandLineOptions.InstrumentationPlaces InstrumentInfer { get; set; } = CommandLineOptions.InstrumentationPlaces.LoopHeaders;
+    public CoreOptions.InstrumentationPlaces InstrumentInfer { get; set; } = CoreOptions.InstrumentationPlaces.LoopHeaders;
 
     public int? RandomSeed { get; set; }
     
@@ -914,10 +914,10 @@ namespace Microsoft.Boogie
 
     public bool PrettyPrint { get; set; } = true;
 
-    public CommandLineOptions.ProverWarnings PrintProverWarnings { get; set; } = CommandLineOptions.ProverWarnings.None;
+    public CoreOptions.ProverWarnings PrintProverWarnings { get; set; } = CoreOptions.ProverWarnings.None;
 
 
-    public CommandLineOptions.SubsumptionOption UseSubsumption { get; set; } = CommandLineOptions.SubsumptionOption.Always;
+    public CoreOptions.SubsumptionOption UseSubsumption { get; set; } = CoreOptions.SubsumptionOption.Always;
 
     public bool AlwaysAssumeFreeLoopInvariants { get; set; }
 
@@ -1079,7 +1079,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public CommandLineOptions.Inlining ProcedureInlining { get; set; } = CommandLineOptions.Inlining.Assume;
+    public CoreOptions.Inlining ProcedureInlining { get; set; } = CoreOptions.Inlining.Assume;
 
     public bool PrintInlined {
       get => printInlined;
@@ -1102,7 +1102,7 @@ namespace Microsoft.Boogie
     public bool ExtractLoopsUnrollIrreducible { get; set; } = true; // unroll irreducible loops? (set programmatically)
 
 
-    public CommandLineOptions.TypeEncoding TypeEncodingMethod { get; set; } = CommandLineOptions.TypeEncoding.Predicates;
+    public CoreOptions.TypeEncoding TypeEncodingMethod { get; set; } = CoreOptions.TypeEncoding.Predicates;
 
     public bool Monomorphize { get; set; } = false;
 
@@ -1126,7 +1126,7 @@ namespace Microsoft.Boogie
       Contract.Invariant(Ai != null);
     }
 
-    public CommandLineOptions.AiFlags /*!*/ Ai  { get; private set; } = new();
+    public CoreOptions.AiFlags /*!*/ Ai  { get; private set; } = new();
 
     private bool proverHelpRequested = false;
     private bool restartProverPerVc = false;
@@ -1159,7 +1159,7 @@ namespace Microsoft.Boogie
     private bool normalizeNames;
     private bool normalizeDeclarationOrder = true;
 
-    public List<CommandLineOptions.ConcurrentHoudiniOptions> Cho { get; set; } = new();
+    public List<CoreOptions.ConcurrentHoudiniOptions> Cho { get; set; } = new();
 
     protected override bool ParseOption(string name, CommandLineOptionEngine.CommandLineParseState ps)
     {
@@ -1336,13 +1336,13 @@ namespace Microsoft.Boogie
             switch (pw)
             {
               case 0:
-                PrintProverWarnings = CommandLineOptions.ProverWarnings.None;
+                PrintProverWarnings = CoreOptions.ProverWarnings.None;
                 break;
               case 1:
-                PrintProverWarnings = CommandLineOptions.ProverWarnings.Stdout;
+                PrintProverWarnings = CoreOptions.ProverWarnings.Stdout;
                 break;
               case 2:
-                PrintProverWarnings = CommandLineOptions.ProverWarnings.Stderr;
+                PrintProverWarnings = CoreOptions.ProverWarnings.Stderr;
                 break;
               default:
               {
@@ -1456,13 +1456,13 @@ namespace Microsoft.Boogie
             switch (s)
             {
               case 0:
-                UseSubsumption = CommandLineOptions.SubsumptionOption.Never;
+                UseSubsumption = CoreOptions.SubsumptionOption.Never;
                 break;
               case 1:
-                UseSubsumption = CommandLineOptions.SubsumptionOption.NotForQuantifiers;
+                UseSubsumption = CoreOptions.SubsumptionOption.NotForQuantifiers;
                 break;
               case 2:
-                UseSubsumption = CommandLineOptions.SubsumptionOption.Always;
+                UseSubsumption = CoreOptions.SubsumptionOption.Always;
                 break;
               default:
               {
@@ -1623,16 +1623,16 @@ namespace Microsoft.Boogie
             switch (args[ps.i])
             {
               case "none":
-                ProcedureInlining = CommandLineOptions.Inlining.None;
+                ProcedureInlining = CoreOptions.Inlining.None;
                 break;
               case "assert":
-                ProcedureInlining = CommandLineOptions.Inlining.Assert;
+                ProcedureInlining = CoreOptions.Inlining.Assert;
                 break;
               case "assume":
-                ProcedureInlining = CommandLineOptions.Inlining.Assume;
+                ProcedureInlining = CoreOptions.Inlining.Assume;
                 break;
               case "spec":
-                ProcedureInlining = CommandLineOptions.Inlining.Spec;
+                ProcedureInlining = CoreOptions.Inlining.Spec;
                 break;
               default:
                 ps.Error("Invalid argument \"{0}\" to option {1}", args[ps.i], ps.s);
@@ -1663,11 +1663,11 @@ namespace Microsoft.Boogie
             {
               case "p":
               case "predicates":
-                TypeEncodingMethod = CommandLineOptions.TypeEncoding.Predicates;
+                TypeEncodingMethod = CoreOptions.TypeEncoding.Predicates;
                 break;
               case "a":
               case "arguments":
-                TypeEncodingMethod = CommandLineOptions.TypeEncoding.Arguments;
+                TypeEncodingMethod = CoreOptions.TypeEncoding.Arguments;
                 break;
               default:
                 ps.Error("Invalid argument \"{0}\" to option {1}", args[ps.i], ps.s);
@@ -1691,10 +1691,10 @@ namespace Microsoft.Boogie
             switch (args[ps.i])
             {
               case "e":
-                InstrumentInfer = CommandLineOptions.InstrumentationPlaces.Everywhere;
+                InstrumentInfer = CoreOptions.InstrumentationPlaces.Everywhere;
                 break;
               case "h":
-                InstrumentInfer = CommandLineOptions.InstrumentationPlaces.LoopHeaders;
+                InstrumentInfer = CoreOptions.InstrumentationPlaces.LoopHeaders;
                 break;
               default:
                 ps.Error("Invalid argument \"{0}\" to option {1}", args[ps.i], ps.s);
@@ -1938,7 +1938,7 @@ namespace Microsoft.Boogie
 
       if (StratifiedInlining > 0)
       {
-        TypeEncodingMethod = CommandLineOptions.TypeEncoding.Monomorphic;
+        TypeEncodingMethod = CoreOptions.TypeEncoding.Monomorphic;
         UseArrayTheory = true;
         UseAbstractInterpretation = false;
         if (ProverDllName == "SMTLib")

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -424,29 +424,36 @@ namespace Microsoft.Boogie
     public void PrintBplFile(string filename, Program program, bool allowPrintDesugaring, bool setTokens = true,
       bool pretty = false)
     {
+      PrintBplFile(Options, filename, program, allowPrintDesugaring, setTokens, pretty);
+    }
+
+    public static void PrintBplFile(ExecutionEngineOptions options, string filename, Program program, bool allowPrintDesugaring, bool setTokens = true,
+      bool pretty = false)
+
+    {
       Contract.Requires(program != null);
       Contract.Requires(filename != null);
-      bool oldPrintDesugaring = Options.PrintDesugarings;
+      bool oldPrintDesugaring = options.PrintDesugarings;
       if (!allowPrintDesugaring)
       {
-        Options.PrintDesugarings = false;
+        options.PrintDesugarings = false;
       }
 
       using (TokenTextWriter writer = filename == "-"
         ? new TokenTextWriter("<console>", Console.Out, setTokens, pretty)
         : new TokenTextWriter(filename, setTokens, pretty))
       {
-        if (Options.ShowEnv != ExecutionEngineOptions.ShowEnvironment.Never)
+        if (options.ShowEnv != ExecutionEngineOptions.ShowEnvironment.Never)
         {
-          writer.WriteLine("// " + Options.Version);
-          writer.WriteLine("// " + Options.Environment);
+          writer.WriteLine("// " + options.Version);
+          writer.WriteLine("// " + options.Environment);
         }
 
         writer.WriteLine();
         program.Emit(writer);
       }
 
-      Options.PrintDesugarings = oldPrintDesugaring;
+      options.PrintDesugarings = oldPrintDesugaring;
     }
 
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -295,7 +295,12 @@ namespace Microsoft.Boogie
       if (0 <= Options.VerifySnapshots && lookForSnapshots)
       {
         var snapshotsByVersion = LookForSnapshots(fileNames);
-        return snapshotsByVersion.All(s => ProcessFiles( new List<string>(s), false, programId));
+        return snapshotsByVersion.All(s =>
+        {
+          // BUG: Reusing checkers during snapshots doesn't work, even though it should. We create a new engine (and thus checker pool) to workaround this.
+          using var engine = new ExecutionEngine(Options);
+          return engine.ProcessFiles(new List<string>(s), false, programId);
+        });
       }
 
       using XmlFileScope xf = new XmlFileScope(Options.XmlSink, fileNames[^1]);

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Boogie
       return -1;
     }
 
-    public readonly static VerificationResultCache Cache = new VerificationResultCache();
+    public static readonly VerificationResultCache Cache = new VerificationResultCache();
 
     static readonly MemoryCache programCache = new MemoryCache("ProgramCache");
 
@@ -576,14 +576,14 @@ namespace Microsoft.Boogie
 
       if (MonomorphismChecker.IsMonomorphic(program))
       {
-        options.TypeEncodingMethod = CommandLineOptions.TypeEncoding.Monomorphic;
+        options.TypeEncodingMethod = CoreOptions.TypeEncoding.Monomorphic;
       }
       else if (options.Monomorphize)
       {
         var monomorphizableStatus = Monomorphizer.Monomorphize(program);
         if (monomorphizableStatus == MonomorphizableStatus.Monomorphizable)
         {
-          options.TypeEncodingMethod = CommandLineOptions.TypeEncoding.Monomorphic;
+          options.TypeEncodingMethod = CoreOptions.TypeEncoding.Monomorphic;
         }
         else if (monomorphizableStatus == MonomorphizableStatus.UnhandledPolymorphism)
         {
@@ -642,7 +642,7 @@ namespace Microsoft.Boogie
       // Inline
       var TopLevelDeclarations = cce.NonNull(program.TopLevelDeclarations);
 
-      if (options.ProcedureInlining != CommandLineOptions.Inlining.None)
+      if (options.ProcedureInlining != CoreOptions.Inlining.None)
       {
         bool inline = false;
         foreach (var d in TopLevelDeclarations)
@@ -783,8 +783,8 @@ namespace Microsoft.Boogie
       Implementation[] stablePrioritizedImpls = null;
       if (0 < options.VerifySnapshots)
       {
-        OtherDefinitionAxiomsCollector.Collect(program.Axioms);
-        DependencyCollector.Collect(program);
+        OtherDefinitionAxiomsCollector.Collect(options, program.Axioms);
+        DependencyCollector.Collect(options, program);
         stablePrioritizedImpls = impls.OrderByDescending(
           impl => impl.Priority != 1 ? impl.Priority : Cache.VerificationPriority(impl)).ToArray();
       }
@@ -797,7 +797,7 @@ namespace Microsoft.Boogie
 
       if (1 < options.VerifySnapshots)
       {
-        CachedVerificationResultInjector.Inject(program, stablePrioritizedImpls, requestId, programId,
+        CachedVerificationResultInjector.Inject(options, program, stablePrioritizedImpls, requestId, programId,
           out stats.CachingActionCounts);
       }
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Boogie
     }
   }
 
-  public class ExecutionEngine
+  public class ExecutionEngine : IDisposable
   {
     public static OutputPrinter printer;
 
@@ -256,7 +256,14 @@ namespace Microsoft.Boogie
       return result;
     }
 
-    private static CheckerPool checkerPool;
+    public ExecutionEngine(ExecutionEngineOptions options)
+    {
+      this.Options = options;
+      checkerPool = new CheckerPool(options);
+    }
+
+    public ExecutionEngineOptions Options { get; }
+    private readonly CheckerPool checkerPool;
 
     static DateTime FirstRequestStart;
 
@@ -276,71 +283,71 @@ namespace Microsoft.Boogie
 
     static TextWriter ModelWriter = null;
 
-    public static bool ProcessFiles(ExecutionEngineOptions options, IList<string> fileNames, bool lookForSnapshots = true, string programId = null)
+    public bool ProcessFiles(IList<string> fileNames, bool lookForSnapshots = true, string programId = null)
     {
       Contract.Requires(cce.NonNullElements(fileNames));
 
-      if (options.VerifySeparately && 1 < fileNames.Count)
+      if (Options.VerifySeparately && 1 < fileNames.Count)
       {
-        return fileNames.All(f => ProcessFiles(options, new List<string> {f}, lookForSnapshots, f));
+        return fileNames.All(f => ProcessFiles( new List<string> {f}, lookForSnapshots, f));
       }
 
-      if (0 <= options.VerifySnapshots && lookForSnapshots)
+      if (0 <= Options.VerifySnapshots && lookForSnapshots)
       {
         var snapshotsByVersion = LookForSnapshots(fileNames);
-        return snapshotsByVersion.All(s => ProcessFiles(options, new List<string>(s), false, programId));
+        return snapshotsByVersion.All(s => ProcessFiles( new List<string>(s), false, programId));
       }
 
-      using XmlFileScope xf = new XmlFileScope(options.XmlSink, fileNames[^1]);
-      Program program = ParseBoogieProgram(options, fileNames, false);
+      using XmlFileScope xf = new XmlFileScope(Options.XmlSink, fileNames[^1]);
+      Program program = ParseBoogieProgram(fileNames, false);
       var bplFileName = fileNames[^1];
       if (program == null)
       {
         return true;
       }
-      return ProcessProgram(options, program, bplFileName, programId);
+      return ProcessProgram(program, bplFileName, programId);
     }
 
-    public static bool ProcessProgram(ExecutionEngineOptions options, Program program, string bplFileName, string programId = null)
+    public bool ProcessProgram(Program program, string bplFileName, string programId = null)
     {
       if (programId == null)
       {
         programId = "main_program_id";
       }
       
-      if (options.PrintFile != null) {
-        PrintBplFile(options, options.PrintFile, program, false, true, options.PrettyPrint);
+      if (Options.PrintFile != null) {
+        PrintBplFile(Options.PrintFile, program, false, true, Options.PrettyPrint);
       }
 
-      PipelineOutcome oc = ResolveAndTypecheck(options, program, bplFileName, out var civlTypeChecker);
+      PipelineOutcome oc = ResolveAndTypecheck(program, bplFileName, out var civlTypeChecker);
       if (oc != PipelineOutcome.ResolvedAndTypeChecked) {
         return true;
       }
 
-      if (options.PrintCFGPrefix != null) {
+      if (Options.PrintCFGPrefix != null) {
         foreach (var impl in program.Implementations) {
-          using StreamWriter sw = new StreamWriter(options.PrintCFGPrefix + "." + impl.Name + ".dot");
+          using StreamWriter sw = new StreamWriter(Options.PrintCFGPrefix + "." + impl.Name + ".dot");
           sw.Write(program.ProcessLoops(impl).ToDot());
         }
       }
 
-      CivlVCGeneration.Transform(options, civlTypeChecker);
-      if (options.CivlDesugaredFile != null) {
-        int oldPrintUnstructured = options.PrintUnstructured;
-        options.PrintUnstructured = 1;
-        PrintBplFile(options, options.CivlDesugaredFile, program, false, false,
-          options.PrettyPrint);
-        options.PrintUnstructured = oldPrintUnstructured;
+      CivlVCGeneration.Transform(Options, civlTypeChecker);
+      if (Options.CivlDesugaredFile != null) {
+        int oldPrintUnstructured = Options.PrintUnstructured;
+        Options.PrintUnstructured = 1;
+        PrintBplFile(Options.CivlDesugaredFile, program, false, false,
+          Options.PrettyPrint);
+        Options.PrintUnstructured = oldPrintUnstructured;
       }
 
       EliminateDeadVariables(program);
 
-      CoalesceBlocks(options, program);
+      CoalesceBlocks(program);
 
-      Inline(options, program);
+      Inline(program);
 
       var stats = new PipelineStatistics();
-      oc = InferAndVerify(options, program, stats, 1 < options.VerifySnapshots ? programId : null);
+      oc = InferAndVerify(program, stats, 1 < Options.VerifySnapshots ? programId : null);
       switch (oc) {
         case PipelineOutcome.Done:
         case PipelineOutcome.VerificationCompleted:
@@ -385,11 +392,11 @@ namespace Microsoft.Boogie
     }
 
 
-    public static void CoalesceBlocks(ExecutionEngineOptions options, Program program)
+    public void CoalesceBlocks(Program program)
     {
-      if (options.CoalesceBlocks)
+      if (Options.CoalesceBlocks)
       {
-        if (options.Trace)
+        if (Options.Trace)
         {
           Console.WriteLine("Coalescing blocks...");
         }
@@ -399,47 +406,47 @@ namespace Microsoft.Boogie
     }
 
 
-    public static void CollectModSets(ExecutionEngineOptions options, Program program)
+    public void CollectModSets(Program program)
     {
-      if (options.DoModSetAnalysis)
+      if (Options.DoModSetAnalysis)
       {
         new ModSetCollector().DoModSetAnalysis(program);
       }
     }
 
 
-    public static void EliminateDeadVariables(Program program)
+    public void EliminateDeadVariables(Program program)
     {
       Microsoft.Boogie.UnusedVarEliminator.Eliminate(program);
     }
 
 
-    public static void PrintBplFile(ExecutionEngineOptions options, string filename, Program program, bool allowPrintDesugaring, bool setTokens = true,
+    public void PrintBplFile(string filename, Program program, bool allowPrintDesugaring, bool setTokens = true,
       bool pretty = false)
     {
       Contract.Requires(program != null);
       Contract.Requires(filename != null);
-      bool oldPrintDesugaring = options.PrintDesugarings;
+      bool oldPrintDesugaring = Options.PrintDesugarings;
       if (!allowPrintDesugaring)
       {
-        options.PrintDesugarings = false;
+        Options.PrintDesugarings = false;
       }
 
       using (TokenTextWriter writer = filename == "-"
         ? new TokenTextWriter("<console>", Console.Out, setTokens, pretty)
         : new TokenTextWriter(filename, setTokens, pretty))
       {
-        if (options.ShowEnv != ExecutionEngineOptions.ShowEnvironment.Never)
+        if (Options.ShowEnv != ExecutionEngineOptions.ShowEnvironment.Never)
         {
-          writer.WriteLine("// " + options.Version);
-          writer.WriteLine("// " + options.Environment);
+          writer.WriteLine("// " + Options.Version);
+          writer.WriteLine("// " + Options.Environment);
         }
 
         writer.WriteLine();
         program.Emit(writer);
       }
 
-      options.PrintDesugarings = oldPrintDesugaring;
+      Options.PrintDesugarings = oldPrintDesugaring;
     }
 
 
@@ -447,7 +454,7 @@ namespace Microsoft.Boogie
     /// Parse the given files into one Boogie program.  If an I/O or parse error occurs, an error will be printed
     /// and null will be returned.  On success, a non-null program is returned.
     /// </summary>
-    public static Program ParseBoogieProgram(ExecutionEngineOptions options, IList<string> fileNames, bool suppressTraceOutput)
+    public Program ParseBoogieProgram(IList<string> fileNames, bool suppressTraceOutput)
     {
       Contract.Requires(cce.NonNullElements(fileNames));
 
@@ -459,14 +466,14 @@ namespace Microsoft.Boogie
         string bplFileName = fileNames[fileId];
         if (!suppressTraceOutput)
         {
-          if (options.XmlSink != null)
+          if (Options.XmlSink != null)
           {
-            options.XmlSink.WriteFileFragment(bplFileName);
+            Options.XmlSink.WriteFileFragment(bplFileName);
           }
 
-          if (options.Trace)
+          if (Options.Trace)
           {
-            Console.WriteLine("Parsing " + GetFileNameForConsole(options, bplFileName));
+            Console.WriteLine("Parsing " + GetFileNameForConsole(Options, bplFileName));
           }
         }
 
@@ -474,10 +481,10 @@ namespace Microsoft.Boogie
         {
           var defines = new List<string>() {"FILE_" + fileId};
           int errorCount = Parser.Parse(bplFileName, defines, out Program programSnippet,
-            options.UseBaseNameForFileName);
+            Options.UseBaseNameForFileName);
           if (programSnippet == null || errorCount != 0)
           {
-            Console.WriteLine("{0} parse errors detected in {1}", errorCount, GetFileNameForConsole(options, bplFileName));
+            Console.WriteLine("{0} parse errors detected in {1}", errorCount, GetFileNameForConsole(Options, bplFileName));
             okay = false;
           }
           else
@@ -487,8 +494,8 @@ namespace Microsoft.Boogie
         }
         catch (IOException e)
         {
-          printer.ErrorWriteLine(Console.Out, "Error opening file \"{0}\": {1}", GetFileNameForConsole(options, bplFileName),
-            e.Message);
+          printer.ErrorWriteLine(Console.Out, "Error opening file \"{0}\": {1}",
+            GetFileNameForConsole(Options, bplFileName), e.Message);
           okay = false;
         }
       }
@@ -501,13 +508,13 @@ namespace Microsoft.Boogie
       {
         if (program.TopLevelDeclarations.Any(d => d.HasCivlAttribute()))
         {
-          options.UseLibrary = true;
+          Options.UseLibrary = true;
         }
 
-        if (options.UseLibrary)
+        if (Options.UseLibrary)
         {
-          options.UseArrayTheory = true;
-          options.Monomorphize = true;
+          Options.UseArrayTheory = true;
+          Options.Monomorphize = true;
           var library = Parser.ParseLibraryDefinitions();
           program.AddTopLevelDeclarations(library.TopLevelDeclarations);
         }
@@ -533,7 +540,7 @@ namespace Microsoft.Boogie
     ///  - TypeCheckingError if a type checking error occurred
     ///  - ResolvedAndTypeChecked if both resolution and type checking succeeded
     /// </summary>
-    public static PipelineOutcome ResolveAndTypecheck(ExecutionEngineOptions options, Program program, string bplFileName,
+    public PipelineOutcome ResolveAndTypecheck(Program program, string bplFileName,
       out CivlTypeChecker civlTypeChecker)
     {
       Contract.Requires(program != null);
@@ -543,7 +550,7 @@ namespace Microsoft.Boogie
 
       // ---------- Resolve ------------------------------------------------------------
 
-      if (options.NoResolve)
+      if (Options.NoResolve)
       {
         return PipelineOutcome.Done;
       }
@@ -551,13 +558,13 @@ namespace Microsoft.Boogie
       int errorCount = program.Resolve();
       if (errorCount != 0)
       {
-        Console.WriteLine("{0} name resolution errors detected in {1}", errorCount, GetFileNameForConsole(options, bplFileName));
+        Console.WriteLine("{0} name resolution errors detected in {1}", errorCount, GetFileNameForConsole(Options, bplFileName));
         return PipelineOutcome.ResolutionError;
       }
 
       // ---------- Type check ------------------------------------------------------------
 
-      if (options.NoTypecheck)
+      if (Options.NoTypecheck)
       {
         return PipelineOutcome.Done;
       }
@@ -570,20 +577,20 @@ namespace Microsoft.Boogie
       errorCount = program.Typecheck();
       if (errorCount != 0)
       {
-        Console.WriteLine("{0} type checking errors detected in {1}", errorCount, GetFileNameForConsole(options, bplFileName));
+        Console.WriteLine("{0} type checking errors detected in {1}", errorCount, GetFileNameForConsole(Options, bplFileName));
         return PipelineOutcome.TypeCheckingError;
       }
 
       if (MonomorphismChecker.IsMonomorphic(program))
       {
-        options.TypeEncodingMethod = CoreOptions.TypeEncoding.Monomorphic;
+        Options.TypeEncodingMethod = CoreOptions.TypeEncoding.Monomorphic;
       }
-      else if (options.Monomorphize)
+      else if (Options.Monomorphize)
       {
         var monomorphizableStatus = Monomorphizer.Monomorphize(program);
         if (monomorphizableStatus == MonomorphizableStatus.Monomorphizable)
         {
-          options.TypeEncodingMethod = CoreOptions.TypeEncoding.Monomorphic;
+          Options.TypeEncodingMethod = CoreOptions.TypeEncoding.Monomorphic;
         }
         else if (monomorphizableStatus == MonomorphizableStatus.UnhandledPolymorphism)
         {
@@ -596,7 +603,7 @@ namespace Microsoft.Boogie
           return PipelineOutcome.FatalError;
         }
       }
-      else if (options.UseArrayTheory)
+      else if (Options.UseArrayTheory)
       {
         Console.WriteLine(
           "Option /useArrayTheory only supported for monomorphic programs, polymorphism is detected in input program, try using -monomorphize");
@@ -609,32 +616,32 @@ namespace Microsoft.Boogie
         return PipelineOutcome.FatalError;
       }
 
-      CollectModSets(options, program);
+      CollectModSets(program);
 
-      civlTypeChecker = new CivlTypeChecker(options, program);
+      civlTypeChecker = new CivlTypeChecker(Options, program);
       civlTypeChecker.TypeCheck();
       if (civlTypeChecker.checkingContext.ErrorCount != 0)
       {
         Console.WriteLine("{0} type checking errors detected in {1}", civlTypeChecker.checkingContext.ErrorCount,
-          GetFileNameForConsole(options, bplFileName));
+          GetFileNameForConsole(Options, bplFileName));
         return PipelineOutcome.TypeCheckingError;
       }
 
-      if (options.PrintFile != null && options.PrintDesugarings)
+      if (Options.PrintFile != null && Options.PrintDesugarings)
       {
         // if PrintDesugaring option is engaged, print the file here, after resolution and type checking
-        PrintBplFile(options, options.PrintFile, program, true, true, options.PrettyPrint);
+        PrintBplFile(Options.PrintFile, program, true, true, Options.PrettyPrint);
       }
 
       return PipelineOutcome.ResolvedAndTypeChecked;
     }
 
 
-    public static void Inline(ExecutionEngineOptions options, Program program)
+    public void Inline(Program program)
     {
       Contract.Requires(program != null);
 
-      if (options.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Inlining...");
       }
@@ -642,7 +649,7 @@ namespace Microsoft.Boogie
       // Inline
       var TopLevelDeclarations = cce.NonNull(program.TopLevelDeclarations);
 
-      if (options.ProcedureInlining != CoreOptions.Inlining.None)
+      if (Options.ProcedureInlining != CoreOptions.Inlining.None)
       {
         bool inline = false;
         foreach (var d in TopLevelDeclarations)
@@ -663,7 +670,7 @@ namespace Microsoft.Boogie
 
           foreach (var impl in TopLevelDeclarations.OfType<Implementation>())
           {
-            if (options.UserWantsToCheckRoutine(impl.Name) && !impl.SkipVerification)
+            if (Options.UserWantsToCheckRoutine(impl.Name) && !impl.SkipVerification)
             {
               Inliner.ProcessImplementation(program, impl);
             }
@@ -687,7 +694,7 @@ namespace Microsoft.Boogie
     ///  - VerificationCompleted if inference and verification completed, in which the out
     ///    parameters contain meaningful values
     /// </summary>
-    public static PipelineOutcome InferAndVerify(ExecutionEngineOptions options,
+    public PipelineOutcome InferAndVerify(
       Program program,
       PipelineStatistics stats,
       string programId = null,
@@ -698,18 +705,14 @@ namespace Microsoft.Boogie
       Contract.Ensures(0 <= Contract.ValueAtReturn(out stats.InconclusiveCount) &&
                        0 <= Contract.ValueAtReturn(out stats.TimeoutCount));
 
-      if (checkerPool == null) {
-        checkerPool = new CheckerPool(options);
-      }
-      
       if (requestId == null)
       {
         requestId = FreshRequestId();
       }
 
-      if (options.PrintErrorModelFile != null)
+      if (Options.PrintErrorModelFile != null)
       {
-        ExecutionEngine.ModelWriter = new StreamWriter(options.PrintErrorModelFile, false);
+        ExecutionEngine.ModelWriter = new StreamWriter(Options.PrintErrorModelFile, false);
       }
 
       var start = DateTime.UtcNow;
@@ -719,12 +722,12 @@ namespace Microsoft.Boogie
       // Doing lambda expansion before abstract interpretation means that the abstract interpreter
       // never needs to see any lambda expressions.  (On the other hand, if it were useful for it
       // to see lambdas, then it would be better to more lambda expansion until after inference.)
-      if (options.ExpandLambdas)
+      if (Options.ExpandLambdas)
       {
         LambdaHelper.ExpandLambdas(program);
-        if (options.PrintFile != null && options.PrintLambdaLifting)
+        if (Options.PrintFile != null && Options.PrintLambdaLifting)
         {
-          PrintBplFile(options, options.PrintFile, program, false, true, options.PrettyPrint);
+          PrintBplFile(Options.PrintFile, program, false, true, Options.PrettyPrint);
         }
       }
 
@@ -732,7 +735,7 @@ namespace Microsoft.Boogie
 
       #region Infer invariants using Abstract Interpretation
 
-      if (options.UseAbstractInterpretation)
+      if (Options.UseAbstractInterpretation)
       {
         AbstractInterpretation.NativeAbstractInterpretation.RunAbstractInterpretation(program);
       }
@@ -741,34 +744,34 @@ namespace Microsoft.Boogie
 
       #region Do some post-abstract-interpretation preprocessing on the program (e.g., loop unrolling)
 
-      if (options.LoopUnrollCount != -1)
+      if (Options.LoopUnrollCount != -1)
       {
-        program.UnrollLoops(options.LoopUnrollCount, options.SoundLoopUnrolling);
+        program.UnrollLoops(Options.LoopUnrollCount, Options.SoundLoopUnrolling);
       }
 
       Dictionary<string, Dictionary<string, Block>> extractLoopMappingInfo = null;
-      if (options.ExtractLoops)
+      if (Options.ExtractLoops)
       {
         extractLoopMappingInfo = program.ExtractLoops();
       }
 
-      if (options.PrintInstrumented)
+      if (Options.PrintInstrumented)
       {
-        program.Emit(new TokenTextWriter(Console.Out, options.PrettyPrint));
+        program.Emit(new TokenTextWriter(Console.Out, Options.PrettyPrint));
       }
 
       #endregion
 
-      if (!options.Verify)
+      if (!Options.Verify)
       {
         return PipelineOutcome.Done;
       }
 
       #region Run Houdini and verify
 
-      if (options.ContractInfer)
+      if (Options.ContractInfer)
       {
-        return RunHoudini(options, program, stats, er);
+        return RunHoudini(program, stats, er);
       }
 
       #endregion
@@ -776,15 +779,15 @@ namespace Microsoft.Boogie
       #region Select and prioritize implementations that should be verified
 
       var impls = program.Implementations.Where(
-        impl => impl != null && options.UserWantsToCheckRoutine(cce.NonNull(impl.Name)) &&
+        impl => impl != null && Options.UserWantsToCheckRoutine(cce.NonNull(impl.Name)) &&
                 !impl.SkipVerification);
 
       // operate on a stable copy, in case it gets updated while we're running
       Implementation[] stablePrioritizedImpls = null;
-      if (0 < options.VerifySnapshots)
+      if (0 < Options.VerifySnapshots)
       {
-        OtherDefinitionAxiomsCollector.Collect(options, program.Axioms);
-        DependencyCollector.Collect(options, program);
+        OtherDefinitionAxiomsCollector.Collect(Options, program.Axioms);
+        DependencyCollector.Collect(Options, program);
         stablePrioritizedImpls = impls.OrderByDescending(
           impl => impl.Priority != 1 ? impl.Priority : Cache.VerificationPriority(impl)).ToArray();
       }
@@ -795,9 +798,9 @@ namespace Microsoft.Boogie
 
       #endregion
 
-      if (1 < options.VerifySnapshots)
+      if (1 < Options.VerifySnapshots)
       {
-        CachedVerificationResultInjector.Inject(options, program, stablePrioritizedImpls, requestId, programId,
+        CachedVerificationResultInjector.Inject(Options, program, stablePrioritizedImpls, requestId, programId,
           out stats.CachingActionCounts);
       }
 
@@ -813,7 +816,7 @@ namespace Microsoft.Boogie
 
         var tasks = new Task[stablePrioritizedImpls.Length];
         // We use this semaphore to limit the number of tasks that are currently executing.
-        var semaphore = new SemaphoreSlim(options.VcsCores);
+        var semaphore = new SemaphoreSlim(Options.VcsCores);
 
         // Create a task per implementation.
         for (int i = 0; i < stablePrioritizedImpls.Length; i++)
@@ -842,7 +845,7 @@ namespace Microsoft.Boogie
                 cts.Token.ThrowIfCancellationRequested();
               }
 
-              VerifyImplementation(options, program, stats, er, requestId, extractLoopMappingInfo, stablePrioritizedImpls,
+              VerifyImplementation(program, stats, er, requestId, extractLoopMappingInfo, stablePrioritizedImpls,
                 taskIndex, outputCollector, checkerPool, programId);
               ImplIdToCancellationTokenSource.TryRemove(id, out old);
             }
@@ -896,25 +899,25 @@ namespace Microsoft.Boogie
       }
       finally
       {
-        CleanupCheckers(requestId);
+        CleanupRequest(requestId);
       }
 
-      if (options.PrintNecessaryAssumes && program.NecessaryAssumes.Any())
+      if (Options.PrintNecessaryAssumes && program.NecessaryAssumes.Any())
       {
         Console.WriteLine("Necessary assume command(s): {0}", string.Join(", ", program.NecessaryAssumes));
       }
 
-      cce.NonNull(options.TheProverFactory).Close();
+      cce.NonNull(Options.TheProverFactory).Close();
 
       outputCollector.WriteMoreOutput();
 
-      if (1 < options.VerifySnapshots && programId != null)
+      if (1 < Options.VerifySnapshots && programId != null)
       {
         program.FreezeTopLevelDeclarations();
         programCache.Set(programId, program, policy);
       }
 
-      if (0 <= options.VerifySnapshots && options.TraceCachingForBenchmarking)
+      if (0 <= Options.VerifySnapshots && Options.TraceCachingForBenchmarking)
       {
         var end = DateTime.UtcNow;
         if (TimePerRequest.Count == 0)
@@ -967,30 +970,20 @@ namespace Microsoft.Boogie
       {
         cts.Cancel();
 
-        CleanupCheckers(requestId);
+        CleanupRequest(requestId);
       }
     }
 
-
-    private static void CleanupCheckers(string requestId)
+    private static void CleanupRequest(string requestId)
     {
       if (requestId != null)
       {
         RequestIdToCancellationTokenSource.TryRemove(requestId, out var old);
       }
-
-      lock (RequestIdToCancellationTokenSource)
-      {
-        if (RequestIdToCancellationTokenSource.IsEmpty)
-        {
-          checkerPool?.Dispose();
-          checkerPool = null;
-        }
-      }
     }
 
 
-    private static void VerifyImplementation(ExecutionEngineOptions options, Program program, PipelineStatistics stats, ErrorReporterDelegate er,
+    private void VerifyImplementation(Program program, PipelineStatistics stats, ErrorReporterDelegate er,
       string requestId, Dictionary<string, Dictionary<string, Block>> extractLoopMappingInfo,
       Implementation[] stablePrioritizedImpls, int index, OutputCollector outputCollector, CheckerPool checkerPool,
       string programId)
@@ -1004,19 +997,19 @@ namespace Microsoft.Boogie
 
       int priority = 0;
       var wasCached = false;
-      if (0 < options.VerifySnapshots)
+      if (0 < Options.VerifySnapshots)
       {
         var cachedResults = Cache.Lookup(impl, out priority);
         if (cachedResults != null && priority == Priority.SKIP)
         {
-          if (options.XmlSink != null)
+          if (Options.XmlSink != null)
           {
-            options.XmlSink.WriteStartMethod(impl.Name, cachedResults.Start);
+            Options.XmlSink.WriteStartMethod(impl.Name, cachedResults.Start);
           }
 
           printer.Inform(string.Format("Retrieving cached verification result for implementation {0}...", impl.Name),
             output);
-          if (options.VerifySnapshots < 3 ||
+          if (Options.VerifySnapshots < 3 ||
               cachedResults.Outcome == ConditionGeneration.Outcome.Correct)
           {
             verificationResult = cachedResults;
@@ -1037,16 +1030,16 @@ namespace Microsoft.Boogie
           verificationResult.ProofObligationCountBefore = vcgen.CumulativeAssertionCount;
           verificationResult.Start = DateTime.UtcNow;
 
-          if (options.XmlSink != null)
+          if (Options.XmlSink != null)
           {
-            options.XmlSink.WriteStartMethod(impl.Name, verificationResult.Start);
+            Options.XmlSink.WriteStartMethod(impl.Name, verificationResult.Start);
           }
 
           try {
             var cancellationToken = RequestIdToCancellationTokenSource[requestId].Token;
             verificationResult.Outcome =
               vcgen.VerifyImplementation(impl, out verificationResult.Errors, requestId, cancellationToken);
-            if (options.ExtractLoops && verificationResult.Errors != null) {
+            if (Options.ExtractLoops && verificationResult.Errors != null) {
               var vcg = vcgen as VCGen;
               if (vcg != null) {
                 for (int i = 0; i < verificationResult.Errors.Count; i++) {
@@ -1110,7 +1103,7 @@ namespace Microsoft.Boogie
 
         #region Cache the verification result
 
-        if (0 < options.VerifySnapshots && !string.IsNullOrEmpty(impl.Checksum))
+        if (0 < Options.VerifySnapshots && !string.IsNullOrEmpty(impl.Checksum))
         {
           Cache.Insert(impl, verificationResult);
         }
@@ -1120,15 +1113,15 @@ namespace Microsoft.Boogie
 
       #region Process the verification results and statistics
 
-      ProcessOutcome(options, verificationResult.Outcome, verificationResult.Errors, TimeIndication(options, verificationResult), stats,
+      ProcessOutcome(verificationResult.Outcome, verificationResult.Errors, TimeIndication(verificationResult), stats,
         output, impl.TimeLimit, er, verificationResult.ImplementationName, verificationResult.ImplementationToken,
         verificationResult.RequestId, verificationResult.MessageIfVerifies, wasCached);
 
-      ProcessErrors(options, verificationResult.Errors, verificationResult.Outcome, output, er, impl);
+      ProcessErrors(verificationResult.Errors, verificationResult.Outcome, output, er, impl);
 
-      if (options.XmlSink != null)
+      if (Options.XmlSink != null)
       {
-        options.XmlSink.WriteEndMethod(verificationResult.Outcome.ToString().ToLowerInvariant(),
+        Options.XmlSink.WriteEndMethod(verificationResult.Outcome.ToString().ToLowerInvariant(),
           verificationResult.End, verificationResult.End - verificationResult.Start,
           verificationResult.ResourceCount);
       }
@@ -1137,7 +1130,7 @@ namespace Microsoft.Boogie
 
       outputCollector.WriteMoreOutput();
 
-      if (verificationResult.Outcome == VCGen.Outcome.Errors || options.Trace)
+      if (verificationResult.Outcome == VCGen.Outcome.Errors || Options.Trace)
       {
         Console.Out.Flush();
       }
@@ -1189,21 +1182,21 @@ namespace Microsoft.Boogie
 
     #region Houdini
 
-    private static PipelineOutcome RunHoudini(ExecutionEngineOptions options, Program program, PipelineStatistics stats, ErrorReporterDelegate er)
+    private PipelineOutcome RunHoudini(Program program, PipelineStatistics stats, ErrorReporterDelegate er)
     {
       Contract.Requires(stats != null);
       
-      if (options.StagedHoudini != null)
+      if (Options.StagedHoudini != null)
       {
-        return RunStagedHoudini(options, program, stats, er);
+        return RunStagedHoudini(program, stats, er);
       }
 
       Houdini.HoudiniSession.HoudiniStatistics houdiniStats = new Houdini.HoudiniSession.HoudiniStatistics();
-      Houdini.Houdini houdini = new Houdini.Houdini(options, program, houdiniStats);
+      Houdini.Houdini houdini = new Houdini.Houdini(Options, program, houdiniStats);
       Houdini.HoudiniOutcome outcome = houdini.PerformHoudiniInference();
       houdini.Close();
 
-      if (options.PrintAssignment)
+      if (Options.PrintAssignment)
       {
         Console.WriteLine("Assignment computed by Houdini:");
         foreach (var x in outcome.assignment)
@@ -1212,7 +1205,7 @@ namespace Microsoft.Boogie
         }
       }
 
-      if (options.Trace)
+      if (Options.Trace)
       {
         int numTrueAssigns = 0;
         foreach (var x in outcome.assignment)
@@ -1234,29 +1227,29 @@ namespace Microsoft.Boogie
 
       foreach (Houdini.VCGenOutcome x in outcome.implementationOutcomes.Values)
       {
-        ProcessOutcome(options, x.outcome, x.errors, "", stats, Console.Out, options.TimeLimit, er);
-        ProcessErrors(options, x.errors, x.outcome, Console.Out, er);
+        ProcessOutcome(x.outcome, x.errors, "", stats, Console.Out, Options.TimeLimit, er);
+        ProcessErrors(x.errors, x.outcome, Console.Out, er);
       }
 
       return PipelineOutcome.Done;
     }
 
-    public static Program ProgramFromFile(ExecutionEngineOptions options, string filename)
+    public Program ProgramFromFile(string filename)
     {
-      Program p = ParseBoogieProgram(options, new List<string> {filename}, false);
+      Program p = ParseBoogieProgram( new List<string> {filename}, false);
       Debug.Assert(p != null);
-      PipelineOutcome oc = ResolveAndTypecheck(options, p, filename, out var civlTypeChecker);
+      PipelineOutcome oc = ResolveAndTypecheck(p, filename, out var civlTypeChecker);
       Debug.Assert(oc == PipelineOutcome.ResolvedAndTypeChecked);
       return p;
     }
 
-    private static PipelineOutcome RunStagedHoudini(ExecutionEngineOptions options, Program program, PipelineStatistics stats, ErrorReporterDelegate er)
+    private PipelineOutcome RunStagedHoudini(Program program, PipelineStatistics stats, ErrorReporterDelegate er)
     {
       Houdini.HoudiniSession.HoudiniStatistics houdiniStats = new Houdini.HoudiniSession.HoudiniStatistics();
-      Houdini.StagedHoudini stagedHoudini = new Houdini.StagedHoudini(options, program, houdiniStats, f => ProgramFromFile(options, f));
+      var stagedHoudini = new Houdini.StagedHoudini(Options, program, houdiniStats, ProgramFromFile);
       Houdini.HoudiniOutcome outcome = stagedHoudini.PerformStagedHoudiniInference();
 
-      if (options.PrintAssignment)
+      if (Options.PrintAssignment)
       {
         Console.WriteLine("Assignment computed by Houdini:");
         foreach (var x in outcome.assignment)
@@ -1265,7 +1258,7 @@ namespace Microsoft.Boogie
         }
       }
 
-      if (options.Trace)
+      if (Options.Trace)
       {
         int numTrueAssigns = 0;
         foreach (var x in outcome.assignment)
@@ -1287,8 +1280,8 @@ namespace Microsoft.Boogie
 
       foreach (Houdini.VCGenOutcome x in outcome.implementationOutcomes.Values)
       {
-        ProcessOutcome(options, x.outcome, x.errors, "", stats, Console.Out, options.TimeLimit, er);
-        ProcessErrors(options, x.errors, x.outcome, Console.Out, er);
+        ProcessOutcome(x.outcome, x.errors, "", stats, Console.Out, Options.TimeLimit, er);
+        ProcessErrors(x.errors, x.outcome, Console.Out, er);
       }
 
       return PipelineOutcome.Done;
@@ -1297,10 +1290,10 @@ namespace Microsoft.Boogie
     #endregion
 
 
-    private static string TimeIndication(ExecutionEngineOptions options, VerificationResult verificationResult)
+    private string TimeIndication(VerificationResult verificationResult)
     {
       var result = "";
-      if (options.Trace)
+      if (Options.Trace)
       {
         result = string.Format("  [{0:F3} s, solver resource count: {1}, {2} proof obligation{3}]  ",
           (verificationResult.End - verificationResult.Start).TotalSeconds,
@@ -1308,7 +1301,7 @@ namespace Microsoft.Boogie
           verificationResult.ProofObligationCount,
           verificationResult.ProofObligationCount == 1 ? "" : "s");
       }
-      else if (options.TraceProofObligations)
+      else if (Options.TraceProofObligations)
       {
         result = string.Format("  [{0} proof obligation{1}]  ", verificationResult.ProofObligationCount,
           verificationResult.ProofObligationCount == 1 ? "" : "s");
@@ -1318,7 +1311,7 @@ namespace Microsoft.Boogie
     }
 
 
-    private static void ProcessOutcome(ExecutionEngineOptions options, VC.VCGen.Outcome outcome, List<Counterexample> errors, string timeIndication,
+    private void ProcessOutcome(VC.VCGen.Outcome outcome, List<Counterexample> errors, string timeIndication,
       PipelineStatistics stats, TextWriter tw, uint timeLimit, ErrorReporterDelegate er = null, string implName = null,
       IToken implTok = null, string requestId = null, string msgIfVerifies = null, bool wasCached = false)
     {
@@ -1328,11 +1321,11 @@ namespace Microsoft.Boogie
 
       printer.Inform(timeIndication + OutcomeIndication(outcome, errors), tw);
 
-      ReportOutcome(options, outcome, er, implName, implTok, requestId, msgIfVerifies, tw, timeLimit, errors);
+      ReportOutcome(outcome, er, implName, implTok, requestId, msgIfVerifies, tw, timeLimit, errors);
     }
 
 
-    private static void ReportOutcome(ExecutionEngineOptions options, VC.VCGen.Outcome outcome, ErrorReporterDelegate er, string implName,
+    private void ReportOutcome(VC.VCGen.Outcome outcome, ErrorReporterDelegate er, string implName,
       IToken implTok, string requestId, string msgIfVerifies, TextWriter tw, uint timeLimit, List<Counterexample> errors)
     {
       ErrorInformation errorInfo = null;
@@ -1347,7 +1340,7 @@ namespace Microsoft.Boogie
           break;
         case VCGen.Outcome.ReachedBound:
           tw.WriteLine(string.Format("Stratified Inlining: Reached recursion bound of {0}",
-            options.RecursionBound));
+            Options.RecursionBound));
           break;
         case VCGen.Outcome.Errors:
         case VCGen.Outcome.TimedOut:
@@ -1402,7 +1395,7 @@ namespace Microsoft.Boogie
                   }
                   else
                   {
-                    if (assertError.FailingAssert.ErrorMessage == null || options.ForceBplErrors)
+                    if (assertError.FailingAssert.ErrorMessage == null || Options.ForceBplErrors)
                     {
                       msg = assertError.FailingAssert.ErrorData as string;
                     }
@@ -1594,7 +1587,7 @@ namespace Microsoft.Boogie
     }
 
 
-    private static void ProcessErrors(ExecutionEngineOptions options, List<Counterexample> errors, VC.VCGen.Outcome outcome, TextWriter tw,
+    private void ProcessErrors(List<Counterexample> errors, VC.VCGen.Outcome outcome, TextWriter tw,
       ErrorReporterDelegate er, Implementation impl = null)
     {
       var implName = impl != null ? impl.Name : null;
@@ -1609,30 +1602,30 @@ namespace Microsoft.Boogie
             continue;
           }
 
-          var errorInfo = CreateErrorInformation(options, error, outcome);
+          var errorInfo = CreateErrorInformation(error, outcome);
           errorInfo.ImplementationName = implName;
 
-          if (options.XmlSink != null)
+          if (Options.XmlSink != null)
           {
-            WriteErrorInformationToXmlSink(options.XmlSink, errorInfo, error.Trace);
+            WriteErrorInformationToXmlSink(Options.XmlSink, errorInfo, error.Trace);
           }
 
-          if (options.ErrorTrace > 0)
+          if (Options.ErrorTrace > 0)
           {
             errorInfo.Out.WriteLine("Execution trace:");
             error.Print(4, errorInfo.Out, b => { errorInfo.AddAuxInfo(b.tok, b.Label, "Execution trace"); });
-            if (options.EnhancedErrorMessages == 1 && error.AugmentedTrace != null && error.AugmentedTrace.Count > 0)
+            if (Options.EnhancedErrorMessages == 1 && error.AugmentedTrace != null && error.AugmentedTrace.Count > 0)
             {
               errorInfo.Out.WriteLine("Augmented execution trace:");
               error.AugmentedTrace.Iter(elem => errorInfo.Out.Write(elem));
             }
-            if (options.PrintErrorModel >= 1 && error.Model != null)
+            if (Options.PrintErrorModel >= 1 && error.Model != null)
             {
               error.Model.Write(ExecutionEngine.ModelWriter == null ? errorInfo.Out : ExecutionEngine.ModelWriter);
             }
           }
 
-          if (options.ModelViewFile != null) {
+          if (Options.ModelViewFile != null) {
             error.PrintModel(errorInfo.Model, error);
           }
 
@@ -1650,7 +1643,7 @@ namespace Microsoft.Boogie
     }
 
 
-    private static ErrorInformation CreateErrorInformation(ExecutionEngineOptions options, Counterexample error, VC.VCGen.Outcome outcome)
+    private ErrorInformation CreateErrorInformation(Counterexample error, VC.VCGen.Outcome outcome)
     {
       ErrorInformation errorInfo;
       var cause = "Error";
@@ -1673,7 +1666,7 @@ namespace Microsoft.Boogie
 
       if (error is CallCounterexample callError)
       {
-        if (callError.FailingRequires.ErrorMessage == null || options.ForceBplErrors)
+        if (callError.FailingRequires.ErrorMessage == null || Options.ForceBplErrors)
         {
           errorInfo = errorInformationFactory.CreateErrorInformation(callError.FailingCall.tok,
             callError.FailingCall.ErrorData as string ?? "A precondition for this call might not hold.",
@@ -1692,7 +1685,7 @@ namespace Microsoft.Boogie
       }
       else if (error is ReturnCounterexample returnError)
       {
-        if (returnError.FailingEnsures.ErrorMessage == null || options.ForceBplErrors)
+        if (returnError.FailingEnsures.ErrorMessage == null || Options.ForceBplErrors)
         {
           errorInfo = errorInformationFactory.CreateErrorInformation(returnError.FailingReturn.tok,
             "A postcondition might not hold on this return path.",
@@ -1739,7 +1732,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          if (assertError.FailingAssert.ErrorMessage == null || options.ForceBplErrors)
+          if (assertError.FailingAssert.ErrorMessage == null || Options.ForceBplErrors)
           {
             string msg = assertError.FailingAssert.ErrorData as string ?? "This assertion might not hold.";
             errorInfo = errorInformationFactory.CreateErrorInformation(assertError.FailingAssert.tok, msg,
@@ -1782,6 +1775,11 @@ namespace Microsoft.Boogie
 
       var relatedError = errorInfo.Aux.FirstOrDefault();
       sink.WriteError(msg, errorInfo.Tok, relatedError.Tok, trace);
+    }
+
+    public void Dispose()
+    {
+      checkerPool.Dispose();
     }
   }
 }

--- a/Source/Houdini/AnnotationDependenceAnalyser.cs
+++ b/Source/Houdini/AnnotationDependenceAnalyser.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Boogie.Houdini
 
     public void Analyse()
     {
-      if (CommandLineOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine("Annotation dependence analysis: Getting annotations");
       }
@@ -68,7 +68,7 @@ namespace Microsoft.Boogie.Houdini
 
     private void ConstructStagesDAG()
     {
-      if (CommandLineOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine("Annotation dependence analysis: Computing SCCs");
       }
@@ -79,7 +79,7 @@ namespace Microsoft.Boogie.Houdini
         AnnotationDependences.Nodes, next, prev);
       SCCs.Compute();
 
-      if (CommandLineOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine("Annotation dependence analysis: Building stages DAG");
       }
@@ -112,7 +112,7 @@ namespace Microsoft.Boogie.Houdini
 
     private void ConstructAnnotationDependenceGraph()
     {
-      if (CommandLineOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine("Annotation dependence analysis: Building dependence graph");
       }
@@ -204,7 +204,7 @@ namespace Microsoft.Boogie.Houdini
 
     private void DetermineAnnotationVariableDependences()
     {
-      if (CommandLineOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine("Annotation dependence analysis: Working out what annotations depend on");
       }
@@ -345,7 +345,7 @@ namespace Microsoft.Boogie.Houdini
 
     public void dump()
     {
-      if (CommandLineOptions.Clo.DebugStagedHoudini)
+      if (options.DebugStagedHoudini)
       {
         varDepAnalyser.dump();
 

--- a/Source/Houdini/Checker.cs
+++ b/Source/Houdini/Checker.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Boogie.Houdini
       this.descriptiveName = impl.Name;
       this.houdini = houdini;
       this.stats = stats;
-      collector = new ConditionGeneration.CounterexampleCollector();
+      collector = new ConditionGeneration.CounterexampleCollector(houdini.Options);
       collector.OnProgress?.Invoke("HdnVCGen", 0, 0, 0.0);
 
       vcgen.ConvertCFG2DAG(impl, taskID: taskID);
@@ -190,7 +190,7 @@ namespace Microsoft.Boogie.Houdini
         new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "", Type.Bool), false));
       proverInterface.DefineMacro(macro, conjecture);
       conjecture = exprGen.Function(macro);
-      handler = new VCGen.ErrorReporter(gotoCmdOrigins, absyIds, impl.Blocks, vcgen.debugInfos, collector,
+      handler = new VCGen.ErrorReporter(this.houdini.Options, gotoCmdOrigins, absyIds, impl.Blocks, vcgen.debugInfos, collector,
         mvInfo, proverInterface.Context, program);
     }
 

--- a/Source/Houdini/Checker.cs
+++ b/Source/Houdini/Checker.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Boogie.Houdini
       }
        */
 
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Houdini assignment axiom: " + expr);
       }
@@ -245,12 +245,14 @@ namespace Microsoft.Boogie.Houdini
       return expr;
     }
 
+    public HoudiniOptions Options => houdini.Options;
+
     public ProverInterface.Outcome Verify(ProverInterface proverInterface, Dictionary<Variable, bool> assignment,
       out List<Counterexample> errors, int errorLimit)
     {
       collector.examples.Clear();
 
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Verifying " + descriptiveName);
       }
@@ -264,7 +266,7 @@ namespace Microsoft.Boogie.Houdini
       double queryTime = (DateTime.UtcNow - now).TotalSeconds;
       stats.proverTime += queryTime;
       stats.numProverQueries++;
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Outcome = " + proverOutcome);
         Console.WriteLine("Time taken = " + queryTime);
@@ -376,15 +378,15 @@ namespace Microsoft.Boogie.Houdini
       var controlExprFalse = exprGen.And(controlExpr,
         exprGen.And(exprGen.Not(exprTranslator.LookupVariable(pc)), exprGen.Not(exprTranslator.LookupVariable(nc))));
 
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Verifying (MaxSat) " + descriptiveName);
       }
 
       DateTime now = DateTime.UtcNow;
 
-      var el = CommandLineOptions.Clo.ErrorLimit;
-      CommandLineOptions.Clo.ErrorLimit = 1;
+      var el = Options.ErrorLimit;
+      Options.ErrorLimit = 1;
 
       var outcome = ProverInterface.Outcome.Undetermined;
 
@@ -403,7 +405,7 @@ namespace Microsoft.Boogie.Houdini
 
         var reason = new HashSet<string>();
         unsatisfiedSoftAssumptions.Iter(i => reason.Add(softAssumptions[i].ToString()));
-        if (CommandLineOptions.Clo.Trace)
+        if (Options.Trace)
         {
           Console.Write("Reason for removal of {0}: ", refutedConstant.Name);
           reason.Iter(r => Console.Write("{0} ", r));
@@ -439,7 +441,7 @@ namespace Microsoft.Boogie.Houdini
         var reason1 = new HashSet<string>(); //these are the reasons for inconsistency
         unsatisfiedSoftAssumptions2.Iter(i => reason1.Add(softAssumptions2[i].ToString()));
 
-        if (CommandLineOptions.Clo.Trace)
+        if (Options.Trace)
         {
           Console.Write("Revised reason for removal of {0}: ", refutedConstant.Name);
           reason.Iter(r => Console.Write("{0} ", r));
@@ -467,12 +469,12 @@ namespace Microsoft.Boogie.Houdini
           "TimeOut", descriptiveName);
       }
 
-      CommandLineOptions.Clo.ErrorLimit = el;
+      Options.ErrorLimit = el;
 
       double queryTime = (DateTime.UtcNow - now).TotalSeconds;
       stats.proverTime += queryTime;
       stats.numProverQueries++;
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Time taken = " + queryTime);
       }

--- a/Source/Houdini/Houdini.cs
+++ b/Source/Houdini/Houdini.cs
@@ -426,27 +426,27 @@ namespace Microsoft.Boogie.Houdini
 
     protected void Initialize(Program program, HoudiniSession.HoudiniStatistics stats)
     {
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Collecting existential constants...");
       }
 
       this.houdiniConstants = CollectExistentialConstants();
 
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Building call graph...");
       }
 
       this.callGraph = Program.BuildCallGraph(program);
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Number of implementations = {0}", callGraph.Nodes.Count);
       }
 
       if (Options.HoudiniUseCrossDependencies)
       {
-        if (CommandLineOptions.Clo.Trace)
+        if (Options.Trace)
         {
           Console.WriteLine("Computing procedure cross dependencies ...");
         }
@@ -458,24 +458,24 @@ namespace Microsoft.Boogie.Houdini
       Inline();
       /*
       {
-          int oldPrintUnstructured = CommandLineOptions.Clo.PrintUnstructured;
-          CommandLineOptions.Clo.PrintUnstructured = 1;
+          int oldPrintUnstructured = Options.PrintUnstructured;
+          Options.PrintUnstructured = 1;
           using (TokenTextWriter stream = new TokenTextWriter("houdini_inline.bpl"))
           {
               program.Emit(stream);
           }
-          CommandLineOptions.Clo.PrintUnstructured = oldPrintUnstructured;
+          Options.PrintUnstructured = oldPrintUnstructured;
       }
       */
 
       var checkerPool = new CheckerPool(Options);
       this.vcgen = new VCGen(program, checkerPool);
-      this.proverInterface = ProverInterface.CreateProver(Options, program, CommandLineOptions.Clo.ProverLogFilePath,
-        CommandLineOptions.Clo.ProverLogFileAppend, CommandLineOptions.Clo.TimeLimit, taskID: GetTaskID());
+      this.proverInterface = ProverInterface.CreateProver(Options, program, Options.ProverLogFilePath,
+        Options.ProverLogFileAppend, Options.TimeLimit, taskID: GetTaskID());
 
       vcgenFailures = new HashSet<Implementation>();
       Dictionary<Implementation, HoudiniSession> houdiniSessions = new Dictionary<Implementation, HoudiniSession>();
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Beginning VC generation for Houdini...");
       }
@@ -484,7 +484,7 @@ namespace Microsoft.Boogie.Houdini
       {
         try
         {
-          if (CommandLineOptions.Clo.Trace)
+          if (Options.Trace)
           {
             Console.WriteLine("Generating VC for {0}", impl.Name);
           }
@@ -495,7 +495,7 @@ namespace Microsoft.Boogie.Houdini
         }
         catch (VCGenException)
         {
-          if (CommandLineOptions.Clo.Trace)
+          if (Options.Trace)
           {
             Console.WriteLine("VC generation failed");
           }
@@ -522,7 +522,7 @@ namespace Microsoft.Boogie.Houdini
 
     protected void Inline()
     {
-      if (CommandLineOptions.Clo.InlineDepth <= 0)
+      if (Options.InlineDepth <= 0)
       {
         return;
       }
@@ -541,10 +541,10 @@ namespace Microsoft.Boogie.Houdini
 
       foreach (Implementation impl in callGraph.Nodes)
       {
-        CommandLineOptions.Inlining savedOption = CommandLineOptions.Clo.ProcedureInlining;
-        CommandLineOptions.Clo.ProcedureInlining = CommandLineOptions.Inlining.Spec;
+        CommandLineOptions.Inlining savedOption = Options.ProcedureInlining;
+        Options.ProcedureInlining = CommandLineOptions.Inlining.Spec;
         Inliner.ProcessImplementationForHoudini(program, impl);
-        CommandLineOptions.Clo.ProcedureInlining = savedOption;
+        Options.ProcedureInlining = savedOption;
       }
 
       foreach (Implementation impl in callGraph.Nodes)
@@ -565,7 +565,7 @@ namespace Microsoft.Boogie.Houdini
         callGraph.AddEdge(edge.Item1, edge.Item2);
       }
 
-      int count = CommandLineOptions.Clo.InlineDepth;
+      int count = Options.InlineDepth;
       while (count > 0)
       {
         foreach (Implementation impl in oldCallGraph.Nodes)
@@ -908,7 +908,7 @@ namespace Microsoft.Boogie.Houdini
 
     protected void UpdateAssignment(RefutedAnnotation refAnnot)
     {
-      if (CommandLineOptions.Clo.Trace)
+      if (Options.Trace)
       {
         Console.WriteLine("Removing " + refAnnot.Constant);
         using var cexWriter = new System.IO.StreamWriter(cexTraceFile, true);
@@ -964,7 +964,7 @@ namespace Microsoft.Boogie.Houdini
 
               #region Extra debugging output
 
-              if (CommandLineOptions.Clo.Trace) {
+              if (Options.Trace) {
                 using var cexWriter = new System.IO.StreamWriter(cexTraceFile, true);
                 cexWriter.WriteLine("Counter example for " + refutedAnnotation.Constant);
                 cexWriter.Write(error.ToString());
@@ -988,7 +988,7 @@ namespace Microsoft.Boogie.Houdini
 
           break;
         default:
-          if (CommandLineOptions.Clo.Trace)
+          if (Options.Trace)
           {
             Console.WriteLine("Timeout/Spaceout while verifying " + currentHoudiniState.Implementation.Name);
           }
@@ -996,7 +996,7 @@ namespace Microsoft.Boogie.Houdini
           houdiniSessions.TryGetValue(currentHoudiniState.Implementation, out var houdiniSession);
           foreach (Variable v in houdiniSession.houdiniAssertConstants)
           {
-            if (CommandLineOptions.Clo.Trace)
+            if (Options.Trace)
             {
               Console.WriteLine("Removing " + v);
             }
@@ -1509,11 +1509,11 @@ namespace Microsoft.Boogie.Houdini
     {
       var taskID = GetTaskID();
       int errorLimit;
-      if (CommandLineOptions.Clo.ConcurrentHoudini) {
+      if (Options.ConcurrentHoudini) {
         Contract.Assert(taskID >= 0);
-        errorLimit = CommandLineOptions.Clo.Cho[taskID].ErrorLimit;
+        errorLimit = Options.Cho[taskID].ErrorLimit;
       } else {
-        errorLimit = CommandLineOptions.Clo.ErrorLimit;
+        errorLimit = Options.ErrorLimit;
       }
 
       return errorLimit;

--- a/Source/Houdini/Houdini.cs
+++ b/Source/Houdini/Houdini.cs
@@ -541,8 +541,8 @@ namespace Microsoft.Boogie.Houdini
 
       foreach (Implementation impl in callGraph.Nodes)
       {
-        CommandLineOptions.Inlining savedOption = Options.ProcedureInlining;
-        Options.ProcedureInlining = CommandLineOptions.Inlining.Spec;
+        CoreOptions.Inlining savedOption = Options.ProcedureInlining;
+        Options.ProcedureInlining = CoreOptions.Inlining.Spec;
         Inliner.ProcessImplementationForHoudini(program, impl);
         Options.ProcedureInlining = savedOption;
       }

--- a/Source/Houdini/StagedHoudini.cs
+++ b/Source/Houdini/StagedHoudini.cs
@@ -39,11 +39,11 @@ namespace Microsoft.Boogie.Houdini
       var annotationDependenceAnalyser = new AnnotationDependenceAnalyser(options, program);
       annotationDependenceAnalyser.Analyse();
       this.plan = annotationDependenceAnalyser.ApplyStages();
-      if (CommandLineOptions.Clo.Trace)
+      if (options.Trace)
       {
         annotationDependenceAnalyser.dump();
 
-        if (CommandLineOptions.Clo.DebugStagedHoudini)
+        if (options.DebugStagedHoudini)
         {
           Console.WriteLine("Plan\n====\n");
           if (plan == null)
@@ -297,10 +297,10 @@ namespace Microsoft.Boogie.Houdini
     private void EmitProgram(string filename)
     {
       using TokenTextWriter writer = new TokenTextWriter(filename, true);
-      int oldPrintUnstructured = CommandLineOptions.Clo.PrintUnstructured;
-      CommandLineOptions.Clo.PrintUnstructured = 2;
+      int oldPrintUnstructured = options.PrintUnstructured;
+      options.PrintUnstructured = 2;
       program.Emit(writer);
-      CommandLineOptions.Clo.PrintUnstructured = oldPrintUnstructured;
+      options.PrintUnstructured = oldPrintUnstructured;
     }
 
 

--- a/Source/Provers/SMTLib/ProverContext.cs
+++ b/Source/Provers/SMTLib/ProverContext.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Boogie
         }
 
         axioms = gen.AndSimp(gen.Distinct(distinctVars), axioms);
-        if (CommandLineOptions.Clo.TypeEncodingMethod != CommandLineOptions.TypeEncoding.Monomorphic)
+        if (CoreOptions.Clo.TypeEncodingMethod != CoreOptions.TypeEncoding.Monomorphic)
         {
           axioms = gen.AndSimp(orderingAxiomBuilder.Axioms, axioms);
         }

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -32,11 +32,11 @@ public abstract class ProverInterface
 
     if (taskID >= 0)
     {
-      options.Parse(CommandLineOptions.Clo.Cho[taskID].ProverOptions);
+      options.Parse(libOptions.Cho[taskID].ProverOptions);
     }
     else
     {
-      options.Parse(CommandLineOptions.Clo.ProverOptions);
+      options.Parse(libOptions.ProverOptions);
     }
 
     ProverContext ctx = libOptions.TheProverFactory.NewProverContext(options);
@@ -104,6 +104,13 @@ public abstract class ProverInterface
 
   public class ErrorHandler
   {
+    private SMTLibOptions options;
+
+    public ErrorHandler(SMTLibOptions options)
+    {
+      this.options = options;
+    }
+
     public virtual void AddNecessaryAssume(string id)
     {
       throw new System.NotImplementedException();
@@ -129,7 +136,7 @@ public abstract class ProverInterface
     public virtual void OnProverWarning(string message)
     {
       Contract.Requires(message != null);
-      switch (CommandLineOptions.Clo.PrintProverWarnings)
+      switch (options.PrintProverWarnings)
       {
         case CommandLineOptions.ProverWarnings.None:
           break;

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -138,12 +138,12 @@ public abstract class ProverInterface
       Contract.Requires(message != null);
       switch (options.PrintProverWarnings)
       {
-        case CommandLineOptions.ProverWarnings.None:
+        case CoreOptions.ProverWarnings.None:
           break;
-        case CommandLineOptions.ProverWarnings.Stdout:
+        case CoreOptions.ProverWarnings.Stdout:
           Console.WriteLine("Prover warning: " + message);
           break;
-        case CommandLineOptions.ProverWarnings.Stderr:
+        case CoreOptions.ProverWarnings.Stderr:
           Console.Error.WriteLine("Prover warning: " + message);
           break;
         default:

--- a/Source/Provers/SMTLib/ProverUtil.cs
+++ b/Source/Provers/SMTLib/ProverUtil.cs
@@ -172,7 +172,7 @@ The generic options may or may not be used by the prover plugin.
       Contract.Requires(proverPath != null);
       Contract.Ensures(confirmedProverPath != null);
       confirmedProverPath = proverPath;
-      if (CommandLineOptions.Clo.Trace)
+      if (CoreOptions.Clo.Trace)
       {
         Console.WriteLine("[TRACE] Using prover: " + confirmedProverPath);
       }

--- a/Source/Provers/SMTLib/SMTLibOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibOptions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Microsoft.Boogie
 {
   // TODO move to SMTLib
-  public interface SMTLibOptions : CommandLineOptions
+  public interface SMTLibOptions : CoreOptions
   {
     ProverFactory TheProverFactory { get; }
 

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -108,11 +108,11 @@ namespace Microsoft.Boogie.SMTLib
     {
       switch (libOptions.TypeEncodingMethod)
       {
-        case CommandLineOptions.TypeEncoding.Arguments:
+        case CoreOptions.TypeEncoding.Arguments:
           AxBuilder = new TypeAxiomBuilderArguments(gen);
           AxBuilder.Setup();
           break;
-        case CommandLineOptions.TypeEncoding.Monomorphic:
+        case CoreOptions.TypeEncoding.Monomorphic:
           AxBuilder = null;
           break;
         default:
@@ -1733,13 +1733,13 @@ namespace Microsoft.Boogie.SMTLib
         VCExpr exprWithoutTypes;
         switch (libOptions.TypeEncodingMethod)
         {
-          case CommandLineOptions.TypeEncoding.Arguments:
+          case CoreOptions.TypeEncoding.Arguments:
           {
             TypeEraser eraser = new TypeEraserArguments((TypeAxiomBuilderArguments) AxBuilder, gen);
             exprWithoutTypes = AxBuilder.Cast(eraser.Erase(expr, polarity), Type.Bool);
             break;
           }
-          case CommandLineOptions.TypeEncoding.Monomorphic:
+          case CoreOptions.TypeEncoding.Monomorphic:
           {
             exprWithoutTypes = expr;
             break;
@@ -1827,7 +1827,7 @@ namespace Microsoft.Boogie.SMTLib
       //throws ProverException, System.IO.FileNotFoundException;
       if (_backgroundPredicates == null)
       {
-        if (libOptions.TypeEncodingMethod == CommandLineOptions.TypeEncoding.Monomorphic)
+        if (libOptions.TypeEncodingMethod == CoreOptions.TypeEncoding.Monomorphic)
         {
           _backgroundPredicates = "";
         }

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Boogie.SMTLib
         return;
       }
 
-      if (type.IsMap && options.TypeEncodingMethod == CommandLineOptions.TypeEncoding.Monomorphic)
+      if (type.IsMap && options.TypeEncodingMethod == CoreOptions.TypeEncoding.Monomorphic)
       {
         KnownTypes.Add(type);
         MapType mapType = type.AsMap;
@@ -352,7 +352,7 @@ namespace Microsoft.Boogie.SMTLib
         }
       }
 
-      if (options.TypeEncodingMethod == CommandLineOptions.TypeEncoding.Monomorphic)
+      if (options.TypeEncodingMethod == CoreOptions.TypeEncoding.Monomorphic)
       {
         AddDeclaration("(declare-sort " + TypeToString(type) + " 0)");
         KnownTypes.Add(type);
@@ -399,7 +399,7 @@ namespace Microsoft.Boogie.SMTLib
                       TypeToString(node.Type) + ")";
         AddDeclaration(decl);
 
-        if (options.TypeEncodingMethod == CommandLineOptions.TypeEncoding.Monomorphic)
+        if (options.TypeEncodingMethod == CoreOptions.TypeEncoding.Monomorphic)
         {
           var sel = new SMTLibExprLineariser(options).SelectOpName(node);
           sel = Namer.GetQuotedName(sel, sel);

--- a/Source/UnitTests/CoreTests/Duplicator.cs
+++ b/Source/UnitTests/CoreTests/Duplicator.cs
@@ -119,7 +119,7 @@ namespace CoreTests
     [Test()]
     public void GotoTargets()
     {
-      CommandLineOptions.Clo = new CommandLineOptionsImpl();
+      CoreOptions.Clo = new CommandLineOptions();
       Program p = TestUtil.ProgramLoader.LoadProgramFrom(@"
         procedure main()
         {
@@ -218,7 +218,7 @@ namespace CoreTests
     [Test()]
     public void CallCmdResolving()
     {
-      CommandLineOptions.Clo = new CommandLineOptionsImpl();
+      CoreOptions.Clo = new CommandLineOptions();
       Program p = TestUtil.ProgramLoader.LoadProgramFrom(@"
         procedure main()
         {

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -26,8 +26,8 @@ namespace ExecutionEngineTests
     
     [Test]
     public async Task InferAndVerifyCanBeCancelledWhileWaitingForProver() {
-      var options = CommandLineOptionsImpl.FromArguments();
-      CommandLineOptionsImpl.Install(options);
+      var options = CommandLineOptions.FromArguments();
+      CommandLineOptions.Install(options);
       var infiniteProgram = GetProgram(options, slow);
       var terminatingProgram = GetProgram(options, fast);
       

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Boogie;
 using NUnit.Framework;
@@ -9,18 +7,18 @@ namespace ExecutionEngineTests
   [TestFixture]
   public class CancellationTests
   {
-    public Program GetProgram(ExecutionEngineOptions options, string code) {
+    public Program GetProgram(ExecutionEngine engine, string code) {
       var bplFileName = "1";
       int errorCount = Parser.Parse(code, bplFileName, out Program program,
-        options.UseBaseNameForFileName);
+        engine.Options.UseBaseNameForFileName);
       Assert.AreEqual(0, errorCount);
 
-      ExecutionEngine.printer = new ConsolePrinter(options);
-      ExecutionEngine.ResolveAndTypecheck(options, program, bplFileName, out _);
-      ExecutionEngine.EliminateDeadVariables(program);
-      ExecutionEngine.CollectModSets(options, program);
-      ExecutionEngine.CoalesceBlocks(options, program);
-      ExecutionEngine.Inline(options, program);
+      ExecutionEngine.printer = new ConsolePrinter(engine.Options);
+      engine.ResolveAndTypecheck(program, bplFileName, out _);
+      engine.EliminateDeadVariables(program);
+      engine.CollectModSets(program);
+      engine.CoalesceBlocks(program);
+      engine.Inline(program);
       return program;
     }
     
@@ -28,20 +26,21 @@ namespace ExecutionEngineTests
     public async Task InferAndVerifyCanBeCancelledWhileWaitingForProver() {
       var options = CommandLineOptions.FromArguments();
       CommandLineOptions.Install(options);
-      var infiniteProgram = GetProgram(options, slow);
-      var terminatingProgram = GetProgram(options, fast);
+      using var executionEngine = new ExecutionEngine(options);
+      var infiniteProgram = GetProgram(executionEngine, slow);
+      var terminatingProgram = GetProgram(executionEngine, fast);
       
       // We limit the number of checkers to 1.
       options.VcsCores = 1;
 
       var requestId = ExecutionEngine.FreshRequestId();
-      var outcomeTask = Task.Run(() => ExecutionEngine.InferAndVerify(options, infiniteProgram, new PipelineStatistics(), requestId, null, requestId));
+      var outcomeTask = Task.Run(() => executionEngine.InferAndVerify(infiniteProgram, new PipelineStatistics(), requestId, null, requestId));
       await Task.Delay(1000);
       ExecutionEngine.CancelRequest(requestId);
       var outcome = await outcomeTask;
       Assert.AreEqual(PipelineOutcome.Cancelled, outcome);
       var requestId2 = ExecutionEngine.FreshRequestId();
-      var outcome2 = ExecutionEngine.InferAndVerify(options, terminatingProgram, new PipelineStatistics(), requestId2, null, requestId2);
+      var outcome2 = executionEngine.InferAndVerify(terminatingProgram, new PipelineStatistics(), requestId2, null, requestId2);
       Assert.AreEqual(PipelineOutcome.VerificationCompleted, outcome2);
     }
 

--- a/Source/UnitTests/ExecutionEngineTests/GetProverLogs.cs
+++ b/Source/UnitTests/ExecutionEngineTests/GetProverLogs.cs
@@ -10,7 +10,7 @@ public static class GetProverLogs
 {
   public static string GetProverLogForProgram(ExecutionEngineOptions options, string procedure)
   {
-    CommandLineOptionsImpl.Install(options);
+    CommandLineOptions.Install(options);
     var logs = GetProverLogsForProgram(options, procedure).ToList();
     Assert.AreEqual(1, logs.Count);
     return logs[0];

--- a/Source/UnitTests/ExecutionEngineTests/GetProverLogs.cs
+++ b/Source/UnitTests/ExecutionEngineTests/GetProverLogs.cs
@@ -18,19 +18,20 @@ public static class GetProverLogs
     
   public static IEnumerable<string> GetProverLogsForProgram(ExecutionEngineOptions options, string procedure1)
   {
-    ExecutionEngine.printer = new ConsolePrinter(options);
+    using var engine = new ExecutionEngine(options);
+    ExecutionEngine.printer = new ConsolePrinter(engine.Options);
     var defines = new List<string>() { "FILE_0" };
 
     // Parse error are printed to StdOut :/
     int errorCount = Parser.Parse(new StringReader(procedure1), "1", defines, out Program program1,
-      options.UseBaseNameForFileName);
+      engine.Options.UseBaseNameForFileName);
     Assert.AreEqual(0, errorCount);
     string directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
     Directory.CreateDirectory(directory);
     var temp1 = directory + "/proverLog";
-    options.ProverLogFilePath = temp1;
-    options.ProverOptions.Add("SOLVER=noop");
-    var success1 = ExecutionEngine.ProcessProgram(options, program1, "1");
+    engine.Options.ProverLogFilePath = temp1;
+    engine.Options.ProverOptions.Add("SOLVER=noop");
+    var success1 = engine.ProcessProgram(program1, "1");
     foreach (var proverFile in Directory.GetFiles(directory)) {
       yield return File.ReadAllText(proverFile);
     }

--- a/Source/UnitTests/ExecutionEngineTests/RandomSeedTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/RandomSeedTest.cs
@@ -27,18 +27,18 @@ public class RandomSeedTest
   [Test]
   public void AttributeAndCommandLineOptionProduceSameResult()
   {
-    var options = CommandLineOptionsImpl.FromArguments();
+    var options = CommandLineOptions.FromArguments();
     options.RandomSeed = randomSeed;
     var randomOptionsLogs = GetProverLogs.GetProverLogForProgram(options, program);
     var randomAttributeLogs =
-      GetProverLogs.GetProverLogForProgram(CommandLineOptionsImpl.FromArguments(), GetProgramWithAttribute(randomSeed));
+      GetProverLogs.GetProverLogForProgram(CommandLineOptions.FromArguments(), GetProgramWithAttribute(randomSeed));
     Assert.AreEqual(randomOptionsLogs, randomAttributeLogs);
   }
 
   [Test]
   public void Z3RandomisationOptionsAreSet()
   {
-    var options = CommandLineOptionsImpl.FromArguments();
+    var options = CommandLineOptions.FromArguments();
     options.RandomSeed = randomSeed;
     var randomOptionsLogs = GetProverLogs.GetProverLogForProgram(options, program);
     Assert.IsTrue(randomOptionsLogs.Contains("(set-option :smt.random_seed 12312314)"));
@@ -48,7 +48,7 @@ public class RandomSeedTest
   [Test]
   public void DeclarationOrderIsRandomised()
   {
-    var options = CommandLineOptionsImpl.FromArguments();
+    var options = CommandLineOptions.FromArguments();
     options.NormalizeDeclarationOrder = false;
     var noRandomLogs = GetProverLogs.GetProverLogForProgram(options, program);
     options.RandomSeed = 10000;
@@ -68,7 +68,7 @@ public class RandomSeedTest
   [Test]
   public void SomeVariablesAreRenamed()
   {
-    var options = CommandLineOptionsImpl.FromArguments();
+    var options = CommandLineOptions.FromArguments();
     options.RandomSeed = randomSeed;
     options.NormalizeNames = false;
     var randomOptionsLogs = GetProverLogs.GetProverLogForProgram(options, program);

--- a/Source/UnitTests/ExecutionEngineTests/SolverLogStabilityTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/SolverLogStabilityTest.cs
@@ -41,7 +41,7 @@ procedure M(p: Person)
 {
 }";
 
-      var options = CommandLineOptionsImpl.FromArguments();
+      var options = CommandLineOptions.FromArguments();
       options.NormalizeNames = true;
       options.EmitDebugInformation = false;
       
@@ -64,7 +64,7 @@ procedure M(x: int)
   assert (forall y:int :: x + y + x - y == 4);
 }";
       
-      var options = CommandLineOptionsImpl.FromArguments();
+      var options = CommandLineOptions.FromArguments();
       
       var proverLog1 = GetProverLogs.GetProverLogForProgram(options, procedure);
       Assert.True(proverLog1.Contains("skolemid"));
@@ -146,7 +146,7 @@ procedure M(x2: int, coloredBarrel: Barrel2 RGBColor2)
 }
 ";
       
-      var options = CommandLineOptionsImpl.FromArguments();
+      var options = CommandLineOptions.FromArguments();
       options.NormalizeNames = true;
       
       var proverLog1 = GetProverLogs.GetProverLogForProgram(options, procedure1);
@@ -176,7 +176,7 @@ procedure N(x: int)
       var procedure2And1 = $@"
 {procedure1}
 {procedure2}";
-      var options = CommandLineOptionsImpl.FromArguments();
+      var options = CommandLineOptions.FromArguments();
       
       var proverLog1 = GetProverLogs.GetProverLogForProgram(options, procedure1);
       options.ProcsToCheck.Add("M");
@@ -260,7 +260,7 @@ procedure M2(x: int, coloredBarrel: Barrel2 RGBColor2)
       var procedure2And1 = $@"
 {procedure1}
 {procedure2}";
-      var options = CommandLineOptionsImpl.FromArguments();
+      var options = CommandLineOptions.FromArguments();
       options.Prune = true;
       
       var proverLog1 = GetProverLogs.GetProverLogForProgram(options, procedure1);

--- a/Source/VCExpr/TypeErasureArguments.cs
+++ b/Source/VCExpr/TypeErasureArguments.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Boogie.TypeErasure
       select = HelperFuns.BoogieFunction(baseName + "Select", selectTypes);
       store = HelperFuns.BoogieFunction(baseName + "Store", storeTypes);
 
-      if (CommandLineOptions.Clo.UseArrayTheory)
+      if (CoreOptions.Clo.UseArrayTheory)
       {
         select.AddAttribute("builtin", "select");
         store.AddAttribute("builtin", "store");

--- a/Source/VCExpr/TypeErasurePremisses.cs
+++ b/Source/VCExpr/TypeErasurePremisses.cs
@@ -729,7 +729,7 @@ namespace Microsoft.Boogie.TypeErasure
       // the store function does not have any explicit type parameters
       Contract.Assert(explicitStoreParams.Count == 0);
 
-      if (CommandLineOptions.Clo.UseArrayTheory)
+      if (CoreOptions.Clo.UseArrayTheory)
       {
         select.AddAttribute("builtin", "select");
         store.AddAttribute("builtin", "store");
@@ -1343,8 +1343,8 @@ namespace Microsoft.Boogie.TypeErasure
       List<VCExprVar /*!*/> /*!*/
         newVarsWithTypeSpecs = new List<VCExprVar /*!*/>();
       if (!IsUniversalQuantifier(node) ||
-          CommandLineOptions.Clo.TypeEncodingMethod
-          == CommandLineOptions.TypeEncoding.Predicates)
+          CoreOptions.Clo.TypeEncodingMethod
+          == CoreOptions.TypeEncoding.Predicates)
       {
         foreach (VCExprVar /*!*/ oldVar in occurringVars)
         {

--- a/Source/VCExpr/VCExprASTPrinter.cs
+++ b/Source/VCExpr/VCExprASTPrinter.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       //Contract.Requires(wr != null);
       //Contract.Requires(node != null);
-      if (CommandLineOptions.Clo.ReflectAdd)
+      if (CoreOptions.Clo.ReflectAdd)
       {
         return PrintNAry("Reflect$Add", node, wr);
       }

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Boogie
         }
       }
 
-      SolverOptions.Parse(CommandLineOptions.Clo.ProverOptions);
+      SolverOptions.Parse(Options.ProverOptions);
 
       var ctx = Pool.Options.TheProverFactory.NewProverContext(SolverOptions);
 
@@ -151,7 +151,7 @@ namespace Microsoft.Boogie
     /// </summary>
     private void Setup(Program prog, ProverContext ctx, Split split = null)
     {
-      SolverOptions.RandomSeed = split?.RandomSeed ?? CommandLineOptions.Clo.RandomSeed;
+      SolverOptions.RandomSeed = split?.RandomSeed ?? Options.RandomSeed;
       var random = SolverOptions.RandomSeed == null ? null : new Random(SolverOptions.RandomSeed.Value);
       
       Program = prog;
@@ -186,11 +186,11 @@ namespace Microsoft.Boogie
       }
     }
 
-    private static IEnumerable<Declaration> GetReorderedDeclarations(IEnumerable<Declaration> declarations, Random random)
+    private IEnumerable<Declaration> GetReorderedDeclarations(IEnumerable<Declaration> declarations, Random random)
     {
       if (random == null) {
         // By ordering the declarations based on their content and naming them based on order, the solver input stays constant under reordering and renaming.
-        return CommandLineOptions.Clo.NormalizeDeclarationOrder
+        return Options.NormalizeDeclarationOrder
           ? declarations.OrderBy(d => d.ContentHash)
           : declarations;
       }
@@ -258,7 +258,7 @@ namespace Microsoft.Boogie
     private async Task WaitForOutput(object dummy, CancellationToken cancellationToken)
     {
       try {
-        outcome = await thmProver.CheckOutcome(cce.NonNull(handler), CommandLineOptions.Clo.ErrorLimit,
+        outcome = await thmProver.CheckOutcome(cce.NonNull(handler), Options.ErrorLimit,
           cancellationToken);
       }
       catch (OperationCanceledException) {

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Boogie
     public volatile Program Program;
     public readonly ProverOptions SolverOptions;
 
+    public VCGenOptions Options => Pool.Options;
     public CheckerPool Pool { get; }
 
     public void GetReady()

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -603,9 +603,9 @@ namespace Microsoft.Boogie
 
   public class VerifierCallback
   {
-    private CommandLineOptions.ProverWarnings printProverWarnings;
+    private CoreOptions.ProverWarnings printProverWarnings;
 
-    public VerifierCallback(CommandLineOptions.ProverWarnings printProverWarnings)
+    public VerifierCallback(CoreOptions.ProverWarnings printProverWarnings)
     {
       this.printProverWarnings = printProverWarnings;
     }
@@ -647,12 +647,12 @@ namespace Microsoft.Boogie
       Contract.Requires(msg != null);
       switch (printProverWarnings)
       {
-        case CommandLineOptions.ProverWarnings.None:
+        case CoreOptions.ProverWarnings.None:
           break;
-        case CommandLineOptions.ProverWarnings.Stdout:
+        case CoreOptions.ProverWarnings.Stdout:
           Console.WriteLine("Prover warning: " + msg);
           break;
-        case CommandLineOptions.ProverWarnings.Stderr:
+        case CoreOptions.ProverWarnings.Stderr:
           Console.Error.WriteLine("Prover warning: " + msg);
           break;
         default:

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Boogie
       Contract.Invariant(cce.NonNullDictionaryAndValues(calleeCounterexamples));
     }
 
+    protected readonly VCGenOptions options;
     [Peer] public List<Block> Trace;
     public List<object> AugmentedTrace;
     public Model Model;
@@ -87,10 +88,11 @@ namespace Microsoft.Boogie
 
     public Dictionary<TraceLocation, CalleeCounterexampleInfo> calleeCounterexamples;
 
-    internal Counterexample(List<Block> trace, List<object> augmentedTrace, Model model, VC.ModelViewInfo mvInfo, ProverContext context)
+    internal Counterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, Model model, VC.ModelViewInfo mvInfo, ProverContext context)
     {
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
+      this.options = options;
       this.Trace = trace;
       this.Model = model;
       this.MvInfo = mvInfo;
@@ -175,7 +177,7 @@ namespace Microsoft.Boogie
           // for ErrorTrace == 1 restrict the output;
           // do not print tokens with -17:-4 as their location because they have been
           // introduced in the translation and do not give any useful feedback to the user
-          if (!(CommandLineOptions.Clo.ErrorTrace == 1 && b.tok.line == -17 && b.tok.col == -4))
+          if (!(options.ErrorTrace == 1 && b.tok.line == -17 && b.tok.col == -4))
           {
             if (blockAction != null)
             {
@@ -192,7 +194,7 @@ namespace Microsoft.Boogie
                 var cmd = getTraceCmd(loc);
                 var calleeName = getCalledProcName(cmd);
                 if (calleeName.StartsWith(VC.StratifiedVCGenBase.recordProcName) &&
-                    CommandLineOptions.Clo.StratifiedInlining > 0)
+                    options.StratifiedInlining > 0)
                 {
                   Contract.Assert(calleeCounterexamples[loc].args.Count == 1);
                   var arg = calleeCounterexamples[loc].args[0];
@@ -217,8 +219,8 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(counterexample != null);
 
-      var filename = CommandLineOptions.Clo.ModelViewFile;
-      if (Model == null || filename == null || CommandLineOptions.Clo.StratifiedInlining > 0)
+      var filename = options.ModelViewFile;
+      if (Model == null || filename == null || options.StratifiedInlining > 0)
       {
         return;
       }
@@ -473,9 +475,9 @@ namespace Microsoft.Boogie
     }
 
 
-    public AssertCounterexample(List<Block> trace, List<object> augmentedTrace, AssertCmd failingAssert, Model model, VC.ModelViewInfo mvInfo,
+    public AssertCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, AssertCmd failingAssert, Model model, VC.ModelViewInfo mvInfo,
       ProverContext context)
-      : base(trace, augmentedTrace, model, mvInfo, context)
+      : base(options, trace, augmentedTrace, model, mvInfo, context)
     {
       Contract.Requires(trace != null);
       Contract.Requires(failingAssert != null);
@@ -495,7 +497,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new AssertCounterexample(Trace, AugmentedTrace, FailingAssert, Model, MvInfo, Context);
+      var ret = new AssertCounterexample(options, Trace, AugmentedTrace, FailingAssert, Model, MvInfo, Context);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -514,9 +516,9 @@ namespace Microsoft.Boogie
     }
 
 
-    public CallCounterexample(List<Block> trace, List<object> augmentedTrace, CallCmd failingCall, Requires failingRequires, Model model,
+    public CallCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, CallCmd failingCall, Requires failingRequires, Model model,
       VC.ModelViewInfo mvInfo, ProverContext context, byte[] checksum = null)
-      : base(trace, augmentedTrace, model, mvInfo, context)
+      : base(options, trace, augmentedTrace, model, mvInfo, context)
     {
       Contract.Requires(!failingRequires.Free);
       Contract.Requires(trace != null);
@@ -543,7 +545,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new CallCounterexample(Trace, AugmentedTrace, FailingCall, FailingRequires, Model, MvInfo, Context, Checksum);
+      var ret = new CallCounterexample(options, Trace, AugmentedTrace, FailingCall, FailingRequires, Model, MvInfo, Context, Checksum);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -562,9 +564,9 @@ namespace Microsoft.Boogie
     }
 
 
-    public ReturnCounterexample(List<Block> trace, List<object> augmentedTrace, TransferCmd failingReturn, Ensures failingEnsures, Model model,
+    public ReturnCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, TransferCmd failingReturn, Ensures failingEnsures, Model model,
       VC.ModelViewInfo mvInfo, ProverContext context, byte[] checksum)
-      : base(trace, augmentedTrace, model, mvInfo, context)
+      : base(options, trace, augmentedTrace, model, mvInfo, context)
     {
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
@@ -593,7 +595,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new ReturnCounterexample(Trace, AugmentedTrace, FailingReturn, FailingEnsures, Model, MvInfo, Context, checksum);
+      var ret = new ReturnCounterexample(options, Trace, AugmentedTrace, FailingReturn, FailingEnsures, Model, MvInfo, Context, checksum);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -601,6 +603,13 @@ namespace Microsoft.Boogie
 
   public class VerifierCallback
   {
+    private CommandLineOptions.ProverWarnings printProverWarnings;
+
+    public VerifierCallback(CommandLineOptions.ProverWarnings printProverWarnings)
+    {
+      this.printProverWarnings = printProverWarnings;
+    }
+
     // reason == null means this is genuine counterexample returned by the prover
     // other reason means it's time out/memory out/crash
     public virtual void OnCounterexample(Counterexample ce, string /*?*/ reason)
@@ -636,7 +645,7 @@ namespace Microsoft.Boogie
     public virtual void OnWarning(string msg)
     {
       Contract.Requires(msg != null);
-      switch (CommandLineOptions.Clo.PrintProverWarnings)
+      switch (printProverWarnings)
       {
         case CommandLineOptions.ProverWarnings.None:
           break;

--- a/Source/VCGeneration/Prune/Prune.cs
+++ b/Source/VCGeneration/Prune/Prune.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Boogie
 
     public static Dictionary<object, List<object>> ComputeDeclarationDependencies(Program program)
     {
-      if (!CommandLineOptions.Clo.Prune)
+      if (!CoreOptions.Clo.Prune)
       {
         return null;
       }
@@ -56,7 +56,7 @@ namespace Microsoft.Boogie
      */
     public static IEnumerable<Declaration> GetLiveDeclarations(Program program, List<Block> blocks)
     {
-      if (program.DeclarationDependencies == null || blocks == null || !CommandLineOptions.Clo.Prune)
+      if (program.DeclarationDependencies == null || blocks == null || !CoreOptions.Clo.Prune)
       {
         return program.TopLevelDeclarations;
       }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -17,7 +17,9 @@ namespace VC
 
   public class Split
   {
-      public int? RandomSeed => Implementation.RandomSeed ?? Options.RandomSeed;
+      private VCGenOptions options;
+
+      public int? RandomSeed => Implementation.RandomSeed ?? options.RandomSeed;
     
       class BlockStats
       {
@@ -117,7 +119,8 @@ namespace VC
       private int splitNum;
       internal VCGen.ErrorReporter reporter;
 
-      public Split(List<Block /*!*/> /*!*/ blocks, Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
+      public Split(VCGenOptions options, List<Block /*!*/> /*!*/ blocks,
+        Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
         VCGen /*!*/ par, Implementation /*!*/ implementation)
       {
         Contract.Requires(cce.NonNullElements(blocks));
@@ -128,6 +131,7 @@ namespace VC
         this.gotoCmdOrigins = gotoCmdOrigins;
         this.parent = par;
         this.Implementation = implementation;
+        this.options = options;
         Interlocked.Increment(ref currentId);
 
         TopLevelDeclarations = par.program.TopLevelDeclarations;
@@ -138,14 +142,14 @@ namespace VC
 
       private void PrintTopLevelDeclarationsForPruning(Program program, Implementation implementation, string suffix)
       {
-        if (!Options.Prune || Options.PrintPrunedFile == null)
+        if (!options.Prune || options.PrintPrunedFile == null)
         {
           return;
         }
 
         using var writer = new TokenTextWriter(
-          $"{Options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}", false,
-          Options.PrettyPrint);
+          $"{options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}", false,
+          options.PrettyPrint);
         foreach (var declaration in TopLevelDeclarations ?? program.TopLevelDeclarations) {
           declaration.Emit(writer, 0);
         }
@@ -216,17 +220,17 @@ namespace VC
         string filename = string.Format("{0}.split.{1}.bpl", Implementation.Name, splitNum);
         using (System.IO.StreamWriter sw = System.IO.File.CreateText(filename))
         {
-          int oldPrintUnstructured = Options.PrintUnstructured;
-          Options.PrintUnstructured = 2; // print only the unstructured program
-          bool oldPrintDesugaringSetting = Options.PrintDesugarings;
-          Options.PrintDesugarings = false;
+          int oldPrintUnstructured = options.PrintUnstructured;
+          options.PrintUnstructured = 2; // print only the unstructured program
+          bool oldPrintDesugaringSetting = options.PrintDesugarings;
+          options.PrintDesugarings = false;
           List<Block> backup = Implementation.Blocks;
           Contract.Assert(backup != null);
           Implementation.Blocks = blocks;
           Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false), 0);
           Implementation.Blocks = backup;
-          Options.PrintDesugarings = oldPrintDesugaringSetting;
-          Options.PrintUnstructured = oldPrintUnstructured;
+          options.PrintDesugarings = oldPrintDesugaringSetting;
+          options.PrintUnstructured = oldPrintUnstructured;
         }
       }
 
@@ -432,7 +436,7 @@ namespace VC
           }
         }
 
-        if (Options.VcsPathSplitMult * score > totalCost)
+        if (options.VcsPathSplitMult * score > totalCost)
         {
           splitBlock = null;
           score = -1;
@@ -471,7 +475,7 @@ namespace VC
 
           if (count > 1)
           {
-            s.incomingPaths *= Options.VcsPathJoinMult;
+            s.incomingPaths *= options.VcsPathJoinMult;
           }
         }
       }
@@ -583,14 +587,14 @@ namespace VC
             double local = s.assertionCost;
             if (ShouldAssumize(b))
             {
-              local = (s.assertionCost + s.assumptionCost) * Options.VcsAssumeMult;
+              local = (s.assertionCost + s.assumptionCost) * options.VcsAssumeMult;
             }
             else
             {
-              local = s.assumptionCost * Options.VcsAssumeMult + s.assertionCost;
+              local = s.assumptionCost * options.VcsAssumeMult + s.assertionCost;
             }
 
-            local = local + local * s.incomingPaths * Options.VcsPathCostMult;
+            local = local + local * s.incomingPaths * options.VcsPathCostMult;
             cost += local;
           }
         }
@@ -715,7 +719,7 @@ namespace VC
           }
         }
 
-        return new Split(newBlocks, newGotoCmdOrigins, parent, Implementation);
+        return new Split(options, newBlocks, newGotoCmdOrigins, parent, Implementation);
       }
 
       Split SplitAt(int idx)
@@ -754,7 +758,7 @@ namespace VC
         List<Block> tmp = Implementation.Blocks;
         Contract.Assert(tmp != null);
         Implementation.Blocks = blocks;
-        ConditionGeneration.EmitImpl(Options, Implementation, false);
+        ConditionGeneration.EmitImpl(options, Implementation, false);
         Implementation.Blocks = tmp;
       }
 
@@ -778,7 +782,7 @@ namespace VC
             Contract.Assert(c != null);
             if (c is AssertCmd)
             {
-              return VCGen.AssertCmdToCounterexample(Options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context);
+              return VCGen.AssertCmdToCounterexample(options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context);
             }
           }
         }
@@ -786,8 +790,6 @@ namespace VC
         Contract.Assume(false);
         throw new cce.UnreachableException();
       }
-
-      private VCGenOptions Options => Checker.Options;
 
       private static void PrintSet<T> (HashSet<T> s) {
         foreach(T i in s)
@@ -951,13 +953,13 @@ namespace VC
                || c is AssertCmd && splitOnEveryAssert;
       }
       
-      public static List<Split /*!*/> FindManualSplits(Split s, bool splitOnEveryAssert)
+      public static List<Split /*!*/> FindManualSplits(Split initialSplit, bool splitOnEveryAssert)
       {
-        Contract.Requires(s.Implementation != null);
+        Contract.Requires(initialSplit.Implementation != null);
         Contract.Ensures(Contract.Result<List<Split>>() == null || cce.NonNullElements(Contract.Result<List<Split>>()));
 
         var splitPoints = new Dictionary<Block, int>();
-        foreach (var b in s.blocks)
+        foreach (var b in initialSplit.blocks)
         {
           foreach (Cmd c in b.Cmds)
           {
@@ -969,39 +971,39 @@ namespace VC
             }
           }
         }
-        List<Split> splits = new List<Split>();
-        if (splitPoints.Count() == 0)
+        var splits = new List<Split>();
+        if (!splitPoints.Any())
         {
-          splits.Add(s);
+          splits.Add(initialSplit);
         }
         else
         {
-          Block entryPoint = s.blocks[0];
-          var blockAssignments = PickBlocksToVerify(s.blocks, splitPoints);
+          Block entryPoint = initialSplit.blocks[0];
+          var blockAssignments = PickBlocksToVerify(initialSplit.blocks, splitPoints);
           var entryBlockHasSplit = splitPoints.Keys.Contains(entryPoint);
-          var baseSplitBlocks = PostProcess(DoPreAssignedManualSplit(s.blocks, blockAssignments, -1, entryPoint, !entryBlockHasSplit, splitOnEveryAssert));
-          splits.Add(new Split(baseSplitBlocks, s.gotoCmdOrigins, s.parent, s.Implementation));
+          var baseSplitBlocks = PostProcess(DoPreAssignedManualSplit(initialSplit.blocks, blockAssignments, -1, entryPoint, !entryBlockHasSplit, splitOnEveryAssert));
+          splits.Add(new Split(initialSplit.options, baseSplitBlocks, initialSplit.gotoCmdOrigins, initialSplit.parent, initialSplit.Implementation));
           foreach (KeyValuePair<Block, int> pair in splitPoints)
           {
             for (int i = 0; i < pair.Value; i++)
             {
               bool lastSplitInBlock = i == pair.Value - 1;
-              var newBlocks = DoPreAssignedManualSplit(s.blocks, blockAssignments, i, pair.Key, lastSplitInBlock, splitOnEveryAssert);
-              splits.Add(new Split(PostProcess(newBlocks), s.gotoCmdOrigins, s.parent, s.Implementation)); // REVIEW: Does gotoCmdOrigins need to be changed at all?
+              var newBlocks = DoPreAssignedManualSplit(initialSplit.blocks, blockAssignments, i, pair.Key, lastSplitInBlock, splitOnEveryAssert);
+              splits.Add(new Split(initialSplit.options, PostProcess(newBlocks), initialSplit.gotoCmdOrigins, initialSplit.parent, initialSplit.Implementation)); // REVIEW: Does gotoCmdOrigins need to be changed at all?
             }
           }
         }
         return splits;
       }
 
-      public static List<Split> FocusImpl(Implementation impl, Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins, VCGen par)
+      public static List<Split> FocusImpl(VCGenOptions options, Implementation impl, Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins, VCGen par)
       {
         bool IsFocusCmd(Cmd c) {
           return c is PredicateCmd p && QKeyValue.FindBoolAttribute(p.Attributes, "focus");
         }
 
         List<Block> GetFocusBlocks(List<Block> blocks) {
-          return blocks.Where(blk => blk.Cmds.Where(c => IsFocusCmd(c)).Any()).ToList();
+          return blocks.Where(blk => blk.Cmds.Any(c => IsFocusCmd(c))).ToList();
         }
 
         var dag = Program.GraphFromImpl(impl);
@@ -1014,7 +1016,7 @@ namespace VC
         }
         if (!focusBlocks.Any()) {
           var f = new List<Split>();
-          f.Add(new Split(impl.Blocks, gotoCmdOrigins, par, impl));
+          f.Add(new Split(options, impl.Blocks, gotoCmdOrigins, par, impl));
           return f;
         }
         // finds all the blocks dominated by focusBlock in the subgraph
@@ -1090,7 +1092,7 @@ namespace VC
             }
             newBlocks.Reverse();
             Contract.Assert(newBlocks[0] == oldToNewBlockMap[impl.Blocks[0]]);
-            s.Add(new Split(PostProcess(newBlocks), gotoCmdOrigins, par, impl));
+            s.Add(new Split(options, PostProcess(newBlocks), gotoCmdOrigins, par, impl));
           }
           else if (!blocks.Contains(focusBlocks[focusIdx])
                     || freeBlocks.Contains(focusBlocks[focusIdx]))
@@ -1115,9 +1117,9 @@ namespace VC
         return s;
       }
 
-      public static List<Split> FocusAndSplit(Implementation impl, Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins, VCGen par, bool splitOnEveryAssert)
+      public static List<Split> FocusAndSplit(VCGenOptions options, Implementation impl, Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins, VCGen par, bool splitOnEveryAssert)
       {
-        List<Split> focussedImpl = FocusImpl(impl, gotoCmdOrigins, par);
+        List<Split> focussedImpl = FocusImpl(options, impl, gotoCmdOrigins, par);
         var splits = focussedImpl.Select(s => FindManualSplits(s, splitOnEveryAssert)).SelectMany(x => x).ToList();
         return splits;
       }
@@ -1152,7 +1154,7 @@ namespace VC
 
           Split s0, s1;
 
-          bool splitStats = initial.Options.TraceVerify;
+          bool splitStats = initial.options.TraceVerify;
 
           if (splitStats)
           {
@@ -1225,7 +1227,7 @@ namespace VC
             Console.WriteLine("    --> {0}", s1.Stats);
           }
 
-          if (initial.Options.TraceVerify)
+          if (initial.options.TraceVerify)
           {
             best.Print();
           }
@@ -1285,18 +1287,18 @@ namespace VC
         Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
         ProverInterface.Outcome outcome = cce.NonNull(checker).ReadOutcome();
 
-        if (Options.Trace && splitNum >= 0)
+        if (options.Trace && splitNum >= 0)
         {
           System.Console.WriteLine("      --> split #{0} done,  [{1} s] {2}", splitNum + 1,
             checker.ProverRunTime.TotalSeconds, outcome);
         }
 
-        if (Options.XmlSink != null && splitNum >= 0) {
-          Options.XmlSink.WriteEndSplit(outcome.ToString().ToLowerInvariant(),
+        if (options.XmlSink != null && splitNum >= 0) {
+          options.XmlSink.WriteEndSplit(outcome.ToString().ToLowerInvariant(),
             TimeSpan.FromSeconds(checker.ProverRunTime.TotalSeconds));
         }
 
-        if (Options.VcsDumpSplits)
+        if (options.VcsDumpSplits)
         {
           DumpDot(splitNum);
         }
@@ -1383,10 +1385,10 @@ namespace VC
             exprGen.ControlFlowFunctionApplication(exprGen.Integer(BigNum.ZERO), exprGen.Integer(BigNum.ZERO));
           VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(Implementation.Blocks[0]))));
           vc = exprGen.Implies(eqExpr, vc);
-          reporter = new VCGen.ErrorReporter(Options, gotoCmdOrigins, absyIds, Implementation.Blocks, parent.debugInfos, callback,
+          reporter = new VCGen.ErrorReporter(options, gotoCmdOrigins, absyIds, Implementation.Blocks, parent.debugInfos, callback,
             mvInfo, Checker.TheoremProver.Context, parent.program);
           
-          if (Options.TraceVerify && no >= 0)
+          if (options.TraceVerify && no >= 0)
           {
             Console.WriteLine("-- after split #{0}", no);
             Print();

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -61,7 +61,7 @@ namespace VC
       implementation.CheckBooleanAttribute("vcs_split_on_every_assert", ref splitOnEveryAssert);
 
       ResetPredecessors(implementation.Blocks);
-      manualSplits = Split.FocusAndSplit(implementation, gotoCmdOrigins, vcGen, splitOnEveryAssert);
+      manualSplits = Split.FocusAndSplit(options, implementation, gotoCmdOrigins, vcGen, splitOnEveryAssert);
       
       if (manualSplits.Count == 1 && maxSplits > 1) {
         manualSplits = Split.DoSplit(manualSplits[0], maxVcCost, maxSplits);

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -353,7 +353,7 @@ namespace VC
               Emit();
             }
 
-            ch.BeginCheck(cce.NonNull(impl.Name + "_smoke" + id++), vc, new ErrorHandler(absyIds, this.callback),
+            ch.BeginCheck(cce.NonNull(impl.Name + "_smoke" + id++), vc, new ErrorHandler(Options, absyIds, callback),
               Options.SmokeTimeout, Options.ResourceLimit, CancellationToken.None);
           }
 
@@ -516,7 +516,7 @@ namespace VC
         }
 
 
-        public ErrorHandler(ControlFlowIdMap<Absy> absyIds, VerifierCallback callback)
+        public ErrorHandler(VCGenOptions options, ControlFlowIdMap<Absy> absyIds, VerifierCallback callback)  : base(options)
         {
           Contract.Requires(absyIds != null);
           Contract.Requires(callback != null);
@@ -942,7 +942,7 @@ namespace VC
         VerifierCallback /*!*/ callback,
         ModelViewInfo mvInfo,
         ProverContext /*!*/ context,
-        Program /*!*/ program)
+        Program /*!*/ program) : base(options)
       {
         Contract.Requires(gotoCmdOrigins != null);
         Contract.Requires(absyIds != null);

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -37,12 +37,12 @@ namespace VC
       Contract.Assert(expr != null);
       switch (Wlp.Subsumption(assrt))
       {
-        case CommandLineOptions.SubsumptionOption.Never:
+        case CoreOptions.SubsumptionOption.Never:
           expr = Expr.True;
           break;
-        case CommandLineOptions.SubsumptionOption.Always:
+        case CoreOptions.SubsumptionOption.Always:
           break;
-        case CommandLineOptions.SubsumptionOption.NotForQuantifiers:
+        case CoreOptions.SubsumptionOption.NotForQuantifiers:
           if (expr is QuantifierExpr)
           {
             expr = Expr.True;

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -567,7 +567,7 @@ namespace VC
         vcgen.AddBlocksBetween(codeExpr.Blocks);
         Dictionary<Variable, Expr> gotoCmdOrigins = vcgen.ConvertBlocks2PassiveCmd(codeExpr.Blocks,
           new List<IdentifierExpr>(), new ModelViewInfo(codeExpr));
-        VCExpr startCorrect = LetVC(codeExpr.Blocks, null, absyIds, ctx, out var ac, isPositiveContext);
+        VCExpr startCorrect = vcgen.LetVC(codeExpr.Blocks, null, absyIds, ctx, out var ac, isPositiveContext);
         VCExpr vce = ctx.ExprGen.Let(bindings, startCorrect);
         if (vcgen.CurrentLocalVariables.Count != 0)
         {
@@ -2529,7 +2529,7 @@ namespace VC
      *
      */
 
-    static VCExpr LetVC(List<Block> blocks,
+    VCExpr LetVC(List<Block> blocks,
       VCExpr controlFlowVariableExpr,
       ControlFlowIdMap<Absy> absyIds,
       ProverContext proverCtxt,
@@ -2594,7 +2594,7 @@ namespace VC
           SuccCorrect = gen.NAry(VCExpressionGenerator.AndOp, SuccCorrectVars);
         }
 
-        VCContext context = new VCContext(absyIds, proverCtxt, controlFlowVariableExpr, isPositiveContext);
+        VCContext context = new VCContext(Options, absyIds, proverCtxt, controlFlowVariableExpr, isPositiveContext);
         VCExpr vc = Wlp.Block(block, SuccCorrect, context);
         assertionCount += context.AssertionCount;
 
@@ -2606,7 +2606,7 @@ namespace VC
       return proverCtxt.ExprGen.Let(bindings, blockVariables[blocks[0]]);
     }
 
-    static VCExpr DagVC(Block block,
+    VCExpr DagVC(Block block,
       VCExpr controlFlowVariableExpr,
       ControlFlowIdMap<Absy> absyIds,
       Dictionary<Block, VCExpr> blockEquations,
@@ -2659,7 +2659,7 @@ namespace VC
         SuccCorrect = VCExpressionGenerator.True;
       }
 
-      VCContext context = new VCContext(absyIds, proverCtxt, controlFlowVariableExpr);
+      VCContext context = new VCContext(Options, absyIds, proverCtxt, controlFlowVariableExpr);
       vc = Wlp.Block(block, SuccCorrect, context);
       assertionCount += context.AssertionCount;
 

--- a/Source/VCGeneration/Wlp.cs
+++ b/Source/VCGeneration/Wlp.cs
@@ -3,12 +3,15 @@ using Microsoft.Boogie;
 using Microsoft.Boogie.VCExprAST;
 using System.Diagnostics.Contracts;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.BaseTypes;
 
 namespace VC
 {
   public class VCContext
   {
+    public VCGenOptions Options { get; }
+
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
@@ -21,9 +24,10 @@ namespace VC
     public int AssertionCount; // counts the number of assertions for which Wlp has been computed
     public bool isPositiveContext;
 
-    public VCContext(ControlFlowIdMap<Absy> absyIds, ProverContext ctxt, bool isPositiveContext = true)
+    public VCContext(VCGenOptions options, ControlFlowIdMap<Absy> absyIds, ProverContext ctxt, bool isPositiveContext = true)
     {
       Contract.Requires(ctxt != null);
+      Options = options;
       this.absyIds = absyIds;
       this.Ctxt = ctxt;
       this.isPositiveContext = isPositiveContext;
@@ -112,7 +116,7 @@ namespace VC
           {
             VU = ctxt.Ctxt.BoogieExprTranslator.Translate(ac.VerifiedUnder);
 
-            if (CommandLineOptions.Clo.RunDiagnosticsOnTimeout)
+            if (ctxt.Options.RunDiagnosticsOnTimeout)
             {
               ctxt.Ctxt.TimeoutDiagnosticIDToAssertion[ctxt.Ctxt.TimeoutDiagnosticsCount] =
                 new Tuple<AssertCmd, TransferCmd>(ac, b.TransferCmd);
@@ -121,7 +125,7 @@ namespace VC
                   gen.Integer(BigNum.FromInt(ctxt.Ctxt.TimeoutDiagnosticsCount++))));
             }
           }
-          else if (CommandLineOptions.Clo.RunDiagnosticsOnTimeout)
+          else if (ctxt.Options.RunDiagnosticsOnTimeout)
           {
             ctxt.Ctxt.TimeoutDiagnosticIDToAssertion[ctxt.Ctxt.TimeoutDiagnosticsCount] =
               new Tuple<AssertCmd, TransferCmd>(ac, b.TransferCmd);
@@ -175,7 +179,7 @@ namespace VC
       {
         AssumeCmd ac = (AssumeCmd) cmd;
 
-        if (CommandLineOptions.Clo.StratifiedInlining > 0)
+        if (ctxt.Options.StratifiedInlining > 0)
         {
           // Label the assume if it is a procedure call
           NAryExpr naryExpr = ac.Expr as NAryExpr;

--- a/Source/VCGeneration/Wlp.cs
+++ b/Source/VCGeneration/Wlp.cs
@@ -138,8 +138,8 @@ namespace VC
 
         {
           var subsumption = Subsumption(ac);
-          if (subsumption == CommandLineOptions.SubsumptionOption.Always
-              || (subsumption == CommandLineOptions.SubsumptionOption.NotForQuantifiers && !(C is VCExprQuantifier)))
+          if (subsumption == CoreOptions.SubsumptionOption.Always
+              || (subsumption == CoreOptions.SubsumptionOption.NotForQuantifiers && !(C is VCExprQuantifier)))
           {
             // Translate ac.Expr again so that we create separate VC expressions for the two different
             // occurrences of the translation of ac.Expr.  Pool-based quantifier instantiation assumes
@@ -240,16 +240,16 @@ namespace VC
       return expr;
     }
 
-    public static CommandLineOptions.SubsumptionOption Subsumption(AssertCmd ac)
+    public static CoreOptions.SubsumptionOption Subsumption(AssertCmd ac)
     {
       Contract.Requires(ac != null);
       int n = QKeyValue.FindIntAttribute(ac.Attributes, "subsumption", -1);
       switch (n)
       {
-        case 0: return CommandLineOptions.SubsumptionOption.Never;
-        case 1: return CommandLineOptions.SubsumptionOption.NotForQuantifiers;
-        case 2: return CommandLineOptions.SubsumptionOption.Always;
-        default: return CommandLineOptions.Clo.UseSubsumption;
+        case 0: return CoreOptions.SubsumptionOption.Never;
+        case 1: return CoreOptions.SubsumptionOption.NotForQuantifiers;
+        case 2: return CoreOptions.SubsumptionOption.Always;
+        default: return CoreOptions.Clo.UseSubsumption;
       }
     }
 

--- a/Source/VCGeneration/Wlp.cs
+++ b/Source/VCGeneration/Wlp.cs
@@ -33,10 +33,11 @@ namespace VC
       this.isPositiveContext = isPositiveContext;
     }
 
-    public VCContext(ControlFlowIdMap<Absy> absyIds, ProverContext ctxt, VCExpr controlFlowVariableExpr,
+    public VCContext(VCGenOptions options, ControlFlowIdMap<Absy> absyIds, ProverContext ctxt, VCExpr controlFlowVariableExpr,
       bool isPositiveContext = true)
     {
       Contract.Requires(ctxt != null);
+      Options = options;
       this.absyIds = absyIds;
       this.Ctxt = ctxt;
       this.ControlFlowVariableExpr = controlFlowVariableExpr;


### PR DESCRIPTION
- CheckerPool is now a field of ExecutionEngine and ExecutionEngine inherits from `IDisposable`, to give more control over the lifetime of the `CheckerPool` to Boogie consumers and to ensure `CheckerPool` does not hold a different `ExecutionEngineOptions` object then is used by the rest of the code.
  - Snapshots turn out not to work well when reusing the checkerPool, so when snapshots are used the checker pool is not reused for each snapshot.
- Introduce interfaces `ExecutionEngineOptions`, `HoudiniOptions`, `VCGenOptions` and `ConcurrencyOptions` for holding options related to their respective assemblies.
- Reduce the references to `CoreOptions.Clo` from 204 to 92.