### PR TITLE
[Civl] first commit for primitive linear types

### DIFF
--- a/Source/Concurrency/CivlRewriter.cs
+++ b/Source/Concurrency/CivlRewriter.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Microsoft.Boogie
 {
-  public class CivlVCGeneration
+  public class CivlRewriter
   {
     public static void Transform(ConcurrencyOptions options, CivlTypeChecker civlTypeChecker)
     {

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -1,0 +1,433 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+
+namespace Microsoft.Boogie;
+
+public class LinearRewriter
+{
+  private static HashSet<string> primitives = new HashSet<string>()
+  {
+    "Lmap_Empty", "Lmap_Split", "Lmap_Transfer", "Lmap_Read", "Lmap_Write","Lmap_Add", "Lmap_Remove",
+    "Lset_Empty", "Lset_Split", "Lset_Transfer",
+    "Lval_Split", "Lval_Transfer",
+  };
+
+  private Monomorphizer monomorphizer;
+
+  private ConcurrencyOptions options;
+
+  public LinearRewriter(ConcurrencyOptions options, Monomorphizer monomorphizer)
+  {
+    this.monomorphizer = monomorphizer;
+    this.options = options;
+  }
+
+  public bool IsPrimitive(Procedure proc)
+  {
+    var value = monomorphizer.GetOriginalDecl(proc);
+    return value != null && primitives.Contains(value.Name);
+  }
+  
+  public List<Cmd> RewriteCmdSeq(List<Cmd> cmdSeq)
+  {
+    var newCmdSeq = new List<Cmd>();
+    foreach (var cmd in cmdSeq)
+    {
+      if (cmd is CallCmd callCmd && IsPrimitive(callCmd.Proc))
+      {
+        newCmdSeq.AddRange(RewriteCallCmd(callCmd));
+      }
+      else
+      {
+        newCmdSeq.Add(cmd);
+      }
+    }
+    return newCmdSeq;
+  }
+
+  public List<Cmd> RewriteCallCmd(CallCmd callCmd)
+  {
+    switch (monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
+    {
+      case "Lmap_Empty":
+        return RewriteLmapEmpty(callCmd);
+      case "Lmap_Split":
+        return RewriteLmapSplit(callCmd);
+      case "Lmap_Transfer":
+        return RewriteLmapTransfer(callCmd);
+      case "Lmap_Read":
+        return RewriteLmapRead(callCmd);
+      case "Lmap_Write":
+        return RewriteLmapWrite(callCmd);
+      case "Lmap_Add":
+        return RewriteLmapAdd(callCmd);
+      case "Lmap_Remove":
+        return RewriteLmapRemove(callCmd);
+      case "Lset_Empty":
+        return RewriteLsetEmpty(callCmd);
+      case "Lset_Split":
+        return RewriteLsetSplit(callCmd);
+      case "Lset_Transfer":
+        return RewriteLsetTransfer(callCmd);
+      case "Lval_Split":
+        return RewriteLvalSplit(callCmd);
+      case "Lval_Transfer":
+        return RewriteLvalTransfer(callCmd);
+      default:
+        Contract.Assume(false);
+        return null;
+    }  
+  }
+
+  private Function MapConst(Type domain, Type range)
+  {
+    return monomorphizer.InstantiateFunction("MapConst",
+      new Dictionary<string, Type>() { { "T", domain }, { "U", range } });
+  }
+
+  private Function MapImp(Type domain)
+  {
+    return monomorphizer.InstantiateFunction("MapImp", new Dictionary<string, Type>() { { "T", domain } });
+  }
+
+  private Function MapDiff(Type domain)
+  {
+    return monomorphizer.InstantiateFunction("MapDiff", new Dictionary<string, Type>() { { "T", domain } });  
+  }
+
+  private Function MapOne(Type domain)
+  {
+    return monomorphizer.InstantiateFunction("MapOne", new Dictionary<string, Type>() { { "T", domain } });  
+  }
+  
+  private Function MapOr(Type domain)
+  {
+    return monomorphizer.InstantiateFunction("MapOr", new Dictionary<string, Type>() { { "T", domain } });
+  }
+
+  private Function MapIte(Type domain, Type range)
+  {
+    return monomorphizer.InstantiateFunction("MapIte",new Dictionary<string, Type>() { { "T", domain }, { "U", range } });
+  }
+
+  private Function LmapContains(Type type)
+  {
+    return monomorphizer.InstantiateFunction("Lmap_Contains",new Dictionary<string, Type>() { { "V", type } });
+  }
+  
+  private Function LmapDeref(Type type)
+  {
+    return monomorphizer.InstantiateFunction("Lmap_Deref",new Dictionary<string, Type>() { { "V", type } });
+  }
+  
+  private Function LsetContains(Type type)
+  {
+    return monomorphizer.InstantiateFunction("Lset_Contains",new Dictionary<string, Type>() { { "V", type } });
+  }
+  
+  private static Expr Dom(Expr path)
+  {
+    return ExprHelper.FieldAccess(path, "dom");
+  }
+  
+  private static Expr Val(Expr path)
+  {
+    return ExprHelper.FieldAccess(path, "val");
+  }
+
+  private Expr Default(Type type)
+  {
+    var defaultFunc = monomorphizer.InstantiateFunction("Default", new Dictionary<string, Type>() { { "T", type } });
+    return ExprHelper.FunctionCall(defaultFunc);
+  }
+  
+  private List<Cmd> RewriteLmapEmpty(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+    
+    var cmdSeq = new List<Cmd>();
+    var l = callCmd.Outs[0].Decl;
+    
+    var mapConstFunc1 = MapConst(refType, Type.Bool);
+    var mapConstFunc2 = MapConst(refType, type);
+
+    cmdSeq.Add(CmdHelper.AssignCmd(l,
+      ExprHelper.FunctionCall(lmapConstructor, ExprHelper.FunctionCall(mapConstFunc1, Expr.False),
+        ExprHelper.FunctionCall(mapConstFunc2, Default(type)))));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+  
+  private List<Cmd> RewriteLmapSplit(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+    
+    var cmdSeq = new List<Cmd>();
+    var path = callCmd.Ins[0];
+    var k = callCmd.Ins[1];
+    var l = callCmd.Outs[0].Decl;
+    
+    var mapConstFunc = MapConst(refType, Type.Bool);
+    var mapImpFunc = MapImp(refType);
+    cmdSeq.Add(CmdHelper.AssertCmd(
+      callCmd.tok,
+      Expr.Eq(ExprHelper.FunctionCall(mapImpFunc, k, Dom(path)), ExprHelper.FunctionCall(mapConstFunc, Expr.True)), 
+      "Lmap_Split failed"));
+    
+    cmdSeq.Add(CmdHelper.AssignCmd(l,ExprHelper.FunctionCall(lmapConstructor, k, Val(path))));
+
+    var mapDiffFunc = MapDiff(refType);
+    cmdSeq.Add(
+      CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),ExprHelper.FunctionCall(mapDiffFunc, Dom(path), k)));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+
+  private List<Cmd> RewriteLmapTransfer(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+
+    var cmdSeq = new List<Cmd>();
+    var path1 = callCmd.Ins[0];
+    var path2 = callCmd.Ins[1];
+
+    var mapOrFunc = MapOr(refType);
+    var mapIteFunc = MapIte(refType, type);
+    cmdSeq.Add(CmdHelper.AssignCmd(
+      CmdHelper.ExprToAssignLhs(path2),
+      ExprHelper.FunctionCall(lmapConstructor,
+        ExprHelper.FunctionCall(mapOrFunc, Dom(path2), Dom(path1)),
+        ExprHelper.FunctionCall(mapIteFunc, Dom(path2), Val(path2), Val(path1)))));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+
+  private List<Cmd> RewriteLmapRead(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+    
+    var cmdSeq = new List<Cmd>();
+    var path = callCmd.Ins[0];
+    var k = callCmd.Ins[1];
+    var v = callCmd.Outs[0];
+
+    var lmapContainsFunc = LmapContains(type);
+    cmdSeq.Add(
+      CmdHelper.AssertCmd(callCmd.tok, ExprHelper.FunctionCall(lmapContainsFunc, path, k),"Lmap_Read failed"));
+
+    var lmapDerefFunc = LmapDeref(type);
+    cmdSeq.Add(CmdHelper.AssignCmd(v.Decl, ExprHelper.FunctionCall(lmapDerefFunc, path, k)));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+  
+  private List<Cmd> RewriteLmapWrite(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+    
+    var cmdSeq = new List<Cmd>();
+    var path = callCmd.Ins[0];
+    var k = callCmd.Ins[1];
+    var v = callCmd.Ins[2];
+    
+    var lmapContainsFunc = LmapContains(type);
+    cmdSeq.Add(
+      CmdHelper.AssertCmd(callCmd.tok, ExprHelper.FunctionCall(lmapContainsFunc, path, k),"Lmap_Write failed"));
+
+    cmdSeq.Add(CmdHelper.AssignCmd(CmdHelper.MapAssignLhs(Val(path), new List<Expr>() { k }), v));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+
+  private List<Cmd> RewriteLmapAdd(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+    
+    var cmdSeq = new List<Cmd>();
+    var path = callCmd.Ins[0];
+    var v = callCmd.Ins[1];
+    var k = callCmd.Outs[0];
+    
+    var mapOneFunc = MapOne(refType);
+    var mapConstFunc = MapConst(refType, type);
+    var mapOrFunc = MapOr(refType);
+    var mapIteFunc = MapIte(refType, type);
+    cmdSeq.Add(CmdHelper.AssignCmd(
+      CmdHelper.ExprToAssignLhs(path),
+      ExprHelper.FunctionCall(lmapConstructor,
+        ExprHelper.FunctionCall(mapOrFunc, Dom(path), ExprHelper.FunctionCall(mapOneFunc, k)),
+        ExprHelper.FunctionCall(mapIteFunc, Dom(path), Val(path), ExprHelper.FunctionCall(mapConstFunc, v)))));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+
+  private List<Cmd> RewriteLmapRemove(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+    
+    var cmdSeq = new List<Cmd>();
+    var path = callCmd.Ins[0];
+    var k = callCmd.Ins[1];
+    var v = callCmd.Outs[0];
+    
+    var lmapContainsFunc = LmapContains(type);
+    cmdSeq.Add(
+      CmdHelper.AssertCmd(callCmd.tok, ExprHelper.FunctionCall(lmapContainsFunc, path, k),"Lmap_Remove failed"));
+
+    var lmapDerefFunc = LmapDeref(type);
+    cmdSeq.Add(CmdHelper.AssignCmd(v.Decl, ExprHelper.FunctionCall(lmapDerefFunc, path, k)));
+
+    var mapOneFunc = MapOne(refType);
+    var mapDiffFunc = MapDiff(refType);
+    cmdSeq.Add(
+      CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),
+        ExprHelper.FunctionCall(mapDiffFunc, Dom(path), ExprHelper.FunctionCall(mapOneFunc, k))));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+
+  private List<Cmd> RewriteLsetEmpty(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+    
+    var cmdSeq = new List<Cmd>();
+    var l = callCmd.Outs[0].Decl;
+    
+    var mapConstFunc = MapConst(type, Type.Bool);
+    cmdSeq.Add(CmdHelper.AssignCmd(l, ExprHelper.FunctionCall(lsetConstructor,ExprHelper.FunctionCall(mapConstFunc, Expr.False))));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+  
+  private List<Cmd> RewriteLsetSplit(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+    
+    var cmdSeq = new List<Cmd>();
+    var path = callCmd.Ins[0];
+    var k = callCmd.Ins[1];
+    var l = callCmd.Outs[0].Decl;
+    
+    var mapConstFunc = MapConst(type, Type.Bool);
+    var mapImpFunc = MapImp(type);
+    cmdSeq.Add(CmdHelper.AssertCmd(
+      callCmd.tok,
+      Expr.Eq(ExprHelper.FunctionCall(mapImpFunc, k, Dom(path)), ExprHelper.FunctionCall(mapConstFunc, Expr.True)), 
+      "Lset_Split failed"));
+    
+    cmdSeq.Add(CmdHelper.AssignCmd(l,ExprHelper.FunctionCall(lsetConstructor, k)));
+
+    var mapDiffFunc = MapDiff(type);
+    cmdSeq.Add(
+      CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),ExprHelper.FunctionCall(mapDiffFunc, Dom(path), k)));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+
+  private List<Cmd> RewriteLsetTransfer(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+
+    var cmdSeq = new List<Cmd>();
+    var path1 = callCmd.Ins[0];
+    var path2 = callCmd.Ins[1];
+
+    var mapOrFunc = MapOr(type);
+    cmdSeq.Add(CmdHelper.AssignCmd(
+      CmdHelper.ExprToAssignLhs(path2),
+      ExprHelper.FunctionCall(lsetConstructor, ExprHelper.FunctionCall(mapOrFunc, Dom(path2), Dom(path1)))));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+  
+  private List<Cmd> RewriteLvalSplit(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+
+    var cmdSeq = new List<Cmd>();
+    var path = callCmd.Ins[0];
+    var k = callCmd.Ins[1];
+    var l = callCmd.Outs[0].Decl;
+    
+    var lsetContainsFunc = LsetContains(type);
+    cmdSeq.Add(CmdHelper.AssertCmd(callCmd.tok, ExprHelper.FunctionCall(lsetContainsFunc,path, k),"Lval_Split failed"));
+    
+    cmdSeq.Add(CmdHelper.AssignCmd(l,ExprHelper.FunctionCall(lvalConstructor, k)));
+
+    var mapOneFunc = MapOne(type);
+    var mapDiffFunc = MapDiff(type);
+    cmdSeq.Add(
+      CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),
+        ExprHelper.FunctionCall(mapDiffFunc, Dom(path), ExprHelper.FunctionCall(mapOneFunc, k))));
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+  
+  private List<Cmd> RewriteLvalTransfer(CallCmd callCmd)
+  {
+    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lmapConstructor,
+      out Function lsetConstructor, out Function lvalConstructor);
+
+    var cmdSeq = new List<Cmd>();
+    var l = callCmd.Ins[0];
+    var path2 = callCmd.Ins[1];
+
+    var mapOneFunc = MapOne(type);
+    var mapOrFunc = MapOr(type);
+    cmdSeq.Add(CmdHelper.AssignCmd(
+      CmdHelper.ExprToAssignLhs(path2),
+      ExprHelper.FunctionCall(lsetConstructor,
+        ExprHelper.FunctionCall(mapOrFunc, Dom(path2), ExprHelper.FunctionCall(mapOneFunc, Val(l))))));
+    
+    ResolveAndTypecheck(cmdSeq);
+    return cmdSeq;
+  }
+
+  private void GetRelevantInfo(CallCmd callCmd, out Type type, out Type refType, out Function lmapConstructor,
+    out Function lsetConstructor, out Function lvalConstructor)
+  {
+    var instantiation = monomorphizer.GetTypeInstantiation(callCmd.Proc);
+    type = instantiation["V"];
+    var actualTypeParams = new List<Type>() { instantiation["V"] };
+    var refTypeCtorDecl = monomorphizer.InstantiateTypeCtorDecl("Ref", actualTypeParams);
+    refType = new CtorType(Token.NoToken, refTypeCtorDecl, new List<Type>());
+    var lmapTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lmap", actualTypeParams);
+    lmapConstructor = lmapTypeCtorDecl.Constructors[0];
+    var lsetTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lset", actualTypeParams);
+    lsetConstructor = lsetTypeCtorDecl.Constructors[0];
+    var lvalTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lval", actualTypeParams);
+    lvalConstructor = lvalTypeCtorDecl.Constructors[0];
+  }
+
+  private void ResolveAndTypecheck(List<Cmd> cmdSeq)
+  {
+    foreach (var cmd in cmdSeq)
+    {
+      var rc = new ResolutionContext(null, options);
+      rc.StateMode = ResolutionContext.State.Two;
+      cmd.Resolve(rc);
+      cmd.Typecheck(new TypecheckingContext(null, options));
+    }
+  }
+}

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -53,21 +53,21 @@ namespace Microsoft.Boogie
       this.mapTypeInt = new MapType(Token.NoToken, new List<TypeVariable>(), new List<Type> {this.permissionType},
         Type.Int);
 
-      this.mapConstBool = program.monomorphizer.Monomorphize("MapConst",
+      this.mapConstBool = program.monomorphizer.InstantiateFunction("MapConst",
         new Dictionary<string, Type>() { {"T", permissionType}, {"U", Type.Bool} });
-      this.mapConstInt = program.monomorphizer.Monomorphize("MapConst",
+      this.mapConstInt = program.monomorphizer.InstantiateFunction("MapConst",
         new Dictionary<string, Type>() { {"T", permissionType}, {"U", Type.Int} });
-      this.mapOr = program.monomorphizer.Monomorphize("MapOr",
+      this.mapOr = program.monomorphizer.InstantiateFunction("MapOr",
         new Dictionary<string, Type>() { {"T", permissionType} });
-      this.mapImp = program.monomorphizer.Monomorphize("MapImp",
+      this.mapImp = program.monomorphizer.InstantiateFunction("MapImp",
         new Dictionary<string, Type>() { {"T", permissionType} });
-      this.mapEqInt = program.monomorphizer.Monomorphize("MapEq",
+      this.mapEqInt = program.monomorphizer.InstantiateFunction("MapEq",
         new Dictionary<string, Type>() { {"T", permissionType}, {"U", Type.Int} });
-      this.mapAdd = program.monomorphizer.Monomorphize("MapAdd",
+      this.mapAdd = program.monomorphizer.InstantiateFunction("MapAdd",
         new Dictionary<string, Type>() { {"T", permissionType} });
-      this.mapIteInt = program.monomorphizer.Monomorphize("MapIte",
+      this.mapIteInt = program.monomorphizer.InstantiateFunction("MapIte",
         new Dictionary<string, Type>() { {"T", permissionType}, {"U", Type.Int} });
-      this.mapLe = program.monomorphizer.Monomorphize("MapLe",
+      this.mapLe = program.monomorphizer.InstantiateFunction("MapLe",
         new Dictionary<string, Type>() { {"T", permissionType} });
     }
 
@@ -307,13 +307,13 @@ namespace Microsoft.Boogie
           {
             // add unit collector
             domainNameToCollectors[domainName][variableType] =
-              program.monomorphizer.Monomorphize("MapUnit", new Dictionary<string, Type>() { {"T", variableType} });
+              program.monomorphizer.InstantiateFunction("MapUnit", new Dictionary<string, Type>() { {"T", variableType} });
           }
           else if (variableType.Equals(new MapType(Token.NoToken, new List<TypeVariable>(), new List<Type>{permissionType}, Type.Bool)))
           {
             // add identity collector
             domainNameToCollectors[domainName][variableType] =
-              program.monomorphizer.Monomorphize("Id", new Dictionary<string, Type>() { {"T", variableType} });
+              program.monomorphizer.InstantiateFunction("Id", new Dictionary<string, Type>() { {"T", variableType} });
           }
           else
           {

--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -406,7 +406,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<AssignLhs>() != null);
       FieldAssignLhs clone = (FieldAssignLhs) node.Clone();
-      return base.VisitFieldAssignLhs(node);
+      return base.VisitFieldAssignLhs(clone);
     }
 
     public override MapType VisitMapType(MapType node)

--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -12,6 +12,10 @@ function {:inline} MapDiff<T>(a: [T]bool, b: [T]bool) : [T]bool
 {
   MapAnd(a, MapNot(b))
 }
+function {:inline} MapOne<T>(a: T) : [T]bool
+{
+  MapConst(false)[a := true]
+}
 
 function {:builtin "MapAdd"} MapAdd<T>([T]int, [T]int) : [T]int;
 function {:builtin "MapSub"} MapSub<T>([T]int, [T]int) : [T]int;
@@ -123,3 +127,40 @@ function {:builtin "seq.++"} Seq_Concat<T>(a: Seq T, b: Seq T): Seq T;
 function {:builtin "seq.unit"} Seq_Unit<T>(v: T): Seq T;
 function {:builtin "seq.nth"} Seq_Nth<T>(a: Seq T, i: int): T;
 function {:builtin "seq.extract"} Seq_Extract<T>(a: Seq T, pos: int, length: int): Seq T;
+
+/// linear maps
+type Ref _;
+type {:datatype} Lmap _;
+function {:constructor} Lmap<V>(dom: [Ref V]bool, val: [Ref V]V): Lmap V;
+
+function {:inline} Lmap_Deref<V>(l: Lmap V, k: Ref V): V {
+    val#Lmap(l)[k]
+}
+function {:inline} Lmap_Contains<V>(l: Lmap V, k: Ref V): bool {
+    dom#Lmap(l)[k]
+}
+procedure Lmap_Empty<V>() returns (l: Lmap V);
+procedure Lmap_Split<V>(path: Lmap V, k: [Ref V]bool) returns (l: Lmap V);
+procedure Lmap_Transfer<V>(path1: Lmap V, path2: Lmap V);
+procedure Lmap_Read<V>(path: Lmap V, k: Ref V) returns (v: V);
+procedure Lmap_Write<V>(path: Lmap V, k: Ref V, v: V);
+procedure Lmap_Add<V>(path: Lmap V, v: V) returns (k: Ref V);
+procedure Lmap_Remove<V>(path: Lmap V, k: Ref V) returns (v: V);
+
+/// linear sets
+type {:datatype} Lset _;
+function {:constructor} Lset<V>(dom: [V]bool): Lset V;
+
+function {:inline} Lset_Contains<V>(l: Lset V, k: V): bool {
+    dom#Lset(l)[k]
+}
+procedure Lset_Empty<V>() returns (l: Lset V);
+procedure Lset_Split<V>(path: Lset V, k: [V]bool) returns (l: Lset V);
+procedure Lset_Transfer<V>(path1: Lset V, path2: Lset V);
+
+/// linear vals
+type {:datatype} Lval _;
+function {:constructor} Lval<V>(val: V): Lval V;
+
+procedure Lval_Split<V>(path: Lset V, k: V) returns (l: Lval V);
+procedure Lval_Transfer<V>(l: Lval V, path: Lset V);

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Boogie
         }
       }
 
-      CivlVCGeneration.Transform(Options, civlTypeChecker);
+      CivlRewriter.Transform(Options, civlTypeChecker);
       if (Options.CivlDesugaredFile != null) {
         int oldPrintUnstructured = Options.PrintUnstructured;
         Options.PrintUnstructured = 1;

--- a/Test/civl/Siddharth-queue.bpl
+++ b/Test/civl/Siddharth-queue.bpl
@@ -16,7 +16,6 @@ function Set_ofSeq(q: SeqInvoc) returns (s: SetInvoc);
 var {:layer 1,2} lin: SeqInvoc;
 var {:layer 1,2} vis: [Invoc]SetInvoc;
 
-type Ref;
 type Key;
 
 // ---------- Primitives for manipulating logical/abstract state

--- a/Test/civl/alloc-mem.bpl
+++ b/Test/civl/alloc-mem.bpl
@@ -1,7 +1,7 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-type {:linear "mem"} Ref = int;
+type {:linear "mem"} ref = int;
 
 type lmap;
 function {:linear "mem"} dom(lmap) : [int]bool;

--- a/Test/civl/linear_types.bpl
+++ b/Test/civl/linear_types.bpl
@@ -1,0 +1,36 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure {:atomic} {:layer 1, 2} A0(path: Lmap int, k: [Ref int]bool) returns (path': Lmap int, l: Lmap int) {
+    call path' := Lmap_Empty();
+    call Lmap_Transfer(path, path');
+    call l := Lmap_Split(path', k);
+}
+
+procedure {:atomic} {:layer 1, 2} A1(path: Lmap int, k: Ref int, v: int) returns (path': Lmap int, v': int) {
+    call path' := Lmap_Empty();
+    call Lmap_Transfer(path, path');
+    call Lmap_Write(path', k, v);
+    call v' := Lmap_Read(path', k);
+}
+
+procedure {:atomic} {:layer 1, 2} A2(v: int) returns (path': Lmap int, v': int) {
+    var k: Ref int;
+    call path' := Lmap_Empty();
+    call k := Lmap_Add(path', v);
+    call v' := Lmap_Remove(path', k);
+}
+
+procedure {:atomic} {:layer 1, 2} A3(path: Lset int, k: [int]bool) returns (path': Lset int, l: Lset int) {
+    call path' := Lset_Empty();
+    call Lset_Transfer(path, path');
+    call l := Lset_Split(path', k);
+}
+
+procedure {:atomic} {:layer 1, 2} A4(path: Lset int, k: int) returns (path': Lset int) {
+    var l: Lval int;
+    call path' := Lset_Empty();
+    call Lset_Transfer(path, path');
+    call l := Lval_Split(path', k);
+    call Lval_Transfer(l, path');
+}

--- a/Test/civl/linear_types.bpl.expect
+++ b/Test/civl/linear_types.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
This is the first PR towards adding support for native linear types in Civl. Specifically, this PR implements a rewriter for bodies of atomic actions to desugar calls to primitive linear operations. Typechecking these calls and generation of disjointness constraints will be done in subsequent PRs. To support the work in this PR, more APIs were added to the Monomorphizer class; instantiation of functions and types may be done on demand during the rewriting phase.

The signatures of the new types and operations are in LibraryDefinitions.bpl. All the new names are essentially keywords for Civl. As a result, a few tests had to be changed.