### PR TITLE
Handle hard timeout gracefully in batch solver

### DIFF
--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -163,6 +163,9 @@ namespace Microsoft.Boogie.SMTLib
     private async Task<Outcome> GetResponse(CancellationToken cancellationToken)
     {
       var outcomeSExp = await Process.GetProverResponse().WaitAsync(cancellationToken);
+      if (outcomeSExp.Name.Equals("timeout")) {
+        return Outcome.OutOfResource;
+      }
       var result = ParseOutcome(outcomeSExp, out var wasUnknown);
 
       var unknownSExp = await Process.GetProverResponse().WaitAsync(cancellationToken);


### PR DESCRIPTION
This is much more difficult to do when the solver is in interactive mode, because a timeout kills the whole process.

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).