### PR TITLE
Fix incorrect parsing of double options

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.13.1</Version>
+    <Version>2.13.2</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -908,7 +908,7 @@ namespace Microsoft.Boogie
 
         case "pretty":
           int val = 1;
-          if (ps.GetNumericArgument(x => val = x, 2))
+          if (ps.GetIntArgument(x => val = x, 2))
           {
             PrettyPrint = val == 1;
           }
@@ -926,7 +926,7 @@ namespace Microsoft.Boogie
         case "trustLayersUpto":
           if (ps.ConfirmArgumentCount(1))
           {
-            ps.GetNumericArgument(x => TrustLayersUpto = x);
+            ps.GetIntArgument(x => TrustLayersUpto = x);
           }
 
           return true;
@@ -934,7 +934,7 @@ namespace Microsoft.Boogie
         case "trustLayersDownto":
           if (ps.ConfirmArgumentCount(1))
           {
-            ps.GetNumericArgument(x => TrustLayersDownto = x);
+            ps.GetIntArgument(x => TrustLayersDownto = x);
           }
 
           return true;
@@ -965,13 +965,13 @@ namespace Microsoft.Boogie
           return true;
 
         case "errorTrace":
-          ps.GetNumericArgument(x => ErrorTrace = x, 3);
+          ps.GetIntArgument(x => ErrorTrace = x, 3);
           return true;
 
         case "proverWarnings":
         {
           int pw = 0;
-          if (ps.GetNumericArgument(x => pw = x, 3))
+          if (ps.GetIntArgument(x => pw = x, 3))
           {
             switch (pw)
             {
@@ -998,7 +998,7 @@ namespace Microsoft.Boogie
         case "env":
         {
           int e = 0;
-          if (ps.GetNumericArgument(x => e = x, 3))
+          if (ps.GetIntArgument(x => e = x, 3))
           {
             switch (e)
             {
@@ -1025,7 +1025,7 @@ namespace Microsoft.Boogie
         case "printVerifiedProceduresCount":
         {
           int n = 0;
-          if (ps.GetNumericArgument(x => n = x, 2))
+          if (ps.GetIntArgument(x => n = x, 2))
           {
             ShowVerifiedProcedureCount = n != 0;
           }
@@ -1034,7 +1034,7 @@ namespace Microsoft.Boogie
         }
 
         case "loopUnroll":
-          ps.GetNumericArgument(x => LoopUnrollCount = x);
+          ps.GetIntArgument(x => LoopUnrollCount = x);
           return true;
 
         case "printModel":
@@ -1073,7 +1073,7 @@ namespace Microsoft.Boogie
           return true;
 
         case "enhancedErrorMessages":
-          ps.GetNumericArgument(x => enhancedErrorMessages = x, 2);
+          ps.GetIntArgument(x => enhancedErrorMessages = x, 2);
           return true;
 
         case "printCFG":
@@ -1085,13 +1085,13 @@ namespace Microsoft.Boogie
           return true;
 
         case "inlineDepth":
-          ps.GetNumericArgument(x => InlineDepth = x);
+          ps.GetIntArgument(x => InlineDepth = x);
           return true;
 
         case "subsumption":
         {
           int s = 0;
-          if (ps.GetNumericArgument(x => s = x, 3))
+          if (ps.GetIntArgument(x => s = x, 3))
           {
             switch (s)
             {
@@ -1118,7 +1118,7 @@ namespace Microsoft.Boogie
         case "liveVariableAnalysis":
         {
           int lva = 0;
-          if (ps.GetNumericArgument(x => lva = x, 3))
+          if (ps.GetIntArgument(x => lva = x, 3))
           {
             LiveVariableAnalysis = lva;
           }
@@ -1129,7 +1129,7 @@ namespace Microsoft.Boogie
         case "removeEmptyBlocks":
         {
           int reb = 0;
-          if (ps.GetNumericArgument(x => reb = x, 2))
+          if (ps.GetIntArgument(x => reb = x, 2))
           {
             RemoveEmptyBlocks = reb == 1;
           }
@@ -1140,7 +1140,7 @@ namespace Microsoft.Boogie
         case "coalesceBlocks":
         {
           int cb = 0;
-          if (ps.GetNumericArgument(x => cb = x, 2))
+          if (ps.GetIntArgument(x => cb = x, 2))
           {
             CoalesceBlocks = cb == 1;
           }
@@ -1179,7 +1179,7 @@ namespace Microsoft.Boogie
 
         case "stagedHoudiniThreads":
         {
-          ps.GetNumericArgument(x => stagedHoudiniThreads = x);
+          ps.GetIntArgument(x => stagedHoudiniThreads = x);
           return true;
         }
 
@@ -1369,35 +1369,35 @@ namespace Microsoft.Boogie
           return true;
 
         case "vcBrackets":
-          ps.GetNumericArgument(x => bracketIdsInVC = x, 2);
+          ps.GetIntArgument(x => bracketIdsInVC = x, 2);
           return true;
 
         case "vcsMaxCost":
-          ps.GetNumericArgument(x => VcsMaxCost = x);
+          ps.GetDoubleArgument(x => VcsMaxCost = x);
           return true;
 
         case "vcsPathJoinMult":
-          ps.GetNumericArgument(x => VcsPathJoinMult = x);
+          ps.GetDoubleArgument(x => VcsPathJoinMult = x);
           return true;
 
         case "vcsPathCostMult":
-          ps.GetNumericArgument(x => VcsPathCostMult = x);
+          ps.GetDoubleArgument(x => VcsPathCostMult = x);
           return true;
 
         case "vcsAssumeMult":
-          ps.GetNumericArgument(x => VcsAssumeMult = x);
+          ps.GetDoubleArgument(x => VcsAssumeMult = x);
           return true;
 
         case "vcsPathSplitMult":
-          ps.GetNumericArgument(x => VcsPathSplitMult = x);
+          ps.GetDoubleArgument(x => VcsPathSplitMult = x);
           return true;
 
         case "vcsMaxSplits":
-          ps.GetNumericArgument(x => VcsMaxSplits = x);
+          ps.GetIntArgument(x => VcsMaxSplits = x);
           return true;
 
         case "vcsMaxKeepGoingSplits":
-          ps.GetNumericArgument(x => VcsMaxKeepGoingSplits = x);
+          ps.GetIntArgument(x => VcsMaxKeepGoingSplits = x);
           return true;
 
         case "vcsSplitOnEveryAssert":
@@ -1416,12 +1416,12 @@ namespace Microsoft.Boogie
           return true;
 
         case "vcsCores":
-          ps.GetNumericArgument(x => VcsCores = x, a => 1 <= a);
+          ps.GetIntArgument(x => VcsCores = x, a => 1 <= a);
           return true;
 
         case "vcsLoad":
           double load = 0.0;
-          if (ps.GetNumericArgument(x => load = x))
+          if (ps.GetDoubleArgument(x => load = x))
           {
             if (3.0 <= load)
             {
@@ -1452,37 +1452,37 @@ namespace Microsoft.Boogie
           return true;
 
         case "errorLimit":
-          ps.GetNumericArgument(x => errorLimit = x);
+          ps.GetIntArgument(x => errorLimit = x);
           return true;
 
         case "randomSeed":
           int randomSeed = 0;
-          ps.GetNumericArgument(x => randomSeed = x);
+          ps.GetIntArgument(x => randomSeed = x);
           RandomSeed = randomSeed;
           return true;
         
         case "verifySnapshots":
-          ps.GetNumericArgument(x => VerifySnapshots = x, 4);
+          ps.GetIntArgument(x => VerifySnapshots = x, 4);
           return true;
 
         case "traceCaching":
-          ps.GetNumericArgument(x => TraceCaching = x, 4);
+          ps.GetIntArgument(x => TraceCaching = x, 4);
           return true;
 
         case "kInductionDepth":
-          ps.GetNumericArgument(x => KInductionDepth = x);
+          ps.GetIntArgument(x => KInductionDepth = x);
           return true;
           
         case "emitDebugInformation":
-          ps.GetNumericArgument(x => emitDebugInformation = x);
+          ps.GetIntArgument(x => emitDebugInformation = x);
           return true;
 
         case "normalizeNames":
-          ps.GetNumericArgument(x => normalizeNames = x);
+          ps.GetIntArgument(x => normalizeNames = x);
           return true;
         
         case "normalizeDeclarationOrder":
-          ps.GetNumericArgument(x => normalizeDeclarationOrder = x);
+          ps.GetIntArgument(x => normalizeDeclarationOrder = x);
           return true;
 
         default:

--- a/Source/ExecutionEngine/CommandLineParseState.cs
+++ b/Source/ExecutionEngine/CommandLineParseState.cs
@@ -82,10 +82,10 @@ public class CommandLineParseState
   /// then call "setArg" with that number mapped to a boolean and return "true".
   /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
   /// </summary>
-  public bool GetNumericArgument(Action<bool> setArg)
+  public bool GetIntArgument(Action<bool> setArg)
   {
     int intArg = 0;
-    var result = GetNumericArgument(ref intArg, x => x < 2);
+    var result = GetIntArgument(ref intArg, x => x < 2);
     if (result) {
       setArg(intArg != 0);
     }
@@ -96,10 +96,10 @@ public class CommandLineParseState
   /// If there is one argument and it is a non-negative integer, then set "arg" to that number and return "true".
   /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
   /// </summary>
-  public bool GetNumericArgument(ref bool arg)
+  public bool GetIntArgument(ref bool arg)
   {
     int intArg = 0;
-    var result = GetNumericArgument(ref intArg, x => x < 2);
+    var result = GetIntArgument(ref intArg, x => x < 2);
     if (result) {
       arg = intArg != 0;
     }
@@ -110,7 +110,7 @@ public class CommandLineParseState
   /// If there is one argument and it is a non-negative integer, then call "setArg" with that number and return "true".
   /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
   /// </summary>
-  public bool GetNumericArgument(Action<int> setArg, Predicate<int> filter = null)
+  public bool GetIntArgument(Action<int> setArg, Predicate<int> filter = null)
   {
     filter ??= a => 0 <= a;
 
@@ -149,10 +149,10 @@ public class CommandLineParseState
   /// If there is one argument and it is a non-negative integer, then set "arg" to that number and return "true".
   /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
   /// </summary>
-  public bool GetNumericArgument(ref int arg)
+  public bool GetIntArgument(ref int arg)
   {
     //modifies nextIndex, encounteredErrors, Console.Error.*;
-    return GetNumericArgument(ref arg, a => 0 <= a);
+    return GetIntArgument(ref arg, a => 0 <= a);
   }
 
   public bool GetUnsignedNumericArgument(Action<uint> setArg, Predicate<uint> filter = null)
@@ -221,7 +221,7 @@ public class CommandLineParseState
   /// If there is one argument and the filtering predicate holds, then set "arg" to that number and return "true".
   /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
   /// </summary>
-  public bool GetNumericArgument(ref int arg, Predicate<int> filter)
+  public bool GetIntArgument(ref int arg, Predicate<int> filter)
   {
     Contract.Requires(filter != null);
 
@@ -259,11 +259,11 @@ public class CommandLineParseState
   /// then call "setArg" with that number and return "true".
   /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
   /// </summary>
-  public bool GetNumericArgument(Action<int> setArg, int limit)
+  public bool GetIntArgument(Action<int> setArg, int limit)
   {
     Contract.Requires(this.i < args.Length);
     int a = 0;
-    if (!GetNumericArgument(x => a = x))
+    if (!GetIntArgument(x => a = x))
     {
       return false;
     }
@@ -282,14 +282,14 @@ public class CommandLineParseState
   /// then set "arg" to that number and return "true".
   /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
   /// </summary>
-  public bool GetNumericArgument(ref int arg, int limit)
+  public bool GetIntArgument(ref int arg, int limit)
   {
     Contract.Requires(this.i < args.Length);
     Contract.Ensures(Math.Min(arg, 0) <= Contract.ValueAtReturn(out arg) &&
                      Contract.ValueAtReturn(out arg) < limit);
     //modifies nextIndex, encounteredErrors, Console.Error.*;
     int a = arg;
-    if (!GetNumericArgument(ref a))
+    if (!GetIntArgument(ref a))
     {
       return false;
     }
@@ -306,12 +306,12 @@ public class CommandLineParseState
   }
 
   /// <summary>
-  /// If there is one argument and it is a non-negative real, then set "arg" to that number and return "true".
-  /// Otherwise, emit an error message, leave "arg" unchanged, and return "false".
+  /// If there is one argument and it is a non-negative real,
+  /// then call "setArg" with that number and return "true".
+  /// Otherwise, emit error message, leave "arg" unchanged, and return "false".
   /// </summary>
-  public bool GetNumericArgument(ref double arg)
+  public bool GetDoubleArgument(Action<double> setArg)
   {
-    Contract.Ensures(Contract.ValueAtReturn(out arg) >= 0);
     //modifies nextIndex, encounteredErrors, Console.Error.*;
     if (this.ConfirmArgumentCount(1))
     {
@@ -320,9 +320,8 @@ public class CommandLineParseState
         Contract.Assume(args[i] != null);
         Contract.Assert(args[i] is string); // needed to prove args[i].IsPeerConsistent
         double d = Convert.ToDouble(this.args[this.i]);
-        if (0 <= d)
-        {
-          arg = d;
+        if (0 <= d) {
+          setArg(d);
           return true;
         }
       }


### PR DESCRIPTION
Fixes https://github.com/boogie-org/boogie/issues/546

### Testing

I decided not to add tests for this regression. I think in the future we'll refactor options so there's no more duplication in handling which type an option is then the single type specification can serve as both specification and implementation.