### PR TITLE
[Pool-based QI] added attributes of duplicate lambda to original lambda

### DIFF
--- a/Source/Core/MaxHolesLambdaLifter.cs
+++ b/Source/Core/MaxHolesLambdaLifter.cs
@@ -35,7 +35,7 @@ namespace Core
     private readonly List<Variable> _nestedBoundVariables = new List<Variable>();
 
     private readonly LambdaExpr _lambda;
-    private readonly Dictionary<Expr, FunctionCall> _liftedLambdas;
+    private readonly LiftedLambdas _liftedLambdas;
     private readonly String _freshFnName;
     private readonly List<Function> _lambdaFunctions;
     private readonly List<Axiom> _lambdaAxioms;
@@ -45,7 +45,7 @@ namespace Core
 
     public MaxHolesLambdaLifter(
       LambdaExpr lambda,
-      Dictionary<Expr, FunctionCall> liftedLambdas,
+      LiftedLambdas liftedLambdas,
       string freshFnName,
       List<Function> lambdaFunctions,
       List<Axiom> lambdaAxioms, CoreOptions options, int freshVarCount = 0

--- a/Test/inst/inst1.bpl
+++ b/Test/inst/inst1.bpl
@@ -38,9 +38,7 @@ procedure INV2(n: int)
 
   assume 0 <= i;
   assume i <= n;
-  // add all labels used in :pool attributes on bound variables to the body of the lambda
-  // to avoid the lambda getting unified with the logically identical lambda on line 64
-  PAs := (lambda {:pool "A2"} pa: PA :: {:pool "A2"} if is#ADD(pa) && i < i#ADD(pa) && i#ADD(pa) <= n then 1 else 0);
+  PAs := (lambda {:pool "A2"} pa: PA :: if is#ADD(pa) && i < i#ADD(pa) && i#ADD(pa) <= n then 1 else 0);
   assume (forall pa: PA :: PAs[pa] == 0);
   assert {:add_to_pool "A2", ADD(n)} i == n;
 }
@@ -59,9 +57,7 @@ procedure INV3(n: int)
 
 procedure {:inline 1} CreateLambda(i: int, n: int) returns (PAs: [PA]int)
 {
-  // add all labels used in :pool attributes on bound variables to the body of the lambda
-  // to avoid the lambda getting unified with the logically identical lambda on line 43
-  PAs := (lambda {:pool "A3"} pa: PA :: {:pool "A3"} if is#ADD(pa) && i < i#ADD(pa) && i#ADD(pa) <= n then 1 else 0);
+  PAs := (lambda {:pool "A3"} pa: PA :: if is#ADD(pa) && i < i#ADD(pa) && i#ADD(pa) <= n then 1 else 0);
 }
 
 procedure {:inline 1} LookupLambda(i: int, n: int, PAs: [PA]int)


### PR DESCRIPTION
Lambda lifting sometimes creates a single function from several syntactically separate lambdas, even though these lambdas have different pool annotations on their bound variables. This PR appends all the pool annotations of duplicate lambdas to the unique representative so that all appropriate instantiations can flow to that single lambda.