### PR TITLE
Bump minor version to 2.12.1

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.11.5</Version>
+    <Version>2.12.1</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>


### PR DESCRIPTION
I've bumped the minor instead of the patch version because there are some small API changes.