### PR TITLE
Make more methods of ConsolePrinter virtual

### DIFF
--- a/Source/ExecutionEngine/ConsolePrinter.cs
+++ b/Source/ExecutionEngine/ConsolePrinter.cs
@@ -10,7 +10,7 @@ public class ConsolePrinter : OutputPrinter
 {
   public ExecutionEngineOptions Options { get; set; }
 
-  public void ErrorWriteLine(TextWriter tw, string s)
+  public virtual void ErrorWriteLine(TextWriter tw, string s)
   {
     Contract.Requires(s != null);
     if (!s.Contains("Error: ") && !s.Contains("Error BP"))
@@ -45,7 +45,7 @@ public class ConsolePrinter : OutputPrinter
   }
 
 
-  public void ErrorWriteLine(TextWriter tw, string format, params object[] args)
+  public virtual void ErrorWriteLine(TextWriter tw, string format, params object[] args)
   {
     Contract.Requires(format != null);
     string s = string.Format(format, args);
@@ -53,7 +53,7 @@ public class ConsolePrinter : OutputPrinter
   }
 
 
-  public void AdvisoryWriteLine(TextWriter output, string format, params object[] args)
+  public virtual void AdvisoryWriteLine(TextWriter output, string format, params object[] args)
   {
     Contract.Requires(format != null);
     ConsoleColor col = Console.ForegroundColor;
@@ -67,7 +67,7 @@ public class ConsolePrinter : OutputPrinter
   /// Inform the user about something and proceed with translation normally.
   /// Print newline after the message.
   /// </summary>
-  public void Inform(string s, TextWriter tw)
+  public virtual void Inform(string s, TextWriter tw)
   {
     if (Options.Trace || Options.TraceProofObligations)
     {
@@ -76,7 +76,7 @@ public class ConsolePrinter : OutputPrinter
   }
 
 
-  public void WriteTrailer(TextWriter textWriter, PipelineStatistics stats)
+  public virtual void WriteTrailer(TextWriter textWriter, PipelineStatistics stats)
   {
     Contract.Requires(stats != null);
     Contract.Requires(0 <= stats.VerifiedCount && 0 <= stats.ErrorCount && 0 <= stats.InconclusiveCount &&
@@ -124,7 +124,7 @@ public class ConsolePrinter : OutputPrinter
   }
 
 
-  public void WriteErrorInformation(ErrorInformation errorInfo, TextWriter tw, bool skipExecutionTrace = true)
+  public virtual void WriteErrorInformation(ErrorInformation errorInfo, TextWriter tw, bool skipExecutionTrace = true)
   {
     Contract.Requires(errorInfo != null);
 
@@ -174,19 +174,19 @@ public class ConsolePrinter : OutputPrinter
     }
   }
 
-  public void ReportImplementationsBeforeVerification(Implementation[] implementations) {
+  public virtual void ReportImplementationsBeforeVerification(Implementation[] implementations) {
     // Do not print anything to console
   }
 
-  public void ReportStartVerifyImplementation(Implementation implementation) {
+  public virtual void ReportStartVerifyImplementation(Implementation implementation) {
     // Do not print anything to console
   }
 
-  public void ReportEndVerifyImplementation(Implementation implementation, VerificationResult result) {
+  public virtual void ReportEndVerifyImplementation(Implementation implementation, VerificationResult result) {
     // Do not print anything to console
   }
 
-  public void ReportSplitResult(Split split, VCResult splitResult) {
+  public virtual void ReportSplitResult(Split split, VCResult splitResult) {
     // Do not print anything to console
   }
 }


### PR DESCRIPTION
One method was virtual, because Dafny implements a subclass of
ConsolePrinter that needed to override that method. Now the rest are
virtual, to allow Dafny (or other clients) to override additional
functionality. The primary goal of this is to allow Dafny to override
recently-introduced methods such as ReportEndVerifyImplementation.