### PR TITLE
Replace SMTLibSolver.GetProverResponse

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.15.3</Version>
+    <Version>2.15.4</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/Houdini/HoudiniSession.cs
+++ b/Source/Houdini/HoudiniSession.cs
@@ -265,8 +265,7 @@ namespace Microsoft.Boogie.Houdini
       DateTime now = DateTime.UtcNow;
 
       VCExpr vc = proverInterface.VCExprGen.Implies(BuildAxiom(proverInterface, assignment), conjecture);
-      await proverInterface.BeginCheck(Description, vc, handler);
-      ProverInterface.Outcome proverOutcome = await proverInterface.CheckOutcome(handler, errorLimit, CancellationToken.None);
+      var proverOutcome = await proverInterface.Check(Description, vc, handler, errorLimit, CancellationToken.None);
 
       double queryTime = (DateTime.UtcNow - now).TotalSeconds;
       stats.proverTime += queryTime;

--- a/Source/Provers/SMTLib/Inspector.cs
+++ b/Source/Provers/SMTLib/Inspector.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Boogie.SMTLib
     }
 
 
-    public Inspector(SMTLibProverOptions opts)
+    public Inspector(SMTLibSolverOptions opts)
     {
       Contract.Requires(opts != null);
       ProcessStartInfo psi = new ProcessStartInfo(opts.Inspector);

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -68,4 +68,8 @@ class NoopSolver : SMTLibSolver
   {
     throw new NotSupportedException();
   }
+
+  public override Task PingPong() {
+    return Task.CompletedTask;
+  }
 }

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -42,7 +42,7 @@ class NoopSolver : SMTLibSolver
     return GetProverResponse();
   }
 
-  public override async Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests) {
+  public override async Task<IReadOnlyList<SExpr>> SendRequestsAndCloseInput(IReadOnlyList<string> requests) {
 
     foreach (var request in requests) {
       Send(request);

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -42,13 +42,22 @@ class NoopSolver : SMTLibSolver
     return GetProverResponse();
   }
 
-  public override Task<SExpr> GetProverResponse()
-  {
-    return Task.FromResult(responses.Count > 0 ? responses.Dequeue() : null);
+  public override async Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests) {
+
+    foreach (var request in requests) {
+      Send(request);
+    }
+    var result = new List<SExpr>();
+    foreach (var request in requests) {
+      result.Add(await GetProverResponse());
+    }
+
+    return result;
   }
 
-  public override void IndicateEndOfInput()
+  private Task<SExpr> GetProverResponse()
   {
+    return Task.FromResult(responses.Count > 0 ? responses.Dequeue() : null);
   }
 
   public override void NewProblem(string descriptiveName)

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -37,8 +37,8 @@ class NoopSolver : SMTLibSolver
     if (response is not null) { responses.Enqueue(response); }
   }
 
-  public override Task<SExpr> SendRequest(string cmd) {
-    Send(cmd);
+  public override Task<SExpr> SendRequest(string request) {
+    Send(request);
     return GetProverResponse();
   }
 

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -64,11 +64,6 @@ class NoopSolver : SMTLibSolver
   {
   }
 
-  protected override void HandleError(string msg)
-  {
-    throw new NotSupportedException();
-  }
-
   public override Task PingPong() {
     return Task.CompletedTask;
   }

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -37,6 +37,11 @@ class NoopSolver : SMTLibSolver
     if (response is not null) { responses.Enqueue(response); }
   }
 
+  public override Task<SExpr> SendRequest(string cmd) {
+    Send(cmd);
+    return GetProverResponse();
+  }
+
   public override Task<SExpr> GetProverResponse()
   {
     return Task.FromResult(responses.Count > 0 ? responses.Dequeue() : null);

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -169,10 +169,7 @@ public abstract class ProverInterface
     }
   }
 
-  public abstract Task BeginCheck(string descriptiveName, VCExpr vc, ErrorHandler handler);
-
-  [NoDefaultContract]
-  public abstract Task<Outcome> CheckOutcome(ErrorHandler handler, int errorLimit, CancellationToken cancellationToken);
+  public abstract Task<Outcome> Check(string descriptiveName, VCExpr vc, ErrorHandler handler, int errorLimit, CancellationToken cancellationToken);
 
   public virtual void LogComment(string comment)
   {
@@ -255,12 +252,6 @@ public abstract class ProverInterface
 
   public virtual Task<(Outcome, List<int>)> CheckAssumptions(List<VCExpr> hardAssumptions, List<VCExpr> softAssumptions,
     ErrorHandler handler, CancellationToken cancellationToken)
-  {
-    throw new NotImplementedException();
-  }
-
-  public virtual Task<Outcome> CheckOutcomeCore(ErrorHandler handler,
-    CancellationToken cancellationToken, int errorLimit)
   {
     throw new NotImplementedException();
   }

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -225,7 +225,7 @@ public abstract class ProverInterface
     throw new NotImplementedException();
   }
 
-  public virtual List<string> UnsatCore()
+  public virtual Task<List<string>> UnsatCore()
   {
     throw new NotImplementedException();
   }

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -102,7 +102,6 @@ public abstract class ProverInterface
   }
 
   public readonly ISet<VCExprVar> NamedAssumes = new HashSet<VCExprVar>();
-  public ISet<string> UsedNamedAssumes { get; protected set; }
 
   public class ErrorHandler
   {

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Boogie.SMTLib
       return Task.FromResult(resourceCount);
     }
 
-    public override List<string> UnsatCore()
+    public override Task<List<string>> UnsatCore()
     {
       throw new NotSupportedException("Batch mode solver interface does not support unsat cores.");
     }

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -111,6 +111,15 @@ namespace Microsoft.Boogie.SMTLib
       UsedNamedAssumes = null;
     }
 
+    private Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests) {
+      var sanitizedRequests = requests.Select(Sanitize).ToList();
+      foreach (var request in sanitizedRequests) {
+        currentLogFile.WriteLine(request);
+      }
+      currentLogFile.Flush();
+      return Process.SendRequestsAndClose(sanitizedRequests);
+    }
+
     private async Task<Outcome> CheckSat(ErrorHandler handler, CancellationToken cancellationToken)
     {
       UsedNamedAssumes = null;
@@ -130,7 +139,7 @@ namespace Microsoft.Boogie.SMTLib
         currentErrorHandler = handler;
         FlushProverWarnings();
 
-        var responses = await Process.SendRequestsAndClose(requests.Select(Sanitize).ToList()).WaitAsync(cancellationToken);
+        var responses = await SendRequestsAndClose(requests).WaitAsync(cancellationToken);
 
         var outcomeSExp = responses[0];
         var result = ParseOutcome(outcomeSExp, out var wasUnknown);

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -83,11 +83,11 @@ namespace Microsoft.Boogie.SMTLib
       Push();
       SendVCAndOptions(descriptiveName, vcString);
       SendOptimizationRequests();
-      checkSatSent = true;
 
       FlushLogFile();
 
       Process.NewProblem(descriptiveName);
+      checkSatSent = true;
 
       var result = CheckSat(handler, cancellationToken);
       Pop();

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -111,7 +111,6 @@ namespace Microsoft.Boogie.SMTLib
       AxiomsAreSetup = false;
       DeclCollector.Reset();
       NamedAssumes.Clear();
-      UsedNamedAssumes = null;
     }
 
     private Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests) {
@@ -125,7 +124,6 @@ namespace Microsoft.Boogie.SMTLib
 
     private async Task<Outcome> CheckSat(ErrorHandler handler, CancellationToken cancellationToken)
     {
-      UsedNamedAssumes = null;
       var requests = new List<string>();
       requests.Add("(check-sat)");
       requests.Add("(get-info :reason-unknown)");

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -59,8 +59,8 @@ namespace Microsoft.Boogie.SMTLib
       return 0;
     }
 
-    public override Task BeginCheck(string descriptiveName, VCExpr vc, ErrorHandler handler)
-    {
+    public override Task<Outcome> Check(string descriptiveName, VCExpr vc, ErrorHandler handler, int errorLimit,
+      CancellationToken cancellationToken) {
       SetupProcess();
       CheckSatSent = false;
       FullReset(gen);
@@ -90,7 +90,8 @@ namespace Microsoft.Boogie.SMTLib
       Pop();
 
       FlushLogFile();
-      return Task.CompletedTask;
+
+      return CheckOutcomeCore(handler, cancellationToken, errorLimit);
     }
 
     public override Task Reset(VCExpressionGenerator generator) {
@@ -112,19 +113,8 @@ namespace Microsoft.Boogie.SMTLib
       UsedNamedAssumes = null;
     }
 
-    // TODO: move to base?
     [NoDefaultContract]
-    public override async Task<Outcome> CheckOutcome(ErrorHandler handler, int errorLimit, CancellationToken cancellationToken)
-    {
-      var result = await CheckOutcomeCore(handler, cancellationToken, errorLimit);
-
-      FlushLogFile();
-
-      return result;
-    }
-
-    [NoDefaultContract]
-    public override async Task<Outcome> CheckOutcomeCore(ErrorHandler handler, CancellationToken cancellationToken,
+    public async Task<Outcome> CheckOutcomeCore(ErrorHandler handler, CancellationToken cancellationToken,
       int errorLimit)
     {
       if (Process == null || proverErrors.Count > 0) {

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Boogie.SMTLib
   /// </summary>
   public class SMTLibBatchTheoremProver : SMTLibProcessTheoremProver
   {
+    private bool checkSatSent;
     private int resourceCount;
     private Model errorModel;
     private ScopedNamer namer;
@@ -63,6 +64,7 @@ namespace Microsoft.Boogie.SMTLib
     public override Task<Outcome> Check(string descriptiveName, VCExpr vc, ErrorHandler handler, int errorLimit,
       CancellationToken cancellationToken) {
       SetupProcess();
+      checkSatSent = false;
       FullReset(gen);
 
       if (options.LogFilename != null && currentLogFile == null) {
@@ -81,6 +83,7 @@ namespace Microsoft.Boogie.SMTLib
       Push();
       SendVCAndOptions(descriptiveName, vcString);
       SendOptimizationRequests();
+      checkSatSent = true;
 
       FlushLogFile();
 
@@ -241,7 +244,9 @@ namespace Microsoft.Boogie.SMTLib
       // Boogie emits comments after the solver has responded. In batch
       // mode, sending these to the solver is problematic. But they'll
       // still get sent to the log below.
-      // Process.Send(s);
+      if (Process != null && !checkSatSent) {
+        Process.Send(s);
+      }
 
       if (currentLogFile != null) {
         currentLogFile.WriteLine(s);

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -117,10 +117,10 @@ namespace Microsoft.Boogie.SMTLib
     private Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests) {
       var sanitizedRequests = requests.Select(Sanitize).ToList();
       foreach (var request in sanitizedRequests) {
-        currentLogFile.WriteLine(request);
+        currentLogFile?.WriteLine(request);
       }
-      currentLogFile.Flush();
-      return Process.SendRequestsAndClose(sanitizedRequests);
+      currentLogFile?.Flush();
+      return Process.SendRequestsAndCloseInput(sanitizedRequests);
     }
 
     private async Task<Outcome> CheckSat(ErrorHandler handler, CancellationToken cancellationToken)

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Boogie.SMTLib
     }
 
     private bool hasReset = true;
-    public override async Task BeginCheck(string descriptiveName, VCExpr vc, ErrorHandler handler)
+    public override async Task<Outcome> Check(string descriptiveName, VCExpr vc, ErrorHandler handler, int errorLimit, CancellationToken cancellationToken)
     {
       if (options.SeparateLogFiles)
       {
@@ -110,8 +110,10 @@ namespace Microsoft.Boogie.SMTLib
         hasReset = false;
       }
 
-      SendCheckSat();
-      FlushLogFile();
+      var result = await CheckSat(handler, cancellationToken, errorLimit);
+      SendThisVC("(pop 1)");
+
+      return result;
     }
 
     public override async Task Reset(VCExpressionGenerator generator)
@@ -170,21 +172,11 @@ namespace Microsoft.Boogie.SMTLib
     }
 
     [NoDefaultContract]
-    public override async Task<Outcome> CheckOutcome(ErrorHandler handler, int errorLimit, CancellationToken cancellationToken)
-    {
-      Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
-
-      var result = await CheckOutcomeCore(handler, cancellationToken, errorLimit);
-      SendThisVC("(pop 1)");
-      FlushLogFile();
-
-      return result;
-    }
-
-    [NoDefaultContract]
-    public override async Task<Outcome> CheckOutcomeCore(ErrorHandler handler, CancellationToken cancellationToken,
+    public async Task<Outcome> CheckSat(ErrorHandler handler, CancellationToken cancellationToken,
       int errorLimit)
     {
+      UsedNamedAssumes = null;
+
       Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
 
       var result = Outcome.Undetermined;
@@ -212,7 +204,7 @@ namespace Microsoft.Boogie.SMTLib
           {
             errorsDiscovered++;
 
-            result = await GetResponse(cancellationToken);
+            result = await CheckSatAndGetResponse(cancellationToken);
 
             var reporter = handler;
             // TODO(wuestholz): Is the reporter ever null?
@@ -221,8 +213,7 @@ namespace Microsoft.Boogie.SMTLib
               if (usingUnsatCore)
               {
                 UsedNamedAssumes = new HashSet<string>();
-                SendThisVC("(get-unsat-core)");
-                var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
+                var resp = await SendVcRequest("(get-unsat-core)").WaitAsync(cancellationToken);
                 if (resp.Name != "")
                 {
                   UsedNamedAssumes.Add(resp.Name);
@@ -297,7 +288,6 @@ namespace Microsoft.Boogie.SMTLib
           var target = labels[^1];
           // block the assert which was falsified by this counterexample
           SendThisVC($"(assert (not (= (ControlFlow 0 {source}) (- {target}))))");
-          SendCheckSat();
         }
 
         FlushLogFile();
@@ -313,6 +303,18 @@ namespace Microsoft.Boogie.SMTLib
       {
         currentErrorHandler = null;
       }
+    }
+
+    private Task<SExpr> SendVcRequest(string s) {
+      s = Sanitize(s);
+
+      if (currentLogFile != null)
+      {
+        currentLogFile.WriteLine(s);
+        currentLogFile.Flush();
+      }
+
+      return Process.SendRequest(s);
     }
 
     private T WrapInPushPop<T>(ref bool popLater, Func<T> action)
@@ -458,18 +460,17 @@ namespace Microsoft.Boogie.SMTLib
       }
 
       FlushLogFile();
-      SendCheckSat();
       queries++;
-      return GetResponse(cancellationToken);
+      return CheckSatAndGetResponse(cancellationToken);
     }
 
     private async Task<string[]> CalculatePath(int controlFlowConstant, CancellationToken cancellationToken)
     {
-      SendThisVC($"(get-value (({VCExpressionGenerator.ControlFlowName} " + controlFlowConstant + " 0)))");
       var path = new List<string>();
+      string v = "0";
       while (true)
       {
-        var response = await Process.GetProverResponse().WaitAsync(cancellationToken);
+        var response = await Process.SendRequest($"(get-value (({VCExpressionGenerator.ControlFlowName} {controlFlowConstant} {v})))").WaitAsync(cancellationToken);
         if (response == null)
         {
           break;
@@ -487,7 +488,7 @@ namespace Microsoft.Boogie.SMTLib
         }
 
         response = response.Arguments[1];
-        var v = response.Name;
+        v = response.Name;
         if (v == "-" && response.ArgCount == 1)
         {
           v = response.Arguments[0].Name;
@@ -500,7 +501,6 @@ namespace Microsoft.Boogie.SMTLib
         }
 
         path.Add(v);
-        SendThisVC("(get-value ((ControlFlow " + controlFlowConstant + " " + v + ")))");
       }
 
       return path.ToArray();
@@ -535,37 +535,23 @@ namespace Microsoft.Boogie.SMTLib
       return theModel;
     }
 
-    private async Task<Outcome> GetResponse(CancellationToken cancellationToken)
+    private async Task<Outcome> CheckSatAndGetResponse(CancellationToken cancellationToken)
     {
       var result = Outcome.Undetermined;
       var wasUnknown = false;
 
-      Process.Ping();
-
-      while (true)
+      var checkSatResponse = await SendVcRequest("(check-sat)").WaitAsync(cancellationToken);
+      if (checkSatResponse != null)
       {
-        var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
-        if (resp == null || Process.IsPong(resp))
-        {
-          break;
-        }
-
-        result = ParseOutcome(resp, out wasUnknown);
+        result = ParseOutcome(checkSatResponse, out wasUnknown);
       }
 
       if (wasUnknown)
       {
-        SendThisVC("(get-info :reason-unknown)");
-        Process.Ping();
-        while (true)
+        var getInfoResponse = await SendVcRequest("(get-info :reason-unknown)").WaitAsync(cancellationToken);
+        if (getInfoResponse != null)
         {
-          var resp = await Process.GetProverResponse().WaitAsync(cancellationToken);
-          if (resp == null || Process.IsPong(resp))
-          {
-            break;
-          }
-
-          result = ParseReasonUnknown(resp, result);
+          result = ParseReasonUnknown(getInfoResponse, result);
           if (result == Outcome.OutOfMemory) {
             processNeedsRestart = true;
           }
@@ -683,7 +669,6 @@ namespace Microsoft.Boogie.SMTLib
 
     public override void Check()
     {
-      PrepareCommon();
       SendCheckSat();
       FlushLogFile();
     }
@@ -759,9 +744,8 @@ namespace Microsoft.Boogie.SMTLib
         i++;
       }
 
-      Check();
-
-      var outcome = await CheckOutcomeCore(handler, cancellationToken, libOptions.ErrorLimit);
+      PrepareCommon();
+      var outcome = await CheckSat(handler, cancellationToken, libOptions.ErrorLimit);
 
       if (outcome != Outcome.Valid)
       {
@@ -815,8 +799,8 @@ namespace Microsoft.Boogie.SMTLib
         SendThisVC("(assert " + a + ")");
       }
 
-      Check();
-      var outcome = await GetResponse(cancellationToken);
+      PrepareCommon();
+      var outcome = await CheckSatAndGetResponse(cancellationToken);
       if (outcome != Outcome.Invalid)
       {
         Pop();
@@ -834,8 +818,8 @@ namespace Microsoft.Boogie.SMTLib
           SendThisVC("(assert " + a + ")");
         }
 
-        Check();
-        outcome = await CheckOutcomeCore(handler, cancellationToken, libOptions.ErrorLimit);
+        PrepareCommon();
+        outcome = await CheckSat(handler, cancellationToken, libOptions.ErrorLimit);
         if (outcome != Outcome.Valid)
         {
           break;

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -175,8 +175,6 @@ namespace Microsoft.Boogie.SMTLib
     public async Task<Outcome> CheckSat(ErrorHandler handler, CancellationToken cancellationToken,
       int errorLimit)
     {
-      UsedNamedAssumes = null;
-
       Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
 
       var result = Outcome.Undetermined;
@@ -647,18 +645,6 @@ namespace Microsoft.Boogie.SMTLib
       SendThisVC("(get-unsat-core)");
       var resp = await SendVcRequest("(get-unsat-core)");
       return ParseUnsatCore(resp.ToString());
-    }
-
-    public override void Check()
-    {
-      SendCheckSat();
-      FlushLogFile();
-    }
-
-    private void SendCheckSat()
-    {
-      UsedNamedAssumes = null;
-      SendThisVC("(check-sat)");
     }
 
     protected override void Send(string s, bool isCommon)

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Boogie.SMTLib
     private bool processNeedsRestart;
     private ScopedNamer commonNamer;
     private ScopedNamer finalNamer;
+    private ISet<string> usedNamedAssumes;
 
     [NotDelayed]
     public SMTLibInteractiveTheoremProver(SMTLibOptions libOptions, ProverOptions options, VCExpressionGenerator gen,
@@ -166,7 +167,7 @@ namespace Microsoft.Boogie.SMTLib
         ctx.parent = this;
         DeclCollector.Reset();
         NamedAssumes.Clear();
-        UsedNamedAssumes = null;
+        usedNamedAssumes = null;
         SendThisVC("; did a full reset");
       }
     }
@@ -210,11 +211,11 @@ namespace Microsoft.Boogie.SMTLib
             {
               if (usingUnsatCore)
               {
-                UsedNamedAssumes = new HashSet<string>();
+                usedNamedAssumes = new HashSet<string>();
                 var resp = await SendVcRequest("(get-unsat-core)").WaitAsync(cancellationToken);
                 if (resp.Name != "")
                 {
-                  UsedNamedAssumes.Add(resp.Name);
+                  usedNamedAssumes.Add(resp.Name);
                   if (libOptions.PrintNecessaryAssumes)
                   {
                     reporter.AddNecessaryAssume(resp.Name.Substring("aux$$assume$$".Length));
@@ -223,7 +224,7 @@ namespace Microsoft.Boogie.SMTLib
 
                 foreach (var arg in resp.Arguments)
                 {
-                  UsedNamedAssumes.Add(arg.Name);
+                  usedNamedAssumes.Add(arg.Name);
                   if (libOptions.PrintNecessaryAssumes)
                   {
                     reporter.AddNecessaryAssume(arg.Name.Substring("aux$$assume$$".Length));
@@ -232,7 +233,7 @@ namespace Microsoft.Boogie.SMTLib
               }
               else
               {
-                UsedNamedAssumes = null;
+                usedNamedAssumes = null;
               }
             }
 

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Boogie.SMTLib
   {
     public SMTLibOptions LibOptions { get; }
 
-    public SMTLibExprLineariser(TextWriter wr, UniqueNamer namer, SMTLibOptions libOptions, SMTLibProverOptions opts,
+    public SMTLibExprLineariser(TextWriter wr, UniqueNamer namer, SMTLibOptions libOptions, SMTLibSolverOptions opts,
       ISet<VCExprVar> namedAssumes = null, IList<string> optReqs = null) : this(libOptions)
     {
       Contract.Requires(wr != null);
       Contract.Requires(namer != null);
       this.wr = wr;
       this.Namer = namer;
-      this.ProverOptions = opts;
+      this.solverOptions = opts;
       this.OptimizationRequests = optReqs;
       this.NamedAssumes = namedAssumes;
     }
@@ -62,7 +62,7 @@ namespace Microsoft.Boogie.SMTLib
       return "Select_" + TypeToString(node[0].Type);
     }
     
-    public static string ToString(VCExpr e, UniqueNamer namer, SMTLibOptions libOptions, SMTLibProverOptions opts,
+    public static string ToString(VCExpr e, UniqueNamer namer, SMTLibOptions libOptions, SMTLibSolverOptions opts,
       ISet<VCExprVar> namedAssumes = null, IList<string> optReqs = null, ISet<VCExprVar> tryAssumes = null)
     {
       Contract.Requires(e != null);
@@ -106,7 +106,7 @@ namespace Microsoft.Boogie.SMTLib
 
     internal readonly UniqueNamer Namer;
     internal int UnderQuantifier = 0;
-    internal readonly SMTLibProverOptions ProverOptions;
+    internal readonly SMTLibSolverOptions solverOptions;
 
     readonly IList<string> OptimizationRequests;
     readonly ISet<VCExprVar> NamedAssumes;
@@ -386,7 +386,7 @@ namespace Microsoft.Boogie.SMTLib
       {
         string optOp = node.Op.Equals(VCExpressionGenerator.MinimizeOp) ? "minimize" : "maximize";
         OptimizationRequests.Add(string.Format("({0} {1})", optOp,
-          ToString(node[0], Namer, LibOptions, ProverOptions, NamedAssumes)));
+          ToString(node[0], Namer, LibOptions, solverOptions, NamedAssumes)));
         Linearise(node[1], options);
         return true;
       }
@@ -442,7 +442,7 @@ namespace Microsoft.Boogie.SMTLib
 
         VCQuantifierInfo info = node.Info;
         var weight = info.weight;
-        if (!ProverOptions.UseWeights)
+        if (!solverOptions.UseWeights)
         {
           weight = 1;
         }
@@ -706,7 +706,7 @@ namespace Microsoft.Boogie.SMTLib
       public bool VisitCustomOp(VCExprNAry node, LineariserOptions options)
       {
         VCExprCustomOp op = (VCExprCustomOp) node.Op;
-        if (!ExprLineariser.ProverOptions.UseTickleBool && op.Name == "tickleBool")
+        if (!ExprLineariser.solverOptions.UseTickleBool && op.Name == "tickleBool")
         {
           ExprLineariser.Linearise(VCExpressionGenerator.True, options);
         }

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -94,7 +93,7 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    public override void IndicateEndOfInput()
+    private void IndicateEndOfInput()
     {
       prover.StandardInput.Close();
       toProver = null;
@@ -144,9 +143,22 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
+    public override async Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests) {
+      foreach (var request in requests) {
+        Send(request);
+      }
+      IndicateEndOfInput();
+      var result = new List<SExpr>();
+      foreach (var request in requests) {
+        result.Add(await GetProverResponse());
+      }
+
+      return result;
+    }
+
     private Inspector Inspector { get; }
 
-    public override async Task<SExpr> GetProverResponse()
+    private async Task<SExpr> GetProverResponse()
     {
       if (toProver != null) {
         await toProver.FlushAsync();

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -189,6 +189,7 @@ namespace Microsoft.Boogie.SMTLib
         foreach (var request in requests) {
           Send(request);
         }
+        IndicateEndOfInput();
         foreach (var request in requests) {
           var response = await GetProverResponse();
           result.Add(response);

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -135,9 +135,9 @@ namespace Microsoft.Boogie.SMTLib
     }
 
     // TODO, consider building in a PingPong to catch a missing response.
-    public override Task<SExpr> SendRequest(string cmd) {
+    public override Task<SExpr> SendRequest(string request) {
       lock (myLock) {
-        Send(cmd);
+        Send(request);
         return GetProverResponse();
       }
     }

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -142,9 +142,9 @@ namespace Microsoft.Boogie.SMTLib
       try {
         await previousRequestsAreDone.WaitAsync();
         Console.WriteLine($"entered for {GetHashCode()}");
+        Send(request);
+        Send(PingRequest);
         while (true) {
-          Send(request);
-          Send(PingRequest);
           var response = await GetProverResponse();
           if (IsPong(response)) {
             if (previousResponse == null) {

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -131,7 +131,6 @@ namespace Microsoft.Boogie.SMTLib
         Console.WriteLine("[SMT-INP-{0}] {1}", smtProcessId, log);
       }
 
-      Console.WriteLine($"{GetHashCode()}: sent " + cmd);
       toProver.WriteLine(cmd);
       toProver.Flush();
     }
@@ -141,7 +140,6 @@ namespace Microsoft.Boogie.SMTLib
       SExpr previousResponse = null;
       try {
         await previousRequestsAreDone.WaitAsync();
-        Console.WriteLine($"entered for {GetHashCode()}");
         Send(request);
         Send(PingRequest);
         while (true) {
@@ -156,7 +154,6 @@ namespace Microsoft.Boogie.SMTLib
         }
       }
       finally {
-        Console.WriteLine($"left for {GetHashCode()}");
         previousRequestsAreDone.Release();
       }
     }
@@ -164,7 +161,6 @@ namespace Microsoft.Boogie.SMTLib
     public override async Task PingPong() {
       try {
         await previousRequestsAreDone.WaitAsync();
-        Console.WriteLine($"entered for {GetHashCode()}");
         Send(PingRequest);
         while (true) {
           var response = await GetProverResponse();
@@ -178,11 +174,10 @@ namespace Microsoft.Boogie.SMTLib
             return;
           }
 
-          //HandleError("Invalid PING response from the prover: " + response.ToString());
+          HandleError("Invalid PING response from the prover: " + response.ToString());
         }
       }
       finally {
-        Console.WriteLine($"left for {GetHashCode()}");
         previousRequestsAreDone.Release();
       }
     }
@@ -190,7 +185,6 @@ namespace Microsoft.Boogie.SMTLib
     public override async Task<IReadOnlyList<SExpr>> SendRequestsAndCloseInput(IReadOnlyList<string> requests) {
       try {
         await previousRequestsAreDone.WaitAsync();
-        Console.WriteLine($"entered for {GetHashCode()}");
         var result = new List<SExpr>();
         foreach (var request in requests) {
           Send(request);
@@ -203,7 +197,6 @@ namespace Microsoft.Boogie.SMTLib
         return result;
       }
       finally {
-        Console.WriteLine($"left for {GetHashCode()}");
         previousRequestsAreDone.Release();
       }
     }
@@ -527,7 +520,6 @@ namespace Microsoft.Boogie.SMTLib
           Console.WriteLine("[SMT-OUT-{0}] {1}", smtProcessId, e.Data);
         }
 
-        Console.WriteLine($"{GetHashCode()}: received " + e.Data);
         proverOutput.Enqueue(e.Data);
     }
 

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Boogie.SMTLib
         IndicateEndOfInput();
         foreach (var request in requests) {
           var response = await GetProverResponse();
-          if (response.Name.Equals("timeout")) {
+          if (response is { Name: "timeout" }) {
             throw new TimeoutException();
           }
           result.Add(response);

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -193,7 +193,6 @@ namespace Microsoft.Boogie.SMTLib
         foreach (var request in requests) {
           var response = await GetProverResponse();
           result.Add(response);
-          Console.WriteLine($"response for request {request} was {response}");
         }
 
         return result;

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -190,6 +190,9 @@ namespace Microsoft.Boogie.SMTLib
         IndicateEndOfInput();
         foreach (var request in requests) {
           var response = await GetProverResponse();
+          if (response.Name.Equals("timeout")) {
+            throw new TimeoutException();
+          }
           result.Add(response);
         }
 

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Boogie.SMTLib
       toProver.WriteLine(cmd);
     }
 
+    // TODO, consider building in a PingPong to catch a missing response.
     public override Task<SExpr> SendRequest(string cmd) {
       lock (this) {
         Send(cmd);

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    public override async Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests) {
+    public override async Task<IReadOnlyList<SExpr>> SendRequestsAndCloseInput(IReadOnlyList<string> requests) {
       List<Task<SExpr>> responses;
       lock (myLock) {
         foreach (var request in requests) {

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Boogie.SMTLib
     protected SMTLibOptions libOptions;
     protected SMTLibProverContext ctx;
     protected VCExpressionGenerator gen;
-    protected SMTLibProverOptions options;
+    protected SMTLibSolverOptions options;
     protected bool usingUnsatCore;
     private string backgroundPredicates;
     internal TypeAxiomBuilder AxBuilder { get; set; }
@@ -52,7 +52,7 @@ namespace Microsoft.Boogie.SMTLib
       Contract.Requires(gen != null);
       Contract.Requires(ctx != null);
 
-      this.options = (SMTLibProverOptions) options;
+      this.options = (SMTLibSolverOptions) options;
       this.libOptions = libOptions;
       this.ctx = ctx;
       this.gen = gen;
@@ -1661,7 +1661,7 @@ namespace Microsoft.Boogie.SMTLib
       List<string> /*!>!*/
         proverCommands = new List<string /*!*/>();
       proverCommands.Add("smtlib");
-      var opts = (SMTLibProverOptions) options;
+      var opts = (SMTLibSolverOptions) options;
       if (opts.Solver == SolverKind.Z3)
       {
         proverCommands.Add("z3");
@@ -1677,7 +1677,7 @@ namespace Microsoft.Boogie.SMTLib
 
     public override ProverOptions BlankProverOptions(SMTLibOptions libOptions)
     {
-      return new SMTLibProverOptions(libOptions);
+      return new SMTLibSolverOptions(libOptions);
     }
 
     protected virtual SMTLibProcessTheoremProver SpawnProver(SMTLibOptions libOptions, ProverOptions options,

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,11 +11,10 @@ public abstract class SMTLibSolver
   public abstract void Close();
   public abstract void Send(string cmd);
   public abstract Task<SExpr> SendRequest(string cmd);
-  
-  public abstract Task<SExpr> GetProverResponse();
-  public abstract void NewProblem(string descriptiveName);
 
-  public abstract void IndicateEndOfInput();
+  public abstract Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests);
+
+  public abstract void NewProblem(string descriptiveName);
 
   protected abstract void HandleError(string msg);
 

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -9,7 +9,7 @@ public abstract class SMTLibSolver
   public abstract event Action<string> ErrorHandler;
   public abstract void Close();
   public abstract void Send(string cmd);
-  public abstract Task<SExpr> SendRequest(string cmd);
+  public abstract Task<SExpr> SendRequest(string request);
 
   public abstract Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests);
 

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Boogie.SMTLib;
@@ -18,11 +17,6 @@ public abstract class SMTLibSolver
 
   protected abstract void HandleError(string msg);
 
-  public void Ping()
-  {
-    Send("(get-info :name)");
-  }
-
   public async Task PingPong() {
     var response = await SendRequest("(get-info :name)");
     if (response == null)
@@ -30,18 +24,13 @@ public abstract class SMTLibSolver
       throw new ProverDiedException();
     }
 
-    if (IsPong(response))
+    if (response is { Name: ":name" })
     {
       return;
     }
 
     HandleError("Invalid PING response from the prover: " + response.ToString());
     await PingPong();
-  }
-
-  public bool IsPong(SExpr sx)
-  {
-    return sx is { Name: ":name" };
   }
 
   public async Task<ProverDiedException> GetExceptionIfProverDied()

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -16,8 +16,6 @@ public abstract class SMTLibSolver
 
   public abstract void NewProblem(string descriptiveName);
 
-  protected abstract void HandleError(string msg);
-
   public abstract Task PingPong();
 
   public static bool IsPong(SExpr response)

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -11,7 +11,7 @@ public abstract class SMTLibSolver
   public abstract void Send(string cmd);
   public abstract Task<SExpr> SendRequest(string request);
 
-  public abstract Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests);
+  public abstract Task<IReadOnlyList<SExpr>> SendRequestsAndCloseInput(IReadOnlyList<string> requests);
 
   public abstract void NewProblem(string descriptiveName);
 

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -9,6 +9,8 @@ public abstract class SMTLibSolver
   public abstract event Action<string> ErrorHandler;
   public abstract void Close();
   public abstract void Send(string cmd);
+  public abstract Task<SExpr> SendRequest(string cmd);
+  
   public abstract Task<SExpr> GetProverResponse();
   public abstract void NewProblem(string descriptiveName);
 

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Boogie.SMTLib;
 
 public abstract class SMTLibSolver
 {
+  public const string PingRequest = "(get-info :name)";
   public abstract event Action<string> ErrorHandler;
   public abstract void Close();
   public abstract void Send(string cmd);
@@ -17,20 +18,11 @@ public abstract class SMTLibSolver
 
   protected abstract void HandleError(string msg);
 
-  public async Task PingPong() {
-    var response = await SendRequest("(get-info :name)");
-    if (response == null)
-    {
-      throw new ProverDiedException();
-    }
+  public abstract Task PingPong();
 
-    if (response is { Name: ":name" })
-    {
-      return;
-    }
-
-    HandleError("Invalid PING response from the prover: " + response.ToString());
-    await PingPong();
+  public static bool IsPong(SExpr response)
+  {
+    return response is { Name: ":name" };
   }
 
   public async Task<ProverDiedException> GetExceptionIfProverDied()

--- a/Source/Provers/SMTLib/SMTLibSolver.cs
+++ b/Source/Provers/SMTLib/SMTLibSolver.cs
@@ -23,26 +23,20 @@ public abstract class SMTLibSolver
     Send("(get-info :name)");
   }
 
-  public async Task PingPong()
-  {
-    Ping();
-    while (true)
+  public async Task PingPong() {
+    var response = await SendRequest("(get-info :name)");
+    if (response == null)
     {
-      var sx = await GetProverResponse();
-      if (sx == null)
-      {
-        throw new ProverDiedException();
-      }
-
-      if (IsPong(sx))
-      {
-        return;
-      }
-      else
-      {
-        HandleError("Invalid PING response from the prover: " + sx.ToString());
-      }
+      throw new ProverDiedException();
     }
+
+    if (IsPong(response))
+    {
+      return;
+    }
+
+    HandleError("Invalid PING response from the prover: " + response.ToString());
+    await PingPong();
   }
 
   public bool IsPong(SExpr sx)

--- a/Source/Provers/SMTLib/SMTLibSolverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibSolverOptions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Boogie.SMTLib
     NoOpWithZ3Options
   }
 
-  public class SMTLibProverOptions : ProverOptions
+  public class SMTLibSolverOptions : ProverOptions
   {
     public bool UseWeights = true;
     public bool UseTickleBool => Solver == SolverKind.Z3;
@@ -45,7 +45,7 @@ namespace Microsoft.Boogie.SMTLib
     // Z3 specific (at the moment; some of them make sense also for other provers)
     public string Inspector = null;
 
-    public SMTLibProverOptions(SMTLibOptions libOptions) : base(libOptions)
+    public SMTLibSolverOptions(SMTLibOptions libOptions) : base(libOptions)
     {
     }
 

--- a/Source/Provers/SMTLib/Z3.cs
+++ b/Source/Provers/SMTLib/Z3.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Boogie.SMTLib
     public static string SmtRandomSeed = "smt.random_seed";
     public static string SatRandomSeed = "sat.random_seed";
     
-    public static void SetDefaultOptions(SMTLibProverOptions options)
+    public static void SetDefaultOptions(SMTLibSolverOptions options)
     {
       options.AddWeakSmtOption("smt.mbqi", "false"); // default: true
 

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -87,7 +87,8 @@ Boogie program verifier finished with 0 verified, 2 errors
       var writer = new StringWriter();
       Parser.Parse(programString, "fakeFilename1", out var program);
       await engine.ProcessProgram(writer, program, "fakeFilename");
-      Assert.AreEqual(expected, writer.ToString());
+      var result = writer.ToString();
+      Assert.AreEqual(expected, result, "iteration {0}", i);
     }
   }
 

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -222,12 +222,12 @@ procedure FibTest() {
     options.VerifySnapshots = 1;
     var engine = ExecutionEngine.CreateWithoutSharedCache(options);
 
-    var programString = @"procedure {:checksum ""stable""} Bad(y: int)
+    var programString = @"procedure {:priority 3} {:checksum ""stable""} Bad(y: int)
 {
   assert 2 == 1;
 }
 
-procedure {:checksum ""stable""} Good(y: int)
+procedure {:priority 2} {:checksum ""stable""} Good(y: int)
 {
   assert 2 == 2;
 }

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -88,7 +88,7 @@ Boogie program verifier finished with 0 verified, 2 errors
       Parser.Parse(programString, "fakeFilename1", out var program);
       await engine.ProcessProgram(writer, program, "fakeFilename");
       var result = writer.ToString();
-      Assert.AreEqual(expected, result, "iteration {0}", i);
+      Assert.AreEqual(expected, result, $"iteration {i}, result {result}");
     }
   }
 

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -223,12 +223,12 @@ procedure FibTest() {
     options.VerifySnapshots = 1;
     var engine = ExecutionEngine.CreateWithoutSharedCache(options);
 
-    var programString = @"procedure {:priority 3} {:checksum ""stable""} Bad(y: int)
+    var programString = @"procedure {:priority 7} {:checksum ""stable""} Bad(y: int)
 {
   assert 2 == 1;
 }
 
-procedure {:priority 2} {:checksum ""stable""} Good(y: int)
+procedure {:priority 4} {:checksum ""stable""} Good(y: int)
 {
   assert 2 == 2;
 }

--- a/Source/UnitTests/ExecutionEngineTests/OutputPrinterTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/OutputPrinterTest.cs
@@ -34,7 +34,7 @@ namespace ExecutionEngineTests
       SMTLibOptions smtLibOptions = CommandLineOptions.FromArguments();
       VCExpressionGenerator vgen = new VCExpressionGenerator();
       VCGenerationOptions genOptions = new VCGenerationOptions(new List<string>(){});
-      var smtLibProverOptions = new SMTLibProverOptions(smtLibOptions);
+      var smtLibProverOptions = new SMTLibSolverOptions(smtLibOptions);
       smtLibProverOptions.Solver = SolverKind.NoOpWithZ3Options;
       var smtLibInteractiveTheoremProver = new SMTLibInteractiveTheoremProver(
         smtLibOptions,

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -258,10 +258,10 @@ namespace Microsoft.Boogie
       return thmProver.GetRCount();
     }
 
-    private async Task WaitForOutput(CancellationToken cancellationToken)
-    {
+
+    private async Task Check(string descriptiveName, VCExpr vc, CancellationToken cancellationToken) {
       try {
-        outcome = await thmProver.CheckOutcome(cce.NonNull(handler), Options.ErrorLimit,
+        outcome = await thmProver.Check(descriptiveName, vc, cce.NonNull(handler), Options.ErrorLimit,
           cancellationToken);
       }
       catch (OperationCanceledException) {
@@ -322,10 +322,8 @@ namespace Microsoft.Boogie
       SetTimeout(timeout);
       SetRlimit(rlimit);
       ProverStart = DateTime.UtcNow;
-      await thmProver.BeginCheck(descriptiveName, vc, handler);
-      //  gen.ClearSharedFormulas();    PR: don't know yet what to do with this guy
 
-      ProverTask = WaitForOutput(cancellationToken);
+      ProverTask = Check(descriptiveName, vc, cancellationToken);
     }
 
     public ProverInterface.Outcome ReadOutcome()
@@ -376,19 +374,8 @@ namespace Microsoft.Boogie
       throw new NotImplementedException();
     }
 
-    public override Task BeginCheck(string descriptiveName, VCExpr vc, ErrorHandler handler)
-    {
-      /*Contract.Requires(descriptiveName != null);*/
-      //Contract.Requires(vc != null);
-      //Contract.Requires(handler != null);
-      throw new NotImplementedException();
-    }
-
-    [NoDefaultContract]
-    public override Task<Outcome> CheckOutcome(ErrorHandler handler, int taskID, CancellationToken cancellationToken)
-    {
-      //Contract.Requires(handler != null);
-      Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
+    public override Task<Outcome> Check(string descriptiveName, VCExpr vc, ErrorHandler handler, int errorLimit,
+      CancellationToken cancellationToken) {
       throw new NotImplementedException();
     }
 

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Boogie
       {
         outputExn = e;
       }
-      catch (ProverException e) {
+      catch (ProverException) {
         throw;
       }
       catch (Exception e)

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -271,6 +271,9 @@ namespace Microsoft.Boogie
       {
         outputExn = e;
       }
+      catch (ProverException e) {
+        throw;
+      }
       catch (Exception e)
       {
         outputExn = new UnexpectedProverOutputException(e.Message);


### PR DESCRIPTION
### Changes
Replace `SMTLibSolver.GetProverResponse` with these methods:
```
// Used by interactive mode
public abstract Task<SExpr> SendRequest(string request);
// Used by batch mode
public abstract Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests);
```

The new methods ensure that clients get the correct response for a given request, while previously if we had the concurrent events:
```
- Thread1 call Send
- Thread2 calls Send
- Thread2 calls GetProverResponse
- Thread1 calls GetProverResponse
```

Then thread2 would receive the response for the request of thread1. Since `SMTLibProcessTheoremProver` is generally only used by 1 thread, this might not be such a problem. However, it seems that `GoBackToIdle()` can be called by a different thread than the one currently owning `SMTLibProcessTheoremProver`, so `GoBackToIdle()` can incorrectly interact with the currently running events.

### Testing

I wasn't able to reproduce a problem. When sending a slow to verify problem, waiting for `check-sat` to be sent, then doing a cancellation and sending a new verification problem, the first request indeed has unread responses when the second one begins. However, the second request will send a `(reset)` to the solver and this seems to interrupt the solver and clear any responses that were yet to arrive which could have made the second request read a response from the first.