### PR TITLE
Clean up calls to `ToList()` to reduce memory pressure

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -3106,9 +3106,9 @@ namespace Microsoft.Boogie
     protected void SortTypeParams()
     {
       List<Type> /*!*/
-        allTypes = new List<Type>(InParams.Select(Item => Item.TypedIdent.Type).ToArray());
+        allTypes = InParams.Select(Item => Item.TypedIdent.Type).ToList();
       Contract.Assert(allTypes != null);
-      allTypes.AddRange(new List<Type>(OutParams.Select(Item => Item.TypedIdent.Type).ToArray()));
+      allTypes.AddRange(OutParams.Select(Item => Item.TypedIdent.Type));
       TypeParameters = Type.SortTypeParams(TypeParameters, allTypes, null);
     }
 
@@ -3467,8 +3467,8 @@ namespace Microsoft.Boogie
 
         rc.PopVarContext();
         Type.CheckBoundVariableOccurrences(TypeParameters,
-          new List<Type>(InParams.Select(Item => Item.TypedIdent.Type).ToArray()),
-          new List<Type>(OutParams.Select(Item => Item.TypedIdent.Type).ToArray()),
+          InParams.Select(Item => Item.TypedIdent.Type).ToList(),
+          OutParams.Select(Item => Item.TypedIdent.Type).ToList(),
           this.tok, "function arguments",
           rc);
       }
@@ -4008,8 +4008,8 @@ namespace Microsoft.Boogie
         ResolveAttributes(rc);
 
         Type.CheckBoundVariableOccurrences(TypeParameters,
-          new List<Type>(InParams.Select(Item => Item.TypedIdent.Type).ToArray()),
-          new List<Type>(OutParams.Select(Item => Item.TypedIdent.Type).ToArray()),
+          InParams.Select(Item => Item.TypedIdent.Type).ToList(),
+          OutParams.Select(Item => Item.TypedIdent.Type).ToList(),
           this.tok, "procedure arguments",
           rc);
       }
@@ -4628,8 +4628,8 @@ namespace Microsoft.Boogie
         rc.PopVarContext();
 
         Type.CheckBoundVariableOccurrences(TypeParameters,
-          new List<Type>(InParams.Select(Item => Item.TypedIdent.Type).ToArray()),
-          new List<Type>(OutParams.Select(Item => Item.TypedIdent.Type).ToArray()),
+          InParams.Select(Item => Item.TypedIdent.Type).ToList(),
+          OutParams.Select(Item => Item.TypedIdent.Type).ToList(),
           this.tok, "implementation arguments",
           rc);
       }

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -2816,9 +2816,9 @@ namespace Microsoft.Boogie
       List<Type> actualResultType =
         Type.CheckArgumentTypes(Func.TypeParameters,
           out var resultingTypeArgs,
-          new List<Type>(Func.InParams.Select(Item => Item.TypedIdent.Type).ToArray()),
+          Func.InParams.Select(Item => Item.TypedIdent.Type).ToList(),
           actuals,
-          new List<Type>(Func.OutParams.Select(Item => Item.TypedIdent.Type).ToArray()),
+          Func.OutParams.Select(Item => Item.TypedIdent.Type).ToList(),
           null,
           // we need some token to report a possibly wrong number of
           // arguments

--- a/Source/Core/AbsyQuant.cs
+++ b/Source/Core/AbsyQuant.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Boogie
 
         // establish a canonical order of the type parameters
         this.TypeParameters = Type.SortTypeParams(TypeParameters,
-          new List<Type>(Dummies.Select(Item => Item.TypedIdent.Type).ToArray()), null);
+          Dummies.Select(Item => Item.TypedIdent.Type).ToList(), null);
       }
       finally
       {
@@ -312,7 +312,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<List<TypeVariable>>() != null);
       List<TypeVariable> /*!*/
-        dummyParameters = Type.FreeVariablesIn(new List<Type>(Dummies.Select(Item => Item.TypedIdent.Type).ToArray()));
+        dummyParameters = Type.FreeVariablesIn(Dummies.Select(Item => Item.TypedIdent.Type).ToList());
       Contract.Assert(dummyParameters != null);
       List<TypeVariable> /*!*/
         unmentionedParameters = new List<TypeVariable>();

--- a/Source/Core/InterProceduralReachabilityGraph.cs
+++ b/Source/Core/InterProceduralReachabilityGraph.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Boogie
             Block newBlock;
             if (prev == null)
             {
-              newBlock = new Block(b.tok, "__" + impl.Name + "_" + b.Label, new List<Cmd>(cmds.ToArray()), null);
+              newBlock = new Block(b.tok, "__" + impl.Name + "_" + b.Label, cmds.ToList(), null);
               nodes.Add(newBlock);
               originalToNew[b] = newBlock;
               if (impl.Blocks[0] == b)
@@ -181,7 +181,7 @@ namespace Microsoft.Boogie
             else
             {
               string label = "__" + impl.Name + "_" + b.Label + "_call_" + i;
-              newBlock = new Block(b.tok, label, new List<Cmd>(cmds.ToArray()), null);
+              newBlock = new Block(b.tok, label, cmds.ToList(), null);
               nodes.Add(newBlock);
               originalToNew[newBlock] = newBlock;
               prev.TransferCmd = new GotoCmd(Token.NoToken, new List<String> {label}, new List<Block> {newBlock});

--- a/Source/Predication/SmartBlockPredicator.cs
+++ b/Source/Predication/SmartBlockPredicator.cs
@@ -488,7 +488,7 @@ namespace Microsoft.Boogie
           continue;
         }
 
-        var parts = block.Cmds.Cast<Cmd>().TakeWhile(
+        var parts = block.Cmds.TakeWhile(
           c => c is AssumeCmd &&
                QKeyValue.FindBoolAttribute(((AssumeCmd) c).Attributes, "partition"));
 
@@ -496,8 +496,7 @@ namespace Microsoft.Boogie
         if (parts.Count() > 0)
         {
           pred = parts.Select(a => ((AssumeCmd) a).Expr).Aggregate(Expr.And);
-          block.Cmds =
-            new List<Cmd>(block.Cmds.Cast<Cmd>().Skip(parts.Count()).ToArray());
+          block.Cmds = block.Cmds.Skip(parts.Count()).ToList();
         }
         else
         {


### PR DESCRIPTION
It's a minor part of Boogie's full memory footprint, but it adds up over many calls.  On a single verification of Test/havoc0 I observe a 4-5% reduction of the footprint of the whole program.

I'm not sure why there were so many such calls to ToArray followed by ToList.  Maybe they were there on purpose?