### PR TITLE
Don't allocate a checker if the checker waiter is canceled.

### DIFF
--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -98,10 +98,9 @@ namespace VC
 
     async Task DoWork(Split split, CancellationToken cancellationToken)
     {
-      var checker = await split.parent.CheckerPool.FindCheckerFor(split.parent, split);
+      var checker = await split.parent.CheckerPool.FindCheckerFor(split.parent, split, cancellationToken).WaitAsync(cancellationToken);
 
       try {
-        cancellationToken.ThrowIfCancellationRequested();
         await StartCheck(split, checker, cancellationToken);
         await split.ProverTask;
         await ProcessResult(split, cancellationToken);


### PR DESCRIPTION
I'm wondering if this can help.
While debugging, I have seen a lot of checkers being allocated and prepared to just be thrown away because the task awaiting it has been canceled.
This PR does not even allocate the tasks.

However, it contains something I would like someone (e.g. @cpitclaudel ) to confirm it is not a problem: If we use WaitASync(cancellationToken), can it cause a deadlock in any way?