### PR TITLE
Fix a missing output bug in ConcurrentToSequentialWriteManager

### DIFF
--- a/Source/ExecutionEngine/ConcurrentToSequentialWriteManager.cs
+++ b/Source/ExecutionEngine/ConcurrentToSequentialWriteManager.cs
@@ -53,11 +53,12 @@ public class ConcurrentToSequentialWriteManager
     }
 
     public string SetTargetAndGetBuffer(TextWriter newTarget) {
-      var oldTarget = target;
-      target = newTarget;
-      var result = buffering ? ((StringWriter)oldTarget).ToString() : "";
-      buffering = false;
-      return result;
+      lock (target) {
+        var result = buffering ? ((StringWriter)target).ToString() : "";
+        target = newTarget;
+        buffering = false;
+        return result;
+      }
     }
 
     protected override void Dispose(bool disposing) {

--- a/Source/ExecutionEngine/ConcurrentToSequentialWriteManager.cs
+++ b/Source/ExecutionEngine/ConcurrentToSequentialWriteManager.cs
@@ -26,9 +26,6 @@ public class ConcurrentToSequentialWriteManager
         var disposedWriter = writers.Dequeue();
         Writer.Write(disposedWriter.SetTargetAndGetBuffer(null));
       }
-      if (writers.Count > 0) {
-        Writer.Write(writers.Peek().SetTargetAndGetBuffer(Writer));
-      }
     }
     Writer.Flush();
   }
@@ -52,13 +49,14 @@ public class ConcurrentToSequentialWriteManager
       buffering = target == null;
     }
 
+    /// <summary>
+    /// Only called for disposed writers that aren't being written to any more.
+    /// </summary>
     public string SetTargetAndGetBuffer(TextWriter newTarget) {
-      lock (target) {
-        var result = buffering ? ((StringWriter)target).ToString() : "";
-        target = newTarget;
-        buffering = false;
-        return result;
-      }
+      var result = buffering ? ((StringWriter)target).ToString() : "";
+      target = newTarget;
+      buffering = false;
+      return result;
     }
 
     protected override void Dispose(bool disposing) {

--- a/Source/ExecutionEngine/WriterWrapper.cs
+++ b/Source/ExecutionEngine/WriterWrapper.cs
@@ -15,110 +15,74 @@ class WriterWrapper : TextWriter {
   }
 
   public override void Write(char value) {
-    lock (target) {
-      target.Write(value);
-    }
+    target.Write(value);
   }
 
   public override void Write(char[] buffer, int index, int count) {
-    lock (target) {
-      target.Write(buffer, index, count);
-    }
+    target.Write(buffer, index, count);
   }
 
   public override void Write(ReadOnlySpan<char> buffer) {
-    lock (target) {
-      target.Write(buffer);
-    }
+    target.Write(buffer);
   }
 
   public override void Write(string value) {
-    lock (target) {
-      target.Write(value);
-    }
+    target.Write(value);
   }
 
   public override void WriteLine(char[] buffer, int index, int count) {
-    lock (target) {
-      target.WriteLine(buffer, index, count);
-    }
+    target.WriteLine(buffer, index, count);
   }
 
   public override void WriteLine(ReadOnlySpan<char> buffer) {
-    lock (target) {
-      target.WriteLine(buffer);
-    }
+    target.WriteLine(buffer);
   }
 
   public override void WriteLine(StringBuilder value) {
-    lock (target) {
-      target.WriteLine(value);
-    }
+    target.WriteLine(value);
   }
 
   public override void Write(StringBuilder value) {
-    lock (target) {
-      target.Write(value);
-    }
+    target.Write(value);
   }
 
   public override Task WriteAsync(char value) {
-    lock (target) {
-      return target.WriteAsync(value);
-    }
+    return target.WriteAsync(value);
   }
 
   public override Task WriteAsync(char[] buffer, int index, int count) {
-    lock (target) {
-      return target.WriteAsync(buffer, index, count);
-    }
+    return target.WriteAsync(buffer, index, count);
   }
 
   public override Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = new()) {
-    lock (target) {
-      return target.WriteAsync(buffer, cancellationToken);
-    }
+    return target.WriteAsync(buffer, cancellationToken);
   }
 
   public override Task WriteAsync(string value) {
-    lock (target) {
-      return target.WriteAsync(value);
-    }
+    return target.WriteAsync(value);
   }
 
   public override Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = new()) {
-    lock (target) {
-      return target.WriteAsync(value, cancellationToken);
-    }
+    return target.WriteAsync(value, cancellationToken);
   }
 
   public override Task WriteLineAsync(char value) {
-    lock (target) {
-      return target.WriteLineAsync(value);
-    }
+    return target.WriteLineAsync(value);
   }
 
   public override Task WriteLineAsync(char[] buffer, int index, int count) {
-    lock (target) {
-      return target.WriteLineAsync(buffer, index, count);
-    }
+    return target.WriteLineAsync(buffer, index, count);
   }
 
   public override Task WriteLineAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = new()) {
-    lock (target) {
-      return target.WriteLineAsync(buffer, cancellationToken);
-    }
+    return target.WriteLineAsync(buffer, cancellationToken);
   }
 
   public override Task WriteLineAsync(string value) {
-    lock (target) {
-      return target.WriteLineAsync(value);
-    }
+    return target.WriteLineAsync(value);
   }
 
   public override Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken = new()) {
-    lock (target) {
-      return target.WriteLineAsync(value, cancellationToken);
-    }
+    return target.WriteLineAsync(value, cancellationToken);
   }
 }

--- a/Source/ExecutionEngine/WriterWrapper.cs
+++ b/Source/ExecutionEngine/WriterWrapper.cs
@@ -15,74 +15,110 @@ class WriterWrapper : TextWriter {
   }
 
   public override void Write(char value) {
-    target.Write(value);
+    lock (target) {
+      target.Write(value);
+    }
   }
 
   public override void Write(char[] buffer, int index, int count) {
-    target.Write(buffer, index, count);
+    lock (target) {
+      target.Write(buffer, index, count);
+    }
   }
 
   public override void Write(ReadOnlySpan<char> buffer) {
-    target.Write(buffer);
+    lock (target) {
+      target.Write(buffer);
+    }
   }
 
   public override void Write(string value) {
-    target.Write(value);
+    lock (target) {
+      target.Write(value);
+    }
   }
 
   public override void WriteLine(char[] buffer, int index, int count) {
-    target.WriteLine(buffer, index, count);
+    lock (target) {
+      target.WriteLine(buffer, index, count);
+    }
   }
 
   public override void WriteLine(ReadOnlySpan<char> buffer) {
-    target.WriteLine(buffer);
+    lock (target) {
+      target.WriteLine(buffer);
+    }
   }
 
   public override void WriteLine(StringBuilder value) {
-    target.WriteLine(value);
+    lock (target) {
+      target.WriteLine(value);
+    }
   }
 
   public override void Write(StringBuilder value) {
-    target.Write(value);
+    lock (target) {
+      target.Write(value);
+    }
   }
 
   public override Task WriteAsync(char value) {
-    return target.WriteAsync(value);
+    lock (target) {
+      return target.WriteAsync(value);
+    }
   }
 
   public override Task WriteAsync(char[] buffer, int index, int count) {
-    return target.WriteAsync(buffer, index, count);
+    lock (target) {
+      return target.WriteAsync(buffer, index, count);
+    }
   }
 
   public override Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = new()) {
-    return target.WriteAsync(buffer, cancellationToken);
+    lock (target) {
+      return target.WriteAsync(buffer, cancellationToken);
+    }
   }
 
   public override Task WriteAsync(string value) {
-    return target.WriteAsync(value);
+    lock (target) {
+      return target.WriteAsync(value);
+    }
   }
 
   public override Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = new()) {
-    return target.WriteAsync(value, cancellationToken);
+    lock (target) {
+      return target.WriteAsync(value, cancellationToken);
+    }
   }
 
   public override Task WriteLineAsync(char value) {
-    return target.WriteLineAsync(value);
+    lock (target) {
+      return target.WriteLineAsync(value);
+    }
   }
 
   public override Task WriteLineAsync(char[] buffer, int index, int count) {
-    return target.WriteLineAsync(buffer, index, count);
+    lock (target) {
+      return target.WriteLineAsync(buffer, index, count);
+    }
   }
 
   public override Task WriteLineAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = new()) {
-    return target.WriteLineAsync(buffer, cancellationToken);
+    lock (target) {
+      return target.WriteLineAsync(buffer, cancellationToken);
+    }
   }
 
   public override Task WriteLineAsync(string value) {
-    return target.WriteLineAsync(value);
+    lock (target) {
+      return target.WriteLineAsync(value);
+    }
   }
 
   public override Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken = new()) {
-    return target.WriteLineAsync(value, cancellationToken);
+    lock (target) {
+      return target.WriteLineAsync(value, cancellationToken);
+    }
   }
 }

--- a/Source/UnitTests/ExecutionEngineTests/ConcurrentToSequentialWriteManagerTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ConcurrentToSequentialWriteManagerTest.cs
@@ -1,7 +1,9 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Boogie;
 using NUnit.Framework;
+using VC;
 
 namespace ExecutionEngineTests;
 
@@ -9,7 +11,7 @@ namespace ExecutionEngineTests;
 public class ConcurrentToSequentialWriteManagerTest {
 
   [Test]
-  public async Task ThreeConcurrentWriters() {
+  public async Task FirstNotDisposedWriterWritesImmediately() {
     var writer = new StringWriter();
     var manager = new ConcurrentToSequentialWriteManager(writer);
 
@@ -27,5 +29,59 @@ public class ConcurrentToSequentialWriteManagerTest {
     Assert.AreEqual("firstLine1\nsecondLine1\nsecondLine2\n", writer.ToString().Replace("\r\n", "\n"));
     await second.DisposeAsync();
     Assert.AreEqual("firstLine1\nsecondLine1\nsecondLine2\nthirdLine1\n", writer.ToString().Replace("\r\n", "\n"));
+  }
+
+  [Test]
+  public void ThreeConcurrentWriters()
+  {
+    var amount = 1000;
+    var writer = new StringWriter();
+    var manager = new ConcurrentToSequentialWriteManager(writer);
+
+    var first = manager.AppendWriter();
+    var second = manager.AppendWriter();
+    var third = manager.AppendWriter();
+
+    var thread1 = new Thread(() =>
+    {
+      for (int i = 0; i < amount; i++) {
+        first.WriteLine(i);
+      }
+      first.Dispose();
+    });
+
+    var thread2 = new Thread(() =>
+    {
+      for (int i = 0; i < 2 * amount; i++) {
+        second.WriteLine(i);
+      }
+      second.Dispose();
+    });
+
+    var thread3 = new Thread(() =>
+    {
+      for (int i = 0; i < 3 * amount; i++) {
+        third.WriteLine(i);
+      }
+      third.Dispose();
+    });
+    thread3.Start();
+    thread2.Start();
+    thread1.Start();
+    thread1.Join();
+    thread2.Join();
+    thread3.Join();
+
+    var output = writer.ToString().TrimEnd().Split("\n");
+
+    for (int i = 0; i < amount; i++) {
+      Assert.AreEqual(i.ToString(), output[i]);
+    }
+    for (int i = 0; i < 2 * amount; i++) {
+      Assert.AreEqual(i.ToString(), output[i + amount]);
+    }
+    for (int i = 0; i < 3 * amount; i++) {
+      Assert.AreEqual(i.ToString(), output[i + amount * 3]);
+    }
   }
 }

--- a/Source/UnitTests/ExecutionEngineTests/ConcurrentToSequentialWriteManagerTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ConcurrentToSequentialWriteManagerTest.cs
@@ -35,50 +35,49 @@ public class ConcurrentToSequentialWriteManagerTest {
   [Test]
   public void ManyConcurrentWriterHandovers()
   {
-    var writer = new StringWriter();
-    var manager = new ConcurrentToSequentialWriteManager(writer);
-    Exception thread1Exception = null;
-    var amount = 1000;
-    var running = true;
+    for (int i = 0; i < 100; i++) {
+      var writer = new StringWriter();
+      var manager = new ConcurrentToSequentialWriteManager(writer);
+      Exception thread1Exception = null;
 
-    var first = manager.AppendWriter();
-    var second = manager.AppendWriter();
+      var running = true;
 
-    var thread1 = new Thread(() =>
-    {
-      try {
-        while (running) {
-          second.WriteLine("a");
+      var first = manager.AppendWriter();
+      var second = manager.AppendWriter();
+
+      var thread1 = new Thread(() =>
+      {
+        try {
+          // ReSharper disable once AccessToModifiedClosure
+          while (running) {
+            second.WriteLine("a");
+          }
         }
-      }
-      catch (Exception e) {
-        thread1Exception = e;
-      }
-    });
+        catch (Exception e) {
+          thread1Exception = e;
+        }
+      });
 
-    Exception thread2Exception = null;
-    var thread2 = new Thread(() =>
-    {
-      try {
-        for (int i = 0; i < 1000; i++) {
+      Exception thread2Exception = null;
+      var thread2 = new Thread(() =>
+      {
+        try {
+          Thread.Sleep(1);
           first.Dispose();
-          var newSecond = manager.AppendWriter();
-          first = second;
-          second = newSecond;
         }
-      }
-      catch (Exception e) {
-        thread2Exception = e;
-      }
-    });
+        catch (Exception e) {
+          thread2Exception = e;
+        }
+      });
 
-    thread1.Start();
-    thread2.Start();
-    thread2.Join();
-    running = false;
-    thread1.Join();
-    Assert.IsNull(thread1Exception);
-    Assert.IsNull(thread2Exception);
+      thread1.Start();
+      thread2.Start();
+      thread2.Join();
+      running = false;
+      thread1.Join();
+      Assert.IsNull(thread1Exception);
+      Assert.IsNull(thread2Exception);
+    }
   }
 
   [Test]

--- a/Source/UnitTests/ExecutionEngineTests/ConcurrentToSequentialWriteManagerTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ConcurrentToSequentialWriteManagerTest.cs
@@ -12,7 +12,7 @@ namespace ExecutionEngineTests;
 public class ConcurrentToSequentialWriteManagerTest {
 
   [Test]
-  public async Task FirstNotDisposedWriterWritesImmediately() {
+  public async Task WritesOnlyHappenAfterDispose() {
     var writer = new StringWriter();
     var manager = new ConcurrentToSequentialWriteManager(writer);
 
@@ -27,9 +27,9 @@ public class ConcurrentToSequentialWriteManagerTest {
     await first.DisposeAsync();
     await second.WriteLineAsync("secondLine2");
     await third.WriteLineAsync("thirdLine1");
-    Assert.AreEqual("firstLine1\nsecondLine1\nsecondLine2\n", writer.ToString().Replace("\r\n", "\n"));
+    Assert.AreEqual("firstLine1\n", writer.ToString().Replace("\r\n", "\n"));
     await second.DisposeAsync();
-    Assert.AreEqual("firstLine1\nsecondLine1\nsecondLine2\nthirdLine1\n", writer.ToString().Replace("\r\n", "\n"));
+    Assert.AreEqual("firstLine1\nsecondLine1\nsecondLine2\n", writer.ToString().Replace("\r\n", "\n"));
   }
 
   [Test]

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -46,16 +46,11 @@ Execution trace:
 Boogie program verifier finished with 0 verified, 2 errors
 ".ReplaceLineEndings();
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 300; i++) {
       var writer = new StringWriter();
       Parser.Parse(programString, "fakeFilename1", out var program);
       await engine.ProcessProgram(writer, program, "fakeFilename");
-      var result = writer.ToString();
-      if (!result.Equals(expected)) {
-        Console.WriteLine("Got:\n" + result);
-        Assert.True(false);
-      }
-      // Assert.AreEqual(expected, writer.ToString());
+      Assert.AreEqual(expected, writer.ToString());
     }
   }
 

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -19,6 +19,47 @@ public class FakeDescription : ProofObligationDescription
 public class ExecutionEngineTest {
 
   [Test]
+  public async Task VerifyProceduresConcurrently()
+  {
+
+    var programString = @"procedure Bad(y: int)
+{
+  assert 2 == 1;
+}
+
+procedure Bad2(y: int)
+{
+  assert 2 == 3;
+}
+";
+    var options = CommandLineOptions.FromArguments();
+    options.VcsCores = 4;
+    var engine = ExecutionEngine.CreateWithoutSharedCache(options);
+
+    var expected = @"fakeFilename1(3,3): Error: This assertion might not hold.
+Execution trace:
+    fakeFilename1(3,3): anon0
+fakeFilename1(8,3): Error: This assertion might not hold.
+Execution trace:
+    fakeFilename1(8,3): anon0
+
+Boogie program verifier finished with 0 verified, 2 errors
+".ReplaceLineEndings();
+
+    for (int i = 0; i < 100; i++) {
+      var writer = new StringWriter();
+      Parser.Parse(programString, "fakeFilename1", out var program);
+      await engine.ProcessProgram(writer, program, "fakeFilename");
+      var result = writer.ToString();
+      if (!result.Equals(expected)) {
+        Console.WriteLine("Got:\n" + result);
+        Assert.True(false);
+      }
+      // Assert.AreEqual(expected, writer.ToString());
+    }
+  }
+
+  [Test]
   public async Task ConcurrentInferAndVerifyCalls() {
     var options = CommandLineOptions.FromArguments();
     options.VcsCores = 4;


### PR DESCRIPTION
### Changes
- Fix a concurrency bug in `ConcurrentToSequentialWriteManager` that would result in lost output. Fixes #553
- Turn off switching hot buffered writers to live writers, since it's difficult to get right. Will reintroduce in a different PR.

### Testing
- Add a test for `ExecutionEngine` that reproduces the missing output reported here: https://github.com/boogie-org/boogie/issues/553
- Add a test for `ConcurrentToSequentialWriteManager` that exercises a certain concurrent scenario which reveals the bug this PR fixes