### PR TITLE
Visiting attributes in StandardVisitor

### DIFF
--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -888,13 +888,7 @@ namespace Microsoft.Boogie
         {
           return cmd;
         }
-        var newCmd = BoundVarAndReplacingOldSubstituter.Apply(substMap, oldSubstMap, prefix, cmd);
-        if (cmd is ICarriesAttributes attrCmd && attrCmd.Attributes != null)
-        {
-          var attrCopy = (QKeyValue) attrCmd.Attributes.Clone();
-          ((ICarriesAttributes) newCmd).Attributes = Substituter.ApplyReplacingOldExprs(PartialSubst, PartialOldSubst, attrCopy);
-        }
-        return newCmd;
+        return BoundVarAndReplacingOldSubstituter.Apply(substMap, oldSubstMap, prefix, cmd);
       }
 
       public Expr CopyExpr(Expr expr)

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -808,36 +808,6 @@ namespace Microsoft.Boogie
 
         return expr;
       }
-
-      public override Cmd VisitAssumeCmd(AssumeCmd node)
-      {
-        var returnCmd = (AssumeCmd) base.VisitAssumeCmd(node);
-        if (node.Attributes != null)
-        {
-          returnCmd.Attributes = VisitQKeyValue(node.Attributes);
-        }
-        return returnCmd;
-      }
-      
-      public override Cmd VisitAssertCmd(AssertCmd node)
-      {
-        var returnCmd = (AssertCmd) base.VisitAssertCmd(node);
-        if (node.Attributes != null)
-        {
-          returnCmd.Attributes = VisitQKeyValue(node.Attributes);
-        }
-        return returnCmd;
-      }
-      
-      public override Cmd VisitAssignCmd(AssignCmd node)
-      {
-        var returnCmd = (AssignCmd) base.VisitAssignCmd(node);
-        if (node.Attributes != null)
-        {
-          returnCmd.Attributes = VisitQKeyValue(node.Attributes);
-        }
-        return returnCmd;
-      }
     }
 
     public static MonomorphizationVisitor Initialize(CoreOptions options, Program program,
@@ -976,36 +946,6 @@ namespace Microsoft.Boogie
       }
     }
 
-    public override Cmd VisitAssumeCmd(AssumeCmd node)
-    {
-      var returnCmd = (AssumeCmd) base.VisitAssumeCmd(node);
-      if (node.Attributes != null)
-      {
-        returnCmd.Attributes = VisitQKeyValue(node.Attributes);
-      }
-      return returnCmd;
-    }
-      
-    public override Cmd VisitAssertCmd(AssertCmd node)
-    {
-      var returnCmd = (AssertCmd) base.VisitAssertCmd(node);
-      if (node.Attributes != null)
-      {
-        returnCmd.Attributes = VisitQKeyValue(node.Attributes);
-      }
-      return returnCmd;
-    }
-      
-    public override Cmd VisitAssignCmd(AssignCmd node)
-    {
-      var returnCmd = (AssignCmd) base.VisitAssignCmd(node);
-      if (node.Attributes != null)
-      {
-        returnCmd.Attributes = VisitQKeyValue(node.Attributes);
-      }
-      return returnCmd;
-    }
-    
     public override CtorType VisitCtorType(CtorType node)
     {
       return (CtorType) monomorphizationDuplicator.VisitType(node);
@@ -1056,15 +996,6 @@ namespace Microsoft.Boogie
       constructor.selectors.Iter(selector => base.VisitFunction(selector));
     }
     
-    public override Absy Visit(Absy node)
-    {
-      if (node is ICarriesAttributes attrNode && attrNode.Attributes != null)
-      {
-        VisitQKeyValue(attrNode.Attributes);
-      }
-      return base.Visit(node);
-    }
-
     // this function may be called directly by monomorphizationDuplicator
     // if a non-generic function call is discovered in an expression
     public override Function VisitFunction(Function node)

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -1076,7 +1076,7 @@ namespace Microsoft.Boogie
           this.VisitIdentifierExpr(node.Outs[i]);
         }
       }
-      
+
       return node;
     }
 

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Boogie
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       node.Expr = this.VisitExpr(node.Expr);
+      VisitAttributes(node);
       return node;
     }
 
@@ -90,7 +91,7 @@ namespace Microsoft.Boogie
         node.SetLhs(i, cce.NonNull((AssignLhs) this.Visit(node.Lhss[i])));
         node.SetRhs(i, cce.NonNull((Expr /*!*/) this.VisitExpr(node.Rhss[i])));
       }
-
+      VisitAttributes(node);
       return node;
     }
 
@@ -99,6 +100,7 @@ namespace Microsoft.Boogie
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       node.Expr = this.VisitExpr(node.Expr);
+      VisitAttributes(node);
       return node;
     }
 
@@ -234,7 +236,7 @@ namespace Microsoft.Boogie
           node.Outs[i] = (IdentifierExpr) this.VisitIdentifierExpr(cce.NonNull(node.Outs[i]));
         }
       }
-
+      VisitAttributes(node);
       return node;
     }
 
@@ -249,7 +251,7 @@ namespace Microsoft.Boogie
           node.CallCmds[i] = (CallCmd) this.VisitCallCmd(node.CallCmds[i]);
         }
       }
-
+      VisitAttributes(node);
       return node;
     }
 
@@ -433,6 +435,7 @@ namespace Microsoft.Boogie
       node.Rhss = this.VisitExprSeq(node.Rhss);
       node.Dummies = this.VisitVariableSeq(node.Dummies);
       node.Body = this.VisitExpr(node.Body);
+      VisitAttributes(node);
       return node;
     }
 
@@ -457,7 +460,6 @@ namespace Microsoft.Boogie
       {
         node.DefinitionBody = (NAryExpr) this.VisitExpr(node.DefinitionBody);
       }
-
       return node;
     }
 
@@ -651,6 +653,7 @@ namespace Microsoft.Boogie
       node.Body = this.VisitExpr(node.Body);
       node.Dummies = this.VisitVariableSeq(node.Dummies);
       //node.Type = this.VisitType(node.Type);
+      VisitAttributes(node);
       return node;
     }
 
@@ -864,6 +867,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<Cmd>() != null);
       node.Ensures = this.VisitEnsures(node.Ensures);
       node.Expr = this.VisitExpr(node.Expr);
+      VisitAttributes(node);
       return node;
     }
 
@@ -873,7 +877,16 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<Cmd>() != null);
       node.Requires = this.VisitRequires(node.Requires);
       node.Expr = this.VisitExpr(node.Expr);
+      VisitAttributes(node);
       return node;
+    }
+
+    private void VisitAttributes(ICarriesAttributes node)
+    {
+      if (node.Attributes != null)
+      {
+        node.Attributes = VisitQKeyValue(node.Attributes);
+      }
     }
   }
 
@@ -1055,7 +1068,7 @@ namespace Microsoft.Boogie
           this.VisitIdentifierExpr(node.Outs[i]);
         }
       }
-
+      
       return node;
     }
 

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -881,6 +881,14 @@ namespace Microsoft.Boogie
       return node;
     }
 
+    /*
+     * VisitAttributes is being called in the visitor of those subtypes of Cmd
+     * and Expr that implement ICarriesAttributes. This behavior is introduced so
+     * that hints for pool-based quantifier instantiation present in attributes
+     * are processed naturally during monomorphization and inlining. There
+     * are other subtypes of Absy that implement ICarriesAttributes; if
+     * necessary, this method could be in the visitor for those types also.
+     */
     private void VisitAttributes(ICarriesAttributes node)
     {
       if (node.Attributes != null)


### PR DESCRIPTION
There are many parts of Civl that depend on inlining to work with attributes as well.  Inlining uses Duplicator (which extends StandardVisitor) heavily.  This PR adds code to StandardVisitor so that it visits attributes for all commands and expressions that carry attributes. As a result, inlining and monomorphization have become simpler.