### PR TITLE
Support XML generation with /vcsCores

### DIFF
--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Boogie
       }
 
       cce.BeginExpose(this);
-      lock (this) {
+      {
         XmlWriterSettings settings = new XmlWriterSettings();
         settings.Indent = true;
         wr = XmlWriter.Create(filename, settings);
@@ -62,7 +62,7 @@ namespace Microsoft.Boogie
       if (wr != null)
       {
         cce.BeginExpose(this);
-        lock (this) {
+        {
           wr.WriteEndDocument();
           wr.Close();
           wr = null;
@@ -81,7 +81,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      lock(this) {
+      {
         wr.WriteStartElement("method");
         wr.WriteAttributeString("name", methodName);
         wr.WriteAttributeString("startTime", startTime.ToString(DateTimeFormatString));
@@ -97,7 +97,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      lock (this) {
+      {
         wr.WriteStartElement("conclusion");
         wr.WriteAttributeString("endTime", endTime.ToString(DateTimeFormatString));
         wr.WriteAttributeString("duration", elapsed.TotalSeconds.ToString());
@@ -124,7 +124,7 @@ namespace Microsoft.Boogie
       Contract.Assert(wr != null);
 
       cce.BeginExpose(this);
-      lock (this) {
+      {
         wr.WriteStartElement("split");
         wr.WriteAttributeString("number", splitNum.ToString());
         wr.WriteAttributeString("startTime", startTime.ToString(DateTimeFormatString));
@@ -148,7 +148,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      lock (this) {
+      {
         wr.WriteStartElement("error");
         wr.WriteAttributeString("message", message);
         WriteTokenAttributes(errorToken);
@@ -229,7 +229,7 @@ namespace Microsoft.Boogie
       //modifies this.0, wr.*;
       if (tok != null && tok.filename != null)
       {
-        lock (this) {
+        {
           wr.WriteAttributeString("file", tok.filename);
           wr.WriteAttributeString("line", tok.line.ToString());
           wr.WriteAttributeString("column", tok.col.ToString());
@@ -305,7 +305,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      lock(this) {
+      {
         wr.WriteStartElement("file");
         wr.WriteAttributeString("name", filename);
       }
@@ -319,7 +319,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      lock(this) {
+      {
         wr.WriteEndElement();
       }
       cce.EndExpose();
@@ -333,7 +333,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      lock(this) {
+      {
         wr.WriteStartElement("fileFragment");
         wr.WriteAttributeString("name", fragment);
         wr.WriteEndElement();

--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Boogie
       }
 
       cce.BeginExpose(this);
-      {
+      lock (this) {
         XmlWriterSettings settings = new XmlWriterSettings();
         settings.Indent = true;
         wr = XmlWriter.Create(filename, settings);
@@ -62,7 +62,7 @@ namespace Microsoft.Boogie
       if (wr != null)
       {
         cce.BeginExpose(this);
-        {
+        lock (this) {
           wr.WriteEndDocument();
           wr.Close();
           wr = null;
@@ -81,7 +81,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      {
+      lock(this) {
         wr.WriteStartElement("method");
         wr.WriteAttributeString("name", methodName);
         wr.WriteAttributeString("startTime", startTime.ToString(DateTimeFormatString));
@@ -97,7 +97,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      {
+      lock (this) {
         wr.WriteStartElement("conclusion");
         wr.WriteAttributeString("endTime", endTime.ToString(DateTimeFormatString));
         wr.WriteAttributeString("duration", elapsed.TotalSeconds.ToString());
@@ -114,36 +114,26 @@ namespace Microsoft.Boogie
       cce.EndExpose();
     }
 
-    public void WriteStartSplit(int splitNum, DateTime startTime)
+    public void WriteSplit(int splitNum, DateTime startTime, string outcome, TimeSpan elapsed)
     {
       Contract.Requires(splitNum > 0);
-      Contract.Requires(IsOpen);
-      //modifies this.*;
-      Contract.Ensures(IsOpen);
-      Contract.Assert(wr != null);
-      cce.BeginExpose(this);
-      {
-        wr.WriteStartElement("split");
-        wr.WriteAttributeString("number", splitNum.ToString());
-        wr.WriteAttributeString("startTime", startTime.ToString(DateTimeFormatString));
-      }
-      cce.EndExpose();
-    }
-    
-    public void WriteEndSplit(string outcome, TimeSpan elapsed)
-    {
       Contract.Requires(outcome != null);
       Contract.Requires(IsOpen);
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
+
       cce.BeginExpose(this);
-      {
+      lock (this) {
+        wr.WriteStartElement("split");
+        wr.WriteAttributeString("number", splitNum.ToString());
+        wr.WriteAttributeString("startTime", startTime.ToString(DateTimeFormatString));
+
         wr.WriteStartElement("conclusion");
         wr.WriteAttributeString("duration", elapsed.TotalSeconds.ToString());
         wr.WriteAttributeString("outcome", outcome);
-
         wr.WriteEndElement(); // outcome
+
         wr.WriteEndElement(); // split
       }
       cce.EndExpose();
@@ -158,7 +148,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      {
+      lock (this) {
         wr.WriteStartElement("error");
         wr.WriteAttributeString("message", message);
         WriteTokenAttributes(errorToken);
@@ -239,9 +229,11 @@ namespace Microsoft.Boogie
       //modifies this.0, wr.*;
       if (tok != null && tok.filename != null)
       {
-        wr.WriteAttributeString("file", tok.filename);
-        wr.WriteAttributeString("line", tok.line.ToString());
-        wr.WriteAttributeString("column", tok.col.ToString());
+        lock (this) {
+          wr.WriteAttributeString("file", tok.filename);
+          wr.WriteAttributeString("line", tok.line.ToString());
+          wr.WriteAttributeString("column", tok.col.ToString());
+        }
       }
     }
 
@@ -313,7 +305,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      {
+      lock(this) {
         wr.WriteStartElement("file");
         wr.WriteAttributeString("name", filename);
       }
@@ -327,7 +319,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      {
+      lock(this) {
         wr.WriteEndElement();
       }
       cce.EndExpose();
@@ -341,7 +333,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
       cce.BeginExpose(this);
-      {
+      lock(this) {
         wr.WriteStartElement("fileFragment");
         wr.WriteAttributeString("name", fragment);
         wr.WriteEndElement();

--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -229,11 +229,9 @@ namespace Microsoft.Boogie
       //modifies this.0, wr.*;
       if (tok != null && tok.filename != null)
       {
-        {
-          wr.WriteAttributeString("file", tok.filename);
-          wr.WriteAttributeString("line", tok.line.ToString());
-          wr.WriteAttributeString("column", tok.col.ToString());
-        }
+        wr.WriteAttributeString("file", tok.filename);
+        wr.WriteAttributeString("line", tok.line.ToString());
+        wr.WriteAttributeString("column", tok.col.ToString());
       }
     }
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -198,6 +198,7 @@ namespace Microsoft.Boogie
 
     public ConditionGeneration.Outcome Outcome { get; set; }
     public List<Counterexample> Errors;
+    public List<SplitResult> SplitResults;
 
     public ISet<byte[]> AssertionChecksums { get; private set; }
 
@@ -1014,11 +1015,6 @@ namespace Microsoft.Boogie
         var cachedResults = Cache.Lookup(impl, out priority);
         if (cachedResults != null && priority == Priority.SKIP)
         {
-          if (Options.XmlSink != null)
-          {
-            Options.XmlSink.WriteStartMethod(impl.Name, cachedResults.Start);
-          }
-
           printer.Inform(string.Format("Retrieving cached verification result for implementation {0}...", impl.Name),
             output);
           if (Options.VerifySnapshots < 3 ||
@@ -1042,15 +1038,11 @@ namespace Microsoft.Boogie
           verificationResult.ProofObligationCountBefore = vcgen.CumulativeAssertionCount;
           verificationResult.Start = DateTime.UtcNow;
 
-          if (Options.XmlSink != null)
-          {
-            Options.XmlSink.WriteStartMethod(impl.Name, verificationResult.Start);
-          }
-
           try {
             var cancellationToken = RequestIdToCancellationTokenSource[requestId].Token;
             verificationResult.Outcome =
-              vcgen.VerifyImplementation(impl, out verificationResult.Errors, requestId, cancellationToken);
+              vcgen.VerifyImplementation(impl, out verificationResult.Errors,
+                out verificationResult.SplitResults, requestId, cancellationToken);
             if (Options.ExtractLoops && verificationResult.Errors != null) {
               var vcg = vcgen as VCGen;
               if (vcg != null) {
@@ -1133,9 +1125,17 @@ namespace Microsoft.Boogie
 
       if (Options.XmlSink != null)
       {
-        Options.XmlSink.WriteEndMethod(verificationResult.Outcome.ToString().ToLowerInvariant(),
-          verificationResult.End, verificationResult.End - verificationResult.Start,
-          verificationResult.ResourceCount);
+        lock (Options.XmlSink) {
+          Options.XmlSink.WriteStartMethod(impl.Name, verificationResult.Start);
+          foreach (var splitResult in verificationResult.SplitResults.OrderBy(s => s.splitNum)) {
+            Options.XmlSink.WriteSplit(splitResult.splitNum, splitResult.startTime,
+              splitResult.outcome.ToString().ToLowerInvariant(), splitResult.runTime);
+          }
+
+          Options.XmlSink.WriteEndMethod(verificationResult.Outcome.ToString().ToLowerInvariant(),
+            verificationResult.End, verificationResult.End - verificationResult.Start,
+            verificationResult.ResourceCount);
+        }
       }
 
       outputCollector.Add(index, output);

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Boogie
 
     public ConditionGeneration.Outcome Outcome { get; set; }
     public List<Counterexample> Errors;
-    public List<SplitResult> SplitResults;
+    public List<VCResult> VCResults;
 
     public ISet<byte[]> AssertionChecksums { get; private set; }
 
@@ -1042,7 +1042,7 @@ namespace Microsoft.Boogie
             var cancellationToken = RequestIdToCancellationTokenSource[requestId].Token;
             verificationResult.Outcome =
               vcgen.VerifyImplementation(impl, out verificationResult.Errors,
-                out verificationResult.SplitResults, requestId, cancellationToken);
+                out verificationResult.VCResults, requestId, cancellationToken);
             if (Options.ExtractLoops && verificationResult.Errors != null) {
               var vcg = vcgen as VCGen;
               if (vcg != null) {
@@ -1127,9 +1127,10 @@ namespace Microsoft.Boogie
       {
         lock (Options.XmlSink) {
           Options.XmlSink.WriteStartMethod(impl.Name, verificationResult.Start);
-          foreach (var splitResult in verificationResult.SplitResults.OrderBy(s => s.splitNum)) {
-            Options.XmlSink.WriteSplit(splitResult.splitNum, splitResult.startTime,
-              splitResult.outcome.ToString().ToLowerInvariant(), splitResult.runTime);
+
+          foreach (var vcResult in verificationResult.VCResults.OrderBy(s => s.vcNum)) {
+            Options.XmlSink.WriteSplit(vcResult.vcNum, vcResult.startTime,
+              vcResult.outcome.ToString().ToLowerInvariant(), vcResult.runTime);
           }
 
           Options.XmlSink.WriteEndMethod(verificationResult.Outcome.ToString().ToLowerInvariant(),

--- a/Source/Houdini/Checker.cs
+++ b/Source/Houdini/Checker.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Boogie.Houdini
     public HoudiniStatistics stats;
     private VCExpr conjecture;
     private ProverInterface.ErrorHandler handler;
-    ConditionGeneration.CounterexampleCollector collector;
+    ConditionGeneration.VerificationResultCollector collector;
     HashSet<Variable> unsatCoreSet;
     HashSet<Variable> houdiniConstants;
     public HashSet<Variable> houdiniAssertConstants;
@@ -158,7 +158,7 @@ namespace Microsoft.Boogie.Houdini
       this.descriptiveName = impl.Name;
       this.houdini = houdini;
       this.stats = stats;
-      collector = new ConditionGeneration.CounterexampleCollector(houdini.Options);
+      collector = new ConditionGeneration.VerificationResultCollector(houdini.Options);
       collector.OnProgress?.Invoke("HdnVCGen", 0, 0, 0.0);
 
       vcgen.ConvertCFG2DAG(impl, taskID: taskID);

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Boogie
     private volatile ProverInterface.Outcome outcome;
     private volatile bool hasOutput;
     private volatile UnexpectedProverOutputException outputExn;
-    private DateTime proverStart;
+    public DateTime ProverStart { get; private set; }
     private TimeSpan proverRunTime;
     private volatile ProverInterface.ErrorHandler handler;
     private volatile CheckerStatus status;
@@ -296,7 +296,7 @@ namespace Microsoft.Boogie
       }
 
       hasOutput = true;
-      proverRunTime = DateTime.UtcNow - proverStart;
+      proverRunTime = DateTime.UtcNow - ProverStart;
     }
 
     public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, uint timeout, uint rlimit, CancellationToken cancellationToken)
@@ -318,7 +318,7 @@ namespace Microsoft.Boogie
       }
       SetTimeout(timeout);
       SetRlimit(rlimit);
-      proverStart = DateTime.UtcNow;
+      ProverStart = DateTime.UtcNow;
       thmProver.BeginCheck(descriptiveName, vc, handler);
       //  gen.ClearSharedFormulas();    PR: don't know yet what to do with this guy
 

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -115,7 +115,7 @@ namespace VC
     /// </summary>
     /// <param name="impl"></param>
     public Outcome VerifyImplementation(Implementation impl, out List<Counterexample> /*?*/ errors,
-      out List<SplitResult> splitResults,
+      out List<VCResult> vcResults,
       string requestId, CancellationToken cancellationToken)
     {
       Contract.Requires(impl != null);
@@ -138,7 +138,7 @@ namespace VC
       {
         errors = null;
       }
-      splitResults = collector.splitResults;
+      vcResults = collector.vcResults;
 
       Helpers.ExtraTraceInformation("Finished implementation verification");
       return outcome;
@@ -528,15 +528,15 @@ namespace VC
       void ObjectInvariant()
       {
         Contract.Invariant(cce.NonNullElements(examples));
-        Contract.Invariant(cce.NonNullElements(splitResults));
+        Contract.Invariant(cce.NonNullElements(vcResults));
       }
 
       public string RequestId;
 
       public readonly List<Counterexample> /*!>!*/
         examples = new List<Counterexample>();
-      public readonly List<SplitResult> /*!>!*/
-        splitResults = new List<SplitResult>();
+      public readonly List<VCResult> /*!>!*/
+        vcResults = new List<VCResult>();
 
       public override void OnCounterexample(Counterexample ce, string /*?*/ reason)
       {
@@ -562,9 +562,9 @@ namespace VC
         // TODO report error about next to last in seq
       }
 
-      public override void OnSplitResult(SplitResult result)
+      public override void OnVCResult(VCResult result)
       {
-        splitResults.Add(result);
+        vcResults.Add(result);
       }
     }
 

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Diagnostics.Contracts;
 using Microsoft.Boogie.VCExprAST;
+using VC;
 using Set = Microsoft.Boogie.GSet<object>;
 
 namespace Microsoft.Boogie
@@ -659,6 +659,11 @@ namespace Microsoft.Boogie
           Contract.Assume(false);
           throw new cce.UnreachableException(); // unexpected case
       }
+    }
+
+    public virtual void OnSplitResult(SplitResult result)
+    {
+      Contract.Requires(result != null);
     }
   }
 }

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -661,7 +661,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public virtual void OnSplitResult(SplitResult result)
+    public virtual void OnVCResult(VCResult result)
     {
       Contract.Requires(result != null);
     }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1294,7 +1294,10 @@ namespace VC
         }
 
         if (options.XmlSink != null && splitNum >= 0) {
-          options.XmlSink.WriteEndSplit(outcome.ToString().ToLowerInvariant(),
+          options.XmlSink.WriteSplit(
+            splitNum + 1,
+            checker.ProverStart,
+            outcome.ToString().ToLowerInvariant(),
             TimeSpan.FromSeconds(checker.ProverRunTime.TotalSeconds));
         }
 

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -15,9 +15,9 @@ namespace VC
   using Bpl = Microsoft.Boogie;
   using System.Threading.Tasks;
 
-  public record SplitResult
+  public record VCResult
   (
-    int splitNum,
+    int vcNum,
     DateTime startTime,
     ProverInterface.Outcome outcome,
     TimeSpan runTime
@@ -1301,8 +1301,8 @@ namespace VC
             checker.ProverRunTime.TotalSeconds, outcome);
         }
 
-        var result = new SplitResult(splitNum + 1, checker.ProverStart, outcome, checker.ProverRunTime);
-        callback.OnSplitResult(result);
+        var result = new VCResult(splitNum + 1, checker.ProverStart, outcome, checker.ProverRunTime);
+        callback.OnVCResult(result);
 
         if (options.VcsDumpSplits)
         {

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -117,10 +117,6 @@ namespace VC
           split.Stats, currentSplitNumber + 1, total, 100 * provenCost / (provenCost + remainingCost));
       }
 
-      if (options.XmlSink != null && DoSplitting) {
-        options.XmlSink.WriteStartSplit(currentSplitNumber + 1, DateTime.UtcNow);
-      }
-
       callback.OnProgress?.Invoke("VCprove", currentSplitNumber, total,
         provenCost / (remainingCost + provenCost));
 

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -134,7 +134,7 @@ namespace VC
         }
       }
 
-      split.ReadOutcome(ref outcome, out var proverFailed, ref totalResourceCount);
+      split.ReadOutcome(callback, ref outcome, out var proverFailed, ref totalResourceCount);
 
       if (TrackingProgress) {
         lock (this) {

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -1,12 +1,13 @@
-// Can't use %parallel-boogie here yet - see https://github.com/boogie-org/boogie/issues/460
-// RUN: %boogie -randomSeed:0 -xml:"%t-1.xml" "%s"
-// RUN: %boogie -randomSeed:0 -xml:"%t-2.xml" "%s"
+// RUN: %parallel-boogie -randomSeed:0 -xml:"%t-1.xml" "%s"
+// RUN: %parallel-boogie -randomSeed:0 -xml:"%t-2.xml" "%s"
 // RUN: grep -Eo "resourceCount=\"[0-9]+\"" "%t-1.xml" > "%t-res1"
 // RUN: grep -Eo "resourceCount=\"[0-9]+\"" "%t-2.xml" > "%t-res2"
 // RUN: diff "%t-res1" "%t-res2"
 // Chop off the first line, since OutputCheck expects ASCII and can't handle the byte-order mark
 // RUN: tail -n +2 "%t-1.xml" > "%t.trimmed.xml"
 // RUN: %OutputCheck "%s" --file-to-check="%t.trimmed.xml"
+// We only check for one of the methods in the XML because there's no
+// guarantee about what order they'll appear in.
 // CHECK: \<method name="ExampleWithSplits" startTime=".*"\>
 // CHECK:   \<split number="1" startTime=".*"\>
 // CHECK:     \<conclusion duration=".*" outcome="valid" />
@@ -14,12 +15,6 @@
 // CHECK:   \<split number="2" startTime=".*"\>
 // CHECK:     \<conclusion duration=".*" outcome="valid" />
 // CHECK:   \</split\>
-// CHECK:   \<conclusion endTime=".*" duration=".*" resourceCount=".*" outcome="correct" />
-// CHECK: \</method\>
-// CHECK: \<method name="ExampleWithoutSplits" startTime=".*"\>
-// CHECK:   \<conclusion endTime=".*" duration=".*" resourceCount=".*" outcome="correct" />
-// CHECK: \</method\>
-// CHECK: \<method name="AnotherExampleWithoutSplits" startTime=".*"\>
 // CHECK:   \<conclusion endTime=".*" duration=".*" resourceCount=".*" outcome="correct" />
 // CHECK: \</method\>
 

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -1,7 +1,7 @@
 // RUN: %parallel-boogie -randomSeed:0 -xml:"%t-1.xml" "%s"
 // RUN: %parallel-boogie -randomSeed:0 -xml:"%t-2.xml" "%s"
-// RUN: grep -Eo "resourceCount=\"[0-9]+\"" "%t-1.xml" > "%t-res1"
-// RUN: grep -Eo "resourceCount=\"[0-9]+\"" "%t-2.xml" > "%t-res2"
+// RUN: grep -Eo "resourceCount=\"[0-9]+\"" "%t-1.xml" | sort -g > "%t-res1"
+// RUN: grep -Eo "resourceCount=\"[0-9]+\"" "%t-2.xml" | sort -g > "%t-res2"
 // RUN: diff "%t-res1" "%t-res2"
 // Chop off the first line, since OutputCheck expects ASCII and can't handle the byte-order mark
 // RUN: tail -n +2 "%t-1.xml" > "%t.trimmed.xml"


### PR DESCRIPTION
This PR updates the process of collecting verification results and generating XML from them so that it should be safe to use `/xml` and `/vcsCores` together without getting mangled, interleaved output.

In the process, it makes the results of checking individual splits more readily available at the higher levels of the verification call tree. This should be a step toward allowing clients such as Dafny to access fine-grained verification results without needing to read the XML output. The `VerificationResult` type now includes a list of `SplitResult` objects. If there's any more information a client is likely to need from verification, it should probably wind up in either `VerificationResult` or `SplitResult`.

Fixes #460

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).