### PR TITLE
[Civl] generalized to handle many channels

### DIFF
--- a/Test/civl/inductive-sequentialization/ProducerConsumer.bpl
+++ b/Test/civl/inductive-sequentialization/ProducerConsumer.bpl
@@ -1,17 +1,23 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-type {:linear "pid"} Pid = int;
-var {:layer 0,3} C:[int]int; // FIFO channel
-var {:layer 0,3} head:int;   // head index of the channel
-var {:layer 0,3} tail:int;   // tail index of the channel
+type {:datatype} Channel; // FIFO channel
+function {:constructor} Channel(C: [int]int, head: int, tail: int): Channel;
 
-const unique prod_id:int;
-const unique cons_id:int;
+type ChannelId; // id of a FIFO channel
+
+type {:linear "cid"} {:datatype} ChannelHandle; // permission for sending to or receiving from a channel
+function {:constructor} Send(cid: ChannelId): ChannelHandle;
+function {:constructor} Receive(cid: ChannelId): ChannelHandle;
+function {:inline} {:linear "cid"} ChannelIdCollector(cid: ChannelId) : [ChannelHandle]bool {
+  MapConst(false)[Send(cid) := true][Receive(cid) := true]
+}
+
+var {:layer 0,3} channels: [ChannelId]Channel; // pool of FIFO channels
 
 type {:pending_async}{:datatype} PA;
-function {:constructor} PRODUCER(x:int, pid:int) : PA;
-function {:constructor} CONSUMER(x:int, pid:int) : PA;
+function {:constructor} PRODUCER(x: int, cid: ChannelId, send: ChannelHandle) : PA;
+function {:constructor} CONSUMER(x: int, cid: ChannelId, receive: ChannelHandle) : PA;
 
 function {:inline} NoPAs () : [PA]int
 { (lambda pa:PA :: 0) }
@@ -20,72 +26,79 @@ function {:inline} NoPAs () : [PA]int
 
 procedure {:atomic}{:layer 2}
 {:IS "MAIN'","INV"}{:elim "PRODUCER"}{:elim "CONSUMER","CONSUMER'"}
-MAIN ({:linear_in "pid"} prod_pid:int, {:linear_in "pid"} cons_pid:int)
+MAIN ({:linear_in "cid"} cid: ChannelId)
 returns ({:pending_async "PRODUCER","CONSUMER"} PAs:[PA]int)
 {
-  assert prod_pid == prod_id;
-  assert cons_pid == cons_id;
-  assert head == tail;
-  PAs := NoPAs()[PRODUCER(1, prod_pid) := 1][CONSUMER(1, cons_pid) := 1];
+  assert head#Channel(channels[cid]) == tail#Channel(channels[cid]);
+  PAs := NoPAs()[PRODUCER(1, cid, Send(cid)) := 1][CONSUMER(1, cid, Receive(cid)) := 1];
 }
 
 procedure {:atomic}{:layer 3}
-MAIN' ({:linear_in "pid"} prod_pid:int, {:linear_in "pid"} cons_pid:int)
-modifies C, head, tail;
+MAIN' ({:linear_in "cid"} cid: ChannelId)
+modifies channels;
 {
-  assert prod_pid == prod_id;
-  assert cons_pid == cons_id;
-  assert head == tail;
-  havoc C, head, tail;
-  assume head == tail;
+  var channel: Channel;
+
+  assert head#Channel(channels[cid]) == tail#Channel(channels[cid]);
+  channels[cid] := channel;
 }
 
 procedure {:IS_invariant}{:layer 2}
-INV ({:linear_in "pid"} prod_pid:int, {:linear_in "pid"} cons_pid:int)
+INV ({:linear_in "cid"} cid: ChannelId)
 returns ({:pending_async "PRODUCER","CONSUMER"} PAs:[PA]int, {:choice} choice:PA)
-modifies C, head, tail;
+modifies channels;
 {
-  assert prod_pid == prod_id;
-  assert cons_pid == cons_id;
-  assert head == tail;
+  var {:pool "INV1"} c: int;
+  var {:pool "INV2"} channel: Channel;
+  var C: [int]int;
+  var head, tail: int;
 
-  havoc C, head, tail;
+  assert head#Channel(channels[cid]) == tail#Channel(channels[cid]);
+  channels[cid] := channel;
+  C := C#Channel(channel);
+  head := head#Channel(channel);
+  tail := tail#Channel(channel);
 
-  assume
-  (exists c:int ::  c > 0 &&
-    (
-      (head == tail &&
-       PAs == NoPAs()[PRODUCER(c, prod_pid) := 1][CONSUMER(c, cons_pid) := 1] &&
-       choice == PRODUCER(c, prod_pid))
-      ||
-      (tail == head + 1 && C[head] == 0 &&
-       PAs == NoPAs()[CONSUMER(c, cons_pid) := 1] &&
-       choice == CONSUMER(c, cons_pid))
-      ||
-      (tail == head + 1 && C[head] == c &&
-       PAs == NoPAs()[PRODUCER(c+1, prod_pid) := 1][CONSUMER(c, cons_pid) := 1] &&
-       choice == CONSUMER(c, cons_pid))
-      ||
-      (head == tail &&
-       PAs == NoPAs())
-    )
-  );
+  assume {:add_to_pool "INV1", c} 0 < c;
+  if (*) {
+    assume head == tail;
+    PAs := NoPAs()[PRODUCER(c, cid, Send(cid)) := 1][CONSUMER(c, cid, Receive(cid)) := 1];
+    choice := PRODUCER(c, cid, Send(cid));
+  } else if (*) {
+    assume tail == head + 1 && C[head] == 0;
+    PAs := NoPAs()[CONSUMER(c, cid, Receive(cid)) := 1];
+    choice := CONSUMER(c, cid, Receive(cid));
+  } else if (*) {
+    assume tail == head + 1 && C[head] == c;
+    PAs := NoPAs()[PRODUCER(c+1, cid, Send(cid)) := 1][CONSUMER(c, cid, Receive(cid)) := 1];
+    choice := CONSUMER(c, cid, Receive(cid));
+  } else {
+    assume head == tail;
+    PAs := NoPAs();
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 procedure {:left}{:layer 2}
-PRODUCER (x:int, {:linear_in "pid"} pid:int)
+PRODUCER (x: int, cid: ChannelId, {:linear_in "cid"} send: ChannelHandle)
 returns ({:pending_async "PRODUCER"} PAs:[PA]int)
-modifies C, tail;
+modifies channels;
 {
-  assert pid == prod_id;
+  var channel: Channel;
+  var C: [int]int;
+  var head, tail: int;
 
+  assert send == Send(cid);
+  channel := channels[cid];
+  C := C#Channel(channel);
+  head := head#Channel(channel);
+  tail := tail#Channel(channel);
   if (*)
   {
     C[tail] := x;
     tail := tail + 1;
-    PAs := NoPAs()[PRODUCER(x+1, pid) := 1];
+    PAs := NoPAs()[PRODUCER(x+1, cid, send) := 1];
   }
   else
   {
@@ -93,16 +106,25 @@ modifies C, tail;
     tail := tail + 1;
     PAs := NoPAs();
   }
+  channels[cid] := Channel(C, head, tail);
+  assume {:add_to_pool "INV2", channels[cid]} true;
 }
 
 procedure {:atomic}{:layer 2}
-CONSUMER (x:int, {:linear_in "pid"} pid:int)
+CONSUMER (x: int, cid: ChannelId, {:linear_in "cid"} receive: ChannelHandle)
 returns ({:pending_async "CONSUMER"} PAs:[PA]int)
-modifies head;
+modifies channels;
 {
-  var x':int;
+  var channel: Channel;
+  var C: [int]int;
+  var head, tail: int;
+  var x': int;
 
-  assert pid == cons_id;
+  assert receive == Receive(cid);
+  channel := channels[cid];
+  C := C#Channel(channel);
+  head := head#Channel(channel);
+  tail := tail#Channel(channel);
   assert head < tail ==> C[head] == x || C[head] == 0;  // assertion to discharge
 
   assume head < tail;
@@ -110,83 +132,117 @@ modifies head;
   head := head + 1;
   if (x' != 0)
   {
-    PAs := NoPAs()[CONSUMER(x'+1, pid) := 1];
+    PAs := NoPAs()[CONSUMER(x'+1, cid, receive) := 1];
   }
   else
   {
     PAs := NoPAs();
   }
+  channels[cid] := Channel(C, head, tail);
+  assume {:add_to_pool "INV2", channels[cid]} true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 procedure {:IS_abstraction}{:layer 2}
-CONSUMER' (x:int, {:linear_in "pid"} pid:int)
+CONSUMER' (x:int, cid: ChannelId, {:linear_in "cid"} receive: ChannelHandle)
 returns ({:pending_async "CONSUMER"} PAs:[PA]int)
-modifies head;
+modifies channels;
 {
+  var channel: Channel;
+  var head, tail: int;
+
+  channel := channels[cid];
+  head := head#Channel(channel);
+  tail := tail#Channel(channel);
   assert head < tail;
-  call PAs := CONSUMER(x, pid);
+  call PAs := CONSUMER(x, cid, receive);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 procedure {:yields}{:layer 1}{:refines "MAIN"}
-main ({:linear_in "pid"} prod_pid:int, {:linear_in "pid"} cons_pid:int)
+main ({:linear_in "cid"} cid: ChannelId)
 {
-  async call producer(1, prod_pid);
-  async call consumer(1, cons_pid);
+  var {:linear "cid"} send, receive: ChannelHandle;
+
+  call send, receive := split(cid);
+  async call producer(1, cid, send);
+  async call consumer(1, cid, receive);
 }
 
 procedure {:yields}{:layer 1}{:refines "PRODUCER"}
-producer (x:int, {:linear_in "pid"} pid:int)
+producer (x:int, cid: ChannelId, {:linear_in "cid"} send: ChannelHandle)
 {
   if (*)
   {
-    call send(x);
-    async call producer(x+1, pid);
+    call send(x, cid, send);
+    async call producer(x+1, cid, send);
   }
   else
   {
-    call send(0);
+    call send(0, cid, send);
   }
 }
 
 procedure {:yields}{:layer 1}{:refines "CONSUMER"}
-consumer (y:int, {:linear_in "pid"} pid:int)
+consumer (y:int, cid: ChannelId, {:linear_in "cid"} receive: ChannelHandle)
 {
-  var y':int;
+  var y': int;
 
-  call y' := receive();
+  call y' := receive(cid, receive);
   if (y' != 0)
   {
-    call assert_eq(y', y); // low-level assertion to discharge
-    async call consumer(y'+1, pid);
+    assert {:layer 1} y' == y; // low-level assertion to discharge
+    async call consumer(y'+1, cid, receive);
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-procedure {:atomic}{:layer 1} SEND (m:int)
-modifies C, tail;
+procedure {:atomic}{:layer 1} SEND (m: int, cid: ChannelId, {:linear "cid"} send: ChannelHandle)
+modifies channels;
 {
+  var channel: Channel;
+  var C: [int]int;
+  var head, tail: int;
+
+  assert send == Send(cid);
+  channel := channels[cid];
+  C := C#Channel(channel);
+  head := head#Channel(channel);
+  tail := tail#Channel(channel);
   C[tail] := m;
   tail := tail + 1;
+  channels[cid] := Channel(C, head, tail);
 }
 
-procedure {:atomic}{:layer 1} RECEIVE () returns (m:int)
-modifies C, head;
+procedure {:atomic}{:layer 1} RECEIVE (cid: ChannelId, {:linear "cid"} receive: ChannelHandle) returns (m:int)
+modifies channels;
 {
+  var channel: Channel;
+  var C: [int]int;
+  var head, tail: int;
+
+  assert receive == Receive(cid);
+  channel := channels[cid];
+  C := C#Channel(channel);
+  head := head#Channel(channel);
+  tail := tail#Channel(channel);
   assume head < tail;
   m := C[head];
   head := head + 1;
+  channels[cid] := Channel(C, head, tail);
 }
 
-procedure {:both}{:layer 1} ASSERT_EQ (a:int, b:int)
+procedure {:both}{:layer 1} SPLIT({:linear_in "cid"} cid: ChannelId)
+  returns ({:linear "cid"} send: ChannelHandle, {:linear "cid"} receive: ChannelHandle)
 {
-  assert a == b;
+  send := Send(cid);
+  receive := Receive(cid);
 }
 
-procedure {:yields}{:layer 0}{:refines "SEND"} send (m:int);
-procedure {:yields}{:layer 0}{:refines "RECEIVE"} receive () returns (m:int);
-procedure {:yields}{:layer 0}{:refines "ASSERT_EQ"} assert_eq (a:int, b:int);
+procedure {:yields}{:layer 0}{:refines "SEND"} send (m: int, cid: ChannelId, {:linear "cid"} send: ChannelHandle);
+procedure {:yields}{:layer 0}{:refines "RECEIVE"} receive (cid: ChannelId, {:linear "cid"} receive: ChannelHandle) returns (m: int);
+procedure {:yields}{:layer 0}{:refines "SPLIT"} split({:linear_in "cid"} cid: ChannelId)
+  returns ({:linear "cid"} send: ChannelHandle, {:linear "cid"} receive: ChannelHandle);

--- a/Test/civl/inductive-sequentialization/ProducerConsumer.bpl.expect
+++ b/Test/civl/inductive-sequentialization/ProducerConsumer.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 28 verified, 0 errors
+Boogie program verifier finished with 32 verified, 0 errors


### PR DESCRIPTION
The older version of this sample had a global channel which is a strange way to model the system and gives the wrong impression to a reader attempting to learn Civl. This PR generalizes the sample to a global pool of channels, each of which may be shared between a producer and a consumer. This example also uses split permissions.