### PR TITLE
Concurrency fixes

### DIFF
--- a/Source/Core/AbsyQuant.cs
+++ b/Source/Core/AbsyQuant.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics.Contracts;
+using System.Threading;
 using Set = Microsoft.Boogie.GSet<object>;
 
 namespace Microsoft.Boogie
@@ -94,14 +95,14 @@ namespace Microsoft.Boogie
 
     public abstract BinderKind Kind { get; }
 
-    protected static bool CompareAttributesAndTriggers = false;
+    protected static ThreadLocal<bool> CompareAttributesAndTriggers = new(() => false);
 
     public static bool EqualWithAttributesAndTriggers(object a, object b)
     {
-      CompareAttributesAndTriggers = true;
+      CompareAttributesAndTriggers.Value = true;
       var res = object.Equals(a, b);
-      Contract.Assert(CompareAttributesAndTriggers);
-      CompareAttributesAndTriggers = false;
+      Contract.Assert(CompareAttributesAndTriggers.Value);
+      CompareAttributesAndTriggers.Value = false;
       return res;
     }
 
@@ -129,7 +130,7 @@ namespace Microsoft.Boogie
 
       return this.TypeParameters.SequenceEqual(other.TypeParameters)
              && this.Dummies.SequenceEqual(other.Dummies)
-             && (!CompareAttributesAndTriggers || object.Equals(this.Attributes, other.Attributes))
+             && (!CompareAttributesAndTriggers.Value || object.Equals(this.Attributes, other.Attributes))
              && object.Equals(this.Body, other.Body);
     }
 
@@ -1114,7 +1115,7 @@ namespace Microsoft.Boogie
       else
       {
         return this.BinderEquals(obj) &&
-               (!CompareAttributesAndTriggers || object.Equals(Triggers, other.Triggers));
+               (!CompareAttributesAndTriggers.Value || object.Equals(Triggers, other.Triggers));
       }
     }
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.13.0</Version>
+    <Version>2.13.1</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -804,23 +804,11 @@ namespace Microsoft.Boogie
         foreach (var task in tasks) {
           task.Result.ProcessXml(this);
         }
-      }
-      catch (AggregateException ae) {
-        ae.Flatten().Handle(e =>
-        {
-          if (e is ProverException) {
-            Options.Printer.ErrorWriteLine(Console.Out, "Fatal Error: ProverException: {0}", e.Message);
-            outcome = PipelineOutcome.FatalError;
-            return true;
-          }
-
-          if (e is OperationCanceledException) {
-            outcome = PipelineOutcome.Cancelled;
-            return true;
-          }
-
-          return false;
-        });
+      } catch(TaskCanceledException e) {
+        outcome = PipelineOutcome.Cancelled;
+      } catch(ProverException e) {
+        Options.Printer.ErrorWriteLine(Console.Out, "Fatal Error: ProverException: {0}", e.Message);
+        outcome = PipelineOutcome.FatalError;
       }
       finally {
         CleanupRequest(requestId);

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -804,7 +804,7 @@ namespace Microsoft.Boogie
         foreach (var task in tasks) {
           task.Result.ProcessXml(this);
         }
-      } catch(TaskCanceledException e) {
+      } catch(TaskCanceledException) {
         outcome = PipelineOutcome.Cancelled;
       } catch(ProverException e) {
         Options.Printer.ErrorWriteLine(Console.Out, "Fatal Error: ProverException: {0}", e.Message);

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -854,12 +854,12 @@ namespace Microsoft.Boogie
 
         ImplIdToCancellationTokenSource.AddOrUpdate(id, cts, (k, ov) => cts);
 
-        var coreTask = new Task<VerificationResult>(() => VerifyImplementation(program, stats, er, requestId,
+        var coreTask = new Task<Task<VerificationResult>>(() => VerifyImplementation(program, stats, er, requestId,
           extractLoopMappingInfo, implementation,
-          programId, taskWriter).Result, cts.Token, TaskCreationOptions.None);
+          programId, taskWriter), cts.Token, TaskCreationOptions.None);
 
         coreTask.Start(LargeStackScheduler);
-        var verificationResult = await coreTask;
+        var verificationResult = await await coreTask;
         var output = verificationResult.GetOutput(Options.Printer, this, stats, er, implementation);
 
         await taskWriter.WriteAsync(output);

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -183,7 +183,7 @@ public abstract class ProverInterface
   {
   }
 
-  public abstract void Reset(VCExpressionGenerator gen);
+  public abstract Task Reset(VCExpressionGenerator gen);
 
   public abstract void FullReset(VCExpressionGenerator gen);
 

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Boogie.SMTLib
       FlushLogFile();
     }
 
-    public override void Reset(VCExpressionGenerator generator)
-    {
+    public override Task Reset(VCExpressionGenerator generator) {
+      return Task.CompletedTask;
     }
 
     public override void FullReset(VCExpressionGenerator generator)

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -110,13 +110,13 @@ namespace Microsoft.Boogie.SMTLib
       FlushLogFile();
     }
 
-    public override void Reset(VCExpressionGenerator generator)
+    public override async Task Reset(VCExpressionGenerator generator)
     {
       if (options.Solver == SolverKind.Z3 || options.Solver == SolverKind.NoOpWithZ3Options)
       {
         this.gen = generator;
         SendThisVC("(reset)");
-        RecoverIfProverCrashedAfterReset();
+        await RecoverIfProverCrashedAfterReset();
 
         if (0 < common.Length)
         {
@@ -132,9 +132,9 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    private void RecoverIfProverCrashedAfterReset()
+    private async Task RecoverIfProverCrashedAfterReset()
     {
-      if (Process.GetExceptionIfProverDied().Result is not null)
+      if (await Process.GetExceptionIfProverDied() is not null)
       {
         // We recover the process but don't issue the `(reset)` command that fails.
         SetupProcess();

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Boogie
       proverRunTime = DateTime.UtcNow - ProverStart;
     }
 
-    public void BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, uint timeout, uint rlimit, CancellationToken cancellationToken)
+    public async Task BeginCheck(string descriptiveName, VCExpr vc, ProverInterface.ErrorHandler handler, uint timeout, uint rlimit, CancellationToken cancellationToken)
     {
       Contract.Requires(descriptiveName != null);
       Contract.Requires(vc != null);
@@ -318,7 +318,7 @@ namespace Microsoft.Boogie
       outputExn = null;
       this.handler = handler;
 
-      thmProver.Reset(gen);
+      await thmProver.Reset(gen);
       if (0 < rlimit)
       {
         timeout = 0;
@@ -396,7 +396,7 @@ namespace Microsoft.Boogie
       throw new NotImplementedException();
     }
 
-    public override void Reset(VCExpressionGenerator gen)
+    public override Task Reset(VCExpressionGenerator gen)
     {
       throw new NotImplementedException();
     }

--- a/Source/VCGeneration/CheckerPool.cs
+++ b/Source/VCGeneration/CheckerPool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Threading;
@@ -9,8 +10,8 @@ namespace VC
 {
   public class CheckerPool
   {
-    private readonly Stack<Checker> availableCheckers = new();
-    private readonly Queue<TaskCompletionSource<Checker>> checkerWaiters = new();
+    private readonly ConcurrentStack<Checker> availableCheckers = new();
+    private readonly ConcurrentQueue<TaskCompletionSource<Checker>> checkerWaiters = new();
     private int notCreatedCheckers;
     private bool disposed;
 
@@ -24,35 +25,33 @@ namespace VC
 
     public Task<Checker> FindCheckerFor(ConditionGeneration vcgen, Split split = null)
     {
-      lock (this) {
-        if (disposed) {
-          return Task.FromException<Checker>(new Exception("CheckerPool was already disposed"));
-        }
-        
-        if (availableCheckers.TryPop(out var result)) {
-          PrepareChecker(vcgen.program, split, result);
-          Contract.Assert(result != null);
-          return Task.FromResult(result);
-        }
-
-        if (notCreatedCheckers > 0) {
-          notCreatedCheckers--;
-          var checker = CreateNewChecker();
-          PrepareChecker(vcgen.program, split, checker);
-          Contract.Assert(checker != null);
-          return Task.FromResult(checker);
-        }
-
-        var source = new TaskCompletionSource<Checker>();
-        checkerWaiters.Enqueue(source);
-        return source.Task.ContinueWith(t =>
-        {
-          PrepareChecker(vcgen.program, split, t.Result);
-          Contract.Assert(t.Result != null);
-          return t.Result;
-        });
+      if (disposed) {
+        return Task.FromException<Checker>(new Exception("CheckerPool was already disposed"));
       }
-      
+        
+      if (availableCheckers.TryPop(out var result)) {
+        PrepareChecker(vcgen.program, split, result);
+        Contract.Assert(result != null);
+        return Task.FromResult(result);
+      }
+
+      var afterDecrement = Interlocked.Decrement(ref notCreatedCheckers);
+      if (afterDecrement >= 0) {
+        var checker = CreateNewChecker();
+        PrepareChecker(vcgen.program, split, checker);
+        Contract.Assert(checker != null);
+        return Task.FromResult(checker);
+      }
+      Interlocked.Increment(ref notCreatedCheckers);
+
+      var source = new TaskCompletionSource<Checker>();
+      checkerWaiters.Enqueue(source);
+      return source.Task.ContinueWith(t =>
+      {
+        PrepareChecker(vcgen.program, split, t.Result);
+        Contract.Assert(t.Result != null);
+        return t.Result;
+      });
     }
 
     private Checker CreateNewChecker()
@@ -67,15 +66,10 @@ namespace VC
 
     public void Dispose()
     {
-      lock (this) {
-        foreach (var checker in availableCheckers)
-        {
-          Contract.Assert(checker != null);
-          checker.Close();
-        }
-        availableCheckers.Clear();
-        disposed = true;
+      while (availableCheckers.TryPop(out var checker)) {
+        checker.Close();
       }
+      disposed = true;
     }
 
     void PrepareChecker(Program program, Split split, Checker checker)
@@ -99,26 +93,21 @@ namespace VC
         checker.Close();
         return;
       }
-      lock(this)
-      {
-        if (checkerWaiters.TryDequeue(out var waiter)) {
-          if (waiter.TrySetResult(checker)) {
-            return;
-          }
+      if (checkerWaiters.TryDequeue(out var waiter)) {
+        if (waiter.TrySetResult(checker)) {
+          return;
         }
-
-        availableCheckers.Push(checker);
       }
+
+      availableCheckers.Push(checker);
     }
 
     public void CheckerDied()
     {
-      lock (this) {
-        if (checkerWaiters.TryDequeue(out var waiter)) {
-          waiter.SetResult(CreateNewChecker());
-        } else {
-          notCreatedCheckers++;
-        }
+      if (checkerWaiters.TryDequeue(out var waiter)) {
+        waiter.SetResult(CreateNewChecker());
+      } else {
+        Interlocked.Increment(ref notCreatedCheckers);
       }
     }
   }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1363,7 +1363,7 @@ namespace VC
       /// <summary>
       /// As a side effect, updates "this.parent.CumulativeAssertionCount".
       /// </summary>
-      public void BeginCheck(TextWriter traceWriter, Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int splitIndex, uint timeout,
+      public async Task BeginCheck(TextWriter traceWriter, Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, int splitIndex, uint timeout,
         uint rlimit, CancellationToken cancellationToken)
       {
         Contract.Requires(checker != null);
@@ -1371,6 +1371,7 @@ namespace VC
 
         this.splitIndex = splitIndex;
 
+        VCExpr vc;
         // Lock impl since we're setting impl.Blocks that is used to generate the VC.
         lock (Implementation) {
           Implementation.Blocks = blocks;
@@ -1386,7 +1387,7 @@ namespace VC
 
           var exprGen = ctx.ExprGen;
           VCExpr controlFlowVariableExpr = exprGen.Integer(BigNum.ZERO);
-          VCExpr vc = parent.GenerateVCAux(Implementation, controlFlowVariableExpr, absyIds, checker.TheoremProver.Context);
+          vc = parent.GenerateVCAux(Implementation, controlFlowVariableExpr, absyIds, checker.TheoremProver.Context);
           Contract.Assert(vc != null);
 
           vc = QuantifierInstantiationEngine.Instantiate(Implementation, exprGen, bet, vc);
@@ -1397,15 +1398,15 @@ namespace VC
           vc = exprGen.Implies(eqExpr, vc);
           reporter = new VCGen.ErrorReporter(options, gotoCmdOrigins, absyIds, Implementation.Blocks, parent.debugInfos, callback,
             mvInfo, Checker.TheoremProver.Context, parent.program, this);
-          
-          if (options.TraceVerify && splitIndex >= 0)
-          {
-            Console.WriteLine("-- after split #{0}", splitIndex);
-            Print();
-          }
-
-          checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
         }
+
+        if (options.TraceVerify && splitIndex >= 0)
+        {
+          Console.WriteLine("-- after split #{0}", splitIndex);
+          Print();
+        }
+
+        await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
       }
 
       public string Description

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -100,7 +100,7 @@ namespace VC
 
       try {
         cancellationToken.ThrowIfCancellationRequested();
-        StartCheck(split, checker, cancellationToken);
+        await StartCheck(split, checker, cancellationToken);
         await split.ProverTask;
         await ProcessResult(split, cancellationToken);
       }
@@ -110,7 +110,7 @@ namespace VC
       }
     }
 
-    private void StartCheck(Split split, Checker checker, CancellationToken cancellationToken)
+    private async Task StartCheck(Split split, Checker checker, CancellationToken cancellationToken)
     {
       int currentSplitNumber = DoSplitting ? Interlocked.Increment(ref splitNumber) - 1 : -1;
       if (options.Trace && DoSplitting) {
@@ -124,7 +124,7 @@ namespace VC
       var timeout = KeepGoing && split.LastChance ? options.VcsFinalAssertTimeout :
         KeepGoing ? options.VcsKeepGoingTimeout :
         run.Implementation.GetTimeLimit(options);
-      split.BeginCheck(run.TraceWriter, checker, callback, mvInfo, currentSplitNumber, timeout, Implementation.GetResourceLimit(options), cancellationToken);
+      await split.BeginCheck(run.TraceWriter, checker, callback, mvInfo, currentSplitNumber, timeout, Implementation.GetResourceLimit(options), cancellationToken);
     }
 
     private Implementation Implementation => run.Implementation;

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -355,7 +355,7 @@ namespace VC
             }
 
             ch.BeginCheck(cce.NonNull(Implementation.Name + "_smoke" + id++), vc, new ErrorHandler(Options, absyIds, callback),
-              Options.SmokeTimeout, Options.ResourceLimit, CancellationToken.None);
+              Options.SmokeTimeout, Options.ResourceLimit, CancellationToken.None).Wait();
           }
 
           ch.ProverTask.Wait();


### PR DESCRIPTION
### Changes
Several changes to make using Boogie concurrently either safer or faster.

- Make `AbsyQuant.cs.EqualWithAttributesAndTriggers` thread-safe
- Remove locks from `CheckerPool`
- Remove two calls that waited for a `Task` to complete, one in `ExecutionEngine` and one in `SMTLibInteractiveTheoremProver.cs`

### Testing
Changes should be covered by regression suite. Most Boogie tests are run parallelly.