### PR TITLE
Remove the `ErrorData` property from commands

### DIFF
--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Boogie
     public static AssertCmd AssertCmd(IToken tok, Expr expr, string msg)
     {
       return new AssertCmd(tok, expr)
-        { ErrorData = msg };
+        { Description = new FailureOnlyDescription(msg) };
     }
 
     public static AssignCmd AssignCmd(Variable v, Expr x)

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Boogie
             subst != null
           ? (AssertCmd) Substituter.Apply(subst, gate)
           : new AssertCmd(gate.tok, gate.Expr);
-        cmd.ErrorData = msg;
+        cmd.Description = new FailureOnlyDescription(msg);
         yield return cmd;
       }
     }

--- a/Source/Concurrency/NoninterferenceChecker.cs
+++ b/Source/Concurrency/NoninterferenceChecker.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Boogie
           {
             var newExpr = Substituter.ApplyReplacingOldExprs(subst, oldSubst, predCmd.Expr);
             AssertCmd assertCmd = new AssertCmd(predCmd.tok, newExpr, predCmd.Attributes);
-            assertCmd.ErrorData = "Non-interference check failed";
+            assertCmd.Description = new FailureOnlyDescription("Non-interference check failed");
             newCmds.Add(assertCmd);
           }
         }

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -273,16 +273,6 @@ namespace Microsoft.Boogie
     }
   }
 
-  public interface IPotentialErrorNode<out TGet>
-  {
-    TGet ErrorData { get; }
-  }
-
-  public interface IPotentialErrorNode<out TGet, in TSet> : IPotentialErrorNode<TGet>
-  {
-    new TSet ErrorData { set; }
-  }
-
   public class Program : Absy
   {
     [ContractInvariantMethod]
@@ -3037,7 +3027,7 @@ namespace Microsoft.Boogie
     }
   }
 
-  public class Requires : Absy, ICarriesAttributes, IPotentialErrorNode<string, string>
+  public class Requires : Absy, ICarriesAttributes
   {
     public readonly bool Free;
 
@@ -3067,20 +3057,6 @@ namespace Microsoft.Boogie
     {
       Contract.Invariant(this._condition != null);
     }
-
-
-    // TODO: convert to use generics
-    private string errorData;
-
-    // Note: the `Description` property should cover all the use cases
-    // of `ErrorData` and be used instead. Ideally, `ErrorData` will
-    // eventually go away.
-    public string ErrorData
-    {
-      get { return errorData; }
-      set { errorData = value; }
-    }
-
 
     private MiningStrategy errorDataEnhanced;
 
@@ -3173,7 +3149,7 @@ namespace Microsoft.Boogie
     }
   }
 
-  public class Ensures : Absy, ICarriesAttributes, IPotentialErrorNode<string, string>
+  public class Ensures : Absy, ICarriesAttributes
   {
     public readonly bool Free;
 
@@ -3203,18 +3179,6 @@ namespace Microsoft.Boogie
     }
 
     public string Comment;
-
-    // TODO: convert to use generics
-    private string errorData;
-
-    // Note: the `Description` property should cover all the use cases
-    // of `ErrorData` and be used instead. Ideally, `ErrorData` will
-    // eventually go away.
-    public string ErrorData
-    {
-      get { return errorData; }
-      set { errorData = value; }
-    }
 
     private MiningStrategy errorDataEnhanced;
 

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -2723,7 +2723,7 @@ namespace Microsoft.Boogie
     }
   }
 
-  public class ParCallCmd : CallCommonality, IPotentialErrorNode<object, object>
+  public class ParCallCmd : CallCommonality
   {
     public List<CallCmd> CallCmds;
 
@@ -2742,17 +2742,6 @@ namespace Microsoft.Boogie
     protected override Cmd ComputeDesugaring(PrintOptions options)
     {
       throw new NotImplementedException();
-    }
-
-    private object errorData;
-
-    // Note: the `Description` property should cover all the use cases
-    // of `ErrorData` and be used instead. Ideally, `ErrorData` will
-    // eventually go away.
-    public object ErrorData
-    {
-      get { return errorData; }
-      set { errorData = value; }
     }
 
     public ProofObligationDescription Description { get; set; } = new PreconditionDescription();
@@ -2902,7 +2891,7 @@ namespace Microsoft.Boogie
     }
   }
 
-  public class CallCmd : CallCommonality, IPotentialErrorNode<object, object>
+  public class CallCmd : CallCommonality
   {
     public string /*!*/ callee { get; set; }
     public Procedure Proc;
@@ -2929,18 +2918,6 @@ namespace Microsoft.Boogie
     // The instantiation of type parameters that is determined during
     // type checking
     public TypeParamInstantiation TypeParameters = null;
-
-    // TODO: convert to use generics
-    private object errorData;
-
-    // Note: the `Description` property should cover all the use cases
-    // of `ErrorData` and be used instead. Ideally, `ErrorData` will
-    // eventually go away.
-    public object ErrorData
-    {
-      get { return errorData; }
-      set { errorData = value; }
-    }
 
     public ProofObligationDescription Description { get; set; } = new PreconditionDescription();
 
@@ -3803,7 +3780,7 @@ namespace Microsoft.Boogie
     }
   }
 
-  public class AssertCmd : PredicateCmd, IPotentialErrorNode<object, object>
+  public class AssertCmd : PredicateCmd
   {
     public Expr OrigExpr;
     public Dictionary<Variable, Expr> IncarnationMap;
@@ -3828,18 +3805,6 @@ namespace Microsoft.Boogie
     {
       Attributes = new QKeyValue(tok, "verified_under", new List<object> {expr}, Attributes);
       verifiedUnder = expr;
-    }
-
-    // TODO: convert to use generics
-    private object errorData;
-
-    // Note: the `Description` property should cover all the use cases
-    // of `ErrorData` and be used instead. Ideally, `ErrorData` will
-    // eventually go away.
-    public object ErrorData
-    {
-      get { return errorData; }
-      set { errorData = value; }
     }
 
     public ProofObligationDescription Description { get; set; }

--- a/Source/Core/ProofObligationDescription.cs
+++ b/Source/Core/ProofObligationDescription.cs
@@ -104,3 +104,19 @@ public class InvariantMaintainedDescription : AssertionDescription
 
   public override string ShortDescription => "invariant maintained";
 }
+
+public class FailureOnlyDescription : AssertionDescription
+{
+  public override string SuccessDescription =>
+    $"Error cannot occur: {errorMessage}";
+
+  public override string FailureDescription => errorMessage;
+
+  public override string ShortDescription => "assert";
+
+  private readonly string errorMessage;
+
+  public FailureOnlyDescription(string errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+}

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -1086,16 +1086,13 @@ namespace Microsoft.Boogie
                 string msg = null;
                 if (callError != null) {
                   tok = callError.FailingCall.tok;
-                  msg = callError.FailingCall.ErrorData as string ??
-                        callError.FailingCall.Description.FailureDescription;
+                  msg = callError.FailingCall.Description.FailureDescription;
                 } else if (returnError != null) {
                   tok = returnError.FailingReturn.tok;
                   msg = returnError.FailingReturn.Description.FailureDescription;
                 } else {
                   tok = assertError.FailingAssert.tok;
-                  if (assertError.FailingAssert.ErrorMessage == null || options.ForceBplErrors) {
-                    msg = assertError.FailingAssert.ErrorData as string;
-                  } else {
+                  if (!(assertError.FailingAssert.ErrorMessage == null || options.ForceBplErrors)) {
                     msg = assertError.FailingAssert.ErrorMessage;
                   }
 

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -403,11 +403,11 @@ namespace Microsoft.Boogie
       {
         if (callError.FailingRequires.ErrorMessage == null || forceBplErrors)
         {
-          string msg = callError.FailingCall.ErrorData as string ?? callError.FailingCall.Description.FailureDescription;
+          string msg = callError.FailingCall.Description.FailureDescription;
           errorInfo = ErrorInformation.Create(callError.FailingCall.tok, msg, cause);
           errorInfo.Kind = ErrorKind.Precondition;
           errorInfo.AddAuxInfo(callError.FailingRequires.tok,
-            callError.FailingRequires.ErrorData as string ?? callError.FailingRequires.Description.FailureDescription,
+            callError.FailingRequires.Description.FailureDescription,
             "Related location");
         }
         else
@@ -422,7 +422,7 @@ namespace Microsoft.Boogie
           errorInfo = ErrorInformation.Create(returnError.FailingReturn.tok, returnError.FailingReturn.Description.FailureDescription, cause);
           errorInfo.Kind = ErrorKind.Postcondition;
           errorInfo.AddAuxInfo(returnError.FailingEnsures.tok,
-            returnError.FailingEnsures.ErrorData as string ?? returnError.FailingEnsures.Description.FailureDescription,
+            returnError.FailingEnsures.Description.FailureDescription,
             "Related location");
         }
         else
@@ -440,11 +440,7 @@ namespace Microsoft.Boogie
           errorInfo.Kind = failingAssert is LoopInitAssertCmd ?
             ErrorKind.InvariantEntry : ErrorKind.InvariantMaintainance;
           string relatedMessage = null;
-          if (failingAssert.ErrorData is string)
-          {
-            relatedMessage = failingAssert.ErrorData as string;
-          }
-          else if (failingAssert is LoopInitAssertCmd initCmd)
+          if (failingAssert is LoopInitAssertCmd initCmd)
           {
             var desc = initCmd.originalAssert.Description;
             if (desc is not AssertionDescription)
@@ -469,8 +465,7 @@ namespace Microsoft.Boogie
         {
           if (failingAssert.ErrorMessage == null || forceBplErrors)
           {
-            string msg = failingAssert.ErrorData as string ??
-                         failingAssert.Description.FailureDescription;
+            string msg = failingAssert.Description.FailureDescription;
             errorInfo = ErrorInformation.Create(failingAssert.tok, msg, cause);
             errorInfo.Kind = ErrorKind.Assertion;
           }
@@ -527,13 +522,12 @@ namespace Microsoft.Boogie
           return c;
         }
 
-        // TODO(wuestholz): Generalize this to compare all IPotentialErrorNodes of the counterexample.
+        // TODO(wuestholz): Generalize this to compare all Descriptions of the counterexample.
         var a1 = c1 as AssertCounterexample;
         var a2 = c2 as AssertCounterexample;
-        if (a1 != null && a2 != null)
-        {
-          var s1 = a1.FailingAssert.ErrorData as string;
-          var s2 = a2.FailingAssert.ErrorData as string;
+        if (a1 != null && a2 != null) {
+          var s1 = a1.FailingAssert.Description?.FailureDescription;
+          var s2 = a2.FailingAssert.Description?.FailureDescription;
           if (s1 != null && s2 != null)
           {
             return s1.CompareTo(s2);

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -734,7 +734,6 @@ namespace VC
               }
 
               b.Attributes = c.Attributes;
-              b.ErrorData = c.ErrorData;
               prefixOfPredicateCmdsInit.Add(b);
 
               if (Options.ConcurrentHoudini)
@@ -755,7 +754,6 @@ namespace VC
               }
 
               b.Attributes = c.Attributes;
-              b.ErrorData = c.ErrorData;
               prefixOfPredicateCmdsMaintained.Add(b);
               header.Cmds[i] = new AssumeCmd(c.tok, c.Expr);
             }


### PR DESCRIPTION
This property has been made obsolete by the `Description` property.

Fixes #562.