### PR TITLE
Ensure binary operations always have a token.

### DIFF
--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Boogie
       Contract.Requires(e1 != null);
       Contract.Requires(e0 != null);
       Contract.Ensures(Contract.Result<NAryExpr>() != null);
-      return Binary(Token.NoToken, op, e0, e1);
+      return Binary(e0.tok ?? Token.NoToken, op, e0, e1);
     }
 
     public static NAryExpr Eq(Expr e1, Expr e2)

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Boogie
       Contract.Requires(e1 != null);
       Contract.Requires(e0 != null);
       Contract.Ensures(Contract.Result<NAryExpr>() != null);
-      return Binary(e0.tok ?? Token.NoToken, op, e0, e1);
+      return Binary(e0.tok ?? e1.tok ?? Token.NoToken, op, e0, e1);
     }
 
     public static NAryExpr Eq(Expr e1, Expr e2)

--- a/Source/UnitTests/CoreTests/AbsyMetadata.cs
+++ b/Source/UnitTests/CoreTests/AbsyMetadata.cs
@@ -34,6 +34,17 @@ namespace CoreTests
       Assert.Throws(typeof(ArgumentOutOfRangeException), () => absy.GetMetadata<string>(1));
     }
 
+    [Test]
+    public void EnsureBinaryExpressionsHaveTokensIfLeftOperandHasToken()
+    {
+      var left = Expr.Literal(0);
+      var right = Expr.Literal(1);
+      left.tok = new Token(42, 27);
+      var result = Expr.Gt(left, right);
+      Assert.NotNull(result.tok);
+      Assert.AreEqual(result.tok.line, left.tok.line);
+    }
+
     [Test()]
     public void SimpleMetadata()
     {

--- a/Test/roundingmodes/InvalidOperators.bpl.expect
+++ b/Test/roundingmodes/InvalidOperators.bpl.expect
@@ -3,11 +3,11 @@ InvalidOperators.bpl(14,9): Error: invalid argument types (rmode and rmode) to b
 InvalidOperators.bpl(15,9): Error: invalid argument types (rmode and rmode) to binary operator *
 InvalidOperators.bpl(16,9): Error: invalid argument types (rmode and rmode) to binary operator /
 InvalidOperators.bpl(18,8): Error: invalid argument types (rmode and rmode) to binary operator <=
-(0,-1): Error: invalid argument types (rmode and rmode) to binary operator <
+InvalidOperators.bpl(18,11): Error: invalid argument types (rmode and rmode) to binary operator <
 InvalidOperators.bpl(20,15): Error: invalid argument types (rmode and rmode) to binary operator >=
-(0,-1): Error: invalid argument types (rmode and rmode) to binary operator >
+InvalidOperators.bpl(20,18): Error: invalid argument types (rmode and rmode) to binary operator >
 InvalidOperators.bpl(24,8): Error: invalid argument types (rmode and rmode) to binary operator <
-(0,-1): Error: invalid argument types (rmode and rmode) to binary operator <=
+InvalidOperators.bpl(24,10): Error: invalid argument types (rmode and rmode) to binary operator <=
 InvalidOperators.bpl(26,15): Error: invalid argument types (rmode and rmode) to binary operator >
-(0,-1): Error: invalid argument types (rmode and rmode) to binary operator >=
+InvalidOperators.bpl(26,17): Error: invalid argument types (rmode and rmode) to binary operator >=
 12 type checking errors detected in InvalidOperators.bpl


### PR DESCRIPTION
Previously, binary operations created out of the blue did not have a token, which caused a problem for reporting some errors in Dafny.
Rather than manually adding these tokens in Dafny, I am adding a mechanism by which the token of a newly built BinaryExpr through the helper is by default the token of the first element.