### PR TITLE
[Pool-based QI] Fix bugs

### DIFF
--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -87,25 +87,6 @@ function {:inline} Vec_Concat<T>(v1: Vec T, v2: Vec T): Vec T {
 
 function {:inline} Vec_Slice<T>(v: Vec T, i: int, j: int): Vec T {
     (
-        Vec(
-            (lambda {:pool "Slice"} k: int ::
-                if (0 <= i && i < j && j <= len#Vec(v) && 0 <= k && k < j - i) then Vec_Nth(v, k + i)
-                else Default()),
-            if (0 <= i && i < j && j <= len#Vec(v)) then j - i else 0
-           )
-    )
-}
-
-/*
-// The current implementation of pool-based quantifier instantiation will 
-// not collect a lambda instance if the instance refers to a let-bound 
-// variable as in the alternative definition of Vec_Slice below.
-// This limitation is pervasive and may apply also to quantifiers that
-// occur in the definition of let-bound variables.
-// The solution is to detect that certain let-bindings are interfering 
-// with quantifier instantiation and inline them.
-function {:inline} Vec_Slice<T>(v: Vec T, i: int, j: int): Vec T {
-    (
         var cond := 0 <= i && i < j && j <= len#Vec(v);
         Vec(
             (lambda {:pool "Slice"} k: int ::
@@ -115,7 +96,6 @@ function {:inline} Vec_Slice<T>(v: Vec T, i: int, j: int): Vec T {
            )
     )
 }
-*/
 
 function {:inline} Vec_Swap<T>(v: Vec T, i: int, j: int): Vec T {
     (

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Boogie.SMTLib
     public override bool Visit(VCExprVar node, bool arg)
     {
       Contract.Requires(node != null);
-      if (!BoundTermVars.Contains(node) && !KnownVariables.Contains(node))
+      if (!BoundTermVars.ContainsKey(node) && !KnownVariables.Contains(node))
       {
         string printedName = Namer.GetQuotedName(node, node.Name);
         Contract.Assert(printedName != null);

--- a/Source/VCExpr/Clustering.cs
+++ b/Source/VCExpr/Clustering.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Boogie.Clustering
     public override bool Visit(VCExprVar node, bool arg)
     {
       Contract.Requires(node != null);
-      if (!BoundTermVars.Contains(node))
+      if (!BoundTermVars.ContainsKey(node))
       {
         GlobalVariables[node] = node;
       }

--- a/Source/VCExpr/QuantifierInstantiationEngine.cs
+++ b/Source/VCExpr/QuantifierInstantiationEngine.cs
@@ -416,6 +416,13 @@ namespace Microsoft.Boogie.VCExprAST
   
   class QuantifierCollector : BoundVarTraversingVCExprVisitor<Dictionary<VCExprVar, Polarity>, Polarity>
   {
+    /*
+     * This method collects quantifiers embedded in vcExpr.
+     * If polarity == Polarity.Negative, a quantifier F embedded in expr is collected
+     * if it can be proved that F is a forall quantifier in the NNF version of expr.
+     * If polarity == Polarity.Positive, a quantifier F embedded in expr is collected
+     * if it can be proved that F is an exists quantifier in the NNF version of expr.
+     */
     public static HashSet<VCExprQuantifier> CollectQuantifiers(VCExpr vcExpr, Polarity polarity)
     {
       var visitor = new QuantifierCollector();
@@ -554,11 +561,6 @@ namespace Microsoft.Boogie.VCExprAST
   {
     /*
      * The method Skolemize performs best-effort skolemization of the input expression expr.
-     * If polarity == Polarity.Negative, a quantifier F embedded in expr is skolemized
-     * provided it can be proved that F is a forall quantifier in the NNF version of expr.
-     * If polarity == Polarity.Positive, a quantifier F embedded in expr is skolemized
-     * provided it can be proved that F is an exists quantifier in the NNF version of expr.
-     *
      * Factorization is performed on the resulting expression.
      */
     public static VCExpr Skolemize(QuantifierInstantiationEngine qiEngine, Polarity polarity, VCExpr vcExpr)
@@ -622,8 +624,6 @@ namespace Microsoft.Boogie.VCExprAST
     /* 
      * The method Factorize factors out quantified expressions in expr replacing them with a bound variable.
      * The binding between the bound variable and the quantifier replaced by it is registered in qiEngine.
-     * If polarity == Polarity.Positive, forall quantifiers are factorized.
-     * If polarity == Polarity.Negative, exists quantifiers are factorized.
      */
     
     private QuantifierInstantiationEngine qiEngine;

--- a/Source/VCExpr/QuantifierInstantiationEngine.cs
+++ b/Source/VCExpr/QuantifierInstantiationEngine.cs
@@ -528,7 +528,7 @@ namespace Microsoft.Boogie.VCExprAST
     public override Dictionary<VCExprVar, Polarity> Visit(VCExprQuantifier node, Polarity arg)
     {
       var result = base.Visit(node, arg);
-      if (arg != Polarity.Unknown && !result.Keys.Intersect(BoundTermVars).Any())
+      if (arg != Polarity.Unknown && !result.Keys.Intersect(BoundTermVars.Keys).Any())
       {
         if ((arg == Polarity.Positive) == (node.Quan == Quantifier.EX))
         {
@@ -737,7 +737,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override bool Visit(VCExprVar node, bool arg)
     {
-      if (BoundTermVars.Contains(node))
+      if (BoundTermVars.ContainsKey(node))
       {
         foreach (var instance in instancesOnStack)
         {

--- a/Source/VCExpr/QuantifierInstantiationEngine.cs
+++ b/Source/VCExpr/QuantifierInstantiationEngine.cs
@@ -174,7 +174,13 @@ namespace Microsoft.Boogie.VCExprAST
       }
       lambdaDefinition[lambdaFunction] = translatedExpr;
       quantifierInstantiationInfo[translatedExpr] = new QuantifierInstantiationInfo(boundVariableToLabels);
+      lambdaToInstances[lambdaFunction] = new HashSet<List<VCExpr>>(new ListComparer<VCExpr>());
       return true;
+    }
+
+    public void AddLambdaInstances(Dictionary<Function, HashSet<List<VCExpr>>> lambdaToInstances)
+    {
+      AddDictionary(lambdaToInstances, this.lambdaToInstances);
     }
 
     public static HashSet<string> FindInstantiationHints(ICarriesAttributes o)
@@ -253,31 +259,42 @@ namespace Microsoft.Boogie.VCExprAST
         AddDictionary(FindInstantiationSources(predicateCmd, "add_to_pool", exprTranslator), labelToInstances);
       }));
       vcExpr = Skolemizer.Skolemize(this, Polarity.Negative, vcExpr);
-      lambdaToInstances = LambdaInstanceCollector.CollectInstances(this, vcExpr);
-      while (labelToInstances.Count > 0)
+      while (labelToInstances.Count > 0 || lambdaToInstances.Count > 0)
       {
-        var currLabelToInstances = labelToInstances;
+        /*
+         * Each iteration of this loop
+         * (1) moves the contents of labelToInstances into accLabelToInstances
+         * (2) moves the contents of lambdaToInstances into accLambdaToInstances
+         * (3) instantiates quantifiers in quantifierBinding against accLabelToInstances
+         * (4) instantiates lambdas in lambdaDefinition against accLabelToInstances and accLambdaToInstances
+         * Steps (3) and (4) could add more entries to quantifierBinding and lambdaDefinition.
+         * These entries are handled in the same iteration of this top-level loop.
+         * Steps (3) and (4) could also re-populate labelToInstances and lambdaToInstances;
+         * these new entries are handled in the next iteration of this top-level loop.
+         */
+        AddDictionary(labelToInstances, accLabelToInstances);
         labelToInstances = new Dictionary<string, HashSet<VCExpr>>();
-        AddDictionary(currLabelToInstances, accLabelToInstances);
 
-        var currLambdaToInstances = lambdaToInstances;
+        AddDictionary(lambdaToInstances, accLambdaToInstances);
         lambdaToInstances = new Dictionary<Function, HashSet<List<VCExpr>>>();
-        AddDictionary(currLambdaToInstances, accLambdaToInstances);
 
         var visitedQuantifierBindings = new HashSet<VCExprVar>();
         while (visitedQuantifierBindings.Count < quantifierBinding.Count)
         {
+          /*
+           * quantifierBinding may be modified in each iteration of the following loop.
+           * Therefore, take a snapshot of quantifierBinding.Keys to start the loop.
+           */
           foreach (var v in quantifierBinding.Keys)
           {
             if (visitedQuantifierBindings.Contains(v))
             {
               continue;
             }
-
             visitedQuantifierBindings.Add(v);
             var quantifierExpr = quantifierBinding[v];
             var quantifierInfo = quantifierInstantiationInfo[quantifierExpr];
-            if (quantifierInfo.relevantLabels.Overlaps(currLabelToInstances.Keys))
+            if (quantifierInfo.relevantLabels.Overlaps(accLabelToInstances.Keys))
             {
               InstantiateQuantifier(quantifierExpr);
             }
@@ -287,18 +304,21 @@ namespace Microsoft.Boogie.VCExprAST
         var visitedLambdaFunctions = new HashSet<Function>();
         while (visitedLambdaFunctions.Count < lambdaDefinition.Count)
         {
+          /*
+           * lambdaFunction may be modified in each iteration of the following loop.
+           * Therefore, take a snapshot of lambdaFunction.Keys to start the loop.
+           */
           foreach (var lambdaFunction in lambdaDefinition.Keys)
           {
             if (visitedLambdaFunctions.Contains(lambdaFunction))
             {
               continue;
             }
-
             visitedLambdaFunctions.Add(lambdaFunction);
             var quantifierExpr = lambdaDefinition[lambdaFunction];
             var quantifierInfo = quantifierInstantiationInfo[quantifierExpr];
-            if (quantifierInfo.relevantLabels.Overlaps(currLabelToInstances.Keys) ||
-                currLambdaToInstances[lambdaFunction].Count > 0)
+            if (quantifierInfo.relevantLabels.Overlaps(accLabelToInstances.Keys) ||
+                accLambdaToInstances[lambdaFunction].Count > 0)
             {
               InstantiateLambdaDefinition(lambdaFunction);
             }
@@ -567,6 +587,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       var skolemizer = new Skolemizer(qiEngine, polarity, vcExpr);
       var skolemizedExpr = skolemizer.Mutate(vcExpr, true);
+      LambdaInstanceCollector.CollectInstances(qiEngine, vcExpr);
       return Factorizer.Factorize(qiEngine, QuantifierCollector.Flip(polarity), skolemizedExpr);
     }
 
@@ -686,7 +707,7 @@ namespace Microsoft.Boogie.VCExprAST
   
   class LambdaInstanceCollector : BoundVarTraversingVCExprVisitor<bool, bool>
   {
-    public static Dictionary<Function, HashSet<List<VCExpr>>> CollectInstances(QuantifierInstantiationEngine qiEngine, VCExpr vcExpr)
+    public static void CollectInstances(QuantifierInstantiationEngine qiEngine, VCExpr vcExpr)
     {
       var lambdaInstanceCollector = new LambdaInstanceCollector(qiEngine);
       lambdaInstanceCollector.Traverse(vcExpr, true);
@@ -700,7 +721,7 @@ namespace Microsoft.Boogie.VCExprAST
         }
         lambdaFunctionToInstances[function].Add(instance.UniformArguments.ToList());
       }
-      return lambdaFunctionToInstances;
+      qiEngine.AddLambdaInstances(lambdaFunctionToInstances);
     }
 
     private LambdaInstanceCollector(QuantifierInstantiationEngine qiEngine)


### PR DESCRIPTION
- close issue #422 
- integrate lambda instantiation fully into the top-level loop

To make the first fix above, this PR also adds the let bound expression to each bound variable in BoundVarTraversingVCExprVisitor.