### PR TITLE
Fixes issue #583

### DIFF
--- a/Source/VCExpr/ScopedNamer.cs
+++ b/Source/VCExpr/ScopedNamer.cs
@@ -174,7 +174,11 @@ namespace Microsoft.Boogie.VCExprAST
       }
 
       var uniqueInherentName = NextFreeName(thing, inherentName);
-      if (boogieDeterminedNames.Contains(inherentName))
+      if (thing is DatatypeConstructor || thing is DatatypeMembership || thing is DatatypeSelector)
+      {
+        result = uniqueInherentName;
+      }
+      else if (boogieDeterminedNames.Contains(inherentName))
       {
         result = uniqueInherentName;
       }


### PR DESCRIPTION
Closes issue #583 

Names of datatype-related functions have special meaning in SMT files. So, we should not rename them when randomizing symbol names.