### PR TITLE
Support @PROC@ for the -mv option

### DIFF
--- a/Source/Core/Helpers.cs
+++ b/Source/Core/Helpers.cs
@@ -270,8 +270,11 @@ namespace Microsoft.Boogie
     {
       filename = SubstituteAtPROC(descriptiveName, cce.NonNull(filename));
 
-      var reused = allowReuse && UsedLogNames.ContainsKey(filename);
-      var index = UsedLogNames.AddOrUpdate(filename, 0, (_, i) => allowReuse ? i : i + 1);
+      var reused = false;
+      var index = UsedLogNames.AddOrUpdate(filename, 0, (_, i) => {
+        reused = allowReuse;
+        return allowReuse ? i : i + 1;
+      });
       var filenameWithIndex = index > 0 ? filename + "." + index : filename;
 
       return (filenameWithIndex, reused);

--- a/Source/Core/Helpers.cs
+++ b/Source/Core/Helpers.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Boogie
     private static readonly ConcurrentDictionary<string, int> UsedLogNames = new();
     public static (string fileName, bool reused) GetLogFilename(string descriptiveName, string filename, bool allowReuse)
     {
-      filename = SubstituteAtProc(descriptiveName, cce.NonNull(filename));
+      filename = SubstituteAtPROC(descriptiveName, cce.NonNull(filename));
 
       var reused = allowReuse && UsedLogNames.ContainsKey(filename);
       var index = UsedLogNames.AddOrUpdate(filename, 0, (_, i) => allowReuse ? i : i + 1);
@@ -277,7 +277,7 @@ namespace Microsoft.Boogie
       return (filenameWithIndex, reused);
     }
 
-    private static string SubstituteAtProc(string descriptiveName, string filename)
+    private static string SubstituteAtPROC(string descriptiveName, string filename)
     {
       Contract.Requires(filename != null);
       Contract.Requires(descriptiveName != null);

--- a/Source/ExecutionEngine/ConsolePrinter.cs
+++ b/Source/ExecutionEngine/ConsolePrinter.cs
@@ -142,7 +142,7 @@ public class ConsolePrinter : OutputPrinter
     }
 
     tw.Write(errorInfo.Out.ToString());
-    tw.Write(errorInfo.Model.ToString());
+    tw.Write(errorInfo.ModelWriter.ToString());
     tw.Flush();
   }
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Boogie
     public ErrorKind Kind { get; set; }
     public string ImplementationName { get; set; }
     public TextWriter Out = new StringWriter();
-    public TextWriter Model = new StringWriter();
+    public TextWriter ModelWriter = new StringWriter();
 
     public string FullMsg
     {
@@ -1501,7 +1501,7 @@ namespace Microsoft.Boogie
           }
 
           if (Options.ModelViewFile != null) {
-            error.PrintModel(errorInfo.Model, error);
+            error.PrintModel(errorInfo.ModelWriter, error);
           }
 
           printer.WriteErrorInformation(errorInfo, tw);

--- a/Source/Houdini/HoudiniSession.cs
+++ b/Source/Houdini/HoudiniSession.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Boogie.Houdini
   }
 
 
-  public class HoudiniSession
+  public class HoudiniSession : ProofRun
   {
     public class HoudiniStatistics
     {
@@ -120,7 +120,7 @@ namespace Microsoft.Boogie.Houdini
       public int numUnsatCorePrunings = 0;
     }
 
-    public string descriptiveName;
+    public string Description { get; }
     private readonly Houdini houdini;
     public HoudiniStatistics stats;
     private VCExpr conjecture;
@@ -155,7 +155,7 @@ namespace Microsoft.Boogie.Houdini
     public HoudiniSession(Houdini houdini, VCGen vcgen, ProverInterface proverInterface, Program program,
       Implementation impl, HoudiniStatistics stats, int taskID = -1)
     {
-      this.descriptiveName = impl.Name;
+      this.Description = impl.Name;
       this.houdini = houdini;
       this.stats = stats;
       collector = new ConditionGeneration.VerificationResultCollector(houdini.Options);
@@ -186,12 +186,12 @@ namespace Microsoft.Boogie.Houdini
       VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(impl.Blocks[0]))));
       conjecture = exprGen.Implies(eqExpr, conjecture);
 
-      Macro macro = new Macro(Token.NoToken, descriptiveName, new List<Variable>(),
+      Macro macro = new Macro(Token.NoToken, Description, new List<Variable>(),
         new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "", Type.Bool), false));
       proverInterface.DefineMacro(macro, conjecture);
       conjecture = exprGen.Function(macro);
       handler = new VCGen.ErrorReporter(this.houdini.Options, gotoCmdOrigins, absyIds, impl.Blocks, vcgen.debugInfos, collector,
-        mvInfo, proverInterface.Context, program);
+        mvInfo, proverInterface.Context, program, this);
     }
 
     private VCExpr BuildAxiom(ProverInterface proverInterface, Dictionary<Variable, bool> currentAssignment)
@@ -254,13 +254,13 @@ namespace Microsoft.Boogie.Houdini
 
       if (Options.Trace)
       {
-        Console.WriteLine("Verifying " + descriptiveName);
+        Console.WriteLine("Verifying " + Description);
       }
 
       DateTime now = DateTime.UtcNow;
 
       VCExpr vc = proverInterface.VCExprGen.Implies(BuildAxiom(proverInterface, assignment), conjecture);
-      proverInterface.BeginCheck(descriptiveName, vc, handler);
+      proverInterface.BeginCheck(Description, vc, handler);
       ProverInterface.Outcome proverOutcome = proverInterface.CheckOutcome(handler, errorLimit, CancellationToken.None).Result;
 
       double queryTime = (DateTime.UtcNow - now).TotalSeconds;
@@ -380,7 +380,7 @@ namespace Microsoft.Boogie.Houdini
 
       if (Options.Trace)
       {
-        Console.WriteLine("Verifying (MaxSat) " + descriptiveName);
+        Console.WriteLine("Verifying (MaxSat) " + Description);
       }
 
       DateTime now = DateTime.UtcNow;
@@ -393,8 +393,8 @@ namespace Microsoft.Boogie.Houdini
       do
       {
         hardAssumptions.Add(controlExprNoop);
-        (outcome, var unsatisfiedSoftAssumptions) = proverInterface.CheckAssumptions(hardAssumptions, softAssumptions, 
-          handler, CancellationToken.None).Result;
+        (outcome, var unsatisfiedSoftAssumptions) = proverInterface.CheckAssumptions(hardAssumptions,
+          softAssumptions, handler, CancellationToken.None).Result;
         hardAssumptions.RemoveAt(hardAssumptions.Count - 1);
 
         if (outcome == ProverInterface.Outcome.TimeOut || outcome == ProverInterface.Outcome.OutOfMemory ||
@@ -428,7 +428,7 @@ namespace Microsoft.Boogie.Houdini
           hardAssumptions.Add(softAssumptions[i]);
         }
 
-        (outcome, var unsatisfiedSoftAssumptions2) = proverInterface.CheckAssumptions(hardAssumptions, softAssumptions2, 
+        (outcome, var unsatisfiedSoftAssumptions2) = proverInterface.CheckAssumptions(hardAssumptions, softAssumptions2,
           handler, CancellationToken.None).Result;
 
         if (outcome == ProverInterface.Outcome.TimeOut || outcome == ProverInterface.Outcome.OutOfMemory ||
@@ -451,14 +451,14 @@ namespace Microsoft.Boogie.Houdini
         foreach (var r in reason)
         {
           Houdini.explainHoudiniDottyFile.WriteLine("{0} -> {1} [ label = \"{2}\" color=red ];", refutedConstant.Name,
-            r, descriptiveName);
+            r, Description);
         }
 
         //also add the removed reasons using dotted edges (requires- x != 0, requires- x == 0 ==> assert x != 0)
         foreach (var r in reason1)
         {
           Houdini.explainHoudiniDottyFile.WriteLine("{0} -> {1} [ label = \"{2}\" color=blue style=dotted ];",
-            refutedConstant.Name, r, descriptiveName);
+            refutedConstant.Name, r, Description);
         }
       } while (false);
 
@@ -466,7 +466,7 @@ namespace Microsoft.Boogie.Houdini
           outcome == ProverInterface.Outcome.OutOfResource || outcome == ProverInterface.Outcome.Undetermined)
       {
         Houdini.explainHoudiniDottyFile.WriteLine("{0} -> {1} [ label = \"{2}\" color=red ];", refutedConstant.Name,
-          "TimeOut", descriptiveName);
+          "TimeOut", Description);
       }
 
       Options.ErrorLimit = el;

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Boogie.SMTLib;
 using Microsoft.Boogie.VCExprAST;
 
 namespace Microsoft.Boogie;

--- a/Source/Provers/SMTLib/ProverUtil.cs
+++ b/Source/Provers/SMTLib/ProverUtil.cs
@@ -298,7 +298,7 @@ The generic options may or may not be used by the prover plugin.
         Contract.Assert(filename != null);
         if (descName != null)
         {
-          filename = Helpers.SubstituteAtPROC(descName, filename);
+          filename = Helpers.GetLogFilename(descName, filename, true).fileName;
         }
 
         return new StreamWriter(filename, AppendLogFile);

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -524,22 +524,10 @@ namespace Microsoft.Boogie.SMTLib
       Contract.Requires(descriptiveName != null);
       Contract.Ensures(Contract.Result<TextWriter>() != null);
 
-      string filename = options.LogFilename;
-      filename = Helpers.SubstituteAtPROC(descriptiveName, cce.NonNull(filename));
-      var curFilename = filename;
+      string filenameTemplate = options.LogFilename;
+      var (filename, reused) = Helpers.GetLogFilename(descriptiveName, filenameTemplate, false);
 
-      lock (usedLogNames)
-      {
-        int n = 1;
-        while (usedLogNames.Contains(curFilename))
-        {
-          curFilename = filename + "." + n++;
-        }
-
-        usedLogNames.Add(curFilename);
-      }
-
-      return new StreamWriter(curFilename, false);
+      return new StreamWriter(filename, reused);
     }
 
     protected void FlushProverWarnings()

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.Boogie.VCExprAST;
 using System.Threading.Tasks;
+using Microsoft.Boogie.SMTLib;
 using VC;
 
 namespace Microsoft.Boogie
@@ -261,7 +262,7 @@ namespace Microsoft.Boogie
       return thmProver.GetRCount();
     }
 
-    private async Task WaitForOutput(object dummy, CancellationToken cancellationToken)
+    private async Task WaitForOutput(CancellationToken cancellationToken)
     {
       try {
         outcome = await thmProver.CheckOutcome(cce.NonNull(handler), Options.ErrorLimit,
@@ -328,7 +329,7 @@ namespace Microsoft.Boogie
       thmProver.BeginCheck(descriptiveName, vc, handler);
       //  gen.ClearSharedFormulas();    PR: don't know yet what to do with this guy
 
-      ProverTask = WaitForOutput(null, cancellationToken);
+      ProverTask = WaitForOutput(cancellationToken);
     }
 
     public ProverInterface.Outcome ReadOutcome()

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Boogie
       Contract.Invariant(cce.NonNullDictionaryAndValues(calleeCounterexamples));
     }
 
+    public ProofRun Split { get; }
     protected readonly VCGenOptions options;
     [Peer] public List<Block> Trace;
     public List<object> AugmentedTrace;
@@ -88,7 +89,8 @@ namespace Microsoft.Boogie
 
     public Dictionary<TraceLocation, CalleeCounterexampleInfo> calleeCounterexamples;
 
-    internal Counterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, Model model, VC.ModelViewInfo mvInfo, ProverContext context)
+    internal Counterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, Model model,
+      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun split)
     {
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
@@ -97,6 +99,7 @@ namespace Microsoft.Boogie
       this.Model = model;
       this.MvInfo = mvInfo;
       this.Context = context;
+      this.Split = split;
       this.calleeCounterexamples = new Dictionary<TraceLocation, CalleeCounterexampleInfo>();
       // the call to instance method GetModelValue in the following code requires the fields Model and Context to be initialized
       if (augmentedTrace != null)
@@ -213,14 +216,12 @@ namespace Microsoft.Boogie
       }
     }
 
-    public static bool firstModelFile = true;
-
     public void PrintModel(TextWriter tw, Counterexample counterexample)
     {
       Contract.Requires(counterexample != null);
 
-      var filename = options.ModelViewFile;
-      if (Model == null || filename == null || options.StratifiedInlining > 0)
+      var filenameTemplate = options.ModelViewFile;
+      if (Model == null || filenameTemplate == null || options.StratifiedInlining > 0)
       {
         return;
       }
@@ -238,14 +239,14 @@ namespace Microsoft.Boogie
         Model.ModelHasStatesAlready = true;
       }
 
-      if (filename == "-")
+      if (filenameTemplate == "-")
       {
         Model.Write(tw);
         tw.Flush();
       }
       else {
-        using var wr = new StreamWriter(filename, !firstModelFile);
-        firstModelFile = false;
+        var (filename, reused) = Helpers.GetLogFilename(Split.Description, filenameTemplate, true);
+        using var wr = new StreamWriter(filename, reused);
         Model.Write(wr);
       }
     }
@@ -476,8 +477,8 @@ namespace Microsoft.Boogie
 
 
     public AssertCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, AssertCmd failingAssert, Model model, VC.ModelViewInfo mvInfo,
-      ProverContext context)
-      : base(options, trace, augmentedTrace, model, mvInfo, context)
+      ProverContext context, ProofRun split)
+      : base(options, trace, augmentedTrace, model, mvInfo, context, split)
     {
       Contract.Requires(trace != null);
       Contract.Requires(failingAssert != null);
@@ -497,7 +498,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new AssertCounterexample(options, Trace, AugmentedTrace, FailingAssert, Model, MvInfo, Context);
+      var ret = new AssertCounterexample(options, Trace, AugmentedTrace, FailingAssert, Model, MvInfo, Context, Split);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -517,8 +518,8 @@ namespace Microsoft.Boogie
 
 
     public CallCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, CallCmd failingCall, Requires failingRequires, Model model,
-      VC.ModelViewInfo mvInfo, ProverContext context, byte[] checksum = null)
-      : base(options, trace, augmentedTrace, model, mvInfo, context)
+      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun split, byte[] checksum = null)
+      : base(options, trace, augmentedTrace, model, mvInfo, context, split)
     {
       Contract.Requires(!failingRequires.Free);
       Contract.Requires(trace != null);
@@ -545,7 +546,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new CallCounterexample(options, Trace, AugmentedTrace, FailingCall, FailingRequires, Model, MvInfo, Context, Checksum);
+      var ret = new CallCounterexample(options, Trace, AugmentedTrace, FailingCall, FailingRequires, Model, MvInfo, Context, Split, Checksum);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -565,8 +566,8 @@ namespace Microsoft.Boogie
 
 
     public ReturnCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, TransferCmd failingReturn, Ensures failingEnsures, Model model,
-      VC.ModelViewInfo mvInfo, ProverContext context, byte[] checksum)
-      : base(options, trace, augmentedTrace, model, mvInfo, context)
+      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun split, byte[] checksum)
+      : base(options, trace, augmentedTrace, model, mvInfo, context, split)
     {
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
@@ -595,7 +596,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new ReturnCounterexample(options, Trace, AugmentedTrace, FailingReturn, FailingEnsures, Model, MvInfo, Context, checksum);
+      var ret = new ReturnCounterexample(options, Trace, AugmentedTrace, FailingReturn, FailingEnsures, Model, MvInfo, Context, Split, checksum);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Boogie
       Contract.Invariant(cce.NonNullDictionaryAndValues(calleeCounterexamples));
     }
 
-    public ProofRun Split { get; }
+    public ProofRun ProofRun { get; }
     protected readonly VCGenOptions options;
     [Peer] public List<Block> Trace;
     public List<object> AugmentedTrace;
@@ -90,7 +90,7 @@ namespace Microsoft.Boogie
     public Dictionary<TraceLocation, CalleeCounterexampleInfo> calleeCounterexamples;
 
     internal Counterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, Model model,
-      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun split)
+      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun proofRun)
     {
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
@@ -99,7 +99,7 @@ namespace Microsoft.Boogie
       this.Model = model;
       this.MvInfo = mvInfo;
       this.Context = context;
-      this.Split = split;
+      this.ProofRun = proofRun;
       this.calleeCounterexamples = new Dictionary<TraceLocation, CalleeCounterexampleInfo>();
       // the call to instance method GetModelValue in the following code requires the fields Model and Context to be initialized
       if (augmentedTrace != null)
@@ -245,7 +245,7 @@ namespace Microsoft.Boogie
         tw.Flush();
       }
       else {
-        var (filename, reused) = Helpers.GetLogFilename(Split.Description, filenameTemplate, true);
+        var (filename, reused) = Helpers.GetLogFilename(ProofRun.Description, filenameTemplate, true);
         using var wr = new StreamWriter(filename, reused);
         Model.Write(wr);
       }
@@ -477,8 +477,8 @@ namespace Microsoft.Boogie
 
 
     public AssertCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, AssertCmd failingAssert, Model model, VC.ModelViewInfo mvInfo,
-      ProverContext context, ProofRun split)
-      : base(options, trace, augmentedTrace, model, mvInfo, context, split)
+      ProverContext context, ProofRun proofRun)
+      : base(options, trace, augmentedTrace, model, mvInfo, context, proofRun)
     {
       Contract.Requires(trace != null);
       Contract.Requires(failingAssert != null);
@@ -498,7 +498,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new AssertCounterexample(options, Trace, AugmentedTrace, FailingAssert, Model, MvInfo, Context, Split);
+      var ret = new AssertCounterexample(options, Trace, AugmentedTrace, FailingAssert, Model, MvInfo, Context, ProofRun);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -518,8 +518,8 @@ namespace Microsoft.Boogie
 
 
     public CallCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, CallCmd failingCall, Requires failingRequires, Model model,
-      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun split, byte[] checksum = null)
-      : base(options, trace, augmentedTrace, model, mvInfo, context, split)
+      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun proofRun, byte[] checksum = null)
+      : base(options, trace, augmentedTrace, model, mvInfo, context, proofRun)
     {
       Contract.Requires(!failingRequires.Free);
       Contract.Requires(trace != null);
@@ -546,7 +546,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new CallCounterexample(options, Trace, AugmentedTrace, FailingCall, FailingRequires, Model, MvInfo, Context, Split, Checksum);
+      var ret = new CallCounterexample(options, Trace, AugmentedTrace, FailingCall, FailingRequires, Model, MvInfo, Context, ProofRun, Checksum);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }
@@ -566,8 +566,8 @@ namespace Microsoft.Boogie
 
 
     public ReturnCounterexample(VCGenOptions options, List<Block> trace, List<object> augmentedTrace, TransferCmd failingReturn, Ensures failingEnsures, Model model,
-      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun split, byte[] checksum)
-      : base(options, trace, augmentedTrace, model, mvInfo, context, split)
+      VC.ModelViewInfo mvInfo, ProverContext context, ProofRun proofRun, byte[] checksum)
+      : base(options, trace, augmentedTrace, model, mvInfo, context, proofRun)
     {
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
@@ -596,7 +596,7 @@ namespace Microsoft.Boogie
 
     public override Counterexample Clone()
     {
-      var ret = new ReturnCounterexample(options, Trace, AugmentedTrace, FailingReturn, FailingEnsures, Model, MvInfo, Context, Split, checksum);
+      var ret = new ReturnCounterexample(options, Trace, AugmentedTrace, FailingReturn, FailingEnsures, Model, MvInfo, Context, ProofRun, checksum);
       ret.calleeCounterexamples = calleeCounterexamples;
       return ret;
     }

--- a/Source/VCGeneration/ProofRun.cs
+++ b/Source/VCGeneration/ProofRun.cs
@@ -1,0 +1,5 @@
+namespace VC;
+
+public interface ProofRun {
+  string Description { get; }
+}

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -25,7 +25,7 @@ namespace VC
     int resourceCount
   );
 
-  public class Split
+  public class Split : ProofRun
   {
       private VCGenOptions options;
 
@@ -127,7 +127,7 @@ namespace VC
 
       // async interface
       private Checker checker;
-      private int splitNum;
+      private int splitIndex;
       internal VCGen.ErrorReporter reporter;
 
       public Split(VCGenOptions options, List<Block /*!*/> /*!*/ blocks,
@@ -793,7 +793,7 @@ namespace VC
             Contract.Assert(c != null);
             if (c is AssertCmd)
             {
-              return VCGen.AssertCmdToCounterexample(options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context);
+              return VCGen.AssertCmdToCounterexample(options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context, this);
             }
           }
         }
@@ -1298,21 +1298,21 @@ namespace VC
         Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
         ProverInterface.Outcome outcome = cce.NonNull(checker).ReadOutcome();
 
-        if (options.Trace && splitNum >= 0)
+        if (options.Trace && splitIndex >= 0)
         {
-          System.Console.WriteLine("      --> split #{0} done,  [{1} s] {2}", splitNum + 1,
+          System.Console.WriteLine("      --> split #{0} done,  [{1} s] {2}", splitIndex + 1,
             checker.ProverRunTime.TotalSeconds, outcome);
         }
 
         var resourceCount = checker.GetProverResourceCount().Result;
         totalResourceCount += resourceCount;
 
-        var result = new VCResult(splitNum + 1, checker.ProverStart, outcome, checker.ProverRunTime, Asserts, resourceCount);
+        var result = new VCResult(splitIndex + 1, checker.ProverStart, outcome, checker.ProverRunTime, Asserts, resourceCount);
         callback.OnVCResult(result);
 
         if (options.VcsDumpSplits)
         {
-          DumpDot(splitNum);
+          DumpDot(splitIndex);
         }
 
         proverFailed = false;
@@ -1364,12 +1364,13 @@ namespace VC
       /// <summary>
       /// As a side effect, updates "this.parent.CumulativeAssertionCount".
       /// </summary>
-      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int no, uint timeout, uint rlimit, CancellationToken cancellationToken)
+      public void BeginCheck(Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int splitIndex, uint timeout,
+        uint rlimit, CancellationToken cancellationToken)
       {
         Contract.Requires(checker != null);
         Contract.Requires(callback != null);
 
-        splitNum = no;
+        this.splitIndex = splitIndex;
 
         // Lock impl since we're setting impl.Blocks that is used to generate the VC.
         lock (Implementation) {
@@ -1396,21 +1397,28 @@ namespace VC
           VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(Implementation.Blocks[0]))));
           vc = exprGen.Implies(eqExpr, vc);
           reporter = new VCGen.ErrorReporter(options, gotoCmdOrigins, absyIds, Implementation.Blocks, parent.debugInfos, callback,
-            mvInfo, Checker.TheoremProver.Context, parent.program);
+            mvInfo, Checker.TheoremProver.Context, parent.program, this);
           
-          if (options.TraceVerify && no >= 0)
+          if (options.TraceVerify && splitIndex >= 0)
           {
-            Console.WriteLine("-- after split #{0}", no);
+            Console.WriteLine("-- after split #{0}", splitIndex);
             Print();
           }
 
-          string desc = cce.NonNull(Implementation.Name);
-          if (no >= 0)
-          {
-            desc += "_split" + no;
+          checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
+        }
+      }
+
+      public string Description
+      {
+        get
+        {
+          string description = cce.NonNull(Implementation.Name);
+          if (splitIndex >= 0) {
+            description += "_split" + splitIndex;
           }
 
-          checker.BeginCheck(desc, vc, reporter, timeout, rlimit, cancellationToken);
+          return description;
         }
       }
 

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -894,8 +894,8 @@ namespace VC
       return outcome;
     }
 
-    public class ErrorReporter : ProverInterface.ErrorHandler
-    {
+    public class ErrorReporter : ProverInterface.ErrorHandler {
+      private ProofRun split;
       private VCGenOptions options;
       Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins;
 
@@ -943,7 +943,7 @@ namespace VC
         VerifierCallback /*!*/ callback,
         ModelViewInfo mvInfo,
         ProverContext /*!*/ context,
-        Program /*!*/ program) : base(options)
+        Program /*!*/ program, ProofRun split) : base(options)
       {
         Contract.Requires(gotoCmdOrigins != null);
         Contract.Requires(absyIds != null);
@@ -960,10 +960,12 @@ namespace VC
 
         this.context = context;
         this.program = program;
+        this.split = split;
         this.options = options;
       }
 
-      public override void OnModel(IList<string /*!*/> /*!*/ labels, Model model, ProverInterface.Outcome proverOutcome)
+      public override void OnModel(IList<string> labels /*!*/ /*!*/, Model model,
+        ProverInterface.Outcome proverOutcome)
       {
         // no counter examples reported.
         if (labels.Count == 0)
@@ -993,7 +995,7 @@ namespace VC
         trace.Add(entryBlock);
 
         Counterexample newCounterexample = TraceCounterexample(options, entryBlock, traceNodes, trace, model, MvInfo,
-          debugInfos, context, new Dictionary<TraceLocation, CalleeCounterexampleInfo>());
+          debugInfos, context, split, new Dictionary<TraceLocation, CalleeCounterexampleInfo>());
 
         if (newCounterexample == null)
         {
@@ -1041,7 +1043,8 @@ namespace VC
           foreach (var cmd in assertCmds)
           {
             Counterexample cex =
-              AssertCmdToCounterexample(options, cmd.Item1, cmd.Item2, new List<Block>(), new List<object>(), null, null, context);
+              AssertCmdToCounterexample(options, cmd.Item1, cmd.Item2, new List<Block>(),
+                new List<object>(), null, null, context, null);
             cex.IsAuxiliaryCexForDiagnosingTimeouts = true;
             callback.OnCounterexample(cex, msg);
           }
@@ -2303,6 +2306,7 @@ namespace VC
       Block b, HashSet<Absy> traceNodes, List<Block> trace, Model errModel, ModelViewInfo mvInfo,
       Dictionary<Cmd, List<object>> debugInfos,
       ProverContext context,
+      ProofRun split,
       Dictionary<TraceLocation, CalleeCounterexampleInfo> calleeCounterexamples)
     {
       Contract.Requires(b != null);
@@ -2332,7 +2336,7 @@ namespace VC
           if (cmd is AssertCmd && traceNodes.Contains(cmd))
           {
             Counterexample newCounterexample =
-              AssertCmdToCounterexample(options, (AssertCmd) cmd, transferCmd, trace, augmentedTrace, errModel, mvInfo, context);
+              AssertCmdToCounterexample(options, (AssertCmd) cmd, transferCmd, trace, augmentedTrace, errModel, mvInfo, context, split);
             Contract.Assert(newCounterexample != null);
             newCounterexample.AddCalleeCounterexample(calleeCounterexamples);
             return newCounterexample;
@@ -2367,7 +2371,7 @@ namespace VC
     }
 
     public static Counterexample AssertCmdToCounterexample(VCGenOptions options, AssertCmd cmd, TransferCmd transferCmd, List<Block> trace, List<object> augmentedTrace,
-      Model errModel, ModelViewInfo mvInfo, ProverContext context)
+      Model errModel, ModelViewInfo mvInfo, ProverContext context, ProofRun split)
     {
       Contract.Requires(cmd != null);
       Contract.Requires(transferCmd != null);
@@ -2381,7 +2385,7 @@ namespace VC
         AssertRequiresCmd assertCmd = (AssertRequiresCmd) cmd;
         Contract.Assert(assertCmd != null);
         CallCounterexample cc = new CallCounterexample(options, trace, augmentedTrace, assertCmd.Call, assertCmd.Requires, errModel, mvInfo,
-          context, assertCmd.Checksum);
+          context, split, assertCmd.Checksum);
         return cc;
       }
       else if (cmd is AssertEnsuresCmd)
@@ -2389,12 +2393,12 @@ namespace VC
         AssertEnsuresCmd assertCmd = (AssertEnsuresCmd) cmd;
         Contract.Assert(assertCmd != null);
         ReturnCounterexample rc = new ReturnCounterexample(options, trace, augmentedTrace, transferCmd, assertCmd.Ensures, errModel, mvInfo,
-          context, cmd.Checksum);
+          context, split, cmd.Checksum);
         return rc;
       }
       else
       {
-        AssertCounterexample ac = new AssertCounterexample(options, trace, augmentedTrace, (AssertCmd) cmd, errModel, mvInfo, context);
+        AssertCounterexample ac = new AssertCounterexample(options, trace, augmentedTrace, (AssertCmd) cmd, errModel, mvInfo, context, split);
         return ac;
       }
     }
@@ -2415,7 +2419,7 @@ namespace VC
       if (assrt is AssertRequiresCmd)
       {
         var aa = (AssertRequiresCmd) assrt;
-        cc = new CallCounterexample(options, cex.Trace, cex.AugmentedTrace, aa.Call, aa.Requires, cex.Model, cex.MvInfo, cex.Context, aa.Checksum);
+        cc = new CallCounterexample(options, cex.Trace, cex.AugmentedTrace, aa.Call, aa.Requires, cex.Model, cex.MvInfo, cex.Context, cex.Split, aa.Checksum);
       }
       else if (assrt is AssertEnsuresCmd && cex is ReturnCounterexample)
       {
@@ -2498,11 +2502,11 @@ namespace VC
         }
 
         cc = new ReturnCounterexample(options, reconstructedTrace ?? cex.Trace, cex.AugmentedTrace, returnCmd ?? oldCex.FailingReturn, aa.Ensures,
-          cex.Model, cex.MvInfo, cex.Context, aa.Checksum);
+          cex.Model, cex.MvInfo, cex.Context, cex.Split, aa.Checksum);
       }
       else
       {
-        cc = new AssertCounterexample(options, cex.Trace, cex.AugmentedTrace, assrt, cex.Model, cex.MvInfo, cex.Context);
+        cc = new AssertCounterexample(options, cex.Trace, cex.AugmentedTrace, assrt, cex.Model, cex.MvInfo, cex.Context, cex.Split);
       }
 
       return cc;

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -2419,7 +2419,7 @@ namespace VC
       if (assrt is AssertRequiresCmd)
       {
         var aa = (AssertRequiresCmd) assrt;
-        cc = new CallCounterexample(options, cex.Trace, cex.AugmentedTrace, aa.Call, aa.Requires, cex.Model, cex.MvInfo, cex.Context, cex.Split, aa.Checksum);
+        cc = new CallCounterexample(options, cex.Trace, cex.AugmentedTrace, aa.Call, aa.Requires, cex.Model, cex.MvInfo, cex.Context, cex.ProofRun, aa.Checksum);
       }
       else if (assrt is AssertEnsuresCmd && cex is ReturnCounterexample)
       {
@@ -2502,11 +2502,11 @@ namespace VC
         }
 
         cc = new ReturnCounterexample(options, reconstructedTrace ?? cex.Trace, cex.AugmentedTrace, returnCmd ?? oldCex.FailingReturn, aa.Ensures,
-          cex.Model, cex.MvInfo, cex.Context, cex.Split, aa.Checksum);
+          cex.Model, cex.MvInfo, cex.Context, cex.ProofRun, aa.Checksum);
       }
       else
       {
-        cc = new AssertCounterexample(options, cex.Trace, cex.AugmentedTrace, assrt, cex.Model, cex.MvInfo, cex.Context, cex.Split);
+        cc = new AssertCounterexample(options, cex.Trace, cex.AugmentedTrace, assrt, cex.Model, cex.MvInfo, cex.Context, cex.ProofRun);
       }
 
       return cc;

--- a/Test/test15/MoreCapturedStates.bpl
+++ b/Test/test15/MoreCapturedStates.bpl
@@ -1,4 +1,7 @@
-// RUN: %boogie "%s" -normalizeNames:1 -mv:"%t".model > "%t"
+// RUN: %parallel-boogie "%s" -normalizeNames:1 -mv:"%t@PROC@".model > "%t"
+// RUN: cat %tAbs.model > "%t.model"
+// RUN: cat %tBadCall.model >> "%t.model"
+// RUN: cat %tBadAssert.model >> "%t.model"
 // RUN: grep STATE "%t".model >> "%t"
 // RUN: %diff "%s.expect" "%t"
 // UNSUPPORTED: batch_mode

--- a/Test/test15/MoreCapturedStates.bpl.expect
+++ b/Test/test15/MoreCapturedStates.bpl.expect
@@ -1,20 +1,20 @@
-MoreCapturedStates.bpl(35,1): Error: A postcondition might not hold on this return path.
-MoreCapturedStates.bpl(7,3): Related location: This is the postcondition that might not hold.
+MoreCapturedStates.bpl(38,1): Error: A postcondition might not hold on this return path.
+MoreCapturedStates.bpl(10,3): Related location: This is the postcondition that might not hold.
 Execution trace:
-    MoreCapturedStates.bpl(9,3): anon0
-    MoreCapturedStates.bpl(18,3): LabelB
-    MoreCapturedStates.bpl(33,3): Done
-MoreCapturedStates.bpl(54,3): Error: A precondition for this call might not hold.
-MoreCapturedStates.bpl(63,3): Related location: This is the precondition that might not hold.
+    MoreCapturedStates.bpl(12,3): anon0
+    MoreCapturedStates.bpl(21,3): LabelB
+    MoreCapturedStates.bpl(36,3): Done
+MoreCapturedStates.bpl(57,3): Error: A precondition for this call might not hold.
+MoreCapturedStates.bpl(66,3): Related location: This is the precondition that might not hold.
 Execution trace:
-    MoreCapturedStates.bpl(41,3): anon0
-    MoreCapturedStates.bpl(50,3): LabelB
-MoreCapturedStates.bpl(80,3): Error: This assertion might not hold.
+    MoreCapturedStates.bpl(44,3): anon0
+    MoreCapturedStates.bpl(53,3): LabelB
+MoreCapturedStates.bpl(83,3): Error: This assertion might not hold.
 Execution trace:
-    MoreCapturedStates.bpl(68,3): anon0
-MoreCapturedStates.bpl(86,3): Error: This assertion might not hold.
+    MoreCapturedStates.bpl(71,3): anon0
+MoreCapturedStates.bpl(89,3): Error: This assertion might not hold.
 Execution trace:
-    MoreCapturedStates.bpl(68,3): anon0
+    MoreCapturedStates.bpl(71,3): anon0
 
 Boogie program verifier finished with 0 verified, 4 errors
 *** STATE <initial>


### PR DESCRIPTION
### Changes
- Support @PROC@ in the filename argument of the -mv option

### Testing
- In the MoreCapturedStates.bpl test, use @PROC@ in the -mv option together with %parallel-boogie