### PR TITLE
[Civl] Generalizing PingPong

### DIFF
--- a/Test/civl/inductive-sequentialization/PingPong.bpl
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl
@@ -1,16 +1,32 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-type {:linear "pid"} Pid = int;
-var {:layer 0,3} ping_channel:[int]int; // Incoming channel of Ping
-var {:layer 0,3} pong_channel:[int]int; // Incoming channel of Pong
+// This example shows how to use a bidirectional shared channel to communicate between two processes.
 
-const unique ping_id:int;
-const unique pong_id:int;
+// A bidirectional channel is a pair of ordinary channels with two ends---left and right.
+type {:datatype} ChannelPair;
+function {:constructor} ChannelPair(left: [int]int, right: [int]int): ChannelPair;
+
+type ChannelId;
+var {:layer 0,3} channel: [ChannelId]ChannelPair;
+
+// The id of a bidirectional channel can be split into two permissions---Left and Right.
+// Left permission is used to receive from the left channel and send to the right channel.
+// Right permission is used to receive from the right channel and send to the left channel.
+type {:linear "cid"} {:datatype} Permission;
+function {:constructor} Left(cid: ChannelId): Permission;
+function {:constructor} Right(cid: ChannelId): Permission;
+function {:inline} ChannelId(p: Permission) : ChannelId {
+  if is#Left(p) then cid#Left(p) else cid#Right(p)
+}
+
+function {:inline} {:linear "cid"} ChannelIdCollector(cid: ChannelId) : [Permission]bool {
+  MapConst(false)[Left(cid) := true][Right(cid) := true]
+}
 
 type {:pending_async}{:datatype} PA;
-function {:constructor} PING(x:int, pid:int) : PA;
-function {:constructor} PONG(x:int, pid:int) : PA;
+function {:constructor} PING(x: int, left: Permission): PA;
+function {:constructor} PONG(x: int, right: Permission): PA;
 
 function {:inline} NoPAs () : [PA]int
 { (lambda pa:PA :: 0) }
@@ -21,47 +37,37 @@ function {:inline} EmptyChannel () : [int]int
 ////////////////////////////////////////////////////////////////////////////////
 
 procedure {:atomic}{:layer 3}
-MAIN' ({:linear_in "pid"} ping_pid:int, {:linear_in "pid"} pong_pid:int)
+MAIN' ({:linear_in "cid"} cid: ChannelId)
 {
-  assert ping_pid == ping_id;
-  assert pong_pid == pong_id;
-  assert ping_channel == EmptyChannel();
-  assert pong_channel == EmptyChannel();
+  assert channel[cid] == ChannelPair(EmptyChannel(), EmptyChannel());
 }
 
 procedure {:IS_invariant}{:layer 2}
-INV ({:linear_in "pid"} ping_pid:int, {:linear_in "pid"} pong_pid:int)
-returns ({:pending_async "PING","PONG"} PAs:[PA]int, {:choice} choice:PA)
-modifies ping_channel, pong_channel;
+INV ({:linear_in "cid"} cid: ChannelId)
+returns ({:pending_async "PING","PONG"} PAs: [PA]int, {:choice} choice: PA)
+modifies channel;
 {
-   var {:pool "INV"} c: int;
+  var {:pool "INV"} c: int;
 
-  assert ping_pid == ping_id;
-  assert pong_pid == pong_id;
-  assert ping_channel == EmptyChannel();
-  assert pong_channel == EmptyChannel();
+  assert channel[cid] == ChannelPair(EmptyChannel(), EmptyChannel());
 
   assume
     {:add_to_pool "INV", c, c+1}
     0 < c;
   if (*) {
-    pong_channel := EmptyChannel()[c := 1];
-    ping_channel := EmptyChannel();
-    PAs := NoPAs()[PONG(c, pong_pid) := 1][PING(c, ping_pid) := 1];
-    choice := PONG(c, pong_pid);
+    channel[cid] := ChannelPair(EmptyChannel(), EmptyChannel()[c := 1]);
+    PAs := NoPAs()[PONG(c, Right(cid)) := 1][PING(c, Left(cid)) := 1];
+    choice := PONG(c, Right(cid));
   } else if (*) {
-    pong_channel := EmptyChannel()[0 := 1];
-    ping_channel := EmptyChannel();
-    PAs := NoPAs()[PONG(c, pong_pid) := 1];
-    choice := PONG(c, pong_pid);
+    channel[cid] := ChannelPair(EmptyChannel(), EmptyChannel()[0 := 1]);
+    PAs := NoPAs()[PONG(c, Right(cid)) := 1];
+    choice := PONG(c, Right(cid));
   } else if (*) {
-    ping_channel := EmptyChannel()[c := 1];
-    pong_channel := EmptyChannel();
-    PAs := NoPAs()[PONG(c+1, pong_pid) := 1][PING(c, ping_pid) := 1];
-    choice := PING(c, ping_pid);
+    channel[cid] := ChannelPair(EmptyChannel()[c := 1], EmptyChannel());
+    PAs := NoPAs()[PONG(c+1, Right(cid)) := 1][PING(c, Left(cid)) := 1];
+    choice := PING(c, Left(cid));
   } else {
-    ping_channel := EmptyChannel();
-    pong_channel := EmptyChannel();
+    channel[cid] := ChannelPair(EmptyChannel(), EmptyChannel());
     PAs := NoPAs();
   }
 }
@@ -69,165 +75,216 @@ modifies ping_channel, pong_channel;
 ////////////////////////////////////////////////////////////////////////////////
 
 procedure {:IS_abstraction}{:layer 2}
-PING' (x:int, {:linear_in "pid"} pid:int)
-returns ({:pending_async "PING"} PAs:[PA]int)
-modifies ping_channel, pong_channel;
+PING' (x: int, {:linear_in "cid"} left: Permission)
+returns ({:pending_async "PING"} PAs: [PA]int)
+modifies channel;
 {
-  assert (exists {:pool "INV"} m:int :: ping_channel[m] > 0) && (forall m:int :: pong_channel[m] == 0);
-  call PAs := PING(x, pid);
+  var cid: ChannelId;
+  var left_channel: [int]int;
+  var right_channel: [int]int;
+
+  cid := ChannelId(left);
+  left_channel := left#ChannelPair(channel[cid]);
+  right_channel := right#ChannelPair(channel[cid]);
+
+  assert (exists {:pool "INV"} m:int :: left_channel[m] > 0);
+  assert (forall m:int :: right_channel[m] == 0);
+  call PAs := PING(x, left);
 
 }
 
 procedure {:IS_abstraction}{:layer 2}
-PONG' (y:int, {:linear_in "pid"} pid:int)
-returns ({:pending_async "PONG"} PAs:[PA]int)
-modifies ping_channel, pong_channel;
+PONG' (y: int, {:linear_in "cid"} right: Permission)
+returns ({:pending_async "PONG"} PAs: [PA]int)
+modifies channel;
 {
-  assert (exists {:pool "INV"} m:int :: pong_channel[m] > 0) && (forall m:int :: ping_channel[m] == 0);
-  call PAs := PONG(y, pid);
+  var cid: ChannelId;
+  var left_channel: [int]int;
+  var right_channel: [int]int;
+
+  cid := ChannelId(right);
+  left_channel := left#ChannelPair(channel[cid]);
+  right_channel := right#ChannelPair(channel[cid]);
+
+  assert (exists {:pool "INV"} m:int :: right_channel[m] > 0);
+  assert (forall m:int :: left_channel[m] == 0);
+  call PAs := PONG(y, right);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 procedure {:atomic}{:layer 2}
 {:IS "MAIN'","INV"}{:elim "PING","PING'"}{:elim "PONG","PONG'"}
-MAIN ({:linear_in "pid"} ping_pid:int, {:linear_in "pid"} pong_pid:int)
-returns ({:pending_async "PING","PONG"} PAs:[PA]int)
-modifies pong_channel;
+MAIN ({:linear_in "cid"} cid: ChannelId)
+returns ({:pending_async "PING","PONG"} PAs: [PA]int)
+modifies channel;
 {
-  assert ping_pid == ping_id;
-  assert pong_pid == pong_id;
-  assert ping_channel == EmptyChannel();
-  assert pong_channel == EmptyChannel();
-  pong_channel[1] := pong_channel[1] + 1;
-  PAs := NoPAs()[PING(1, ping_pid) := 1][PONG(1, pong_pid) := 1];
+  assert channel[cid] == ChannelPair(EmptyChannel(), EmptyChannel());
+  channel[cid] := ChannelPair(EmptyChannel(), EmptyChannel()[1 := 1]);
+  PAs := NoPAs()[PING(1, Left(cid)) := 1][PONG(1, Right(cid)) := 1];
 }
 
 procedure {:atomic}{:layer 2}
-PING (x:int, {:linear_in "pid"} pid:int)
-returns ({:pending_async "PING"} PAs:[PA]int)
-modifies ping_channel, pong_channel;
+PING (x: int, {:linear_in "cid"} left: Permission)
+returns ({:pending_async "PING"} PAs: [PA]int)
+modifies channel;
 {
+  var cid: ChannelId;
+  var left_channel: [int]int;
+  var right_channel: [int]int;
+
+  cid := ChannelId(left);
+  left_channel := left#ChannelPair(channel[cid]);
+  right_channel := right#ChannelPair(channel[cid]);
+
   assert x > 0;
-  assert pid == ping_id;
-  assert (forall m:int :: ping_channel[m] > 0 ==> m == x); // assertion to discharge
+  assert is#Left(left);
+  assert (forall m:int :: left_channel[m] > 0 ==> m == x); // assertion to discharge
 
-  assume ping_channel[x] > 0;
-  ping_channel[x] := ping_channel[x] - 1;
+  assume left_channel[x] > 0;
+  left_channel[x] := left_channel[x] - 1;
 
   if (*)
   {
-    pong_channel[x+1] := pong_channel[x+1] + 1;
-    PAs := NoPAs()[PING(x+1, pid) := 1];
+    right_channel[x+1] := right_channel[x+1] + 1;
+    PAs := NoPAs()[PING(x+1, left) := 1];
   }
   else
   {
-    pong_channel[0] := pong_channel[0] + 1;
+    right_channel[0] := right_channel[0] + 1;
     PAs := NoPAs();
   }
+  channel[cid] := ChannelPair(left_channel, right_channel);
 }
 
 procedure {:atomic}{:layer 2}
-PONG (y:int, {:linear_in "pid"} pid:int)
-returns ({:pending_async "PONG"} PAs:[PA]int)
-modifies ping_channel, pong_channel;
+PONG (y: int, {:linear_in "cid"} right: Permission)
+returns ({:pending_async "PONG"} PAs: [PA]int)
+modifies channel;
 {
+  var cid: ChannelId;
+  var left_channel: [int]int;
+  var right_channel: [int]int;
+
+  cid := ChannelId(right);
+  left_channel := left#ChannelPair(channel[cid]);
+  right_channel := right#ChannelPair(channel[cid]);
+
   assert y > 0;
-  assert pid == pong_id;
-  assert (forall m:int :: pong_channel[m] > 0 ==> m == y || m == 0); // assertion to discharge
+  assert is#Right(right);
+  assert (forall m:int :: right_channel[m] > 0 ==> m == y || m == 0); // assertion to discharge
 
   if (*)
   {
-    assume pong_channel[y] > 0;
-    pong_channel[y] := pong_channel[y] - 1;
-    ping_channel[y] := ping_channel[y] + 1;
-    PAs := NoPAs()[PONG(y+1, pid) := 1];
+    assume right_channel[y] > 0;
+    right_channel[y] := right_channel[y] - 1;
+    left_channel[y] := left_channel[y] + 1;
+    PAs := NoPAs()[PONG(y+1, right) := 1];
   }
   else
   {
-    assume pong_channel[0] > 0;
-    pong_channel[0] := pong_channel[0] - 1;
+    assume right_channel[0] > 0;
+    right_channel[0] := right_channel[0] - 1;
     PAs := NoPAs();
   }
+  channel[cid] := ChannelPair(left_channel, right_channel);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 procedure {:yields}{:layer 1}{:refines "MAIN"}
-main ({:linear_in "pid"} ping_pid:int, {:linear_in "pid"} pong_pid:int)
+main ({:linear_in "cid"} cid: ChannelId)
 {
-  call send_pong_channel(1);
-  async call ping(1, ping_pid);
-  async call pong(1, pong_pid);
+  var {:linear "cid"} left: Permission;
+  var {:linear "cid"} right: Permission;
+
+  call left, right := split(cid);
+  call send(left, 1);
+  async call ping(1, left);
+  async call pong(1, right);
 }
 
 procedure {:yields}{:layer 1}{:refines "PING"}
-ping (x:int, {:linear_in "pid"} pid:int)
+ping (x: int, {:linear_in "cid"} left: Permission)
 {
-  var x':int;
+  var x': int;
 
-  call x' := receive_ping_channel();
-  call assert_eq(x', x); // low-level assertion to discharge
+  call x' := receive(left);
+  assert {:layer 1} x' == x; // low-level assertion to discharge
   if (*)
   {
-    call send_pong_channel(x'+1);
-    async call ping(x'+1, pid);
+    call send(left, x'+1);
+    async call ping(x'+1, left);
   }
   else
   {
-    call send_pong_channel(0);
+    call send(left, 0);
   }
 }
 
 procedure {:yields}{:layer 1}{:refines "PONG"}
-pong (y:int, {:linear_in "pid"} pid:int)
+pong (y: int, {:linear_in "cid"} right: Permission)
 {
-  var y':int;
+  var y': int;
 
-  call y' := receive_pong_channel();
+  call y' := receive(right);
   if (y' != 0)
   {
-    call assert_eq(y', y); // low-level assertion to discharge
-    call send_ping_channel(y');
-    async call pong(y'+1, pid);
+    assert {:layer 1} y' == y; // low-level assertion to discharge
+    call send(right, y');
+    async call pong(y'+1, right);
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Bidirectional channels
 
-procedure {:left}{:layer 1} SEND_PING_CHANNEL (m:int)
-modifies ping_channel;
+procedure {:right}{:layer 1} RECEIVE (permission: Permission) returns (m: int)
+modifies channel;
 {
-  ping_channel[m] := ping_channel[m] + 1;
+  var cid: ChannelId;
+  var left_channel: [int]int;
+  var right_channel: [int]int;
+
+  cid := ChannelId(permission);
+  left_channel := left#ChannelPair(channel[cid]);
+  right_channel := right#ChannelPair(channel[cid]);
+  if (is#Left(permission)) {
+    assume left_channel[m] > 0;
+    left_channel[m] := left_channel[m] - 1;
+  } else {
+    assume right_channel[m] > 0;
+    right_channel[m] := right_channel[m] - 1;
+  }
+  channel[cid] := ChannelPair(left_channel, right_channel);
 }
 
-procedure {:left}{:layer 1} SEND_PONG_CHANNEL (m:int)
-modifies pong_channel;
+procedure {:left}{:layer 1} SEND (permission: Permission, m: int)
+modifies channel;
 {
-  pong_channel[m] := pong_channel[m] + 1;
+  var cid: ChannelId;
+  var left_channel: [int]int;
+  var right_channel: [int]int;
+
+  cid := ChannelId(permission);
+  left_channel := left#ChannelPair(channel[cid]);
+  right_channel := right#ChannelPair(channel[cid]);
+  if (is#Left(permission)) {
+    right_channel[m] := right_channel[m] + 1;
+  } else {
+    left_channel[m] := left_channel[m] + 1;
+  }
+  channel[cid] := ChannelPair(left_channel, right_channel);
 }
 
-procedure {:right}{:layer 1} RECEIVE_PING_CHANNEL () returns (m:int)
-modifies ping_channel;
+procedure {:both}{:layer 1} SPLIT({:linear_in "cid"} cid: ChannelId)
+  returns ({:linear "cid"} left: Permission, {:linear "cid"} right: Permission)
 {
-  assume ping_channel[m] > 0;
-  ping_channel[m] := ping_channel[m] - 1;
+  left := Left(cid);
+  right := Right(cid);
 }
 
-procedure {:right}{:layer 1} RECEIVE_PONG_CHANNEL () returns (m:int)
-modifies pong_channel;
-{
-  assume pong_channel[m] > 0;
-  pong_channel[m] := pong_channel[m] - 1;
-}
-
-procedure {:both}{:layer 1} ASSERT_EQ (a:int, b:int)
-{
-  assert a == b;
-}
-
-procedure {:yields}{:layer 0}{:refines "SEND_PING_CHANNEL"} send_ping_channel (m:int);
-procedure {:yields}{:layer 0}{:refines "SEND_PONG_CHANNEL"} send_pong_channel (m:int);
-procedure {:yields}{:layer 0}{:refines "RECEIVE_PING_CHANNEL"} receive_ping_channel () returns (m:int);
-procedure {:yields}{:layer 0}{:refines "RECEIVE_PONG_CHANNEL"} receive_pong_channel () returns (m:int);
-procedure {:yields}{:layer 0}{:refines "ASSERT_EQ"} assert_eq (a:int, b:int);
+procedure {:yields}{:layer 0}{:refines "RECEIVE"} receive (permission: Permission) returns (m: int);
+procedure {:yields}{:layer 0}{:refines "SEND"} send (permission: Permission, m: int);
+procedure {:yields}{:layer 0}{:refines "SPLIT"} split({:linear_in "cid"} cid: ChannelId)
+  returns ({:linear "cid"} left: Permission, {:linear "cid"} right: Permission);

--- a/Test/civl/inductive-sequentialization/PingPong.bpl.expect
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 45 verified, 0 errors
+Boogie program verifier finished with 44 verified, 0 errors


### PR DESCRIPTION
This PR generalizes PingPong to make it more modular so that the code does not depend on global constants and it becomes possible to create any number of PingPong pairs. The revision is implemented atop the abstraction of bidirectional channels. Implementing bidirectional channels atop ordinary channels is a topic of a separate PR.

A side note: it is becoming increasingly problematic to develop Civl programs in the absence of modules for reusing common libraries.