### PR TITLE
Enable recovery after solver restart

### DIFF
--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO;
+using Microsoft.Boogie.SMTLib;
 using VC;
 
 namespace Microsoft.Boogie
@@ -440,6 +441,15 @@ namespace Microsoft.Boogie
       get => normalizeNames;
       set => normalizeNames = value;
     }
+
+    public Func<SMTLibOptions, SMTLibSolverOptions, SMTLibSolver> CreateSolver { get; set; } = (libOptions, options) =>
+    {
+      return options.Solver switch
+      {
+        SolverKind.NoOpWithZ3Options => new NoopSolver(),
+        _ => new SMTLibProcess(libOptions, options)
+      };
+    };
 
     public bool NormalizeDeclarationOrder
     {

--- a/Source/Provers/SMTLib/NoopSolver.cs
+++ b/Source/Provers/SMTLib/NoopSolver.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Boogie.SMTLib;
 
-class NoopSolver : SMTLibSolver
+public class NoopSolver : SMTLibSolver
 {
 #pragma warning disable CS0067
   public override event Action<string> ErrorHandler;
@@ -15,7 +15,7 @@ class NoopSolver : SMTLibSolver
   {
   }
 
-  private readonly Queue<SExpr> responses = new();
+  protected readonly Queue<SExpr> responses = new();
 
   public override void Send(string cmd)
   {

--- a/Source/Provers/SMTLib/OverflowSolver.cs
+++ b/Source/Provers/SMTLib/OverflowSolver.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.Boogie.SMTLib;
+
+public class OverflowSolver : NoopSolver
+{
+  public override void Send(string request)
+  {
+    if (request == "(get-info :reason-unknown)")
+    {
+      responses.Enqueue(new SExpr(":reason-unknown", 
+        new SExpr("Overflow encountered when expanding old_vector")));
+      return;
+    }
+    base.Send(request);
+  }
+}

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Boogie.SMTLib
 
         if (HadErrors)
         {
+          HadErrors = false;
           processNeedsRestart = true;
         }
 

--- a/Source/Provers/SMTLib/SMTLibOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Boogie.SMTLib;
 
 namespace Microsoft.Boogie
 {
@@ -27,5 +28,7 @@ namespace Microsoft.Boogie
      * Boogie program, which prevents unexpected changes in solver output.
      */
     bool NormalizeNames { get; }
+
+    Func<SMTLibOptions, SMTLibSolverOptions, SMTLibSolver> CreateSolver { get; }
   }
 }

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -152,9 +152,8 @@ namespace Microsoft.Boogie.SMTLib
     protected void SetupProcess()
     {
       Process?.Close();
-      Process = options.Solver == SolverKind.NoOpWithZ3Options
-        ? new NoopSolver()
-        : new SMTLibProcess(libOptions, options);
+      Process = libOptions.CreateSolver(libOptions, options);
+      
       Process.ErrorHandler += HandleProverError;
     }
 

--- a/Source/Provers/SMTLib/SMTLibSolverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibSolverOptions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Boogie.SMTLib
     Z3,
     CVC5,
     YICES2,
-    NoOpWithZ3Options
+    NoOpWithZ3Options,
   }
 
   public class SMTLibSolverOptions : ProverOptions

--- a/Source/Provers/SMTLib/UnsatSolver.cs
+++ b/Source/Provers/SMTLib/UnsatSolver.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.Boogie.SMTLib;
+
+public class UnsatSolver : NoopSolver
+{
+  public override void Send(string request)
+  {
+    if (request == "(check-sat)")
+    {
+      responses.Enqueue(new SExpr("unsat"));
+      return;
+    }
+    base.Send(request);
+  }
+}


### PR DESCRIPTION
### Changes

Fix a bug that would prevent Boogie from returning answers other than undetermined after seeing solver errors and restarting the solver. Fixes https://github.com/dafny-lang/dafny/issues/2421

### Testing

Added a test to verify Boogie behaves well after a solver restart.