### PR TITLE
Remove all references to CoreOptions.Clo

### DIFF
--- a/Source/AbsInt/IntervalDomain.cs
+++ b/Source/AbsInt/IntervalDomain.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
 
     class E_Bottom : E_Common
     {
-      public override Expr ToExpr()
+      public override Expr ToExpr(CoreOptions options)
       {
         return Expr.False;
       }
@@ -33,12 +33,12 @@ namespace Microsoft.Boogie.AbstractInterpretation
         N = n;
       }
 
-      public override Expr ToExpr()
+      public override Expr ToExpr(CoreOptions options)
       {
         Expr expr = Expr.True;
         for (var n = N; n != null; n = n.Next)
         {
-          expr = BplAnd(expr, n.ToExpr());
+          expr = BplAnd(expr, n.ToExpr(options));
         }
 
         return expr;
@@ -212,9 +212,9 @@ namespace Microsoft.Boogie.AbstractInterpretation
         }
       }
 
-      public Expr ToExpr()
+      public Expr ToExpr(CoreOptions options)
       {
-        if (!V.IsMutable && CoreOptions.Clo.InstrumentInfer !=
+        if (!V.IsMutable && options.InstrumentInfer !=
           CoreOptions.InstrumentationPlaces.Everywhere)
         {
           // omit invariants about readonly variables

--- a/Source/AbsInt/NativeLattice.cs
+++ b/Source/AbsInt/NativeLattice.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
     /// </summary>
     public abstract class Element
     {
-      public abstract Expr ToExpr();
+      public abstract Expr ToExpr(CoreOptions options);
     }
 
     public abstract Element Top { get; }
@@ -70,14 +70,21 @@ namespace Microsoft.Boogie.AbstractInterpretation
 
   public class NativeAbstractInterpretation
   {
-    public static void RunAbstractInterpretation(Program program)
+    private CoreOptions options;
+
+    public NativeAbstractInterpretation(CoreOptions options)
+    {
+      this.options = options;
+    }
+
+    public void RunAbstractInterpretation(Program program)
     {
       Contract.Requires(program != null);
 
-      Helpers.ExtraTraceInformation("Starting abstract interpretation");
+      Helpers.ExtraTraceInformation(options, "Starting abstract interpretation");
 
       DateTime start = new DateTime(); // to please compiler's definite assignment rules
-      if (CoreOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine();
         Console.WriteLine("Running abstract interpretation...");
@@ -87,11 +94,11 @@ namespace Microsoft.Boogie.AbstractInterpretation
       WidenPoints.Compute(program);
 
       NativeLattice lattice = null;
-      if (CoreOptions.Clo.Ai.J_Trivial)
+      if (options.Ai.J_Trivial)
       {
         lattice = new TrivialDomain();
       }
-      else if (CoreOptions.Clo.Ai.J_Intervals)
+      else if (options.Ai.J_Intervals)
       {
         lattice = new NativeIntervalDomain();
       }
@@ -100,13 +107,13 @@ namespace Microsoft.Boogie.AbstractInterpretation
       {
         Dictionary<Procedure, Implementation[]> procedureImplementations = ComputeProcImplMap(program);
         ComputeProgramInvariants(program, procedureImplementations, lattice);
-        if (CoreOptions.Clo.Ai.DebugStatistics)
+        if (options.Ai.DebugStatistics)
         {
           Console.Error.WriteLine(lattice.DebugStatistics);
         }
       }
 
-      if (CoreOptions.Clo.Trace)
+      if (options.Trace)
       {
         DateTime end = DateTime.UtcNow;
         TimeSpan elapsed = end - start;
@@ -132,7 +139,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
     /// <summary>
     /// Compute and apply the invariants for the program using the underlying abstract domain.
     /// </summary>
-    public static void ComputeProgramInvariants(Program program,
+    public void ComputeProgramInvariants(Program program,
       Dictionary<Procedure, Implementation[]> procedureImplementations, NativeLattice lattice)
     {
       Contract.Requires(program != null);
@@ -157,7 +164,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
           foreach (var impl in procedureImplementations[proc])
           {
             // add the precondition to the axioms
-            Substitution formalProcImplSubst = Substituter.SubstitutionFromDictionary(impl.GetImplFormalMap());
+            Substitution formalProcImplSubst = Substituter.SubstitutionFromDictionary(impl.GetImplFormalMap(options));
             var start = initialElement;
             foreach (Requires pre in proc.Requires)
             {
@@ -173,14 +180,14 @@ namespace Microsoft.Boogie.AbstractInterpretation
       }
     }
 
-    public static void Analyze(Implementation impl, NativeLattice lattice, NativeLattice.Element start)
+    public void Analyze(Implementation impl, NativeLattice lattice, NativeLattice.Element start)
     {
       // We need to keep track of some information for each(some) block(s).  To do that efficiently,
       // we number the implementation's blocks sequentially, and then we can use arrays to store
       // the additional information.
       var pre = new NativeLattice.Element[impl.Blocks
         .Count]; // set to null if we never compute a join/widen at this block
-      var post = CoreOptions.Clo.InstrumentInfer == CoreOptions.InstrumentationPlaces.Everywhere
+      var post = options.InstrumentInfer == CoreOptions.InstrumentationPlaces.Everywhere
         ? new NativeLattice.Element[impl.Blocks.Count]
         : null;
       var iterations = new int[impl.Blocks.Count];
@@ -223,7 +230,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
           // no change
           continue;
         }
-        else if (b.widenBlock && CoreOptions.Clo.Ai.StepsBeforeWidening <= iterations[id])
+        else if (b.widenBlock && options.Ai.StepsBeforeWidening <= iterations[id])
         {
           e = lattice.Widen(pre[id], e);
           pre[id] = e;
@@ -261,7 +268,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
       Instrument(impl, pre, post);
     }
 
-    static void Instrument(Implementation impl, NativeLattice.Element[] pre, NativeLattice.Element[] post)
+    void Instrument(Implementation impl, NativeLattice.Element[] pre, NativeLattice.Element[] post)
     {
       Contract.Requires(impl != null);
       Contract.Requires(pre != null);
@@ -269,14 +276,14 @@ namespace Microsoft.Boogie.AbstractInterpretation
       foreach (var b in impl.Blocks)
       {
         var element = pre[b.aiId];
-        if (element != null && (b.widenBlock || CoreOptions.Clo.InstrumentInfer ==
+        if (element != null && (b.widenBlock || options.InstrumentInfer ==
           CoreOptions.InstrumentationPlaces.Everywhere))
         {
           List<Cmd> newCommands = new List<Cmd>();
-          Expr inv = element.ToExpr();
+          Expr inv = element.ToExpr(options);
           PredicateCmd cmd;
           var kv = new QKeyValue(Token.NoToken, "inferred", new List<object>(), null);
-          if (CoreOptions.Clo.InstrumentWithAsserts)
+          if (options.InstrumentWithAsserts)
           {
             cmd = new AssertCmd(Token.NoToken, inv, kv);
           }
@@ -289,9 +296,9 @@ namespace Microsoft.Boogie.AbstractInterpretation
           newCommands.AddRange(b.Cmds);
           if (post != null && post[b.aiId] != null)
           {
-            inv = post[b.aiId].ToExpr();
+            inv = post[b.aiId].ToExpr(options);
             kv = new QKeyValue(Token.NoToken, "inferred", new List<object>(), null);
-            if (CoreOptions.Clo.InstrumentWithAsserts)
+            if (options.InstrumentWithAsserts)
             {
               cmd = new AssertCmd(Token.NoToken, inv, kv);
             }
@@ -312,7 +319,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
     /// The abstract transition relation.
     /// 'cmd' is allowed to be a StateCmd.
     /// </summary>
-    static NativeLattice.Element Step(NativeLattice lattice, Cmd cmd, NativeLattice.Element elmt)
+    NativeLattice.Element Step(NativeLattice lattice, Cmd cmd, NativeLattice.Element elmt)
     {
       Contract.Requires(lattice != null);
       Contract.Requires(cmd != null);
@@ -364,7 +371,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
       else if (cmd is SugaredCmd)
       {
         var c = (SugaredCmd) cmd;
-        elmt = Step(lattice, c.Desugaring, elmt);
+        elmt = Step(lattice, c.GetDesugaring(options), elmt);
       }
       else if (cmd is CommentCmd)
       {

--- a/Source/AbsInt/TrivialDomain.cs
+++ b/Source/AbsInt/TrivialDomain.cs
@@ -11,7 +11,7 @@
         IsTop = isTop;
       }
 
-      public override Expr ToExpr()
+      public override Expr ToExpr(CoreOptions options)
       {
         return Expr.Literal(IsTop);
       }

--- a/Source/BoogieDriver/BoogieDriver.cs
+++ b/Source/BoogieDriver/BoogieDriver.cs
@@ -63,13 +63,13 @@ namespace Microsoft.Boogie
         Console.WriteLine("--------------------");
       }
 
-      Helpers.ExtraTraceInformation("Becoming sentient");
+      Helpers.ExtraTraceInformation(options, "Becoming sentient");
 
       var success = executionEngine.ProcessFiles(fileList);
 
-      if (CoreOptions.Clo.XmlSink != null)
+      if (options.XmlSink != null)
       {
-        CoreOptions.Clo.XmlSink.Close();
+        options.XmlSink.Close();
       }
 
       if (options.Wait)

--- a/Source/BoogieDriver/BoogieDriver.cs
+++ b/Source/BoogieDriver/BoogieDriver.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Boogie
         RunningBoogieFromCommandLine = true
       };
       ExecutionEngine.printer = new ConsolePrinter(options);
-      CommandLineOptions.Install(options);
 
       if (!options.Parse(args))
       {

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Boogie
 
   public class AtomicAction : Action
   {
+    private ConcurrencyOptions options;
     public MoverType moverType;
     public AtomicAction refinedAction;
 
@@ -151,10 +152,12 @@ namespace Microsoft.Boogie
 
     public Dictionary<Variable, Function> triggerFunctions;
 
-    public AtomicAction(Procedure proc, Implementation impl, LayerRange layerRange, MoverType moverType) :
+    public AtomicAction(Procedure proc, Implementation impl, LayerRange layerRange,
+      MoverType moverType, ConcurrencyOptions options) :
       base(proc, impl, layerRange)
     {
       this.moverType = moverType;
+      this.options = options;
       AtomicActionDuplicator.SetupCopy(this, ref firstGate, ref firstImpl, "first_");
       AtomicActionDuplicator.SetupCopy(this, ref secondGate, ref secondImpl, "second_");
       DeclareTriggerFunctions();
@@ -201,7 +204,7 @@ namespace Microsoft.Boogie
       {
         var f = triggerFunctions[v];
         program.AddTopLevelDeclaration(f);
-        var assume = CmdHelper.AssumeCmd(ExprHelper.FunctionCall(f, Expr.Ident(v)));
+        var assume = CmdHelper.AssumeCmd(ExprHelper.FunctionCall(options, f, Expr.Ident(v)));
         impl.Blocks[0].Cmds.Insert(0, assume);
       }
     }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Boogie
         new List<Variable>(),
         new List<Variable>(),
         new List<Block> {BlockHelper.Block("init", new List<Cmd>())});
-      SkipAtomicAction = new AtomicAction(skipProcedure, skipImplementation, LayerRange.MinMax, MoverType.Both);
+      SkipAtomicAction = new AtomicAction(skipProcedure, skipImplementation, LayerRange.MinMax, MoverType.Both, Options);
     }
 
     public string AddNamePrefix(string name)
@@ -278,7 +278,7 @@ namespace Microsoft.Boogie
         }
 
         Implementation impl = actionImpls[0];
-        impl.PruneUnreachableBlocks();
+        impl.PruneUnreachableBlocks(Options);
         Graph<Block> cfg = Program.GraphFromImpl(impl);
         if (!Graph<Block>.Acyclic(cfg, impl.Blocks[0]))
         {
@@ -325,7 +325,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          var action = new AtomicAction(proc, impl, layerRange, GetActionMoverType(proc));
+          var action = new AtomicAction(proc, impl, layerRange, GetActionMoverType(proc), Options);
           if (proc.HasAttribute(CivlAttributes.IS_INVARIANT))
           {
             procToIsInvariant[proc] = action;
@@ -1512,6 +1512,8 @@ namespace Microsoft.Boogie
       static List<LinearKind> EnsuresAvailable = new List<LinearKind> { LinearKind.LINEAR, LinearKind.LINEAR_OUT };
       static List<LinearKind> PreservesAvailable = new List<LinearKind> { LinearKind.LINEAR };
 
+      private ConcurrencyOptions Options => civlTypeChecker.Options;
+
       public static CallCmd CheckRequires(CivlTypeChecker civlTypeChecker, QKeyValue attr, Procedure caller)
       {
         var v = new YieldInvariantCallChecker(civlTypeChecker, attr, caller, RequiresAvailable);
@@ -1617,7 +1619,7 @@ namespace Microsoft.Boogie
 
         callCmd = new CallCmd(attr.tok, yieldingProc.Name, exprs, new List<IdentifierExpr>()) { Proc = yieldingProc };
 
-        if (CivlUtil.ResolveAndTypecheck(callCmd) != 0)
+        if (CivlUtil.ResolveAndTypecheck(Options, callCmd) != 0)
         {
           callCmd = null;
         }

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -11,23 +11,23 @@ namespace Microsoft.Boogie
       decl.AddAttribute("inline", Expr.Literal(1));
     }
 
-    public static int ResolveAndTypecheck(Absy absy)
+    public static int ResolveAndTypecheck(CoreOptions options, Absy absy)
     {
-      var rc = new ResolutionContext(null);
+      var rc = new ResolutionContext(null, options);
       absy.Resolve(rc);
       if (rc.ErrorCount != 0)
       {
         return rc.ErrorCount;
       }
 
-      var tc = new TypecheckingContext(null);
+      var tc = new TypecheckingContext(null, options);
       absy.Typecheck(tc);
       return tc.ErrorCount;
     }
 
-    public static int ResolveAndTypecheck(Absy absy, ResolutionContext.State state)
+    public static int ResolveAndTypecheck(CoreOptions options, Absy absy, ResolutionContext.State state)
     {
-      var rc = new ResolutionContext(null);
+      var rc = new ResolutionContext(null, options);
       rc.StateMode = state;
       absy.Resolve(rc);
       if (rc.ErrorCount != 0)
@@ -35,17 +35,17 @@ namespace Microsoft.Boogie
         return rc.ErrorCount;
       }
 
-      var tc = new TypecheckingContext(null);
+      var tc = new TypecheckingContext(null, options);
       absy.Typecheck(tc);
       return tc.ErrorCount;
     }
 
-    public static int ResolveAndTypecheck(IEnumerable<Absy> absys)
+    public static int ResolveAndTypecheck(CoreOptions options, IEnumerable<Absy> absys)
     {
       int errorCount = 0;
       foreach (var absy in absys)
       {
-        errorCount += ResolveAndTypecheck(absy);
+        errorCount += ResolveAndTypecheck(options, absy);
       }
 
       return errorCount;
@@ -55,13 +55,13 @@ namespace Microsoft.Boogie
   // Handy syntactic sugar missing in Expr
   public static class ExprHelper
   {
-    public static NAryExpr FunctionCall(Function f, params Expr[] args)
+    public static NAryExpr FunctionCall(ConcurrencyOptions options, Function f, params Expr[] args)
     {
       var expr = new NAryExpr(Token.NoToken, new FunctionCall(f), args);
-      var rc = new ResolutionContext(null);
+      var rc = new ResolutionContext(null, options);
       rc.StateMode = ResolutionContext.State.Two;
       expr.Resolve(rc);
-      expr.Typecheck(new TypecheckingContext(null));
+      expr.Typecheck(new TypecheckingContext(null, options));
       return expr;
     }
 

--- a/Source/Concurrency/CivlVCGeneration.cs
+++ b/Source/Concurrency/CivlVCGeneration.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Boogie
       YieldingProcChecker.AddCheckers(civlTypeChecker, decls);
 
       // Linear type checks
-      LinearTypeChecker.AddCheckers(civlTypeChecker, decls);
+      civlTypeChecker.linearTypeChecker.AddCheckers(decls);
 
       if (!options.TrustInductiveSequentialization)
       {

--- a/Source/Concurrency/LinearPermissionInstrumentation.cs
+++ b/Source/Concurrency/LinearPermissionInstrumentation.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Boogie
     private Dictionary<string, Variable> domainNameToHoleVar;
     private Dictionary<Variable, Variable> localVarMap;
 
+    private ConcurrencyOptions Options => civlTypeChecker.Options;
+
     public LinearPermissionInstrumentation(
       CivlTypeChecker civlTypeChecker,
       int layerNum,
@@ -104,7 +106,7 @@ namespace Microsoft.Boogie
       }
 
       // loop headers
-      impl.PruneUnreachableBlocks();
+      impl.PruneUnreachableBlocks(Options);
       impl.ComputePredecessorsForBlocks();
       var graph = Program.GraphFromImpl(impl);
       graph.ComputeLoops();

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Boogie
       this.failurePreservationCheckerCache = new HashSet<Tuple<AtomicAction, AtomicAction>>();
     }
 
+    private ConcurrencyOptions Options => civlTypeChecker.Options;
+
     public static void AddCheckers(CivlTypeChecker civlTypeChecker, List<Declaration> decls)
     {
       MoverCheck moverChecking = new MoverCheck(civlTypeChecker, decls);
@@ -176,7 +178,7 @@ namespace Microsoft.Boogie
       };
       foreach (var lemma in civlTypeChecker.commutativityHints.GetLemmas(first, second))
       {
-        cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(lemma.function, lemma.args.ToArray())));
+        cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(Options, lemma.function, lemma.args.ToArray())));
       }
       cmds.Add(commutativityCheck);
 

--- a/Source/Concurrency/PendingAsyncChecker.cs
+++ b/Source/Concurrency/PendingAsyncChecker.cs
@@ -21,10 +21,11 @@ namespace Microsoft.Boogie
         var correctTypeExpr = ExprHelper.ForallExpr(new List<Variable> {paBound},
           Expr.Imp(
             Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0)),
-            Expr.Or(action.pendingAsyncs.Select(a => ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa)))));
+            Expr.Or(action.pendingAsyncs.Select(a =>
+              ExprHelper.FunctionCall(civlTypeChecker.Options, a.pendingAsyncCtor.membership, pa)))));
 
-        CivlUtil.ResolveAndTypecheck(nonnegativeExpr);
-        CivlUtil.ResolveAndTypecheck(correctTypeExpr);
+        CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, nonnegativeExpr);
+        CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, correctTypeExpr);
 
         var cmds = new List<Cmd>
         {

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -170,14 +170,14 @@ namespace Microsoft.Boogie
         tok,
         Expr.Or(Expr.Ident(pc), Expr.Or(OldEqualityExprForGlobals(), transitionRelation)),
         $"A yield-to-yield fragment modifies layer-{layerNum + 1} state in a way that does not match the refined atomic action");
-      CivlUtil.ResolveAndTypecheck(skipOrTransitionRelationAssertCmd);
+      CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, skipOrTransitionRelationAssertCmd);
 
       // assert pc ==> g_old == g && o_old == o;
       AssertCmd skipAssertCmd = CmdHelper.AssertCmd(
         tok,
         Expr.Imp(Expr.Ident(pc), Expr.And(OldEqualityExprForGlobals(), OldEqualityExprForOutputs())),
         $"A yield-to-yield fragment modifies layer-{layerNum + 1} state subsequent to a yield-to-yield fragment that already modified layer-{layerNum + 1} state");
-      CivlUtil.ResolveAndTypecheck(skipAssertCmd);
+      CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, skipAssertCmd);
       
       return new List<Cmd> {skipOrTransitionRelationAssertCmd, skipAssertCmd};
     }
@@ -197,14 +197,14 @@ namespace Microsoft.Boogie
         tok,
         Expr.And(this.oldGlobalMap.Select(kvPair => Expr.Eq(Expr.Ident(kvPair.Key), Expr.Ident(kvPair.Value)))),
         $"A yield-to-yield fragment illegally modifies layer-{layerNum + 1} globals");
-      CivlUtil.ResolveAndTypecheck(globalsAssertCmd);
+      CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, globalsAssertCmd);
 
       // assert pc ==> o_old == o;
       AssertCmd outputsAssertCmd = CmdHelper.AssertCmd(
         tok,
         Expr.Imp(Expr.Ident(pc), OldEqualityExprForOutputs()),
         $"A yield-to-yield fragment illegally modifies layer-{layerNum + 1} outputs");
-      CivlUtil.ResolveAndTypecheck(outputsAssertCmd);
+      CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, outputsAssertCmd);
 
       return new List<Cmd> {globalsAssertCmd, outputsAssertCmd};
     }
@@ -231,7 +231,7 @@ namespace Microsoft.Boogie
         cmds.Add(CmdHelper.AssignCmd(pcOkUpdateLHS, pcOkUpdateRHS));
       }
 
-      CivlUtil.ResolveAndTypecheck(cmds);
+      CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, cmds);
 
       return cmds;
     }

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Boogie
     private List<Expr> pathTranslations;
 
     private bool IsJoint => second != null;
+    private ConcurrencyOptions Options => civlTypeChecker.Options;
 
     private IEnumerable<Variable> AllVariables =>
       frame.Union(allInParams).Union(allOutParams).Union(allLocVars).Distinct();
@@ -89,8 +90,8 @@ namespace Microsoft.Boogie
         messagePrefix);
       trc.EnumeratePaths();
       var transitionRelation = Expr.Or(trc.pathTranslations);
-      transitionRelation.Resolve(new ResolutionContext(null) {StateMode = ResolutionContext.State.Two});
-      transitionRelation.Typecheck(new TypecheckingContext(null));
+      transitionRelation.Resolve(new ResolutionContext(null, civlTypeChecker.Options) {StateMode = ResolutionContext.State.Two});
+      transitionRelation.Typecheck(new TypecheckingContext(null, civlTypeChecker.Options));
       return transitionRelation;
     }
 
@@ -207,6 +208,8 @@ namespace Microsoft.Boogie
 
       private IEnumerable<Variable> IntermediateFrameWithWitnesses =>
         trc.FrameWithWitnesses.Select(v => frameIntermediateCopy[v]);
+
+      private ConcurrencyOptions Options => trc.Options;
 
       class Assignment
       {
@@ -433,7 +436,7 @@ namespace Microsoft.Boogie
               if (v == varCopies[orig].First() && trc.triggers.ContainsKey(orig))
               {
                 var f = trc.triggers[orig];
-                exprs.Add(ExprHelper.FunctionCall(f, Expr.Ident(existsVarMap[v])));
+                exprs.Add(ExprHelper.FunctionCall(Options, f, Expr.Ident(existsVarMap[v])));
               }
             }
 
@@ -531,7 +534,7 @@ namespace Microsoft.Boogie
             Enumerable.Zip(varToWitnesses.Keys, witnessSet, Tuple.Create))
           {
             CommutativityWitness witness = pair.Item2;
-            witnessSubst[pair.Item1] = ExprHelper.FunctionCall(
+            witnessSubst[pair.Item1] = ExprHelper.FunctionCall(Options,
               witness.function, witness.args.ToArray()
             );
           }

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Boogie
       {
         var yieldingProc = civlTypeChecker.procToYieldingProc[impl.Proc];
 
-        impl.PruneUnreachableBlocks();
+        impl.PruneUnreachableBlocks(civlTypeChecker.Options);
         Graph<Block> implGraph = Program.GraphFromImpl(impl);
         implGraph.ComputeLoops();
 

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Boogie
     {
       yieldingLoopHeaders = new HashSet<Block>(impl.Blocks.Where(IsYieldingLoopHeader));
 
-      impl.PruneUnreachableBlocks();
+      impl.PruneUnreachableBlocks(civlTypeChecker.Options);
       impl.ComputePredecessorsForBlocks();
       var graph = Program.GraphFromImpl(impl);
       graph.ComputeLoops();

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -375,14 +375,14 @@ namespace Microsoft.Boogie
     /// Returns the number of name resolution errors.
     /// </summary>
     /// <returns></returns>
-    public int Resolve()
+    public int Resolve(CoreOptions options)
     {
-      return Resolve((IErrorSink) null);
+      return Resolve(options, (IErrorSink) null);
     }
 
-    public int Resolve(IErrorSink errorSink)
+    public int Resolve(CoreOptions options, IErrorSink errorSink)
     {
-      ResolutionContext rc = new ResolutionContext(errorSink);
+      ResolutionContext rc = new ResolutionContext(errorSink, options);
       Resolve(rc);
       return rc.ErrorCount;
     }
@@ -390,7 +390,7 @@ namespace Microsoft.Boogie
     public override void Resolve(ResolutionContext rc)
     {
       //Contract.Requires(rc != null);
-      Helpers.ExtraTraceInformation("Starting resolution");
+      Helpers.ExtraTraceInformation(rc.Options, "Starting resolution");
 
       foreach (var d in TopLevelDeclarations)
       {
@@ -436,7 +436,7 @@ namespace Microsoft.Boogie
         {
           int e = rc.ErrorCount;
           d.Resolve(rc);
-          if (CoreOptions.Clo.OverlookBoogieTypeErrors && rc.ErrorCount != e && d is Implementation)
+          if (rc.Options.OverlookBoogieTypeErrors && rc.ErrorCount != e && d is Implementation)
           {
             // ignore this implementation
             System.Console.WriteLine("Warning: Ignoring implementation {0} because of translation resolution errors",
@@ -486,14 +486,14 @@ namespace Microsoft.Boogie
       TypeSynonymDecl.ResolveTypeSynonyms(synonymDecls, rc);
     }
 
-    public int Typecheck()
+    public int Typecheck(CoreOptions options)
     {
-      return this.Typecheck((IErrorSink) null);
+      return this.Typecheck(options, (IErrorSink) null);
     }
 
-    public int Typecheck(IErrorSink errorSink)
+    public int Typecheck(CoreOptions options, IErrorSink errorSink)
     {
-      TypecheckingContext tc = new TypecheckingContext(errorSink);
+      TypecheckingContext tc = new TypecheckingContext(errorSink, options);
       Typecheck(tc);
       return tc.ErrorCount;
     }
@@ -501,7 +501,7 @@ namespace Microsoft.Boogie
     public override void Typecheck(TypecheckingContext tc)
     {
       //Contract.Requires(tc != null);
-      Helpers.ExtraTraceInformation("Starting typechecking");
+      Helpers.ExtraTraceInformation(tc.Options, "Starting typechecking");
 
       int oldErrorCount = tc.ErrorCount;
       foreach (var d in TopLevelDeclarations)
@@ -811,9 +811,9 @@ namespace Microsoft.Boogie
     /// <param name="header"></param>
     /// <param name="backEdgeNode"></param>
     /// <returns></returns>
-    private HashSet<Block> GetBreakBlocksOfLoop(Block header, Block backEdgeNode, Graph<Block /*!*/> /*!*/ g)
+    private HashSet<Block> GetBreakBlocksOfLoop(CoreOptions options, Block header, Block backEdgeNode, Graph<Block /*!*/> /*!*/ g)
     {
-      Contract.Assert(CoreOptions.Clo.DeterministicExtractLoops,
+      Contract.Assert(options.DeterministicExtractLoops,
         "Can only be called with /deterministicExtractLoops option");
       var immSuccBlks = new HashSet<Block>();
       var loopBlocks = g.NaturalLoops(header, backEdgeNode);
@@ -840,9 +840,9 @@ namespace Microsoft.Boogie
       return immSuccBlks;
     }
 
-    private HashSet<Block> GetBlocksInAllNaturalLoops(Block header, Graph<Block /*!*/> /*!*/ g)
+    private HashSet<Block> GetBlocksInAllNaturalLoops(CoreOptions options, Block header, Graph<Block /*!*/> /*!*/ g)
     {
-      Contract.Assert(CoreOptions.Clo.DeterministicExtractLoops,
+      Contract.Assert(options.DeterministicExtractLoops,
         "Can only be called with /deterministicExtractLoops option");
       var allBlocksInNaturalLoops = new HashSet<Block>();
       foreach (Block /*!*/ source in g.BackEdgeNodes(header))
@@ -855,7 +855,7 @@ namespace Microsoft.Boogie
     }
 
 
-    void CreateProceduresForLoops(Implementation impl, Graph<Block /*!*/> /*!*/ g,
+    void CreateProceduresForLoops(CoreOptions options, Implementation impl, Graph<Block /*!*/> /*!*/ g,
       List<Implementation /*!*/> /*!*/ loopImpls,
       Dictionary<string, Dictionary<string, Block>> fullMap)
     {
@@ -882,7 +882,7 @@ namespace Microsoft.Boogie
         AddToFullMap(fullMap, impl.Name, block.Label, block);
       }
 
-      bool detLoopExtract = CoreOptions.Clo.DeterministicExtractLoops;
+      bool detLoopExtract = options.DeterministicExtractLoops;
 
       Dictionary<Block /*!*/, List<Variable> /*!*/> /*!*/
         loopHeaderToInputs = new Dictionary<Block /*!*/, List<Variable> /*!*/>();
@@ -922,7 +922,7 @@ namespace Microsoft.Boogie
           if (detLoopExtract)
           {
             //Need to get the blocks that exit the loop, as we need to add them to targets and footprint
-            immSuccBlks = GetBreakBlocksOfLoop(header, b, g);
+            immSuccBlks = GetBreakBlocksOfLoop(options, header, b, g);
           }
 
           foreach (Block /*!*/ block in g.NaturalLoops(header, b).Union(immSuccBlks))
@@ -1116,7 +1116,7 @@ namespace Microsoft.Boogie
               Contract.Assert(auxGotoCmd != null && auxGotoCmd.labelNames != null &&
                               auxGotoCmd.labelTargets != null && auxGotoCmd.labelTargets.Count >= 1);
               //BUGFIX on 10/26/15: this contains nodes present in NaturalLoops for a different backedgenode
-              var loopNodes = GetBlocksInAllNaturalLoops(header, g); //var loopNodes = g.NaturalLoops(header, source);
+              var loopNodes = GetBlocksInAllNaturalLoops(options, header, g); //var loopNodes = g.NaturalLoops(header, source);
               foreach (var bl in auxGotoCmd.labelTargets)
               {
                 if (g.Nodes.Contains(bl) && //newly created blocks are not present in NaturalLoop(header, xx, g)
@@ -1342,7 +1342,7 @@ namespace Microsoft.Boogie
       fullMap[procName][blockName] = block;
     }
 
-    public static Graph<Implementation> BuildCallGraph(Program program)
+    public static Graph<Implementation> BuildCallGraph(CoreOptions options, Program program)
     {
       Graph<Implementation> callGraph = new Graph<Implementation>();
       Dictionary<Procedure, HashSet<Implementation>> procToImpls = new Dictionary<Procedure, HashSet<Implementation>>();
@@ -1353,7 +1353,7 @@ namespace Microsoft.Boogie
 
       foreach (var impl in program.Implementations)
       {
-        if (impl.SkipVerification)
+        if (impl.IsSkipVerification(options))
         {
           continue;
         }
@@ -1364,7 +1364,7 @@ namespace Microsoft.Boogie
 
       foreach (var impl in program.Implementations)
       {
-        if (impl.SkipVerification)
+        if (impl.IsSkipVerification(options))
         {
           continue;
         }
@@ -1427,9 +1427,9 @@ namespace Microsoft.Boogie
     {
     }
 
-    public Graph<Block> ProcessLoops(Implementation impl)
+    public Graph<Block> ProcessLoops(CoreOptions options, Implementation impl)
     {
-      impl.PruneUnreachableBlocks();
+      impl.PruneUnreachableBlocks(options);
       impl.ComputePredecessorsForBlocks();
       Graph<Block> g = GraphFromImpl(impl);
       g.ComputeLoops();
@@ -1440,13 +1440,14 @@ namespace Microsoft.Boogie
       throw new IrreducibleLoopException();
     }
 
-    public Dictionary<string, Dictionary<string, Block>> ExtractLoops()
+    public Dictionary<string, Dictionary<string, Block>> ExtractLoops(CoreOptions options)
     {
       HashSet<string> procsWithIrreducibleLoops = null;
-      return ExtractLoops(out procsWithIrreducibleLoops);
+      return ExtractLoops(options, out procsWithIrreducibleLoops);
     }
 
-    public Dictionary<string, Dictionary<string, Block>> ExtractLoops(out HashSet<string> procsWithIrreducibleLoops)
+    public Dictionary<string, Dictionary<string, Block>> ExtractLoops(CoreOptions options,
+      out HashSet<string> procsWithIrreducibleLoops)
     {
       procsWithIrreducibleLoops = new HashSet<string>();
       List<Implementation /*!*/> /*!*/
@@ -1458,8 +1459,8 @@ namespace Microsoft.Boogie
         {
           try
           {
-            Graph<Block> g = ProcessLoops(impl);
-            CreateProceduresForLoops(impl, g, loopImpls, fullMap);
+            Graph<Block> g = ProcessLoops(options, impl);
+            CreateProceduresForLoops(options, impl, g, loopImpls, fullMap);
           }
           catch (IrreducibleLoopException)
           {
@@ -1467,7 +1468,7 @@ namespace Microsoft.Boogie
             fullMap[impl.Name] = null;
             procsWithIrreducibleLoops.Add(impl.Name);
 
-            if (CoreOptions.Clo.ExtractLoopsUnrollIrreducible)
+            if (options.ExtractLoopsUnrollIrreducible)
             {
               // statically unroll loops in this procedure
 
@@ -1480,7 +1481,7 @@ namespace Microsoft.Boogie
 
               // unroll
               Block start = impl.Blocks[0];
-              impl.Blocks = LoopUnroll.UnrollLoops(start, CoreOptions.Clo.RecursionBound, false);
+              impl.Blocks = LoopUnroll.UnrollLoops(start, options.RecursionBound, false);
 
               // Now construct the "map back" information
               // Resulting block label -> original block
@@ -1932,32 +1933,26 @@ namespace Microsoft.Boogie
       }
     }
 
-    public uint TimeLimit
+    public uint GetTimeLimit(CoreOptions options)
     {
-      get
-      {
-        uint tl = CoreOptions.Clo.TimeLimit;
-        CheckUIntAttribute("timeLimit", ref tl);
-        if (tl < 0)
-        {
-          tl = CoreOptions.Clo.TimeLimit;
-        }
-        return tl;
+      uint tl = options.TimeLimit;
+      CheckUIntAttribute("timeLimit", ref tl);
+      if (tl < 0) {
+        tl = options.TimeLimit;
       }
+
+      return tl;
     }
 
-    public uint ResourceLimit
+    public uint GetResourceLimit(CoreOptions options)
     {
-      get
-      {
-        uint rl = CoreOptions.Clo.ResourceLimit;
-        CheckUIntAttribute("rlimit", ref rl);
-        if (rl < 0)
-        {
-          rl = CoreOptions.Clo.ResourceLimit;
-        }
-        return rl;
+      uint rl = options.ResourceLimit;
+      CheckUIntAttribute("rlimit", ref rl);
+      if (rl < 0) {
+        rl = options.ResourceLimit;
       }
+
+      return rl;
     }
 
     public int? RandomSeed
@@ -2388,7 +2383,7 @@ namespace Microsoft.Boogie
         EmitAttributes(stream);
       }
 
-      if (CoreOptions.Clo.PrintWithUniqueASTIds && this.TypedIdent.HasName)
+      if (stream.Options.PrintWithUniqueASTIds && this.TypedIdent.HasName)
       {
         stream.Write("h{0}^^",
           this.GetHashCode()); // the idea is that this will prepend the name printed by TypedIdent.Emit
@@ -3043,21 +3038,21 @@ namespace Microsoft.Boogie
       functionDependencies.Add(function);
     }
 
-    public bool SignatureEquals(DeclWithFormals other)
+    public bool SignatureEquals(CoreOptions options, DeclWithFormals other)
     {
       Contract.Requires(other != null);
 
       string sig = null;
       string otherSig = null;
       using (var strWr = new System.IO.StringWriter())
-      using (var tokTxtWr = new TokenTextWriter("<no file>", strWr, false, false))
+      using (var tokTxtWr = new TokenTextWriter("<no file>", strWr, false, false, options))
       {
         EmitSignature(tokTxtWr, this is Function);
         sig = strWr.ToString();
       }
 
       using (var otherStrWr = new System.IO.StringWriter())
-      using (var otherTokTxtWr = new TokenTextWriter("<no file>", otherStrWr, false, false))
+      using (var otherTokTxtWr = new TokenTextWriter("<no file>", otherStrWr, false, false, options))
       {
         EmitSignature(otherTokTxtWr, other is Function);
         otherSig = otherStrWr.ToString();
@@ -3399,7 +3394,7 @@ namespace Microsoft.Boogie
         stream.Write("{:define} ");
       }
 
-      if (CoreOptions.Clo.PrintWithUniqueASTIds)
+      if (stream.Options.PrintWithUniqueASTIds)
       {
         stream.Write("h{0}^^{1}", this.GetHashCode(), TokenTextWriter.SanitizeIdentifier(this.Name));
       }
@@ -4216,40 +4211,32 @@ namespace Microsoft.Boogie
       get { return this.scc != null; }
     }
 
-    public bool SkipVerification
+    public bool IsSkipVerification(CoreOptions options)
     {
-      get
-      {
-        bool verify = true;
-        cce.NonNull(this.Proc).CheckBooleanAttribute("verify", ref verify);
-        this.CheckBooleanAttribute("verify", ref verify);
-        if (!verify)
-        {
+      bool verify = true;
+      cce.NonNull(this.Proc).CheckBooleanAttribute("verify", ref verify);
+      this.CheckBooleanAttribute("verify", ref verify);
+      if (!verify) {
+        return true;
+      }
+
+      if (options.ProcedureInlining == CoreOptions.Inlining.Assert ||
+          options.ProcedureInlining == CoreOptions.Inlining.Assume) {
+        Expr inl = this.FindExprAttribute("inline");
+        if (inl == null) {
+          inl = this.Proc.FindExprAttribute("inline");
+        }
+
+        if (inl != null) {
           return true;
         }
-
-        if (CoreOptions.Clo.ProcedureInlining == CoreOptions.Inlining.Assert ||
-            CoreOptions.Clo.ProcedureInlining == CoreOptions.Inlining.Assume)
-        {
-          Expr inl = this.FindExprAttribute("inline");
-          if (inl == null)
-          {
-            inl = this.Proc.FindExprAttribute("inline");
-          }
-
-          if (inl != null)
-          {
-            return true;
-          }
-        }
-
-        if (CoreOptions.Clo.StratifiedInlining > 0)
-        {
-          return !QKeyValue.FindBoolAttribute(Attributes, "entrypoint");
-        }
-
-        return false;
       }
+
+      if (options.StratifiedInlining > 0) {
+        return !QKeyValue.FindBoolAttribute(Attributes, "entrypoint");
+      }
+
+      return false;
     }
 
     public string Id
@@ -4527,31 +4514,31 @@ namespace Microsoft.Boogie
         v.Emit(stream, level + 1);
       }
 
-      if (this.StructuredStmts != null && !CoreOptions.Clo.PrintInstrumented &&
-          !CoreOptions.Clo.PrintInlined)
+      if (this.StructuredStmts != null && !stream.Options.PrintInstrumented &&
+          !stream.Options.PrintInlined)
       {
         if (this.LocVars.Count > 0)
         {
           stream.WriteLine();
         }
 
-        if (CoreOptions.Clo.PrintUnstructured < 2)
+        if (stream.Options.PrintUnstructured < 2)
         {
-          if (CoreOptions.Clo.PrintUnstructured == 1)
+          if (stream.Options.PrintUnstructured == 1)
           {
             stream.WriteLine(this, level + 1, "/*** structured program:");
           }
 
           this.StructuredStmts.Emit(stream, level + 1);
-          if (CoreOptions.Clo.PrintUnstructured == 1)
+          if (stream.Options.PrintUnstructured == 1)
           {
             stream.WriteLine(level + 1, "**** end structured program */");
           }
         }
       }
 
-      if (this.StructuredStmts == null || 1 <= CoreOptions.Clo.PrintUnstructured ||
-          CoreOptions.Clo.PrintInstrumented || CoreOptions.Clo.PrintInlined)
+      if (this.StructuredStmts == null || 1 <= stream.Options.PrintUnstructured ||
+          stream.Options.PrintInstrumented || stream.Options.PrintInlined)
       {
         foreach (Block b in this.Blocks)
         {
@@ -4756,7 +4743,7 @@ namespace Microsoft.Boogie
       this.formalMap = null;
     }
 
-    public Dictionary<Variable, Expr> /*!*/ GetImplFormalMap()
+    public Dictionary<Variable, Expr> /*!*/ GetImplFormalMap(CoreOptions options)
     {
       Contract.Ensures(Contract.Result<Dictionary<Variable, Expr>>() != null);
 
@@ -4795,11 +4782,11 @@ namespace Microsoft.Boogie
 
         this.formalMap = map;
 
-        if (CoreOptions.Clo.PrintWithUniqueASTIds)
+        if (options.PrintWithUniqueASTIds)
         {
           Console.WriteLine("Implementation.GetImplFormalMap on {0}:", this.Name);
           using TokenTextWriter stream =
-            new TokenTextWriter("<console>", Console.Out, /*setTokens=*/false, /*pretty=*/ false);
+            new TokenTextWriter("<console>", Console.Out, /*setTokens=*/false, /*pretty=*/ false, options);
           foreach (var e in map)
           {
             Console.Write("  ");
@@ -4956,7 +4943,7 @@ namespace Microsoft.Boogie
       this.BlockPredecessorsComputed = true;
     }
 
-    public void PruneUnreachableBlocks()
+    public void PruneUnreachableBlocks(CoreOptions options)
     {
       ArrayList /*Block!*/
         visitNext = new ArrayList /*Block!*/();
@@ -4974,7 +4961,7 @@ namespace Microsoft.Boogie
           reachable.Add(b);
           if (b.TransferCmd is GotoCmd)
           {
-            if (CoreOptions.Clo.PruneInfeasibleEdges)
+            if (options.PruneInfeasibleEdges)
             {
               foreach (Cmd /*!*/ s in b.Cmds)
               {

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -377,7 +377,7 @@ namespace Microsoft.Boogie
     /// <returns></returns>
     public int Resolve(CoreOptions options)
     {
-      return Resolve(options, (IErrorSink) null);
+      return Resolve(options, null);
     }
 
     public int Resolve(CoreOptions options, IErrorSink errorSink)

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Boogie
       if (!Anonymous)
       {
         stream.WriteLine(level, "{0}:",
-          CoreOptions.Clo.PrintWithUniqueASTIds
+          stream.Options.PrintWithUniqueASTIds
             ? String.Format("h{0}^^{1}", this.GetHashCode(), this.LabelName)
             : this.LabelName);
       }
@@ -1331,7 +1331,7 @@ namespace Microsoft.Boogie
         this,
         level,
         "{0}:{1}",
-        CoreOptions.Clo.PrintWithUniqueASTIds
+        stream.Options.PrintWithUniqueASTIds
           ? String.Format("h{0}^^{1}", this.GetHashCode(), this.Label)
           : this.Label,
         this.widenBlock ? "  // cut point" : "");
@@ -1424,10 +1424,10 @@ namespace Microsoft.Boogie
 
   public static class ChecksumHelper
   {
-    public static void ComputeChecksums(Cmd cmd, Implementation impl, ISet<Variable> usedVariables,
+    public static void ComputeChecksums(CoreOptions options, Cmd cmd, Implementation impl, ISet<Variable> usedVariables,
       byte[] currentChecksum = null)
     {
-      if (CoreOptions.Clo.VerifySnapshots < 2)
+      if (options.VerifySnapshots < 2)
       {
         return;
       }
@@ -1448,7 +1448,7 @@ namespace Microsoft.Boogie
       }
 
       using (var strWr = new System.IO.StringWriter())
-      using (var tokTxtWr = new TokenTextWriter("<no file>", strWr, false, false))
+      using (var tokTxtWr = new TokenTextWriter("<no file>", strWr, false, false, options))
       {
         tokTxtWr.UseForComputingChecksums = true;
         var havocCmd = cmd as HavocCmd;
@@ -1498,12 +1498,12 @@ namespace Microsoft.Boogie
       if (sugaredCmd != null)
       {
         // The checksum of a sugared command should not depend on the desugaring itself.
-        var stateCmd = sugaredCmd.Desugaring as StateCmd;
+        var stateCmd = sugaredCmd.GetDesugaring(options) as StateCmd;
         if (stateCmd != null)
         {
           foreach (var c in stateCmd.Cmds)
           {
-            ComputeChecksums(c, impl, usedVariables, currentChecksum);
+            ComputeChecksums(options, c, impl, usedVariables, currentChecksum);
             currentChecksum = c.Checksum;
             if (c.SugaredCmdChecksum == null)
             {
@@ -1513,7 +1513,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          ComputeChecksums(sugaredCmd.Desugaring, impl, usedVariables, currentChecksum);
+          ComputeChecksums(options, sugaredCmd.GetDesugaring(options), impl, usedVariables, currentChecksum);
         }
       }
     }
@@ -1568,7 +1568,7 @@ namespace Microsoft.Boogie
         {
           tc.Error(this, "command assigns to an immutable variable: {0}", v.Name);
         }
-        else if (!CoreOptions.Clo.DoModSetAnalysis && v is GlobalVariable)
+        else if (!tc.Options.DoModSetAnalysis && v is GlobalVariable)
         {
           if (!tc.Yields && !tc.InFrame(v))
           {
@@ -1702,7 +1702,8 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/ false, /*pretty=*/ false);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/ false,
+        /*pretty=*/ false, CoreOptions.Clo);
       this.Emit(stream, 0);
 
       return buffer.ToString();
@@ -1730,7 +1731,7 @@ namespace Microsoft.Boogie
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      if (!CoreOptions.Clo.DoModSetAnalysis && !tc.Yields)
+      if (!tc.Options.DoModSetAnalysis && !tc.Yields)
       {
         tc.Error(this, "enclosing procedure of a yield command must yield");
       }
@@ -2490,19 +2491,15 @@ namespace Microsoft.Boogie
       Contract.Requires(tok != null);
     }
 
-    public Cmd /*!*/ Desugaring
+    public Cmd GetDesugaring(CoreOptions options)
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<Cmd>() != null);
+      Contract.Ensures(Contract.Result<Cmd>() != null);
 
-        if (desugaring == null)
-        {
-          desugaring = ComputeDesugaring();
-        }
-
-        return desugaring;
+      if (desugaring == null) {
+        desugaring = ComputeDesugaring(options);
       }
+
+      return desugaring;
     }
 
     /// <summary>
@@ -2522,12 +2519,12 @@ namespace Microsoft.Boogie
       }
     }
 
-    protected abstract Cmd /*!*/ ComputeDesugaring();
+    protected abstract Cmd /*!*/ ComputeDesugaring(CoreOptions options);
 
-    public void ExtendDesugaring(IEnumerable<Cmd> before, IEnumerable<Cmd> beforePreconditionCheck,
+    public void ExtendDesugaring(CoreOptions options, IEnumerable<Cmd> before, IEnumerable<Cmd> beforePreconditionCheck,
       IEnumerable<Cmd> after)
     {
-      var desug = Desugaring;
+      var desug = GetDesugaring(options);
       var stCmd = desug as StateCmd;
       if (stCmd != null)
       {
@@ -2553,10 +2550,10 @@ namespace Microsoft.Boogie
     public override void Emit(TokenTextWriter stream, int level)
     {
       //Contract.Requires(stream != null);
-      if (CoreOptions.Clo.PrintDesugarings && !stream.UseForComputingChecksums)
+      if (stream.Options.PrintDesugarings && !stream.UseForComputingChecksums)
       {
         stream.WriteLine(this, level, "/*** desugaring:");
-        Desugaring.Emit(stream, level);
+        GetDesugaring(stream.Options).Emit(stream, level);
         stream.WriteLine(level, "**** end desugaring */");
       }
     }
@@ -2569,7 +2566,7 @@ namespace Microsoft.Boogie
     {
     }
 
-    protected override Cmd ComputeDesugaring()
+    protected override Cmd ComputeDesugaring(CoreOptions options)
     {
       Contract.Ensures(Contract.Result<Cmd>() != null);
 
@@ -2672,7 +2669,7 @@ namespace Microsoft.Boogie
       this.CallCmds = callCmds;
     }
 
-    protected override Cmd ComputeDesugaring()
+    protected override Cmd ComputeDesugaring(CoreOptions options)
     {
       throw new NotImplementedException();
     }
@@ -2733,7 +2730,7 @@ namespace Microsoft.Boogie
     public override void Typecheck(TypecheckingContext tc)
     {
       TypecheckAttributes(Attributes, tc);
-      if (!CoreOptions.Clo.DoModSetAnalysis)
+      if (!tc.Options.DoModSetAnalysis)
       {
         if (!tc.Yields)
         {
@@ -3139,7 +3136,7 @@ namespace Microsoft.Boogie
       TypeParameters = SimpleTypeParamInstantiation.From(Proc.TypeParameters,
         actualTypeParams);
 
-      if (!CoreOptions.Clo.DoModSetAnalysis && IsAsync)
+      if (!tc.Options.DoModSetAnalysis && IsAsync)
       {
         if (!tc.Yields)
         {
@@ -3168,7 +3165,7 @@ namespace Microsoft.Boogie
       return res;
     }
 
-    protected override Cmd ComputeDesugaring()
+    protected override Cmd ComputeDesugaring(CoreOptions options)
     {
       Contract.Ensures(Contract.Result<Cmd>() != null);
 
@@ -3310,7 +3307,7 @@ namespace Microsoft.Boogie
           }
         }
         else if (req.CanAlwaysAssume()
-                || CoreOptions.Clo.StratifiedInlining > 0)
+                || options.StratifiedInlining > 0)
         {
           // inject free requires as assume statements at the call site
           AssumeCmd /*!*/
@@ -4184,7 +4181,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/ false, /*pretty=*/ false);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/ false, /*pretty=*/ false, CoreOptions.Clo);
       this.Emit(stream, 0);
 
       return buffer.ToString();
@@ -4312,7 +4309,7 @@ namespace Microsoft.Boogie
       //Contract.Requires(stream != null);
       Contract.Assume(this.labelNames != null);
       stream.Write(this, level, "goto ");
-      if (CoreOptions.Clo.PrintWithUniqueASTIds)
+      if (stream.Options.PrintWithUniqueASTIds)
       {
         if (labelTargets == null)
         {

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -1698,11 +1698,10 @@ namespace Microsoft.Boogie
     }
 
     [Pure]
-    public override string ToString()
-    {
+    public override string ToString() {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false, false, CoreOptions.Clo);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false, false, PrintOptions.Default);
       this.Emit(stream, 0);
 
       return buffer.ToString();
@@ -2490,7 +2489,7 @@ namespace Microsoft.Boogie
       Contract.Requires(tok != null);
     }
 
-    public Cmd GetDesugaring(CoreOptions options)
+    public Cmd GetDesugaring(PrintOptions options)
     {
       Contract.Ensures(Contract.Result<Cmd>() != null);
 
@@ -2518,7 +2517,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    protected abstract Cmd /*!*/ ComputeDesugaring(CoreOptions options);
+    protected abstract Cmd /*!*/ ComputeDesugaring(PrintOptions options);
 
     public void ExtendDesugaring(CoreOptions options, IEnumerable<Cmd> before, IEnumerable<Cmd> beforePreconditionCheck,
       IEnumerable<Cmd> after)
@@ -2565,7 +2564,7 @@ namespace Microsoft.Boogie
     {
     }
 
-    protected override Cmd ComputeDesugaring(CoreOptions options)
+    protected override Cmd ComputeDesugaring(PrintOptions options)
     {
       Contract.Ensures(Contract.Result<Cmd>() != null);
 
@@ -2668,7 +2667,7 @@ namespace Microsoft.Boogie
       this.CallCmds = callCmds;
     }
 
-    protected override Cmd ComputeDesugaring(CoreOptions options)
+    protected override Cmd ComputeDesugaring(PrintOptions options)
     {
       throw new NotImplementedException();
     }
@@ -3164,7 +3163,7 @@ namespace Microsoft.Boogie
       return res;
     }
 
-    protected override Cmd ComputeDesugaring(CoreOptions options)
+    protected override Cmd ComputeDesugaring(PrintOptions options)
     {
       Contract.Ensures(Contract.Result<Cmd>() != null);
 
@@ -4180,7 +4179,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false, false, CoreOptions.Clo);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false, false, PrintOptions.Default);
       this.Emit(stream, 0);
 
       return buffer.ToString();

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -1702,8 +1702,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/ false,
-        /*pretty=*/ false, CoreOptions.Clo);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false, false, CoreOptions.Clo);
       this.Emit(stream, 0);
 
       return buffer.ToString();
@@ -4181,7 +4180,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/ false, /*pretty=*/ false, CoreOptions.Clo);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false, false, CoreOptions.Clo);
       this.Emit(stream, 0);
 
       return buffer.ToString();

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -81,7 +81,8 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/ false, /*pretty=*/ false);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer,
+        /*setTokens=*/ false, /*pretty=*/ false, CoreOptions.Clo);
       this.Emit(stream, 0, false);
 
       return buffer.ToString();
@@ -1294,7 +1295,7 @@ namespace Microsoft.Boogie
     public override void Emit(TokenTextWriter stream, int contextBindingStrength, bool fragileContext)
     {
       //Contract.Requires(stream != null);
-      if (CoreOptions.Clo.PrintWithUniqueASTIds && !stream.UseForComputingChecksums)
+      if (stream.Options.PrintWithUniqueASTIds && !stream.UseForComputingChecksums)
       {
         stream.Write("{0}^^", this.Decl == null ? "NoDecl" : "h" + this.Decl.GetHashCode());
       }

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
       using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer,
-        /*setTokens=*/ false, /*pretty=*/ false, CoreOptions.Clo);
+        /*setTokens=*/ false, /*pretty=*/ false, PrintOptions.Default);
       this.Emit(stream, 0, false);
 
       return buffer.ToString();

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false,  false, CoreOptions.Clo);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false,  false, PrintOptions.Default);
       this.Emit(stream);
 
       return buffer.ToString();

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/false, /*pretty=*/ false);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/false, /*pretty=*/ false, CoreOptions.Clo);
       this.Emit(stream);
 
       return buffer.ToString();

--- a/Source/Core/AbsyType.cs
+++ b/Source/Core/AbsyType.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<string>() != null);
       System.IO.StringWriter buffer = new System.IO.StringWriter();
-      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/false, /*pretty=*/ false, CoreOptions.Clo);
+      using TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false,  false, CoreOptions.Clo);
       this.Emit(stream);
 
       return buffer.ToString();

--- a/Source/Core/CoreOptions.cs
+++ b/Source/Core/CoreOptions.cs
@@ -2,19 +2,13 @@
 
 namespace Microsoft.Boogie
 {
+
   /// <summary>
   /// Boogie command-line options (other tools can subclass this class in order to support a
   /// superset of Boogie's options).
   /// </summary>
-  public interface CoreOptions
+  public interface CoreOptions : PrintOptions
   {
-
-    public static CoreOptions /*!*/ Clo
-    {
-      get;
-      set;
-    }
-
     public enum TypeEncoding
     {
       Predicates,
@@ -48,13 +42,7 @@ namespace Microsoft.Boogie
     bool OverlookBoogieTypeErrors { get; }
     uint TimeLimit { get; }
     uint ResourceLimit { get; }
-    bool PrintWithUniqueASTIds { get; }
-    int StratifiedInlining { get; }
     bool DoModSetAnalysis { get; }
-    bool PrintInstrumented { get; }
-    bool PrintInlined { get; }
-    int PrintUnstructured { get; set; }
-    bool PrintDesugarings { get; set; }
     bool DebugStagedHoudini { get; }
     bool DeterministicExtractLoops { get; }
     string VariableDependenceIgnore { get; }
@@ -70,7 +58,6 @@ namespace Microsoft.Boogie
     bool InstrumentWithAsserts { get; }
     bool UseArrayTheory { get; set; }
     TypeEncoding TypeEncodingMethod { get; set; }
-    bool ReflectAdd { get; }
     SubsumptionOption UseSubsumption { get; }
     int VcsCores { get; }
     List<string> ProverOptions { get; }

--- a/Source/Core/CoreOptions.cs
+++ b/Source/Core/CoreOptions.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Boogie
   /// Boogie command-line options (other tools can subclass this class in order to support a
   /// superset of Boogie's options).
   /// </summary>
-  public interface CoreOptions : PrintOptions
-  {
+  public interface CoreOptions : PrintOptions {
+
     public enum TypeEncoding
     {
       Predicates,

--- a/Source/Core/DeadVarElim.cs
+++ b/Source/Core/DeadVarElim.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Boogie
 
   public class ModSetCollector : ReadOnlyVisitor
   {
+    private CoreOptions options;
     private Procedure enclosingProc;
 
     private Dictionary<Procedure /*!*/, HashSet<Variable /*!*/> /*!*/> /*!*/
@@ -64,8 +65,9 @@ namespace Microsoft.Boogie
       Contract.Invariant(Contract.ForAll(modSets.Values, v => cce.NonNullElements(v)));
     }
 
-    public ModSetCollector()
+    public ModSetCollector(CoreOptions options)
     {
+      this.options = options;
       modSets = new Dictionary<Procedure /*!*/, HashSet<Variable /*!*/> /*!*/>();
       yieldingProcs = new HashSet<Procedure>();
     }
@@ -76,7 +78,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(program != null);
 
-      if (CoreOptions.Clo.Trace)
+      if (options.Trace)
       {
 //          Console.WriteLine();
 //          Console.WriteLine("Running modset analysis ...");
@@ -586,6 +588,13 @@ namespace Microsoft.Boogie
 
   public class LiveVariableAnalysis
   {
+    private CoreOptions options;
+
+    public LiveVariableAnalysis(CoreOptions options)
+    {
+      this.options = options;
+    }
+
     public static void ClearLiveVariables(Implementation impl)
     {
       Contract.Requires(impl != null);
@@ -596,13 +605,13 @@ namespace Microsoft.Boogie
       }
     }
 
-    public static void ComputeLiveVariables(Implementation impl)
+    public void ComputeLiveVariables(Implementation impl)
     {
       Contract.Requires(impl != null);
-      Microsoft.Boogie.Helpers.ExtraTraceInformation("Starting live variable analysis");
+      Microsoft.Boogie.Helpers.ExtraTraceInformation(options, "Starting live variable analysis");
       Graph<Block> dag = Program.GraphFromBlocks(impl.Blocks, false);
       IEnumerable<Block> sortedNodes;
-      if (CoreOptions.Clo.ModifyTopologicalSorting)
+      if (options.ModifyTopologicalSorting)
       {
         sortedNodes = dag.TopologicalSort(true);
       }
@@ -648,7 +657,7 @@ namespace Microsoft.Boogie
             if (InterProcGenKill.HasSummary(proc.Name))
             {
               liveVarsAfter =
-                InterProcGenKill.PropagateLiveVarsAcrossCall(cce.NonNull((CallCmd /*!*/) cmds[i]), liveVarsAfter);
+                InterProcGenKill.PropagateLiveVarsAcrossCall(options, cce.NonNull((CallCmd /*!*/) cmds[i]), liveVarsAfter);
               continue;
             }
           }
@@ -661,7 +670,7 @@ namespace Microsoft.Boogie
     }
 
     // perform in place update of liveSet
-    public static void Propagate(Cmd cmd, HashSet<Variable /*!*/> /*!*/ liveSet)
+    public void Propagate(Cmd cmd, HashSet<Variable /*!*/> /*!*/ liveSet)
     {
       Contract.Requires(cmd != null);
       Contract.Requires(cce.NonNullElements(liveSet));
@@ -749,7 +758,7 @@ namespace Microsoft.Boogie
       {
         SugaredCmd /*!*/
           sugCmd = (SugaredCmd) cce.NonNull(cmd);
-        Propagate(sugCmd.Desugaring, liveSet);
+        Propagate(sugCmd.GetDesugaring(options), liveSet);
       }
       else if (cmd is StateCmd)
       {
@@ -1178,8 +1187,8 @@ namespace Microsoft.Boogie
   // Interprocedural Gen/Kill Analysis
   public class InterProcGenKill
   {
-    Program /*!*/
-      program;
+    private CoreOptions options;
+    Program /*!*/ program;
 
     Dictionary<string /*!*/, ICFG /*!*/> /*!*/
       procICFG;
@@ -1235,11 +1244,12 @@ namespace Microsoft.Boogie
 
 
     [NotDelayed]
-    public InterProcGenKill(Implementation impl, Program program)
+    public InterProcGenKill(Implementation impl, Program program, CoreOptions options)
     {
       Contract.Requires(program != null);
       Contract.Requires(impl != null);
       this.program = program;
+      this.options = options;
       procICFG = new Dictionary<string /*!*/, ICFG /*!*/>();
       name2Proc = new Dictionary<string /*!*/, Procedure /*!*/>();
       workList = new WorkList();
@@ -1409,7 +1419,7 @@ namespace Microsoft.Boogie
     }
 
     public static HashSet<Variable /*!*/> /*!*/
-      PropagateLiveVarsAcrossCall(CallCmd cmd, HashSet<Variable /*!*/> /*!*/ lvAfter)
+      PropagateLiveVarsAcrossCall(CoreOptions options, CallCmd cmd, HashSet<Variable /*!*/> /*!*/ lvAfter)
     {
       Contract.Requires(cmd != null);
       Contract.Requires(cce.NonNullElements(lvAfter));
@@ -1436,7 +1446,7 @@ namespace Microsoft.Boogie
       HashSet<Variable /*!*/> /*!*/
         ret = new HashSet<Variable /*!*/>();
       ret.UnionWith(lvAfter);
-      LiveVariableAnalysis.Propagate(cmd, ret);
+      new LiveVariableAnalysis(options).Propagate(cmd, ret);
       return ret;
     }
 
@@ -1634,12 +1644,12 @@ namespace Microsoft.Boogie
       }
     }
 
-    public static void ComputeLiveVars(Implementation impl, Program /*!*/ prog)
+    public void ComputeLiveVars(Implementation impl, Program /*!*/ prog)
     {
       Contract.Requires(prog != null);
       Contract.Requires(impl != null);
       InterProcGenKill /*!*/
-        ipgk = new InterProcGenKill(impl, prog);
+        ipgk = new InterProcGenKill(impl, prog, options);
       Contract.Assert(ipgk != null);
       ipgk.Compute();
     }
@@ -1698,7 +1708,7 @@ namespace Microsoft.Boogie
         WorkItem /*!*/
           wi = workList.Get();
         Contract.Assert(wi != null);
-        processLV(wi);
+        ProcessLv(wi);
       }
 
       // Set live variable info
@@ -1740,7 +1750,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
     }
 
     // Called when summaries have already been computed
-    private void processLV(WorkItem wi)
+    private void ProcessLv(WorkItem wi)
     {
       Contract.Requires(wi != null);
       ICFG /*!*/
@@ -1800,17 +1810,17 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
 
             // Continue with intra propagation
             GenKillWeight /*!*/
-              summary = getWeightCall(cce.NonNull((CallCmd /*!*/) cmd));
+              summary = GetWeightCall(cce.NonNull((CallCmd /*!*/) cmd));
             prop = summary.getLiveVars(prop);
           }
           else
           {
-            LiveVariableAnalysis.Propagate(cmd, prop);
+            new LiveVariableAnalysis(options).Propagate(cmd, prop);
           }
         }
         else
         {
-          LiveVariableAnalysis.Propagate(cmd, prop);
+          new LiveVariableAnalysis(options).Propagate(cmd, prop);
         }
       }
 
@@ -1848,12 +1858,12 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
         Contract.Assert(c != null);
         if (c is CallCmd && procICFG.ContainsKey(cce.NonNull(cce.NonNull((CallCmd) c).Proc).Name))
         {
-          w = GenKillWeight.extend(getWeightCall(cce.NonNull((CallCmd) c)), w);
+          w = GenKillWeight.extend(GetWeightCall(cce.NonNull((CallCmd) c)), w);
         }
         else
         {
           GenKillWeight /*!*/
-            cweight = getWeight(c, wi.cfg.impl, program);
+            cweight = GetWeight(c, wi.cfg.impl, program);
           Contract.Assert(cweight != null);
           w = GenKillWeight.extend(cweight, w);
         }
@@ -1904,14 +1914,14 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
     static Dictionary<Cmd /*!*/, GenKillWeight /*!*/> /*!*/
       weightCache = new Dictionary<Cmd /*!*/, GenKillWeight /*!*/>();
 
-    private static GenKillWeight getWeight(Cmd cmd)
+    private GenKillWeight GetWeight(Cmd cmd)
     {
       Contract.Requires(cmd != null);
       Contract.Ensures(Contract.Result<GenKillWeight>() != null);
-      return getWeight(cmd, null, null);
+      return GetWeight(cmd, null, null);
     }
 
-    private GenKillWeight getWeightCall(CallCmd cmd)
+    private GenKillWeight GetWeightCall(CallCmd cmd)
     {
       Contract.Requires(cmd != null);
       Contract.Ensures(Contract.Result<GenKillWeight>() != null);
@@ -1927,7 +1937,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
       return GenKillWeight.extend(w1, GenKillWeight.extend(w2, w3));
     }
 
-    private static GenKillWeight getWeight(Cmd cmd, Implementation impl, Program prog)
+    private GenKillWeight GetWeight(Cmd cmd, Implementation impl, Program prog)
     {
       Contract.Requires(cmd != null);
       Contract.Ensures(Contract.Result<GenKillWeight>() != null);
@@ -2060,7 +2070,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
         SugaredCmd /*!*/
           sugCmd = (SugaredCmd) cmd;
         Contract.Assert(sugCmd != null);
-        ret = getWeight(sugCmd.Desugaring, impl, prog);
+        ret = GetWeight(sugCmd.GetDesugaring(options), impl, prog);
       }
       else if (cmd is StateCmd)
       {
@@ -2075,7 +2085,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
         for (int i = len - 1; i >= 0; i--)
         {
           GenKillWeight /*!*/
-            w = getWeight(cmds[i], impl, prog);
+            w = GetWeight(cmds[i], impl, prog);
           Contract.Assert(w != null);
           ret = GenKillWeight.extend(w, ret);
         }

--- a/Source/Core/Helpers.cs
+++ b/Source/Core/Helpers.cs
@@ -252,10 +252,10 @@ namespace Microsoft.Boogie
 
     private static readonly DateTime StartUp = DateTime.UtcNow;
 
-    public static void ExtraTraceInformation(string point)
+    public static void ExtraTraceInformation(CoreOptions options, string point)
     {
       Contract.Requires(point != null);
-      if (CoreOptions.Clo.TraceTimes)
+      if (options.TraceTimes)
       {
         DateTime now = DateTime.UtcNow;
         TimeSpan timeSinceStartUp = now - StartUp;

--- a/Source/Core/InterProceduralReachabilityGraph.cs
+++ b/Source/Core/InterProceduralReachabilityGraph.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Boogie
 
   public class InterproceduralReachabilityGraph : IInterproceduralReachabilityGraph
   {
+    private CoreOptions options;
     private Program prog;
     private HashSet<Block> nodes;
     private Dictionary<Block, Block> originalToNew;
@@ -29,9 +30,10 @@ namespace Microsoft.Boogie
 
     private Graph<Block> reachabilityGraph;
 
-    public InterproceduralReachabilityGraph(Program prog)
+    public InterproceduralReachabilityGraph(Program prog, CoreOptions options)
     {
       this.prog = prog;
+      this.options = options;
       originalToNew = new Dictionary<Block, Block>();
       newProcedureEntryNodes = new Dictionary<string, Block>();
       newProcedureExitNodes = new Dictionary<string, Block>();
@@ -257,7 +259,7 @@ namespace Microsoft.Boogie
     {
       if (ReachabilityGraphSCCsDAG == null)
       {
-        if (CoreOptions.Clo.Trace)
+        if (options.Trace)
         {
           Console.WriteLine("Interprocedural reachability: computing SCCs");
         }
@@ -292,7 +294,7 @@ namespace Microsoft.Boogie
           ReachabilityGraphSCCsDAG.AddEdge(BlockToSCC[n], dummy);
         }
 
-        if (CoreOptions.Clo.Trace)
+        if (options.Trace)
         {
           Console.WriteLine("Interprocedural reachability: SCCs computed!");
         }

--- a/Source/Core/MaxHolesLambdaLifter.cs
+++ b/Source/Core/MaxHolesLambdaLifter.cs
@@ -31,6 +31,7 @@ namespace Core
   /// </summary>
   class MaxHolesLambdaLifter : StandardVisitor
   {
+    private CoreOptions options;
     private readonly List<Variable> _nestedBoundVariables = new List<Variable>();
 
     private readonly LambdaExpr _lambda;
@@ -47,8 +48,7 @@ namespace Core
       Dictionary<Expr, FunctionCall> liftedLambdas,
       string freshFnName,
       List<Function> lambdaFunctions,
-      List<Axiom> lambdaAxioms,
-      int freshVarCount = 0
+      List<Axiom> lambdaAxioms, CoreOptions options, int freshVarCount = 0
     )
     {
       _lambda = lambda;
@@ -56,6 +56,7 @@ namespace Core
       _freshFnName = freshFnName;
       _lambdaFunctions = lambdaFunctions;
       _lambdaAxioms = lambdaAxioms;
+      this.options = options;
       _freshVarCount = freshVarCount;
     }
 
@@ -346,7 +347,7 @@ namespace Core
 
 
       var lambdaAttrs = _lambda.Attributes;
-      if (0 < CoreOptions.Clo.VerifySnapshots && QKeyValue.FindStringAttribute(lambdaAttrs, "checksum") == null)
+      if (0 < options.VerifySnapshots && QKeyValue.FindStringAttribute(lambdaAttrs, "checksum") == null)
       {
         // Attach a dummy checksum to avoid issues in the dependency analysis.
         var checksumAttr = new QKeyValue(_lambda.tok, "checksum", new List<object> {"lambda expression"}, null);
@@ -367,7 +368,7 @@ namespace Core
       var freeVarActuals = freeVars.OfType<Type>().ToList();
 
       var sw = new StringWriter();
-      var wr = new TokenTextWriter(sw, true);
+      var wr = new TokenTextWriter(sw, true, options);
       _lambda.Emit(wr);
       string lam_str = sw.ToString();
 
@@ -381,14 +382,14 @@ namespace Core
 
       if (_liftedLambdas.TryGetValue(liftedLambda, out var fcall))
       {
-        if (CoreOptions.Clo.TraceVerify)
+        if (options.TraceVerify)
         {
           Console.WriteLine("Old lambda: {0}", lam_str);
         }
       }
       else
       {
-        if (CoreOptions.Clo.TraceVerify)
+        if (options.TraceVerify)
         {
           Console.WriteLine("New lambda: {0}", lam_str);
         }

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -839,7 +839,8 @@ namespace Microsoft.Boogie
       }
     }
 
-    public static MonomorphizationVisitor Initialize(Program program, Dictionary<Axiom, TypeCtorDecl> axiomsToBeInstantiated,
+    public static MonomorphizationVisitor Initialize(CoreOptions options, Program program,
+      Dictionary<Axiom, TypeCtorDecl> axiomsToBeInstantiated,
       HashSet<Axiom> polymorphicFunctionAxioms)
     {
       var monomorphizationVisitor = new MonomorphizationVisitor(program, axiomsToBeInstantiated, polymorphicFunctionAxioms);
@@ -847,7 +848,7 @@ namespace Microsoft.Boogie
       // that must be verified. The types in ctorTypes are reused across different implementations.
       var ctorTypes = new List<Type>();
       var typeCtorDecls = new HashSet<TypeCtorDecl>();
-      monomorphizationVisitor.implInstantiations.Keys.Where(impl => !impl.SkipVerification).Iter(impl =>
+      monomorphizationVisitor.implInstantiations.Keys.Where(impl => !impl.IsSkipVerification(options)).Iter(impl =>
       {
         for (int i = ctorTypes.Count; i < impl.TypeParameters.Count; i++)
         {
@@ -1076,12 +1077,12 @@ namespace Microsoft.Boogie
   
   public class Monomorphizer
   {
-    public static MonomorphizableStatus Monomorphize(Program program)
+    public static MonomorphizableStatus Monomorphize(CoreOptions options, Program program)
     {
       var monomorphizableStatus = MonomorphizableChecker.IsMonomorphizable(program, out var axiomsToBeInstantiated, out var polymorphicFunctionAxioms);
       if (monomorphizableStatus == MonomorphizableStatus.Monomorphizable)
       {
-        var monomorphizationVisitor = MonomorphizationVisitor.Initialize(program, axiomsToBeInstantiated, polymorphicFunctionAxioms);
+        var monomorphizationVisitor = MonomorphizationVisitor.Initialize(options, program, axiomsToBeInstantiated, polymorphicFunctionAxioms);
         program.monomorphizer = new Monomorphizer(monomorphizationVisitor);
       }
       return monomorphizableStatus;

--- a/Source/Core/PrintOptions.cs
+++ b/Source/Core/PrintOptions.cs
@@ -1,0 +1,23 @@
+namespace Microsoft.Boogie;
+
+public interface PrintOptions {
+  public static readonly PrintOptions Default = new PrintOptionsRec(
+    false,
+    false,
+    false,
+    0,
+    false);
+
+  bool PrintWithUniqueASTIds { get; }
+  bool PrintInstrumented { get; }
+  bool PrintInlined { get; }
+  int StratifiedInlining { get; }
+  bool PrintDesugarings { get; set; }
+  int PrintUnstructured { get; set; }
+  bool ReflectAdd { get; }
+}
+
+record PrintOptionsRec(bool PrintWithUniqueASTIds, bool PrintInstrumented, bool PrintInlined, int StratifiedInlining, bool ReflectAdd) : PrintOptions {
+  public bool PrintDesugarings { get; set; }
+  public int PrintUnstructured { get; set; }
+}

--- a/Source/Core/ResolutionContext.cs
+++ b/Source/Core/ResolutionContext.cs
@@ -118,9 +118,12 @@ namespace Microsoft.Boogie
 
   public class ResolutionContext : CheckingContext
   {
-    public ResolutionContext(IErrorSink errorSink)
+    public CoreOptions Options { get; }
+
+    public ResolutionContext(IErrorSink errorSink, CoreOptions options)
       : base(errorSink)
     {
+      this.Options = options;
     }
     
     // user-defined types, which can be either TypeCtorDecl or TypeSynonymDecl
@@ -740,12 +743,14 @@ namespace Microsoft.Boogie
 
   public class TypecheckingContext : CheckingContext
   {
+    public CoreOptions Options { get; }
     public List<IdentifierExpr> Frame; // used in checking the assignment targets of implementation bodies
     public bool Yields;
 
-    public TypecheckingContext(IErrorSink errorSink)
+    public TypecheckingContext(IErrorSink errorSink, CoreOptions options)
       : base(errorSink)
     {
+      this.Options = options;
     }
 
     public bool InFrame(Variable v)

--- a/Source/Core/TokenTextWriter.cs
+++ b/Source/Core/TokenTextWriter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Boogie
 {
   public class TokenTextWriter : IDisposable
   {
-    public CoreOptions Options { get; }
+    public PrintOptions Options { get; }
     string /*!*/ filename;
 
     TextWriter /*!*/ writer;
@@ -287,7 +287,7 @@ namespace Microsoft.Boogie
       this.setTokens = setTokens;
     }
 
-    public TokenTextWriter(string filename, TextWriter writer, bool setTokens, bool pretty, CoreOptions options)
+    public TokenTextWriter(string filename, TextWriter writer, bool setTokens, bool pretty, PrintOptions options)
       : base()
     {
       Contract.Requires(writer != null);

--- a/Source/Core/TokenTextWriter.cs
+++ b/Source/Core/TokenTextWriter.cs
@@ -8,11 +8,10 @@ namespace Microsoft.Boogie
 {
   public class TokenTextWriter : IDisposable
   {
-    string /*!*/
-      filename;
+    public CoreOptions Options { get; }
+    string /*!*/ filename;
 
-    TextWriter /*!*/
-      writer;
+    TextWriter /*!*/ writer;
 
     [ContractInvariantMethod]
     void ObjectInvariant()
@@ -262,61 +261,66 @@ namespace Microsoft.Boogie
       }
     }
 
-    public TokenTextWriter(string filename)
-      : this(filename, false)
+    public TokenTextWriter(string filename, CoreOptions options)
+      : this(filename, false, options)
     {
     }
 
-    public TokenTextWriter(string filename, bool pretty)
+    public TokenTextWriter(string filename, bool pretty, CoreOptions options)
       : base()
     {
       Contract.Requires(filename != null);
       this.pretty = pretty;
+      this.Options = options;
       this.filename = filename;
       this.writer = new StreamWriter(filename);
     }
 
-    public TokenTextWriter(string filename, bool setTokens, bool pretty)
+    public TokenTextWriter(string filename, bool setTokens, bool pretty, CoreOptions options)
       : base()
     {
       Contract.Requires(filename != null);
       this.pretty = pretty;
+      this.Options = options;
       this.filename = filename;
       this.writer = new StreamWriter(filename);
       this.setTokens = setTokens;
     }
 
-    public TokenTextWriter(string filename, TextWriter writer, bool setTokens, bool pretty)
+    public TokenTextWriter(string filename, TextWriter writer, bool setTokens, bool pretty, CoreOptions options)
       : base()
     {
       Contract.Requires(writer != null);
       Contract.Requires(filename != null);
       this.pretty = pretty;
+      this.Options = options;
       this.filename = filename;
       this.writer = writer;
       this.setTokens = setTokens;
     }
 
-    public TokenTextWriter(string filename, TextWriter writer, bool pretty)
+    public TokenTextWriter(string filename, TextWriter writer, bool pretty, CoreOptions options)
       : base()
     {
       Contract.Requires(writer != null);
       Contract.Requires(filename != null);
       this.pretty = pretty;
+      this.Options = options;
       this.filename = filename;
       this.writer = writer;
     }
 
-    public TokenTextWriter(TextWriter writer)
-      : this(writer, false)
+    public TokenTextWriter(TextWriter writer, CoreOptions options)
+      : this(writer, false, options)
     {
     }
 
-    public TokenTextWriter(TextWriter writer, bool pretty)
+    public TokenTextWriter(TextWriter writer, bool pretty, CoreOptions options)
       : base()
     {
       Contract.Requires(writer != null);
       this.pretty = pretty;
+      this.Options = options;
       this.filename = "<no file>";
       this.writer = writer;
     }

--- a/Source/Core/VariableDependenceAnalyser.cs
+++ b/Source/Core/VariableDependenceAnalyser.cs
@@ -267,21 +267,21 @@ namespace Microsoft.Boogie
        * 
        */
 
-      if (CoreOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine("Variable dependence analysis: Initialising");
       }
 
       Initialise();
 
-      if (CoreOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine("Variable dependence analysis: Computing control dependence info");
       }
 
       BlockToControllingBlocks = ComputeGlobalControlDependences();
 
-      if (CoreOptions.Clo.Trace)
+      if (options.Trace)
       {
         Console.WriteLine("Variable dependence analysis: Computing control dependence variables");
       }
@@ -289,7 +289,7 @@ namespace Microsoft.Boogie
       ControllingBlockToVariables = ComputeControllingVariables(BlockToControllingBlocks);
       foreach (var Impl in prog.NonInlinedImplementations())
       {
-        if (CoreOptions.Clo.Trace)
+        if (options.Trace)
         {
           Console.WriteLine("Variable dependence analysis: Analysing " + Impl.Name);
         }
@@ -386,7 +386,7 @@ namespace Microsoft.Boogie
     {
       foreach (var n in vs)
       {
-        if (CoreOptions.Clo.DebugStagedHoudini)
+        if (options.DebugStagedHoudini)
         {
           Console.WriteLine("Adding dependence " + v + " -> " + n + ", reason: " + reason + "(" + tok.line + ":" +
                             tok.col + ")");
@@ -473,14 +473,14 @@ namespace Microsoft.Boogie
     private void MakeIgnoreList()
     {
       IgnoredVariables = new HashSet<VariableDescriptor>();
-      if (CoreOptions.Clo.VariableDependenceIgnore == null)
+      if (options.VariableDependenceIgnore == null)
       {
         return;
       }
 
       try
       {
-        var file = System.IO.File.OpenText(CoreOptions.Clo.VariableDependenceIgnore);
+        var file = System.IO.File.OpenText(options.VariableDependenceIgnore);
         while (!file.EndOfStream)
         {
           string line = file.ReadLine();
@@ -509,7 +509,7 @@ namespace Microsoft.Boogie
       catch (System.IO.IOException e)
       {
         Console.Error.WriteLine("Error reading from ignored variables file " +
-                                CoreOptions.Clo.VariableDependenceIgnore + ": " + e);
+                                options.VariableDependenceIgnore + ": " + e);
       }
     }
 
@@ -656,7 +656,7 @@ namespace Microsoft.Boogie
     {
       if (DependsOnSCCsDAG == null)
       {
-        if (CoreOptions.Clo.Trace)
+        if (options.Trace)
         {
           Console.WriteLine("Variable dependence: computing SCCs");
         }
@@ -692,7 +692,7 @@ namespace Microsoft.Boogie
           DependsOnSCCsDAG.AddEdge(VariableDescriptorToSCC[n], dummy);
         }
 
-        if (CoreOptions.Clo.Trace)
+        if (options.Trace)
         {
           Console.WriteLine("Variable dependence: SCCs computed!");
         }

--- a/Source/Core/VariableDependenceAnalyser.cs
+++ b/Source/Core/VariableDependenceAnalyser.cs
@@ -134,14 +134,16 @@ namespace Microsoft.Boogie
   /// </summary>
   public class VariableDependenceAnalyser : IVariableDependenceAnalyser
   {
+    private CoreOptions options;
     private Graph<VariableDescriptor> dependsOnNonTransitive;
     private Program prog;
     private Dictionary<Block, HashSet<Block>> BlockToControllingBlocks;
     private Dictionary<Block, HashSet<VariableDescriptor>> ControllingBlockToVariables;
 
-    public VariableDependenceAnalyser(Program prog)
+    public VariableDependenceAnalyser(Program prog, CoreOptions options)
     {
       this.prog = prog;
+      this.options = options;
       dependsOnNonTransitive = new Graph<VariableDescriptor>();
     }
 
@@ -520,7 +522,7 @@ namespace Microsoft.Boogie
       // Work out and union together local control dependences
       foreach (var Impl in prog.NonInlinedImplementations())
       {
-        Graph<Block> blockGraph = prog.ProcessLoops(Impl);
+        Graph<Block> blockGraph = prog.ProcessLoops(options, Impl);
         LocalCtrlDeps[Impl] = blockGraph.ControlDependence();
         foreach (var KeyValue in LocalCtrlDeps[Impl])
         {
@@ -528,7 +530,7 @@ namespace Microsoft.Boogie
         }
       }
 
-      Graph<Implementation> callGraph = Program.BuildCallGraph(prog);
+      Graph<Implementation> callGraph = Program.BuildCallGraph(options, prog);
 
       // Add inter-procedural control dependence nodes based on calls
       foreach (var Impl in prog.NonInlinedImplementations())

--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Boogie
 {
   public class XmlSink
   {
-    string /*!*/
-      filename;
+    string /*!*/ filename;
+    private CoreOptions options;
 
     [ContractInvariantMethod]
     void ObjectInvariant()
@@ -23,10 +23,11 @@ namespace Microsoft.Boogie
       get { return wr != null; }
     }
 
-    public XmlSink(string filename)
+    public XmlSink(CoreOptions options, string filename)
     {
       Contract.Requires(filename != null);
       this.filename = filename;
+      this.options = options;
     }
 
     /// <summary>
@@ -49,7 +50,7 @@ namespace Microsoft.Boogie
         wr = XmlWriter.Create(filename, settings);
         wr.WriteStartDocument();
         wr.WriteStartElement("boogie");
-        wr.WriteAttributeString("version", CoreOptions.Clo.VersionNumber);
+        wr.WriteAttributeString("version", options.VersionNumber);
         wr.WriteAttributeString("commandLine", Environment.CommandLine);
       }
       cce.EndExpose();

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -2030,7 +2030,7 @@ namespace Microsoft.Boogie
       return semicolonIndex;
     }
 
-    public string ProverHelp => TheProverFactory.BlankProverOptions().Help;
+    public string ProverHelp => TheProverFactory.BlankProverOptions(this).Help;
 
     public override string AttributeHelp =>
 @"Boogie: The following attributes are supported by this version.

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -651,7 +651,6 @@ namespace Microsoft.Boogie
     public static void Install(CoreOptions options)
     {
       Contract.Requires(options != null);
-      CoreOptions.Clo = options;
     }
 
     // Flags and arguments

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -108,17 +108,6 @@ namespace Microsoft.Boogie
       }
     }
 
-    public void ExpandFilename(ref string pattern, string logPrefix, string fileTimestamp)
-    {
-      if (pattern != null)
-      {
-        pattern = pattern.Replace("@PREFIX@", logPrefix).Replace("@TIME@", fileTimestamp);
-        string fn = Files.Count == 0 ? "" : Files[Files.Count - 1];
-        fn = Util.EscapeFilename(fn);
-        pattern = pattern.Replace("@FILE@", fn);
-      }
-    }
-
     public void ExpandFilename(string pattern, Action<string> setPattern, string logPrefix, string fileTimestamp)
     {
       if (pattern != null)

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -108,6 +108,17 @@ namespace Microsoft.Boogie
       }
     }
 
+    public void ExpandFilename(ref string pattern, string logPrefix, string fileTimestamp)
+    {
+      if (pattern != null)
+      {
+        pattern = pattern.Replace("@PREFIX@", logPrefix).Replace("@TIME@", fileTimestamp);
+        string fn = Files.Count == 0 ? "" : Files[Files.Count - 1];
+        fn = Util.EscapeFilename(fn);
+        pattern = pattern.Replace("@FILE@", fn);
+      }
+    }
+
     public void ExpandFilename(string pattern, Action<string> setPattern, string logPrefix, string fileTimestamp)
     {
       if (pattern != null)
@@ -627,8 +638,8 @@ namespace Microsoft.Boogie
   /// Boogie command-line options (other tools can subclass this class in order to support a
   /// superset of Boogie's options).
   /// </summary>
-  public class CommandLineOptions : CommandLineOptionEngine, ExecutionEngineOptions
-  {
+  public class CommandLineOptions : CommandLineOptionEngine, ExecutionEngineOptions {
+
     public static CommandLineOptions FromArguments(params string[] arguments)
     {
       var result = new CommandLineOptions();
@@ -646,11 +657,6 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(toolName != null);
       Contract.Requires(descriptiveName != null);
-    }
-
-    public static void Install(CoreOptions options)
-    {
-      Contract.Requires(options != null);
     }
 
     // Flags and arguments

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -1927,7 +1927,7 @@ namespace Microsoft.Boogie
       Contract.Assume(XmlSink == null); // XmlSink is to be set here
       if (XmlSinkFilename != null)
       {
-        XmlSink = new XmlSink(XmlSinkFilename);
+        XmlSink = new XmlSink(this, XmlSinkFilename);
       }
 
       if (TheProverFactory == null)

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Boogie
         return snapshotsByVersion.All(s =>
         {
           // BUG: Reusing checkers during snapshots doesn't work, even though it should. We create a new engine (and thus checker pool) to workaround this.
-          using var engine = new ExecutionEngine(Options);
+          using var engine = new ExecutionEngine(Options, Cache);
           return engine.ProcessFiles(new List<string>(s), false, programId);
         });
       }

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -10,7 +10,6 @@ using VC;
 using BoogiePL = Microsoft.Boogie;
 using System.Runtime.Caching;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Boogie
 {
@@ -824,7 +823,7 @@ namespace Microsoft.Boogie
       }
 
       #region Verify each implementation
-      program.DeclarationDependencies = Prune.ComputeDeclarationDependencies(program);
+      program.DeclarationDependencies = Prune.ComputeDeclarationDependencies(Options, program);
       var outputCollector = new OutputCollector(stablePrioritizedImpls);
       var outcome = PipelineOutcome.VerificationCompleted;
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -264,6 +264,11 @@ namespace Microsoft.Boogie
       checkerPool = new CheckerPool(options);
     }
 
+    public ExecutionEngine(ExecutionEngineOptions options) : this(options, new VerificationResultCache(options))
+    {
+
+    }
+
     public ExecutionEngineOptions Options { get; }
     private readonly CheckerPool checkerPool;
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Boogie
 
   #endregion
 
-
   public enum PipelineOutcome
   {
     Done,
@@ -264,7 +263,7 @@ namespace Microsoft.Boogie
     }
 
     public static ExecutionEngine CreateWithoutSharedCache(ExecutionEngineOptions options) {
-      return new ExecutionEngine(options, new VerificationResultCache(options.RunDiagnosticsOnTimeout));
+      return new ExecutionEngine(options, new VerificationResultCache());
     }
 
     public ExecutionEngineOptions Options { get; }
@@ -400,7 +399,6 @@ namespace Microsoft.Boogie
 
       return result;
     }
-
 
     public void CoalesceBlocks(Program program)
     {
@@ -806,7 +804,7 @@ namespace Microsoft.Boogie
         OtherDefinitionAxiomsCollector.Collect(Options, program.Axioms);
         DependencyCollector.Collect(Options, program);
         stablePrioritizedImpls = impls.OrderByDescending(
-          impl => impl.Priority != 1 ? impl.Priority : Cache.VerificationPriority(impl)).ToArray();
+          impl => impl.Priority != 1 ? impl.Priority : Cache.VerificationPriority(impl, Options.RunDiagnosticsOnTimeout)).ToArray();
       }
       else
       {
@@ -1016,7 +1014,7 @@ namespace Microsoft.Boogie
       var wasCached = false;
       if (0 < Options.VerifySnapshots)
       {
-        var cachedResults = Cache.Lookup(impl, out priority);
+        var cachedResults = Cache.Lookup(impl, Options.RunDiagnosticsOnTimeout, out priority);
         if (cachedResults != null && priority == Priority.SKIP)
         {
           if (Options.XmlSink != null)

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -10,6 +10,7 @@ using VC;
 using BoogiePL = Microsoft.Boogie;
 using System.Runtime.Caching;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Boogie
 {
@@ -243,7 +244,7 @@ namespace Microsoft.Boogie
       return -1;
     }
 
-    public static readonly VerificationResultCache Cache = new VerificationResultCache();
+    public readonly VerificationResultCache Cache;
 
     static readonly MemoryCache programCache = new MemoryCache("ProgramCache");
 
@@ -256,9 +257,10 @@ namespace Microsoft.Boogie
       return result;
     }
 
-    public ExecutionEngine(ExecutionEngineOptions options)
+    public ExecutionEngine(ExecutionEngineOptions options, VerificationResultCache cache)
     {
-      this.Options = options;
+      Options = options;
+      Cache = cache;
       checkerPool = new CheckerPool(options);
     }
 
@@ -812,7 +814,7 @@ namespace Microsoft.Boogie
 
       if (1 < Options.VerifySnapshots)
       {
-        CachedVerificationResultInjector.Inject(Options, program, stablePrioritizedImpls, requestId, programId,
+        CachedVerificationResultInjector.Inject(this, program, stablePrioritizedImpls, requestId, programId,
           out stats.CachingActionCounts);
       }
 

--- a/Source/ExecutionEngine/VerificationResultCache.cs
+++ b/Source/ExecutionEngine/VerificationResultCache.cs
@@ -171,10 +171,10 @@ namespace Microsoft.Boogie
       return result;
     }
 
-    public static void Inject(ExecutionEngineOptions options, Program program, IEnumerable<Implementation> implementations, string requestId,
+    public static void Inject(ExecutionEngine engine, Program program, IEnumerable<Implementation> implementations, string requestId,
       string programId, out long[] cachingActionCounts)
     {
-      var eai = new CachedVerificationResultInjector(options, program);
+      var eai = new CachedVerificationResultInjector(engine.Options, program);
 
       cachingActionCounts = new long[Enum.GetNames(typeof(VC.ConditionGeneration.CachingAction)).Length];
       var run = new CachedVerificationResultInjectorRun
@@ -184,7 +184,7 @@ namespace Microsoft.Boogie
       };
       foreach (var impl in implementations)
       {
-        var vr = ExecutionEngine.Cache.Lookup(impl, out var priority);
+        var vr = engine.Cache.Lookup(impl, out var priority);
         if (vr != null && vr.ProgramId == programId)
         {
           if (priority == Priority.LOW)
@@ -204,7 +204,7 @@ namespace Microsoft.Boogie
             run.SkippedImplementationCount++;
           }
 
-          if (priority == Priority.LOW || priority == Priority.MEDIUM || options.VerifySnapshots >= 3)
+          if (priority == Priority.LOW || priority == Priority.MEDIUM || engine.Options.VerifySnapshots >= 3)
           {
             if (TimeThreshold < vr.End.Subtract(vr.Start).TotalMilliseconds)
             {

--- a/Source/ExecutionEngine/VerificationResultCache.cs
+++ b/Source/ExecutionEngine/VerificationResultCache.cs
@@ -114,9 +114,9 @@ namespace Microsoft.Boogie
         var after = new List<Cmd>();
         Expr assumedExpr = new LiteralExpr(Token.NoToken, false);
         var canUseSpecs = DependencyCollector.CanExpressOldSpecs(oldProc, Program, true);
-        if (canUseSpecs && oldProc.SignatureEquals(currentImplementation.Proc))
+        if (canUseSpecs && oldProc.SignatureEquals(options, currentImplementation.Proc))
         {
-          var always = Substituter.SubstitutionFromDictionary(currentImplementation.GetImplFormalMap(), true,
+          var always = Substituter.SubstitutionFromDictionary(currentImplementation.GetImplFormalMap(options), true,
             currentImplementation.Proc);
           var forOld = Substituter.SubstitutionFromDictionary(new Dictionary<Variable, Expr>());
           var clauses = oldProc.Requires.Select(r =>
@@ -142,7 +142,7 @@ namespace Microsoft.Boogie
         }
 
         if (options.TraceCachingForTesting || options.TraceCachingForBenchmarking) {
-          using var tokTxtWr = new TokenTextWriter("<console>", Console.Out, false, false);
+          using var tokTxtWr = new TokenTextWriter("<console>", Console.Out, false, false, options);
           var loc = currentImplementation.tok != null && currentImplementation.tok != Token.NoToken
             ? string.Format("{0}({1},{2})", currentImplementation.tok.filename, currentImplementation.tok.line,
               currentImplementation.tok.col)
@@ -260,9 +260,9 @@ namespace Microsoft.Boogie
         Expr assumedExpr = new LiteralExpr(Token.NoToken, false);
         // TODO(wuestholz): Try out two alternatives: only do this for low priority implementations or not at all.
         var canUseSpecs = DependencyCollector.CanExpressOldSpecs(oldProc, Program);
-        if (canUseSpecs && oldProc.SignatureEquals(node.Proc))
+        if (canUseSpecs && oldProc.SignatureEquals(options, node.Proc))
         {
-          var desugaring = node.Desugaring;
+          var desugaring = node.GetDesugaring(options);
           Contract.Assert(desugaring != null);
           var precond = node.CheckedPrecondition(oldProc, Program, e => FunctionExtractor.Extract(e, Program, axioms));
           if (precond != null)
@@ -329,9 +329,9 @@ namespace Microsoft.Boogie
           after.Add(assumed);
         }
 
-        node.ExtendDesugaring(before, beforePreconditionCheck, after);
+        node.ExtendDesugaring(options, before, beforePreconditionCheck, after);
         if (options.TraceCachingForTesting || options.TraceCachingForBenchmarking) {
-          using var tokTxtWr = new TokenTextWriter("<console>", Console.Out, false, false);
+          using var tokTxtWr = new TokenTextWriter("<console>", Console.Out, false, false, options);
           var loc = node.tok != null && node.tok != Token.NoToken
             ? string.Format("{0}({1},{2})", node.tok.filename, node.tok.line, node.tok.col)
             : "<unknown location>";

--- a/Source/ExecutionEngine/VerificationResultCache.cs
+++ b/Source/ExecutionEngine/VerificationResultCache.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Boogie
       };
       foreach (var impl in implementations)
       {
-        var vr = engine.Cache.Lookup(impl, out var priority);
+        var vr = engine.Cache.Lookup(impl, engine.Options.RunDiagnosticsOnTimeout, out var priority);
         if (vr != null && vr.ProgramId == programId)
         {
           if (priority == Priority.LOW)
@@ -677,15 +677,10 @@ namespace Microsoft.Boogie
 
   public sealed class VerificationResultCache
   {
-    public bool RunDiagnosticsOnTimeout { get; }
     private readonly MemoryCache Cache = new MemoryCache("VerificationResultCache");
 
     private readonly CacheItemPolicy Policy = new CacheItemPolicy
       {SlidingExpiration = new TimeSpan(0, 10, 0), Priority = CacheItemPriority.Default};
-
-    public VerificationResultCache(bool runDiagnosticsOnTimeout) {
-      this.RunDiagnosticsOnTimeout = runDiagnosticsOnTimeout;
-    }
 
     public void Insert(Implementation impl, VerificationResult result)
     {
@@ -696,7 +691,7 @@ namespace Microsoft.Boogie
     }
 
 
-    public VerificationResult Lookup(Implementation impl, out int priority)
+    public VerificationResult Lookup(Implementation impl, bool runDiagnosticsOnTimeout, out int priority)
     {
       Contract.Requires(impl != null);
 
@@ -713,7 +708,7 @@ namespace Microsoft.Boogie
       {
         priority = Priority.LOW;
       }
-      else if (result.Outcome == ConditionGeneration.Outcome.TimedOut && RunDiagnosticsOnTimeout)
+      else if (result.Outcome == ConditionGeneration.Outcome.TimedOut && runDiagnosticsOnTimeout)
       {
         priority = Priority.MEDIUM;
       }
@@ -746,11 +741,11 @@ namespace Microsoft.Boogie
     }
 
 
-    public int VerificationPriority(Implementation impl)
+    public int VerificationPriority(Implementation impl, bool runDiagnosticsOnTimeout)
     {
       Contract.Requires(impl != null);
 
-      Lookup(impl, out var priority);
+      Lookup(impl, runDiagnosticsOnTimeout, out var priority);
       return priority;
     }
   }

--- a/Source/ExecutionEngine/VerificationResultCache.cs
+++ b/Source/ExecutionEngine/VerificationResultCache.cs
@@ -677,10 +677,16 @@ namespace Microsoft.Boogie
 
   public sealed class VerificationResultCache
   {
+    private ExecutionEngineOptions options;
     private readonly MemoryCache Cache = new MemoryCache("VerificationResultCache");
 
     private readonly CacheItemPolicy Policy = new CacheItemPolicy
       {SlidingExpiration = new TimeSpan(0, 10, 0), Priority = CacheItemPriority.Default};
+
+    public VerificationResultCache(ExecutionEngineOptions options)
+    {
+      this.options = options;
+    }
 
     public void Insert(Implementation impl, VerificationResult result)
     {
@@ -708,7 +714,7 @@ namespace Microsoft.Boogie
       {
         priority = Priority.LOW;
       }
-      else if (result.Outcome == ConditionGeneration.Outcome.TimedOut && CoreOptions.Clo.RunDiagnosticsOnTimeout)
+      else if (result.Outcome == ConditionGeneration.Outcome.TimedOut && options.RunDiagnosticsOnTimeout)
       {
         priority = Priority.MEDIUM;
       }

--- a/Source/Houdini/AnnotationDependenceAnalyser.cs
+++ b/Source/Houdini/AnnotationDependenceAnalyser.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Boogie.Houdini
     {
       this.options = options;
       this.prog = prog;
-      this.varDepAnalyser = new VariableDependenceAnalyser(prog);
+      this.varDepAnalyser = new VariableDependenceAnalyser(prog, options);
       varDepAnalyser.Analyse();
     }
 
@@ -121,7 +121,7 @@ namespace Microsoft.Boogie.Houdini
 
       if (options.StagedHoudiniReachabilityAnalysis)
       {
-        reachabilityChecker = new AnnotationReachabilityChecker(prog, AllAnnotationIdentifiers());
+        reachabilityChecker = new AnnotationReachabilityChecker(options, prog, AllAnnotationIdentifiers());
       }
       else
       {
@@ -900,11 +900,11 @@ namespace Microsoft.Boogie.Houdini
     private IInterproceduralReachabilityGraph reachabilityGraph;
     private Dictionary<string, HashSet<object>> annotationToOccurences;
 
-    internal AnnotationReachabilityChecker(Program prog, IEnumerable<string> AnnotationIdentifiers)
+    internal AnnotationReachabilityChecker(CoreOptions options, Program prog, IEnumerable<string> AnnotationIdentifiers)
     {
       this.prog = prog;
       this.AnnotationIdentifiers = AnnotationIdentifiers;
-      this.reachabilityGraph = new InterproceduralReachabilityGraph(prog);
+      this.reachabilityGraph = new InterproceduralReachabilityGraph(prog, options);
       this.annotationToOccurences = new Dictionary<string, HashSet<object>>();
 
       // Add all annotation occurrences in blocks

--- a/Source/Houdini/Houdini.cs
+++ b/Source/Houdini/Houdini.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Boogie.Houdini
         Console.WriteLine("Building call graph...");
       }
 
-      this.callGraph = Program.BuildCallGraph(program);
+      this.callGraph = Program.BuildCallGraph(Options, program);
       if (Options.Trace)
       {
         Console.WriteLine("Number of implementations = {0}", callGraph.Nodes.Count);
@@ -543,7 +543,7 @@ namespace Microsoft.Boogie.Houdini
       {
         CoreOptions.Inlining savedOption = Options.ProcedureInlining;
         Options.ProcedureInlining = CoreOptions.Inlining.Spec;
-        Inliner.ProcessImplementationForHoudini(program, impl);
+        Inliner.ProcessImplementationForHoudini(Options, program, impl);
         Options.ProcedureInlining = savedOption;
       }
 
@@ -969,7 +969,7 @@ namespace Microsoft.Boogie.Houdini
                 cexWriter.WriteLine("Counter example for " + refutedAnnotation.Constant);
                 cexWriter.Write(error.ToString());
                 cexWriter.WriteLine();
-                using var writer = new Microsoft.Boogie.TokenTextWriter(cexWriter, /*pretty=*/ false);
+                using var writer = new TokenTextWriter(cexWriter, false, Options);
                 foreach (Microsoft.Boogie.Block blk in error.Trace)
                 {
                   blk.Emit(writer, 15);

--- a/Source/Houdini/StagedHoudini.cs
+++ b/Source/Houdini/StagedHoudini.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Boogie.Houdini
 
     private void EmitProgram(string filename)
     {
-      using TokenTextWriter writer = new TokenTextWriter(filename, true);
+      using TokenTextWriter writer = new TokenTextWriter(filename, true, options);
       int oldPrintUnstructured = options.PrintUnstructured;
       options.PrintUnstructured = 2;
       program.Emit(writer);

--- a/Source/Predication/UniformityAnalyser.cs
+++ b/Source/Predication/UniformityAnalyser.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Boogie
 {
   public class UniformityAnalyser
   {
+    private CoreOptions options;
     private Program prog;
 
     private bool doAnalysis;
@@ -37,9 +38,9 @@ namespace Microsoft.Boogie
     /// being used then blocks will only be merged if they are both uniform
     /// or both non-uniform
     /// </summary>
-    public static void MergeBlocksIntoPredecessors(Program prog, Implementation impl, UniformityAnalyser uni)
+    public void MergeBlocksIntoPredecessors(Program prog, Implementation impl, UniformityAnalyser uni)
     {
-      var blockGraph = prog.ProcessLoops(impl);
+      var blockGraph = prog.ProcessLoops(options, impl);
       var predMap = new Dictionary<Block, Block>();
       foreach (var block in blockGraph.Nodes)
       {
@@ -71,12 +72,13 @@ namespace Microsoft.Boogie
     }
 
     public UniformityAnalyser(Program prog, bool doAnalysis, ISet<Implementation> entryPoints,
-      IEnumerable<Variable> nonUniformVars)
+      IEnumerable<Variable> nonUniformVars, CoreOptions options)
     {
       this.prog = prog;
       this.doAnalysis = doAnalysis;
       this.entryPoints = entryPoints;
       this.nonUniformVars = nonUniformVars;
+      this.options = options;
       uniformityInfo = new Dictionary<string, KeyValuePair<bool, Dictionary<string, bool>>>();
       nonUniformLoops = new Dictionary<string, HashSet<int>>();
       nonUniformBlocks = new Dictionary<string, HashSet<Block>>();
@@ -263,7 +265,7 @@ namespace Microsoft.Boogie
         return;
       }
 
-      Graph<Block> blockGraph = prog.ProcessLoops(Impl);
+      Graph<Block> blockGraph = prog.ProcessLoops(options, Impl);
       var ctrlDep = blockGraph.ControlDependence();
 
       // Compute transitive closure of control dependence info.

--- a/Source/Provers/SMTLib/ProverContext.cs
+++ b/Source/Provers/SMTLib/ProverContext.cs
@@ -122,6 +122,7 @@ namespace Microsoft.Boogie
   /// </summary>
   public class DeclFreeProverContext : ProverContext
   {
+    private SMTLibOptions options;
     protected VCExpressionGenerator gen;
     protected VCGenerationOptions genOptions;
     protected Boogie2VCExprTranslator translator;
@@ -146,12 +147,13 @@ namespace Microsoft.Boogie
       exprTranslator;
 
     public DeclFreeProverContext(VCExpressionGenerator gen,
-      VCGenerationOptions genOptions)
+      VCGenerationOptions genOptions, SMTLibOptions options)
     {
       Contract.Requires(gen != null);
       Contract.Requires(genOptions != null);
       this.gen = gen;
       this.genOptions = genOptions;
+      this.options = options;
       Boogie2VCExprTranslator t = new Boogie2VCExprTranslator(gen, genOptions);
       this.translator = t;
 
@@ -187,6 +189,7 @@ namespace Microsoft.Boogie
     protected DeclFreeProverContext(DeclFreeProverContext ctxt)
     {
       Contract.Requires(ctxt != null);
+      this.options = ctxt.options;
       this.gen = ctxt.gen;
       this.genOptions = ctxt.genOptions;
       Boogie2VCExprTranslator t = (Boogie2VCExprTranslator) ctxt.translator.Clone();
@@ -265,7 +268,7 @@ namespace Microsoft.Boogie
         }
 
         axioms = gen.AndSimp(gen.Distinct(distinctVars), axioms);
-        if (CoreOptions.Clo.TypeEncodingMethod != CoreOptions.TypeEncoding.Monomorphic)
+        if (options.TypeEncodingMethod != CoreOptions.TypeEncoding.Monomorphic)
         {
           axioms = gen.AndSimp(orderingAxiomBuilder.Axioms, axioms);
         }

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -9,12 +9,13 @@ namespace Microsoft.Boogie;
 
 public abstract class ProverInterface
 {
-  public static ProverInterface CreateProver(SMTLibOptions libOptions, Program prog, string /*?*/ logFilePath, bool appendLogFile, uint timeout,
+  public static ProverInterface CreateProver(SMTLibOptions libOptions, Program prog,
+    string /*?*/ logFilePath, bool appendLogFile, uint timeout,
     int taskID = -1)
   {
     Contract.Requires(prog != null);
 
-    ProverOptions options = cce.NonNull(libOptions.TheProverFactory).BlankProverOptions();
+    ProverOptions options = cce.NonNull(libOptions.TheProverFactory).BlankProverOptions(libOptions);
 
     if (logFilePath != null)
     {

--- a/Source/Provers/SMTLib/ProverUtil.cs
+++ b/Source/Provers/SMTLib/ProverUtil.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Boogie
 {
   public class ProverOptions
   {
-    public string /*?*/
-      LogFilename = null;
+    public SMTLibOptions LibOptions { get; }
+    public string /*?*/ LogFilename = null;
 
     public bool AppendLogFile = false;
 
@@ -30,6 +30,11 @@ namespace Microsoft.Boogie
 
     private string /*!*/
       stringRepr = "";
+
+    public ProverOptions(SMTLibOptions libOptions)
+    {
+      this.LibOptions = libOptions;
+    }
 
     [ContractInvariantMethod]
     void ObjectInvariant()
@@ -172,7 +177,7 @@ The generic options may or may not be used by the prover plugin.
       Contract.Requires(proverPath != null);
       Contract.Ensures(confirmedProverPath != null);
       confirmedProverPath = proverPath;
-      if (CoreOptions.Clo.Trace)
+      if (LibOptions.Trace)
       {
         Console.WriteLine("[TRACE] Using prover: " + confirmedProverPath);
       }
@@ -306,10 +311,10 @@ The generic options may or may not be used by the prover plugin.
     // Really returns ProverContext
     public abstract ProverContext /*!*/ NewProverContext(ProverOptions /*!*/ options);
 
-    public virtual ProverOptions BlankProverOptions()
+    public virtual ProverOptions BlankProverOptions(SMTLibOptions libOptions)
     {
       Contract.Ensures(Contract.Result<ProverOptions>() != null);
-      return new ProverOptions();
+      return new ProverOptions(libOptions);
     }
 
     // return true if the prover supports DAG AST as opposed to LET AST

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Boogie.SMTLib
         else
         {
           System.IO.StringWriter buffer = new System.IO.StringWriter();
-          using (TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, /*setTokens=*/false, /*pretty=*/false)
+          using (TokenTextWriter stream = new TokenTextWriter("<buffer>", buffer, false, false, LibOptions)
           )
           {
             t.Emit(stream);

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -2422,8 +2422,8 @@ namespace Microsoft.Boogie.SMTLib
     public readonly Dictionary<Function, VCExprNAry> DefinedFunctions = new Dictionary<Function, VCExprNAry>();
 
     public SMTLibProverContext(VCExpressionGenerator gen,
-      VCGenerationOptions genOptions)
-      : base(gen, genOptions)
+      VCGenerationOptions genOptions, SMTLibOptions options)
+      : base(gen, genOptions, options)
     {
     }
 
@@ -2519,12 +2519,12 @@ namespace Microsoft.Boogie.SMTLib
       }
 
       VCGenerationOptions genOptions = new VCGenerationOptions(proverCommands);
-      return new SMTLibProverContext(gen, genOptions);
+      return new SMTLibProverContext(gen, genOptions, options.LibOptions);
     }
 
-    public override ProverOptions BlankProverOptions()
+    public override ProverOptions BlankProverOptions(SMTLibOptions libOptions)
     {
-      return new SMTLibProverOptions();
+      return new SMTLibProverOptions(libOptions);
     }
 
     protected virtual SMTLibProcessTheoremProver SpawnProver(SMTLibOptions libOptions, ProverOptions options,

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -109,14 +109,14 @@ namespace Microsoft.Boogie.SMTLib
       switch (libOptions.TypeEncodingMethod)
       {
         case CoreOptions.TypeEncoding.Arguments:
-          AxBuilder = new TypeAxiomBuilderArguments(gen);
+          AxBuilder = new TypeAxiomBuilderArguments(gen, libOptions);
           AxBuilder.Setup();
           break;
         case CoreOptions.TypeEncoding.Monomorphic:
           AxBuilder = null;
           break;
         default:
-          AxBuilder = new TypeAxiomBuilderPremisses(gen);
+          AxBuilder = new TypeAxiomBuilderPremisses(gen, libOptions);
           AxBuilder.Setup();
           break;
       }

--- a/Source/Provers/SMTLib/SMTLibProverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibProverOptions.cs
@@ -45,6 +45,10 @@ namespace Microsoft.Boogie.SMTLib
     // Z3 specific (at the moment; some of them make sense also for other provers)
     public string Inspector = null;
 
+    public SMTLibProverOptions(SMTLibOptions libOptions) : base(libOptions)
+    {
+    }
+
     public void AddSolverArgument(string s)
     {
       SolverArguments.Add(s);

--- a/Source/UnitTests/CoreTests/Duplicator.cs
+++ b/Source/UnitTests/CoreTests/Duplicator.cs
@@ -119,8 +119,9 @@ namespace CoreTests
     [Test()]
     public void GotoTargets()
     {
-      CoreOptions.Clo = new CommandLineOptions();
-      Program p = TestUtil.ProgramLoader.LoadProgramFrom(@"
+      var options = CommandLineOptions.FromArguments();
+      CommandLineOptions.Install(options);
+      Program p = TestUtil.ProgramLoader.LoadProgramFrom(options, @"
         procedure main()
         {
             entry:
@@ -186,7 +187,8 @@ namespace CoreTests
     [Test()]
     public void ImplementationProcedureResolving()
     {
-      Program p = TestUtil.ProgramLoader.LoadProgramFrom(@"
+      var options = CommandLineOptions.FromArguments();
+      Program p = TestUtil.ProgramLoader.LoadProgramFrom(options, @"
         procedure main(a:int) returns (r:int);
         requires a > 0;
         ensures  r > a;
@@ -206,7 +208,7 @@ namespace CoreTests
       var newProgram = (Program) d.Visit(p);
 
       // Resolving doesn't seem to fix this.
-      var rc = new ResolutionContext(this);
+      var rc = new ResolutionContext(this, options);
       newProgram.Resolve(rc);
 
       // Check resolved
@@ -218,8 +220,8 @@ namespace CoreTests
     [Test()]
     public void CallCmdResolving()
     {
-      CoreOptions.Clo = new CommandLineOptions();
-      Program p = TestUtil.ProgramLoader.LoadProgramFrom(@"
+      var options = CommandLineOptions.FromArguments();
+      Program p = TestUtil.ProgramLoader.LoadProgramFrom(options, @"
         procedure main()
         {
             var x:int;

--- a/Source/UnitTests/CoreTests/Duplicator.cs
+++ b/Source/UnitTests/CoreTests/Duplicator.cs
@@ -120,7 +120,6 @@ namespace CoreTests
     public void GotoTargets()
     {
       var options = CommandLineOptions.FromArguments();
-      CommandLineOptions.Install(options);
       Program p = TestUtil.ProgramLoader.LoadProgramFrom(options, @"
         procedure main()
         {

--- a/Source/UnitTests/CoreTests/ExprImmutability.cs
+++ b/Source/UnitTests/CoreTests/ExprImmutability.cs
@@ -150,11 +150,12 @@ namespace CoreTests
     [Test()]
     public void ProtectedExprType()
     {
+      var options = CommandLineOptions.FromArguments();
       var e = GetUnTypedImmutableNAry();
 
       // Now Typecheck
       // Even though it's immutable we allow the TypeCheck field to be set if the Expr has never been type checked
-      var TC = new TypecheckingContext(this);
+      var TC = new TypecheckingContext(this, options);
       e.Typecheck(TC);
       Assert.IsNotNull(e.Type);
       Assert.IsTrue(e.Type.IsBool);
@@ -163,11 +164,12 @@ namespace CoreTests
     [Test()]
     public void ProtectedExprChangeTypeFail()
     {
+      var options = CommandLineOptions.FromArguments();
       var e = GetUnTypedImmutableNAry();
 
       // Now Typecheck
       // Even though it's immutable we allow the TypeCheck field to be set if the Expr has never been type checked
-      var TC = new TypecheckingContext(this);
+      var TC = new TypecheckingContext(this, options);
       e.Typecheck(TC);
       Assert.IsNotNull(e.Type);
       Assert.IsTrue(e.Type.IsBool);
@@ -179,11 +181,12 @@ namespace CoreTests
     [Test()]
     public void ProtectedExprTypeChangeTypeSucceed()
     {
+      var options = CommandLineOptions.FromArguments();
       var e = GetUnTypedImmutableNAry();
 
       // Now Typecheck
       // Even though it's immutable we allow the TypeCheck field to be set if the Expr has never been type checked
-      var TC = new TypecheckingContext(this);
+      var TC = new TypecheckingContext(this, options);
       e.Typecheck(TC);
       Assert.IsNotNull(e.Type);
       Assert.IsTrue(e.Type.IsBool);

--- a/Source/UnitTests/CoreTests/ExprTypeChecking.cs
+++ b/Source/UnitTests/CoreTests/ExprTypeChecking.cs
@@ -12,6 +12,7 @@ namespace CoreTests
     [Test()]
     public void FunctionCall()
     {
+      var options = CommandLineOptions.FromArguments();
       var fc = CreateFunctionCall("bv8slt", Microsoft.Boogie.Type.Bool, new List<Microsoft.Boogie.Type>()
       {
         BasicType.GetBvType(8),
@@ -27,7 +28,7 @@ namespace CoreTests
       // Deep type check (this was not broken before writing this test)
       Assert.IsNull(nary.Type);
 
-      var tc = new TypecheckingContext(this);
+      var tc = new TypecheckingContext(this, options);
       nary.Typecheck(tc);
 
       Assert.AreEqual(BasicType.Bool, nary.Type);
@@ -36,11 +37,12 @@ namespace CoreTests
     [Test()]
     public void FunctionCallTypeResolved()
     {
+      var options = CommandLineOptions.FromArguments();
       // This test case requires that function calls have been resolved
       // correctly and that the ShallowType is correct.
       // It's simpler to let the parser and resolver do all the work here
       // than try to build all the objects manually.
-      var program = TestUtil.ProgramLoader.LoadProgramFrom(@"
+      var program = TestUtil.ProgramLoader.LoadProgramFrom(options, @"
                 function {:bvbuiltin ""bvugt""} bv8ugt(bv8,bv8) returns(bool);
 
                 procedure main(a:bv8)

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -25,7 +25,6 @@ namespace ExecutionEngineTests
     [Test]
     public async Task InferAndVerifyCanBeCancelledWhileWaitingForProver() {
       var options = CommandLineOptions.FromArguments();
-      CommandLineOptions.Install(options);
       using var executionEngine = ExecutionEngine.CreateWithoutSharedCache(options);
       var infiniteProgram = GetProgram(executionEngine, slow);
       var terminatingProgram = GetProgram(executionEngine, fast);

--- a/Source/UnitTests/ExecutionEngineTests/GetProverLogs.cs
+++ b/Source/UnitTests/ExecutionEngineTests/GetProverLogs.cs
@@ -10,7 +10,6 @@ public static class GetProverLogs
 {
   public static string GetProverLogForProgram(ExecutionEngineOptions options, string procedure)
   {
-    CommandLineOptions.Install(options);
     var logs = GetProverLogsForProgram(options, procedure).ToList();
     Assert.AreEqual(1, logs.Count);
     return logs[0];

--- a/Source/UnitTests/TestUtil/ProgramLoader.cs
+++ b/Source/UnitTests/TestUtil/ProgramLoader.cs
@@ -5,7 +5,7 @@ namespace TestUtil
 {
   public class ProgramLoader
   {
-    public static Program LoadProgramFrom(string programText, string fileName = "file.bpl")
+    public static Program LoadProgramFrom(CoreOptions options, string programText, string fileName = "file.bpl")
     {
       Assert.That(programText, Is.Not.Null.And.Not.Empty);
       Assert.That(fileName, Is.Not.Null.And.Not.Empty);
@@ -18,11 +18,11 @@ namespace TestUtil
       Assert.IsNotNull(p);
 
       // Resolve
-      errors = p.Resolve();
+      errors = p.Resolve(options);
       Assert.AreEqual(0, errors);
 
       // Type check
-      errors = p.Typecheck();
+      errors = p.Typecheck(options);
       Assert.AreEqual(0, errors);
 
       return p;

--- a/Source/VCExpr/TypeErasureArguments.cs
+++ b/Source/VCExpr/TypeErasureArguments.cs
@@ -11,20 +11,23 @@ namespace Microsoft.Boogie.TypeErasure
 {
   public class TypeAxiomBuilderArguments : TypeAxiomBuilderIntBoolU
   {
-    public TypeAxiomBuilderArguments(VCExpressionGenerator gen)
+    private CoreOptions options;
+    public TypeAxiomBuilderArguments(VCExpressionGenerator gen, CoreOptions options)
       : base(gen)
     {
       Contract.Requires(gen != null);
+      this.options = options;
 
       Typed2UntypedFunctions = new Dictionary<Function /*!*/, Function /*!*/>();
     }
 
     // constructor to allow cloning
     [NotDelayed]
-    internal TypeAxiomBuilderArguments(TypeAxiomBuilderArguments builder)
+    internal TypeAxiomBuilderArguments(TypeAxiomBuilderArguments builder, CoreOptions options)
       : base(builder)
     {
       Contract.Requires(builder != null);
+      this.options = options;
       Typed2UntypedFunctions =
         new Dictionary<Function /*!*/, Function /*!*/>(builder.Typed2UntypedFunctions);
 
@@ -33,7 +36,7 @@ namespace Microsoft.Boogie.TypeErasure
         builder.MapTypeAbstracterAttr == null
           ? null
           : new MapTypeAbstractionBuilderArguments(this, builder.Gen,
-            builder.MapTypeAbstracterAttr);
+            builder.MapTypeAbstracterAttr, options);
     }
 
     public override Object Clone()
@@ -77,7 +80,7 @@ namespace Microsoft.Boogie.TypeErasure
 
         if (MapTypeAbstracterAttr == null)
         {
-          MapTypeAbstracterAttr = new MapTypeAbstractionBuilderArguments(this, Gen);
+          MapTypeAbstracterAttr = new MapTypeAbstractionBuilderArguments(this, Gen, options);
         }
 
         return MapTypeAbstracterAttr;
@@ -157,6 +160,7 @@ namespace Microsoft.Boogie.TypeErasure
 
   internal class MapTypeAbstractionBuilderArguments : MapTypeAbstractionBuilder
   {
+    private CoreOptions options;
     private readonly TypeAxiomBuilderArguments /*!*/
       AxBuilderArguments;
 
@@ -167,24 +171,26 @@ namespace Microsoft.Boogie.TypeErasure
     }
 
 
-    internal MapTypeAbstractionBuilderArguments(TypeAxiomBuilderArguments axBuilder, VCExpressionGenerator gen)
+    internal MapTypeAbstractionBuilderArguments(TypeAxiomBuilderArguments axBuilder, VCExpressionGenerator gen, CoreOptions options)
       : base(axBuilder, gen)
     {
       Contract.Requires(gen != null);
       Contract.Requires(axBuilder != null);
 
       this.AxBuilderArguments = axBuilder;
+      this.options = options;
     }
 
     // constructor for cloning
     internal MapTypeAbstractionBuilderArguments(TypeAxiomBuilderArguments axBuilder, VCExpressionGenerator gen,
-      MapTypeAbstractionBuilderArguments builder)
+      MapTypeAbstractionBuilderArguments builder, CoreOptions options)
       : base(axBuilder, gen, builder)
     {
       Contract.Requires(builder != null);
       Contract.Requires(gen != null);
       Contract.Requires(axBuilder != null);
       this.AxBuilderArguments = axBuilder;
+      this.options = options;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -243,7 +249,7 @@ namespace Microsoft.Boogie.TypeErasure
       select = HelperFuns.BoogieFunction(baseName + "Select", selectTypes);
       store = HelperFuns.BoogieFunction(baseName + "Store", storeTypes);
 
-      if (CoreOptions.Clo.UseArrayTheory)
+      if (options.UseArrayTheory)
       {
         select.AddAttribute("builtin", "select");
         store.AddAttribute("builtin", "store");

--- a/Source/VCExpr/TypeErasureArguments.cs
+++ b/Source/VCExpr/TypeErasureArguments.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Boogie.TypeErasure
 
     // constructor to allow cloning
     [NotDelayed]
-    internal TypeAxiomBuilderArguments(TypeAxiomBuilderArguments builder, CoreOptions options)
+    internal TypeAxiomBuilderArguments(TypeAxiomBuilderArguments builder)
       : base(builder)
     {
       Contract.Requires(builder != null);
-      this.options = options;
+      this.options = builder.options;
       Typed2UntypedFunctions =
         new Dictionary<Function /*!*/, Function /*!*/>(builder.Typed2UntypedFunctions);
 

--- a/Source/VCExpr/TypeErasurePremisses.cs
+++ b/Source/VCExpr/TypeErasurePremisses.cs
@@ -628,8 +628,8 @@ namespace Microsoft.Boogie.TypeErasure
 
   internal class MapTypeAbstractionBuilderPremisses : MapTypeAbstractionBuilder
   {
-    private readonly TypeAxiomBuilderPremisses /*!*/
-      AxBuilderPremisses;
+    private readonly TypeAxiomBuilderPremisses /*!*/ AxBuilderPremisses;
+    private CoreOptions options;
 
     [ContractInvariantMethod]
     void ObjectInvariant()
@@ -638,18 +638,19 @@ namespace Microsoft.Boogie.TypeErasure
     }
 
 
-    internal MapTypeAbstractionBuilderPremisses(TypeAxiomBuilderPremisses axBuilder, VCExpressionGenerator gen)
+    internal MapTypeAbstractionBuilderPremisses(TypeAxiomBuilderPremisses axBuilder, VCExpressionGenerator gen, CoreOptions options)
       : base(axBuilder, gen)
     {
       Contract.Requires(gen != null);
       Contract.Requires(axBuilder != null);
 
       this.AxBuilderPremisses = axBuilder;
+      this.options = options;
     }
 
     // constructor for cloning
     internal MapTypeAbstractionBuilderPremisses(TypeAxiomBuilderPremisses axBuilder, VCExpressionGenerator gen,
-      MapTypeAbstractionBuilderPremisses builder)
+      MapTypeAbstractionBuilderPremisses builder, CoreOptions options)
       : base(axBuilder, gen, builder)
     {
       Contract.Requires(builder != null);
@@ -657,6 +658,7 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Requires(axBuilder != null);
 
       this.AxBuilderPremisses = axBuilder;
+      this.options = options;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -729,7 +731,7 @@ namespace Microsoft.Boogie.TypeErasure
       // the store function does not have any explicit type parameters
       Contract.Assert(explicitStoreParams.Count == 0);
 
-      if (CoreOptions.Clo.UseArrayTheory)
+      if (options.UseArrayTheory)
       {
         select.AddAttribute("builtin", "select");
         store.AddAttribute("builtin", "store");
@@ -1120,8 +1122,7 @@ namespace Microsoft.Boogie.TypeErasure
 
   public class TypeEraserPremisses : TypeEraser
   {
-    private readonly TypeAxiomBuilderPremisses /*!*/
-      AxBuilderPremisses;
+    private readonly TypeAxiomBuilderPremisses /*!*/ AxBuilderPremisses;
 
     [ContractInvariantMethod]
     void ObjectInvariant()
@@ -1343,7 +1344,7 @@ namespace Microsoft.Boogie.TypeErasure
       List<VCExprVar /*!*/> /*!*/
         newVarsWithTypeSpecs = new List<VCExprVar /*!*/>();
       if (!IsUniversalQuantifier(node) ||
-          CoreOptions.Clo.TypeEncodingMethod
+          options.TypeEncodingMethod
           == CoreOptions.TypeEncoding.Predicates)
       {
         foreach (VCExprVar /*!*/ oldVar in occurringVars)

--- a/Source/VCExpr/TypeErasurePremisses.cs
+++ b/Source/VCExpr/TypeErasurePremisses.cs
@@ -58,10 +58,13 @@ namespace Microsoft.Boogie.TypeErasure
 
   public class TypeAxiomBuilderPremisses : TypeAxiomBuilderIntBoolU
   {
-    public TypeAxiomBuilderPremisses(VCExpressionGenerator gen)
+    public CoreOptions Options { get; }
+
+    public TypeAxiomBuilderPremisses(VCExpressionGenerator gen, CoreOptions options)
       : base(gen)
     {
       Contract.Requires(gen != null);
+      this.Options = options;
 
       TypeFunction = HelperFuns.BoogieFunction("dummy", Type.Int);
       Typed2UntypedFunctions = new Dictionary<Function /*!*/, UntypedFunction>();
@@ -74,6 +77,7 @@ namespace Microsoft.Boogie.TypeErasure
       : base(builder)
     {
       Contract.Requires(builder != null);
+      this.Options = builder.Options;
       TypeFunction = builder.TypeFunction;
       Typed2UntypedFunctions =
         new Dictionary<Function /*!*/, UntypedFunction>(builder.Typed2UntypedFunctions);
@@ -81,8 +85,7 @@ namespace Microsoft.Boogie.TypeErasure
       MapTypeAbstracterAttr =
         builder.MapTypeAbstracterAttr == null
           ? null
-          : new MapTypeAbstractionBuilderPremisses(this, builder.Gen,
-            builder.MapTypeAbstracterAttr);
+          : new MapTypeAbstractionBuilderPremisses(this, builder.Gen, builder.MapTypeAbstracterAttr);
     }
 
     public override Object Clone()
@@ -629,7 +632,6 @@ namespace Microsoft.Boogie.TypeErasure
   internal class MapTypeAbstractionBuilderPremisses : MapTypeAbstractionBuilder
   {
     private readonly TypeAxiomBuilderPremisses /*!*/ AxBuilderPremisses;
-    private CoreOptions options;
 
     [ContractInvariantMethod]
     void ObjectInvariant()
@@ -638,19 +640,18 @@ namespace Microsoft.Boogie.TypeErasure
     }
 
 
-    internal MapTypeAbstractionBuilderPremisses(TypeAxiomBuilderPremisses axBuilder, VCExpressionGenerator gen, CoreOptions options)
+    internal MapTypeAbstractionBuilderPremisses(TypeAxiomBuilderPremisses axBuilder, VCExpressionGenerator gen)
       : base(axBuilder, gen)
     {
       Contract.Requires(gen != null);
       Contract.Requires(axBuilder != null);
 
       this.AxBuilderPremisses = axBuilder;
-      this.options = options;
     }
 
     // constructor for cloning
     internal MapTypeAbstractionBuilderPremisses(TypeAxiomBuilderPremisses axBuilder, VCExpressionGenerator gen,
-      MapTypeAbstractionBuilderPremisses builder, CoreOptions options)
+      MapTypeAbstractionBuilderPremisses builder)
       : base(axBuilder, gen, builder)
     {
       Contract.Requires(builder != null);
@@ -658,7 +659,6 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Requires(axBuilder != null);
 
       this.AxBuilderPremisses = axBuilder;
-      this.options = options;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -731,7 +731,7 @@ namespace Microsoft.Boogie.TypeErasure
       // the store function does not have any explicit type parameters
       Contract.Assert(explicitStoreParams.Count == 0);
 
-      if (options.UseArrayTheory)
+      if (AxBuilderPremisses.Options.UseArrayTheory)
       {
         select.AddAttribute("builtin", "select");
         store.AddAttribute("builtin", "store");
@@ -1344,7 +1344,7 @@ namespace Microsoft.Boogie.TypeErasure
       List<VCExprVar /*!*/> /*!*/
         newVarsWithTypeSpecs = new List<VCExprVar /*!*/>();
       if (!IsUniversalQuantifier(node) ||
-          options.TypeEncodingMethod
+          AxBuilderPremisses.Options.TypeEncodingMethod
           == CoreOptions.TypeEncoding.Predicates)
       {
         foreach (VCExprVar /*!*/ oldVar in occurringVars)

--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       Contract.Ensures(Contract.Result<string>() != null);
       StringWriter sw = new StringWriter();
-      VCExprPrinter printer = new VCExprPrinter(CoreOptions.Clo);
+      VCExprPrinter printer = new VCExprPrinter(PrintOptions.Default);
       printer.Print(this, sw);
       return cce.NonNull(sw.ToString());
     }

--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       Contract.Ensures(Contract.Result<string>() != null);
       StringWriter sw = new StringWriter();
-      VCExprPrinter printer = new VCExprPrinter();
+      VCExprPrinter printer = new VCExprPrinter(CoreOptions.Clo);
       printer.Print(this, sw);
       return cce.NonNull(sw.ToString());
     }

--- a/Source/VCExpr/VCExprASTPrinter.cs
+++ b/Source/VCExpr/VCExprASTPrinter.cs
@@ -10,6 +10,12 @@ namespace Microsoft.Boogie.VCExprAST
   public class VCExprPrinter : IVCExprVisitor<bool, TextWriter /*!*/>
   {
     private VCExprOpPrinter OpPrinterVar = null;
+    public CoreOptions Options { get; }
+
+    public VCExprPrinter(CoreOptions options)
+    {
+      Options = options;
+    }
 
     private VCExprOpPrinter /*!*/ OpPrinter
     {
@@ -206,8 +212,7 @@ namespace Microsoft.Boogie.VCExprAST
 
   public class VCExprOpPrinter : IVCExprOpVisitor<bool, TextWriter /*!*/>
   {
-    private VCExprPrinter /*!*/
-      ExprPrinter;
+    private VCExprPrinter /*!*/ ExprPrinter;
 
     [ContractInvariantMethod]
     void ObjectInvariant()
@@ -416,7 +421,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       //Contract.Requires(wr != null);
       //Contract.Requires(node != null);
-      if (CoreOptions.Clo.ReflectAdd)
+      if (ExprPrinter.Options.ReflectAdd)
       {
         return PrintNAry("Reflect$Add", node, wr);
       }

--- a/Source/VCExpr/VCExprASTPrinter.cs
+++ b/Source/VCExpr/VCExprASTPrinter.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Boogie.VCExprAST
   public class VCExprPrinter : IVCExprVisitor<bool, TextWriter /*!*/>
   {
     private VCExprOpPrinter OpPrinterVar = null;
-    public CoreOptions Options { get; }
+    public PrintOptions Options { get; }
 
-    public VCExprPrinter(CoreOptions options)
+    public VCExprPrinter(PrintOptions options)
     {
       Options = options;
     }

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Boogie
     {
       Pool = pool;
 
-      SolverOptions = cce.NonNull(Pool.Options.TheProverFactory).BlankProverOptions();
+      SolverOptions = cce.NonNull(Pool.Options.TheProverFactory).BlankProverOptions(pool.Options);
 
       if (logFilePath != null)
       {

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -1171,7 +1171,7 @@ namespace VC
           Contract.Assert(ac.IncarnationMap == null);
           ac.IncarnationMap = (Dictionary<Variable, Expr>) cce.NonNull(new Dictionary<Variable, Expr>(incarnationMap));
 
-          var subsumption = Wlp.Subsumption(ac);
+          var subsumption = Wlp.Subsumption(Options, ac);
           if (relevantDoomedAssumpVars.Any())
           {
             TraceCachingAction(pc, CachingAction.DoNothingToAssert);

--- a/Source/VCGeneration/Prune/Prune.cs
+++ b/Source/VCGeneration/Prune/Prune.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Boogie
 {
   public class Prune {
 
-    public static Dictionary<object, List<object>> ComputeDeclarationDependencies(Program program)
+    public static Dictionary<object, List<object>> ComputeDeclarationDependencies(VCGenOptions options, Program program)
     {
-      if (!CoreOptions.Clo.Prune)
+      if (!options.Prune)
       {
         return null;
       }
@@ -54,9 +54,9 @@ namespace Microsoft.Boogie
      * See Checker.Setup for more information.
      * Data type constructor declarations are not pruned and they do affect VC generation.
      */
-    public static IEnumerable<Declaration> GetLiveDeclarations(Program program, List<Block> blocks)
+    public static IEnumerable<Declaration> GetLiveDeclarations(VCGenOptions options, Program program, List<Block> blocks)
     {
-      if (program.DeclarationDependencies == null || blocks == null || !CoreOptions.Clo.Prune)
+      if (program.DeclarationDependencies == null || blocks == null || !options.Prune)
       {
         return program.TopLevelDeclarations;
       }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -149,7 +149,7 @@ namespace VC
 
         using var writer = new TokenTextWriter(
           $"{options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}", false,
-          options.PrettyPrint);
+          options.PrettyPrint, options);
         foreach (var declaration in TopLevelDeclarations ?? program.TopLevelDeclarations) {
           declaration.Emit(writer, 0);
         }
@@ -227,7 +227,7 @@ namespace VC
           List<Block> backup = Implementation.Blocks;
           Contract.Assert(backup != null);
           Implementation.Blocks = blocks;
-          Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false), 0);
+          Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false, options), 0);
           Implementation.Blocks = backup;
           options.PrintDesugarings = oldPrintDesugaringSetting;
           options.PrintUnstructured = oldPrintUnstructured;

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -136,7 +136,7 @@ namespace VC
 
         TopLevelDeclarations = par.program.TopLevelDeclarations;
         PrintTopLevelDeclarationsForPruning(par.program, implementation, "before");        
-        TopLevelDeclarations = Prune.GetLiveDeclarations(par.program, blocks).ToList();
+        TopLevelDeclarations = Prune.GetLiveDeclarations(options, par.program, blocks).ToList();
         PrintTopLevelDeclarationsForPruning(par.program, implementation, "after");
       }
 
@@ -642,7 +642,7 @@ namespace VC
 
             if (swap)
             {
-              theNewCmd = VCGen.AssertTurnedIntoAssume(a);
+              theNewCmd = VCGen.AssertTurnedIntoAssume(options, a);
             }
           }
 
@@ -832,7 +832,7 @@ namespace VC
         }
         return blockAssignments;
       }
-      private static List<Block> DoPreAssignedManualSplit(List<Block> blocks, Dictionary<Block, Block> blockAssignments, int splitNumberWithinBlock,
+      private static List<Block> DoPreAssignedManualSplit(VCGenOptions options, List<Block> blocks, Dictionary<Block, Block> blockAssignments, int splitNumberWithinBlock,
         Block containingBlock, bool lastSplitInBlock, bool splitOnEveryAssert)
       {
         var newBlocks = new List<Block>(blocks.Count()); // Copies of the original blocks
@@ -855,7 +855,7 @@ namespace VC
                 splitCount++;
                 verify = splitCount == splitNumberWithinBlock;
               }
-              newCmds.Add(verify ? c : Split.AssertIntoAssume(c));
+              newCmds.Add(verify ? c : AssertIntoAssume(options, c));
             }
             newBlock.Cmds = newCmds;
           }
@@ -864,14 +864,14 @@ namespace VC
             var verify = true;
             var newCmds = new List<Cmd>();
             foreach(Cmd c in currentBlock.Cmds) {
-              verify = ShouldSplitHere(c, splitOnEveryAssert) ? false : verify;
-              newCmds.Add(verify ? c : Split.AssertIntoAssume(c));
+              verify = !ShouldSplitHere(c, splitOnEveryAssert) && verify;
+              newCmds.Add(verify ? c : AssertIntoAssume(options, c));
             }
             newBlock.Cmds = newCmds;
           }
           else
           {
-            newBlock.Cmds = currentBlock.Cmds.Select<Cmd, Cmd>(c => Split.AssertIntoAssume(c)).ToList();
+            newBlock.Cmds = currentBlock.Cmds.Select<Cmd, Cmd>(x => AssertIntoAssume(options, x)).ToList();
           }
         }
         // Patch the edges between the new blocks
@@ -981,14 +981,14 @@ namespace VC
           Block entryPoint = initialSplit.blocks[0];
           var blockAssignments = PickBlocksToVerify(initialSplit.blocks, splitPoints);
           var entryBlockHasSplit = splitPoints.Keys.Contains(entryPoint);
-          var baseSplitBlocks = PostProcess(DoPreAssignedManualSplit(initialSplit.blocks, blockAssignments, -1, entryPoint, !entryBlockHasSplit, splitOnEveryAssert));
+          var baseSplitBlocks = PostProcess(DoPreAssignedManualSplit(initialSplit.options, initialSplit.blocks, blockAssignments, -1, entryPoint, !entryBlockHasSplit, splitOnEveryAssert));
           splits.Add(new Split(initialSplit.options, baseSplitBlocks, initialSplit.gotoCmdOrigins, initialSplit.parent, initialSplit.Implementation));
           foreach (KeyValuePair<Block, int> pair in splitPoints)
           {
             for (int i = 0; i < pair.Value; i++)
             {
               bool lastSplitInBlock = i == pair.Value - 1;
-              var newBlocks = DoPreAssignedManualSplit(initialSplit.blocks, blockAssignments, i, pair.Key, lastSplitInBlock, splitOnEveryAssert);
+              var newBlocks = DoPreAssignedManualSplit(initialSplit.options, initialSplit.blocks, blockAssignments, i, pair.Key, lastSplitInBlock, splitOnEveryAssert);
               splits.Add(new Split(initialSplit.options, PostProcess(newBlocks), initialSplit.gotoCmdOrigins, initialSplit.parent, initialSplit.Implementation)); // REVIEW: Does gotoCmdOrigins need to be changed at all?
             }
           }
@@ -1080,7 +1080,7 @@ namespace VC
               // Their assertions turn into assumes and any splits inside them are disabled.
               if(freeBlocks.Contains(b))
               {
-                newBlock.Cmds = b.Cmds.Select(c => Split.AssertIntoAssume(c)).Select(c => DisableSplits(c)).ToList();
+                newBlock.Cmds = b.Cmds.Select(c => Split.AssertIntoAssume(options, c)).Select(c => DisableSplits(c)).ToList();
               }
               if (b.TransferCmd is GotoCmd gtc)
               {
@@ -1404,11 +1404,11 @@ namespace VC
         }
       }
 
-      private static Cmd AssertIntoAssume(Cmd c)
+      private static Cmd AssertIntoAssume(VCGenOptions options, Cmd c)
       {
         if (c is AssertCmd assrt)
         {
-          return VCGen.AssertTurnedIntoAssume(assrt);
+          return VCGen.AssertTurnedIntoAssume(options, assrt);
         }
 
         return c;

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -126,8 +126,8 @@ namespace VC
 
       var timeout = KeepGoing && split.LastChance ? options.VcsFinalAssertTimeout :
         KeepGoing ? options.VcsKeepGoingTimeout :
-        implementation.TimeLimit;
-      split.BeginCheck(checker, callback, mvInfo, currentSplitNumber, timeout, implementation.ResourceLimit, cancellationToken);
+        implementation.GetTimeLimit(options);
+      split.BeginCheck(checker, callback, mvInfo, currentSplitNumber, timeout, implementation.GetResourceLimit(options), cancellationToken);
     }
 
     private async Task ProcessResult(Split split, CancellationToken cancellationToken)

--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -486,7 +486,7 @@ namespace VC
       vcgen.InstrumentCallSites(impl);
 
       // typecheck
-      var tc = new TypecheckingContext(null);
+      var tc = new TypecheckingContext(null, options);
       impl.Typecheck(tc);
 
       ///////////////////

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -28,14 +28,14 @@ namespace VC
       Contract.Requires(program != null);
     }
 
-    public static AssumeCmd AssertTurnedIntoAssume(AssertCmd assrt)
+    public static AssumeCmd AssertTurnedIntoAssume(VCGenOptions options, AssertCmd assrt)
     {
       Contract.Requires(assrt != null);
       Contract.Ensures(Contract.Result<AssumeCmd>() != null);
 
       Expr expr = assrt.Expr;
       Contract.Assert(expr != null);
-      switch (Wlp.Subsumption(assrt))
+      switch (Wlp.Subsumption(options, assrt))
       {
         case CoreOptions.SubsumptionOption.Never:
           expr = Expr.True;
@@ -178,7 +178,7 @@ namespace VC
           }
           else
           {
-            seq.Add(AssertTurnedIntoAssume(turn));
+            seq.Add(AssertTurnedIntoAssume(Options, turn));
           }
         }
 
@@ -2038,7 +2038,7 @@ namespace VC
 
     #endregion
 
-    private static void HandleSelectiveChecking(Implementation impl)
+    private void HandleSelectiveChecking(Implementation impl)
     {
       if (QKeyValue.FindBoolAttribute(impl.Attributes, "selective_checking") ||
           QKeyValue.FindBoolAttribute(impl.Proc.Attributes, "selective_checking"))
@@ -2114,7 +2114,7 @@ namespace VC
             }
             else
             {
-              newCmds.Add(AssertTurnedIntoAssume(asrt));
+              newCmds.Add(AssertTurnedIntoAssume(Options, asrt));
             }
           }
 

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -616,7 +616,7 @@ namespace VC
       Contract.Requires(proverContext != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
-      TypecheckingContext tc = new TypecheckingContext(null);
+      TypecheckingContext tc = new TypecheckingContext(null, Options);
       impl.Typecheck(tc);
 
       VCExpr vc;
@@ -817,7 +817,7 @@ namespace VC
     {
       Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
 
-      if (impl.SkipVerification)
+      if (impl.IsSkipVerification(Options))
       {
         return Outcome.Inconclusive; // not sure about this one
       }
@@ -1070,7 +1070,7 @@ namespace VC
     public void ConvertCFG2DAG(Implementation impl, Dictionary<Block, List<Block>> edgesCut = null, int taskID = -1)
     {
       Contract.Requires(impl != null);
-      impl.PruneUnreachableBlocks(); // This is needed for VCVariety.BlockNested, and is otherwise just an optimization
+      impl.PruneUnreachableBlocks(Options); // This is needed for VCVariety.BlockNested, and is otherwise just an optimization
 
       CurrentLocalVariables = impl.LocVars;
       variable2SequenceNumber = new Dictionary<Variable, int>();
@@ -1543,7 +1543,7 @@ namespace VC
             }
           }
 
-          impl.PruneUnreachableBlocks();
+          impl.PruneUnreachableBlocks(Options);
 
           #endregion
 
@@ -1673,7 +1673,7 @@ namespace VC
           SugaredCmd sugaredCmd = cmd as SugaredCmd;
           if (sugaredCmd != null)
           {
-            StateCmd stateCmd = sugaredCmd.Desugaring as StateCmd;
+            StateCmd stateCmd = sugaredCmd.GetDesugaring(Options) as StateCmd;
             foreach (Variable v in stateCmd.Locals)
             {
               impl.LocVars.Add(v);
@@ -1788,7 +1788,7 @@ namespace VC
 
       if (Options.LiveVariableAnalysis > 0)
       {
-        Microsoft.Boogie.LiveVariableAnalysis.ComputeLiveVariables(impl);
+        new LiveVariableAnalysis(Options).ComputeLiveVariables(impl);
       }
 
       mvInfo = new ModelViewInfo(program, impl);
@@ -1807,7 +1807,7 @@ namespace VC
 
         {
           RemoveEmptyBlocks(impl.Blocks);
-          impl.PruneUnreachableBlocks();
+          impl.PruneUnreachableBlocks(Options);
         }
 
         #endregion Get rid of empty blocks

--- a/Source/VCGeneration/Wlp.cs
+++ b/Source/VCGeneration/Wlp.cs
@@ -138,7 +138,7 @@ namespace VC
         }
 
         {
-          var subsumption = Subsumption(ac);
+          var subsumption = Subsumption(ctxt.Options, ac);
           if (subsumption == CoreOptions.SubsumptionOption.Always
               || (subsumption == CoreOptions.SubsumptionOption.NotForQuantifiers && !(C is VCExprQuantifier)))
           {
@@ -241,7 +241,7 @@ namespace VC
       return expr;
     }
 
-    public static CoreOptions.SubsumptionOption Subsumption(AssertCmd ac)
+    public static CoreOptions.SubsumptionOption Subsumption(VCGenOptions options, AssertCmd ac)
     {
       Contract.Requires(ac != null);
       int n = QKeyValue.FindIntAttribute(ac.Attributes, "subsumption", -1);
@@ -250,7 +250,7 @@ namespace VC
         case 0: return CoreOptions.SubsumptionOption.Never;
         case 1: return CoreOptions.SubsumptionOption.NotForQuantifiers;
         case 2: return CoreOptions.SubsumptionOption.Always;
-        default: return CoreOptions.Clo.UseSubsumption;
+        default: return options.UseSubsumption;
       }
     }
 


### PR DESCRIPTION
- Add a fix to `Source/VCGeneration/Checker.GoBackToIdle` for when a model view file is used.
- ExecutionEngine takes a `VerificationResultCache` as an argument instead of storing it in a static variable, so consumers have control over the lifetime of the cache. Consumers who want to migrate cheaply should create their own static `VerificationResultCache`.
- Remove all references to `CoreOptions.Clo`