### PR TITLE
Fixes issue #483

### DIFF
--- a/Source/Provers/SMTLib/ProverUtil.cs
+++ b/Source/Provers/SMTLib/ProverUtil.cs
@@ -148,34 +148,7 @@ The generic options may or may not be used by the prover plugin.
         return ConfirmProverPath(ProverPath);
       }
 
-      var exes = new string[] {ProverName, ProverName + ".exe"};
-
-      // Otherwise we look in the executable directory
-      foreach (var exe in exes)
-      {
-        var tryProverPath = Path.Combine(CodebaseString(), exe);
-
-        if (File.Exists(tryProverPath))
-        {
-          return ConfirmProverPath(tryProverPath);
-        }
-      }
-
-      // And finally we look in the system PATH
-      var exePaths = Environment.GetEnvironmentVariable("PATH");
-      foreach (var exePath in exePaths.Split(Path.PathSeparator))
-      {
-        foreach (var exe in exes)
-        {
-          var tryProverPath = Path.Combine(exePath, exe);
-          if (File.Exists(tryProverPath))
-          {
-            return ConfirmProverPath(tryProverPath);
-          }
-        }
-      }
-
-      throw new ProverException("Cannot find any prover executable");
+      return ConfirmProverPath(ProverName);
     }
 
     private string ConfirmProverPath(string proverPath)


### PR DESCRIPTION
This PR eliminates the search for the prover binary. Now the user has to either supply ProverPath as a command-line option or have the solver binary present in the path. I verified that if the z3 executable in not present in my path, I get the following error message which should clue the user.

Fatal Error: ProverException: Unable to start the process z3: An error occurred trying to start process 'z3' with working directory '/Users/shaz/Source/boogie/Test/datatypes'. No such file or directory

It is possible that this PR will also fix issue #519 .