### PR TITLE
Fix model parsing bug

### DIFF
--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1291,7 +1291,7 @@ namespace Microsoft.Boogie.SMTLib
 
     protected Model ParseErrorModel(SExpr resp)
     {
-      if (resp is null || resp.Name.Contains("error")) {
+      if (resp is null || resp.Name == "error") {
         return null;
       }
 

--- a/Test/test21/issue-607.bpl
+++ b/Test/test21/issue-607.bpl
@@ -1,0 +1,8 @@
+// RUN: %parallel-boogie /enhancedErrorMessages:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+procedure p(error:bool) {
+    if (error) {
+        assume {:print "ModelCaptured"} true;
+        assert false;
+    }
+}

--- a/Test/test21/issue-607.bpl.expect
+++ b/Test/test21/issue-607.bpl.expect
@@ -1,0 +1,8 @@
+issue-607.bpl(6,9): Error: This assertion might not hold.
+Execution trace:
+    issue-607.bpl(4,5): anon0
+    issue-607.bpl(5,9): anon2_Then
+Augmented execution trace:
+ModelCaptured
+
+Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
Counterexample model parsing will currently return `null` on input programs containing fields named `"error"`. I propose a fix and add a test that exposes the bug (current version of Boogie will not print augmented execution trace for this example). 

Among other things, merging this with Dafny should increase the number of successfully extracted counterexamples.