### PR TITLE
Fixed: Concurrency problem on the Process

### DIFF
--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -309,7 +309,7 @@ public abstract class ProverInterface
     throw new NotImplementedException();
   }
 
-  public abstract Task GoBackToIdle();
+  public abstract Task GoBackToIdle(int msBeforeAssumingProverDied);
 }
 public class UnexpectedProverOutputException : ProverException
 {

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    public override Task GoBackToIdle()
+    public override Task GoBackToIdle(int msBeforeAssumingProverDied)
     {
       return Task.CompletedTask;
     }
@@ -127,6 +127,7 @@ namespace Microsoft.Boogie.SMTLib
     public override async Task<Outcome> CheckOutcomeCore(ErrorHandler handler, CancellationToken cancellationToken,
       int errorLimit)
     {
+      // TODO: shouldn't we restart the prover if proverErrors.Count > 0 ?
       if (Process == null || proverErrors.Count > 0) {
         return Outcome.Undetermined;
       }

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -539,14 +539,14 @@ namespace Microsoft.Boogie.SMTLib
     /// Returns the final result returned by collector, or the default value
     /// </summary>
     private async Task<T> ReadOutputAsync<T>(T defaultValue, Func<SExpr, T, T> collector, CancellationToken cancellationToken) {
-      Process.Ping1();
+      var isPong = Process.Ping("readOutput");
 
       T result = defaultValue;
 
       while (true)
       {
         var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
-        if (resp == null || Process.IsPong1(resp))
+        if (resp == null || isPong(resp))
         {
           break;
         }

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -16,9 +16,14 @@ public abstract class SMTLibSolver
 
   protected abstract void HandleError(string msg);
 
-  public void Ping()
+  public void Ping1()
   {
     Send("(get-info :name)");
+  }
+  
+  public void Ping2()
+  {
+    Send("(get-info :version)");
   }
 
   /// <summary>
@@ -26,7 +31,7 @@ public abstract class SMTLibSolver
   /// </summary>
   public async Task PingPong(int msBeforeAssumingProverDied)
   {
-    Ping();
+    Ping2();
     while (true) {
       SExpr sx;
       try {
@@ -39,17 +44,22 @@ public abstract class SMTLibSolver
       {
         throw new ProverDiedException();
       }
-        
-      if (IsPong(sx))
+      
+      if (IsPong2(sx))
       {
-        return;
+        break;
       }
     }
   }
 
-  public bool IsPong(SExpr sx)
+  public bool IsPong1(SExpr sx)
   {
     return sx is { Name: ":name" };
+  }
+  
+  public bool IsPong2(SExpr sx)
+  {
+    return sx is { Name: ":version" };
   }
 
   public async Task<ProverDiedException> GetExceptionIfProverDied(int msBeforeAssumingProverDied)

--- a/Source/UnitTests/ExecutionEngineTests/ConcurrentToSequentialWriteManagerTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ConcurrentToSequentialWriteManagerTest.cs
@@ -121,7 +121,7 @@ public class ConcurrentToSequentialWriteManagerTest {
     thread2.Join();
     thread3.Join();
 
-    var output = writer.ToString().TrimEnd().Split("\n");
+    var output = writer.ToString().TrimEnd().Replace("\r", "").Split("\n");
 
     for (int i = 0; i < amount; i++) {
       Assert.AreEqual(i.ToString(), output[i]);

--- a/Source/UnitTests/ExecutionEngineTests/OutputPrinterTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/OutputPrinterTest.cs
@@ -44,7 +44,7 @@ namespace ExecutionEngineTests
         );
       smtLibInteractiveTheoremProver.Close();
       // No null pointer exception should arise here
-      await smtLibInteractiveTheoremProver.GoBackToIdle();
+      await smtLibInteractiveTheoremProver.GoBackToIdle(1000);
       Assert.IsTrue(true);
     }
     

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -65,10 +65,9 @@ namespace Microsoft.Boogie
 
       status = CheckerStatus.Idle;
       try {
-        await thmProver.GoBackToIdle().WaitAsync(TimeSpan.FromMilliseconds(100));
+        await thmProver.GoBackToIdle(100);
         Pool.AddChecker(this);
-      }
-      catch(TimeoutException) {
+      } catch (ProverDiedException) {
         Pool.CheckerDied();
         Close();
       }
@@ -371,7 +370,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public override Task GoBackToIdle()
+    public override Task GoBackToIdle(int msBeforeAssumingProverDied)
     {
       throw new NotImplementedException();
     }


### PR DESCRIPTION
Here is a bug that @cpitclaudel  and I identified, when working with Dafny Language Server
1) A verification request is sent to the SMTLibProcess
2) The user press "space" before the verification request is completed

The problem is that the process output can be ignored and never read.

However, because the Dafny Language Server often immediately sends a new verification request, and that this verification requests tries to use the same Checker and thus the same Z3 process, the first "PingPong" request fails because, after sending "ping", it collects the result that was never read in 1)

Moreover, a single proverErrors.Add() and then everything becomes inconclusive, as in this screenshot below:
![image](https://user-images.githubusercontent.com/3601079/172710195-05864c30-24d9-4c77-88dc-9a207e6da575.png)

Note that, if we used the same Ping/Pong pair for PingPong (where it is now time-sensitive) than for the other places (where it can be cancelled using a CancellationToken), we run into the problem that other places could send a Ping, get cancelled, and then on process recovery PingPong sends a Ping and reads their Pong, and assumes it's ok, but there remains an unread Pong

Thus, this PR solves this problem once and forall by the following change
* PingPong now requires a timeout
* If the time expires, it throws a ProverDiedException.
* PingPong uses a Ping2/Pong2 scheme (based on version rather than name)
* Other places that use Ping/Pong to get all the output now use Ping1/Pong1 so that it won't interfere with PingPong.

I also refactored other places that use Ping1/Pong1 so that their logic is centralized into `ReadOutputAsync`

This is not the end of the journey. I still get these kinds of errors when debugging why sometimes the language server crashes:
![image](https://user-images.githubusercontent.com/3601079/172718884-0e0a3775-6be8-4056-a9ac-7153d43195c4.png)

TODO: I still need to create some tests.... but how?