### PR TITLE
Don't generate SMT-Lib with empty attribute lists

### DIFF
--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -447,7 +447,10 @@ namespace Microsoft.Boogie.SMTLib
           weight = 1;
         }
 
-        var hasAttrs = node.Triggers.Count > 0 || info.qid != null || weight != 1 || info.uniqueId != -1;
+        var hasAttrs = node.Triggers.Count > 0 ||
+                       weight != 1 ||
+                       (LibOptions.EmitDebugInformation &&
+                        (info.qid != null || info.uniqueId != -1));
 
         if (hasAttrs)
         {


### PR DESCRIPTION
When using `(! ... :attr)` to add a attributes to an SMT-Lib expression, fix the calculation of whether or not any attributes exist (because it's invalid SMT-Lib syntax if there are none).

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).