### PR TITLE
Enable rerunning a cancelled ImplementationTask

### DIFF
--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -3494,8 +3494,8 @@ namespace Microsoft.Boogie
     }
   }
 
-  public class Implementation : DeclWithFormals
-  {
+  public class Implementation : DeclWithFormals {
+
     public List<Variable> /*!*/
       LocVars;
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.15.2</Version>
+    <Version>2.15.3</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -696,7 +696,7 @@ namespace Microsoft.Boogie
 
     /// The outer task is to wait for a semaphore to let verification start
     /// The inner task is the actual verification of the implementation
-    public async Task<Task<VerificationResult>> EnqueueVerifyImplementation(
+    public Task<Task<VerificationResult>> EnqueueVerifyImplementation(
       ProcessedProgram processedProgram, PipelineStatistics stats,
       string programId, ErrorReporterDelegate er, Implementation implementation,
       CancellationTokenSource cts,
@@ -707,17 +707,33 @@ namespace Microsoft.Boogie
         old.Cancel();
       }
 
-      await verifyImplementationSemaphore.WaitAsync(cts.Token);
-      ImplIdToCancellationTokenSource.AddOrUpdate(id, cts, (k, ov) => cts);
+      var result = EnqueueVerifyImplementation(processedProgram, stats, programId, er, implementation, cts.Token,
+        taskWriter);
+      var _ = result.Unwrap().ContinueWith(t =>
+      {
+        ImplIdToCancellationTokenSource.TryRemove(id, out old);
+      });
+      return result;
+    }
 
-      var coreTask = Task.Run(() => VerifyImplementation(processedProgram, stats, er, cts.Token,
+    /// The outer task is to wait for a semaphore to let verification start
+    /// The inner task is the actual verification of the implementation
+    public async Task<Task<VerificationResult>> EnqueueVerifyImplementation(
+      ProcessedProgram processedProgram, PipelineStatistics stats,
+      string programId, ErrorReporterDelegate er, Implementation implementation,
+      CancellationToken cancellationToken,
+      TextWriter taskWriter)
+    {
+
+      await verifyImplementationSemaphore.WaitAsync(cancellationToken);
+
+      var coreTask = Task.Run(() => VerifyImplementation(processedProgram, stats, er, cancellationToken,
         implementation,
-        programId, taskWriter), cts.Token);
+        programId, taskWriter), cancellationToken);
 
       var _ = coreTask.ContinueWith(t => {
         verifyImplementationSemaphore.Release();
-        ImplIdToCancellationTokenSource.TryRemove(id, out old);
-      });
+      }, CancellationToken.None);
       return coreTask;
     }
 

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -694,8 +694,10 @@ namespace Microsoft.Boogie
       return GetPrioritizedImplementations(program).Select(implementation => new ImplementationTask(this, processedProgram, implementation)).ToList();
     }
 
+    /// <returns>
     /// The outer task is to wait for a semaphore to let verification start
     /// The inner task is the actual verification of the implementation
+    /// </returns>
     public Task<Task<VerificationResult>> EnqueueVerifyImplementation(
       ProcessedProgram processedProgram, PipelineStatistics stats,
       string programId, ErrorReporterDelegate er, Implementation implementation,
@@ -716,8 +718,10 @@ namespace Microsoft.Boogie
       return result;
     }
 
+    /// <returns>
     /// The outer task is to wait for a semaphore to let verification start
     /// The inner task is the actual verification of the implementation
+    /// </returns>
     public async Task<Task<VerificationResult>> EnqueueVerifyImplementation(
       ProcessedProgram processedProgram, PipelineStatistics stats,
       string programId, ErrorReporterDelegate er, Implementation implementation,

--- a/Source/ExecutionEngine/ImplementationTask.cs
+++ b/Source/ExecutionEngine/ImplementationTask.cs
@@ -9,13 +9,26 @@ namespace Microsoft.Boogie;
 
 public interface IVerificationStatus {}
 
-public record Completed(VerificationResult Result) : IVerificationStatus; // Results are available
+/// <summary>
+/// Results are available
+/// </summary>
+public record Completed(VerificationResult Result) : IVerificationStatus;
 
-public record Queued : IVerificationStatus; // Scheduled to be run but waiting for resources
 
-public record Stale : IVerificationStatus; // Not scheduled to be run
+/// <summary>
+/// Scheduled to be run but waiting for resources
+/// </summary>
+public record Queued : IVerificationStatus;
 
-public record Running : IVerificationStatus; // Currently running
+/// <summary>
+/// Not scheduled to be run
+/// </summary>
+public record Stale : IVerificationStatus;
+
+/// <summary>
+///
+/// </summary>
+public record Running : IVerificationStatus;
 
 public interface IImplementationTask {
   IVerificationStatus CacheStatus { get; }
@@ -53,7 +66,7 @@ public class ImplementationTask : IImplementationTask {
 
   public IObservable<IVerificationStatus> RunAndAllowCancel() {
     if (cancellationSource != null) {
-      throw new InvalidOperationException();
+      throw new InvalidOperationException("Cancel must be called after Run before calling Run again");
     }
 
     cancellationSource = new();

--- a/Source/ExecutionEngine/ImplementationTask.cs
+++ b/Source/ExecutionEngine/ImplementationTask.cs
@@ -74,11 +74,12 @@ public class ImplementationTask : IImplementationTask {
   }
 
   public void Run() {
-    runWasCalled.SetResult();
+    runWasCalled.TrySetResult();
   }
 
   public void Cancel() {
     taskCancellationSource.Cancel();
+    observableStatus.OnCompleted();
     runWasCalled.TrySetCanceled(taskCancellationSource.Token);
   }
 }

--- a/Source/ExecutionEngine/ImplementationTask.cs
+++ b/Source/ExecutionEngine/ImplementationTask.cs
@@ -65,7 +65,7 @@ public class ImplementationTask : IImplementationTask {
 
   public void Cancel() {
     if (cancellationSource == null) {
-      throw new InvalidOperationException("There is no ongoing run to cancel");
+      throw new InvalidOperationException("There is no ongoing run to cancel.");
     }
 
     cancellationSource.Cancel();

--- a/Source/ExecutionEngine/ImplementationTask.cs
+++ b/Source/ExecutionEngine/ImplementationTask.cs
@@ -3,90 +3,77 @@ using System.IO;
 using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
-using VC;
 
 namespace Microsoft.Boogie;
-
-public interface IImplementationTask {
-  IObservable<VerificationStatus> ObservableStatus { get; }
-  VerificationStatus CurrentStatus { get; }
-  ProcessedProgram ProcessedProgram { get; }
-  Implementation Implementation { get; }
-  Task<VerificationResult> ActualTask { get; }
-  void Run();
-  void Cancel();
-}
-
-public class ImplementationTask : IImplementationTask {
-  private readonly CancellationTokenSource taskCancellationSource;
-
-  private readonly Subject<VerificationStatus> observableStatus = new();
-  
-  private VerificationStatus currentStatus;
-  public IObservable<VerificationStatus> ObservableStatus => observableStatus;
-
-  public VerificationStatus CurrentStatus {
-    get => currentStatus;
-    private set {
-      currentStatus = value;
-      observableStatus.OnNext(value);
-    }
-  }
-  public ProcessedProgram ProcessedProgram { get; }
-
-  public Task<VerificationResult> ActualTask { get; }
-  public Implementation Implementation { get; }
-
-  private readonly TaskCompletionSource runWasCalled = new();
-  
-  public ImplementationTask(ExecutionEngine engine, ProcessedProgram processedProgram, Implementation implementation) {
-    ProcessedProgram = processedProgram;
-    Implementation = implementation;
-    taskCancellationSource = new CancellationTokenSource();
-    
-    var cachedVerificationResult = engine.GetCachedVerificationResult(Implementation, TextWriter.Null);
-    if (cachedVerificationResult != null) {
-      ActualTask = Task.FromResult(cachedVerificationResult);
-      CurrentStatus = VerificationStatus.Completed;
-    } else {
-      CurrentStatus = VerificationStatus.Stale;
-      ActualTask = VerifyImplementationWithStatusTracking(engine);
-    }
-  }
-
-  private async Task<VerificationResult> VerifyImplementationWithStatusTracking(ExecutionEngine engine) {
-    await runWasCalled.Task;
-
-    var enqueueTask = engine.EnqueueVerifyImplementation(ProcessedProgram, new PipelineStatistics(),
-      null, null, Implementation, taskCancellationSource, TextWriter.Null);
-
-    CurrentStatus = enqueueTask.IsCompleted ? VerificationStatus.Running : VerificationStatus.Queued;
-
-    var verifyTask = await enqueueTask;
-    if (CurrentStatus != VerificationStatus.Running) {
-      CurrentStatus = VerificationStatus.Running;
-    }
-
-    var result = await verifyTask;
-    CurrentStatus = VerificationStatus.Completed;
-    observableStatus.OnCompleted();
-    return result;
-  }
-
-  public void Run() {
-    runWasCalled.TrySetResult();
-  }
-
-  public void Cancel() {
-    taskCancellationSource.Cancel();
-    observableStatus.OnCompleted();
-    runWasCalled.TrySetCanceled(taskCancellationSource.Token);
-  }
-}
 
 public enum VerificationStatus {
   Stale,      // Not scheduled to be run
   Queued,     // Scheduled to be run but waiting for resources
   Running,    // Currently running
   Completed,  // Results are available
+}
+
+public interface IImplementationTask {
+  VerificationStatus CacheStatus { get; }
+  ProcessedProgram ProcessedProgram { get; }
+  Implementation Implementation { get; }
+  (Task<VerificationResult>, IObservable<VerificationStatus>) Run(CancellationToken cancellationToken);
+}
+
+public class ImplementationTask : IImplementationTask {
+  private readonly ExecutionEngine engine;
+
+  public VerificationStatus CacheStatus { get; }
+
+  public ProcessedProgram ProcessedProgram { get; }
+
+  public Implementation Implementation { get; }
+  private VerificationResult cachedResult;
+  
+  public ImplementationTask(ExecutionEngine engine, ProcessedProgram processedProgram, Implementation implementation) {
+    this.engine = engine;
+    ProcessedProgram = processedProgram;
+    Implementation = implementation;
+    
+    var cachedVerificationResult = engine.GetCachedVerificationResult(Implementation, TextWriter.Null);
+    if (cachedVerificationResult != null) {
+      cachedResult = cachedVerificationResult;
+      CacheStatus = VerificationStatus.Completed;
+    } else {
+      CacheStatus = VerificationStatus.Stale;
+    }
+  }
+
+  public (Task<VerificationResult>, IObservable<VerificationStatus>) Run(CancellationToken cancellationToken)
+  {
+    var observableStatus = new Subject<VerificationStatus>();
+    var task = RunInternal(cancellationToken, observableStatus.OnNext);
+    task.ContinueWith(r =>
+    {
+      if (r.Exception != null) {
+        observableStatus.OnError(r.Exception);
+      } else {
+        observableStatus.OnCompleted();
+      }
+    }, TaskScheduler.Current);
+    return (task, observableStatus);
+  }
+
+  private async Task<VerificationResult> RunInternal(CancellationToken cancellationToken, Action<VerificationStatus> notifyStatusChange) {
+
+    var enqueueTask = engine.EnqueueVerifyImplementation(ProcessedProgram, new PipelineStatistics(),
+      null, null, Implementation, cancellationToken, TextWriter.Null);
+
+    var afterEnqueueStatus = enqueueTask.IsCompleted ? VerificationStatus.Running : VerificationStatus.Queued;
+    notifyStatusChange(afterEnqueueStatus);
+
+    var verifyTask = await enqueueTask;
+    if (afterEnqueueStatus != VerificationStatus.Running) {
+      notifyStatusChange(VerificationStatus.Running);
+    }
+
+    var result = await verifyTask;
+    notifyStatusChange(VerificationStatus.Completed);
+    return result;
+  }
 }

--- a/Source/ExecutionEngine/ImplementationTask.cs
+++ b/Source/ExecutionEngine/ImplementationTask.cs
@@ -65,7 +65,7 @@ public class ImplementationTask : IImplementationTask {
 
   public void Cancel() {
     if (cancellationSource == null) {
-      throw new InvalidOperationException();
+      throw new InvalidOperationException("There is no ongoing run to cancel");
     }
 
     cancellationSource.Cancel();
@@ -75,7 +75,7 @@ public class ImplementationTask : IImplementationTask {
   public IObservable<IVerificationStatus> Run()
   {
     if (cancellationSource != null) {
-      throw new InvalidOperationException("Cancel must be called after Run before calling Run again");
+      throw new InvalidOperationException("There already an ongoing run.");
     }
     cancellationSource = new();
     var cancellationToken = cancellationSource.Token;

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -27,7 +27,7 @@ namespace ExecutionEngineTests
       var options = CommandLineOptions.FromArguments();
       using var executionEngine = ExecutionEngine.CreateWithoutSharedCache(options);
       var infiniteProgram = GetProgram(executionEngine, SuperSlow);
-      var terminatingProgram = GetProgram(executionEngine, fast);
+      var terminatingProgram = GetProgram(executionEngine, Fast);
       
       // We limit the number of checkers to 1.
       options.VcsCores = 1;
@@ -44,12 +44,12 @@ namespace ExecutionEngineTests
       Assert.AreEqual(PipelineOutcome.VerificationCompleted, outcome2);
     }
 
-    public const string fast = @"
+    private const string Fast = @"
 procedure easy() ensures 1 + 1 == 0; {
 }
 ";
 
-    public const string SuperSlow = @"
+    private const string SuperSlow = @"
   type LayerType;
   function {:identity} LitInt(x: int) : int;
   axiom (forall x: int :: {:identity} { LitInt(x): int } LitInt(x): int == x);

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -26,7 +26,7 @@ namespace ExecutionEngineTests
     public async Task InferAndVerifyCanBeCancelledWhileWaitingForProver() {
       var options = CommandLineOptions.FromArguments();
       using var executionEngine = ExecutionEngine.CreateWithoutSharedCache(options);
-      var infiniteProgram = GetProgram(executionEngine, Slow);
+      var infiniteProgram = GetProgram(executionEngine, SuperSlow);
       var terminatingProgram = GetProgram(executionEngine, fast);
       
       // We limit the number of checkers to 1.
@@ -49,7 +49,7 @@ procedure easy() ensures 1 + 1 == 0; {
 }
 ";
 
-    public const string Slow = @"
+    public const string SuperSlow = @"
   type LayerType;
   function {:identity} LitInt(x: int) : int;
   axiom (forall x: int :: {:identity} { LitInt(x): int } LitInt(x): int == x);

--- a/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/CancellationTests.cs
@@ -26,7 +26,7 @@ namespace ExecutionEngineTests
     public async Task InferAndVerifyCanBeCancelledWhileWaitingForProver() {
       var options = CommandLineOptions.FromArguments();
       using var executionEngine = ExecutionEngine.CreateWithoutSharedCache(options);
-      var infiniteProgram = GetProgram(executionEngine, slow);
+      var infiniteProgram = GetProgram(executionEngine, Slow);
       var terminatingProgram = GetProgram(executionEngine, fast);
       
       // We limit the number of checkers to 1.
@@ -44,12 +44,12 @@ namespace ExecutionEngineTests
       Assert.AreEqual(PipelineOutcome.VerificationCompleted, outcome2);
     }
 
-    private string fast = @"
+    public const string fast = @"
 procedure easy() ensures 1 + 1 == 0; {
 }
 ";
 
-    string slow = @"
+    public const string Slow = @"
   type LayerType;
   function {:identity} LitInt(x: int) : int;
   axiom (forall x: int :: {:identity} { LitInt(x): int } LitInt(x): int == x);

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -50,7 +50,10 @@ procedure Second(y: int)
     Assert.AreEqual(true, firstResult.Errors[0].Model.ModelHasStatesAlready);
 
     tasks[1].Run();
+    var taskSource = new TaskCompletionSource();
+    tasks[1].ObservableStatus.Subscribe(_ => { }, () => taskSource.SetResult());
     tasks[1].Cancel();
+    await taskSource.Task;
     Assert.CatchAsync<TaskCanceledException>(() => tasks[1].ActualTask);
   }
 

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -53,6 +53,7 @@ procedure Second(y: int)
     var taskSource = new TaskCompletionSource();
     tasks[1].ObservableStatus.Subscribe(_ => { }, () => taskSource.SetResult());
     tasks[1].Cancel();
+    tasks[1].Run();
     await taskSource.Task;
     Assert.CatchAsync<TaskCanceledException>(() => tasks[1].ActualTask);
   }

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -219,8 +219,8 @@ procedure {:checksum ""stable""} Good(y: int)
       Merge(second.ObservableStatus.Select(status => (second.Implementation.Name, s: status)));
     statuses.Subscribe(t => statusList.Add(t));
 
-    Assert.AreEqual(VerificationStatus.Stale, first.CurrentStatus);
-    Assert.AreEqual(VerificationStatus.Stale, second.CurrentStatus);
+    Assert.AreEqual(VerificationStatus.Stale, first.CacheStatus);
+    Assert.AreEqual(VerificationStatus.Stale, second.CacheStatus);
 
     first.Run();
     second.Run();
@@ -233,10 +233,10 @@ procedure {:checksum ""stable""} Good(y: int)
     Assert.AreEqual((secondName, VerificationStatus.Completed), statusList[4]);
     
     var tasks2 = engine.GetImplementationTasks(program);
-    Assert.AreEqual(VerificationStatus.Completed, tasks2[0].CurrentStatus);
+    Assert.AreEqual(VerificationStatus.Completed, tasks2[0].CacheStatus);
     Assert.AreEqual(ConditionGeneration.Outcome.Errors, tasks2[0].ActualTask.Result.Outcome);
 
-    Assert.AreEqual(VerificationStatus.Completed, tasks2[1].CurrentStatus);
+    Assert.AreEqual(VerificationStatus.Completed, tasks2[1].CacheStatus);
     Assert.AreEqual(ConditionGeneration.Outcome.Correct, tasks2[1].ActualTask.Result.Outcome);
     var statuses2 = first.ObservableStatus.Merge(second.ObservableStatus);
     Assert.IsFalse(await statuses2.Any().ToTask());

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -44,12 +44,12 @@ procedure Second(y: int)
     var tasks = engine.GetImplementationTasks(program);
     Assert.AreEqual(2, tasks.Count);
     Assert.NotNull(tasks[0].Implementation);
-    var result1 = await tasks[0].RunAndAllowCancel().ToTask();
+    var result1 = await tasks[0].Run().ToTask();
     var verificationResult1 = ((Completed)result1).Result;
     Assert.AreEqual(ConditionGeneration.Outcome.Errors, verificationResult1.Outcome);
     Assert.AreEqual(true, verificationResult1.Errors[0].Model.ModelHasStatesAlready);
 
-    var result2 = await tasks[1].RunAndAllowCancel().ToTask();
+    var result2 = await tasks[1].Run().ToTask();
     var verificationResult2 = ((Completed)result2).Result;
     Assert.AreEqual(ConditionGeneration.Outcome.Correct, verificationResult2.Outcome);
   }
@@ -192,10 +192,10 @@ Boogie program verifier finished with 0 verified, 1 error
     Parser.Parse(source, "fakeFilename1", out var program);
     var tasks = engine.GetImplementationTasks(program)[0];
     var statusList = new List<IVerificationStatus>();
-    var firstStatuses = tasks.RunAndAllowCancel();
+    var firstStatuses = tasks.Run();
     firstStatuses.Subscribe(statusList.Add);
     tasks.Cancel();
-    var secondStatuses = tasks.RunAndAllowCancel();
+    var secondStatuses = tasks.Run();
     secondStatuses.Subscribe(statusList.Add);
     var finalResult = await secondStatuses.ToTask();
     Assert.IsTrue(finalResult is Completed);
@@ -238,9 +238,9 @@ procedure {:checksum ""stable""} Good(y: int)
     Assert.True(first.CacheStatus is Stale);
     Assert.True(second.CacheStatus is Stale);
 
-    var firstStatuses = first.RunAndAllowCancel();
+    var firstStatuses = first.Run();
     firstStatuses.Subscribe(t => statusList.Add(new (firstName, t)));
-    var secondStatuses = second.RunAndAllowCancel();
+    var secondStatuses = second.Run();
     secondStatuses.Subscribe(t => statusList.Add((secondName, t)));
     await firstStatuses.Concat(secondStatuses).ToTask();
 

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -335,6 +335,16 @@ namespace VC
 
     public VCGenOptions Options => CheckerPool.Options;
 
+    record ImplementationTransformationData {
+
+      public bool Passified { get; set; } = false;
+      public bool ConvertedToDAG { get; set; } = false;
+      public Dictionary<TransferCmd, ReturnCmd> GotoCmdOrigins { get; set; }
+      public ModelViewInfo ModelViewInfo { get; set; }
+    }
+
+    private static ConditionalWeakTable<Implementation, ImplementationTransformationData> implementationData = new();
+
     public override async Task<Outcome> VerifyImplementation(ImplementationRun run, VerifierCallback callback,
       CancellationToken cancellationToken)
     {
@@ -356,18 +366,26 @@ namespace VC
       watch.Start();
 #endif
 
-      ConvertCFG2DAG(run.Implementation);
-
-      SmokeTester smoke_tester = null;
-      if (Options.SoundnessSmokeTest)
-      {
-        smoke_tester = new SmokeTester(this, run, callback);
-        smoke_tester.Copy();
+      var data = implementationData.GetOrCreateValue(run.Implementation)!;
+      if (!data.ConvertedToDAG) {
+        data.ConvertedToDAG = true;
+        ConvertCFG2DAG(run.Implementation);
       }
 
-      var gotoCmdOrigins = PassifyImpl(run, out var mvInfo);
+      SmokeTester smokeTester = null;
+      if (Options.SoundnessSmokeTest)
+      {
+        smokeTester = new SmokeTester(this, run, callback);
+        smokeTester.Copy();
+      }
 
-      ExpandAsserts(impl);
+      if (!data.Passified) {
+        data.GotoCmdOrigins = PassifyImpl(run, out var mvInfo);
+        data.ModelViewInfo = mvInfo;
+        data.Passified = true;
+
+        ExpandAsserts(impl);
+      }
 
       Outcome outcome = Outcome.Correct;
 
@@ -387,20 +405,21 @@ namespace VC
             else
             {
               // If possible, we use the old counterexample, but with the location information of "a"
-              var cex = AssertCmdToCloneCounterexample(CheckerPool.Options, a, oldCex, impl.Blocks[0], gotoCmdOrigins);
+              var cex = AssertCmdToCloneCounterexample(CheckerPool.Options, a, oldCex, impl.Blocks[0], data.GotoCmdOrigins);
               callback.OnCounterexample(cex, null);
             }
           }
         }
       }
 
-      var worker = new SplitAndVerifyWorker(Options, this, run, gotoCmdOrigins, callback, mvInfo, outcome);
+      var worker = new SplitAndVerifyWorker(Options, this, run, data.GotoCmdOrigins, callback,
+        data.ModelViewInfo, outcome);
       outcome = await worker.WorkUntilDone(cancellationToken);
       ResourceCount = worker.ResourceCount;
-      
-      if (outcome == Outcome.Correct && smoke_tester != null)
+
+      if (outcome == Outcome.Correct && smokeTester != null)
       {
-        await smoke_tester.Test(run.TraceWriter);
+        await smokeTester.Test(run.TraceWriter);
       }
 
       callback.OnProgress?.Invoke("done", 0, 0, 1.0);

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -380,9 +380,9 @@ namespace VC
       }
 
       if (!data.Passified) {
+        data.Passified = true;
         data.GotoCmdOrigins = PassifyImpl(run, out var mvInfo);
         data.ModelViewInfo = mvInfo;
-        data.Passified = true;
 
         ExpandAsserts(impl);
       }


### PR DESCRIPTION
### Changes

- `Task<VerificationResult> ActualTask`, `VerificationStatus CurrentStatus` and `IObservable<VerificationStatus>` jave been turned into `IVerificationStatus CacheStatus` and `IObservable<IVerificationStatus>`, which leads to cleaner code on the client side.
- Enable calling `IImplementationTask.Run` after cancelling a previous run.

### Testing
Added a test `RunCancelRun`