### PR TITLE
[Civl] separate function call construction from resolution/typecheck

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Boogie
     public HashSet<Variable> actionUsedGlobalVars;
     public HashSet<Variable> modifiedGlobalVars;
 
-    protected Action(Procedure proc, Implementation impl, LayerRange layerRange, LinearRewriter linearRewriter)
+    protected Action(Procedure proc, Implementation impl, LayerRange layerRange)
     {
       this.proc = proc;
       this.impl = impl;
@@ -99,7 +99,7 @@ namespace Microsoft.Boogie
         impl.OutParams[i].Attributes = proc.OutParams[i].Attributes;
       }
       
-      gate = HoistAsserts(impl, linearRewriter);
+      gate = HoistAsserts(impl);
       gateUsedGlobalVars = new HashSet<Variable>(VariableCollector.Collect(gate).Where(x => x is GlobalVariable));
       actionUsedGlobalVars = new HashSet<Variable>(VariableCollector.Collect(impl).Where(x => x is GlobalVariable));
       modifiedGlobalVars = new HashSet<Variable>(AssignedVariables().Where(x => x is GlobalVariable));
@@ -127,7 +127,7 @@ namespace Microsoft.Boogie
      * reverse order, thus ensuring that a block is processed only once the wlp
      * of all its successors has been computed.
      */
-    private static List<AssertCmd> HoistAsserts(Implementation impl, LinearRewriter linearRewriter)
+    private static List<AssertCmd> HoistAsserts(Implementation impl)
     {
       Dictionary<Block, List<AssertCmd>> wlps = new Dictionary<Block, List<AssertCmd>>();
       Graph<Block> dag = Program.GraphFromBlocks(impl.Blocks, false);
@@ -135,13 +135,13 @@ namespace Microsoft.Boogie
       {
         if (block.TransferCmd is ReturnCmd)
         {
-          var wlp = HoistAsserts(block, new List<AssertCmd>(), linearRewriter);
+          var wlp = HoistAsserts(block, new List<AssertCmd>());
           wlps.Add(block, wlp);
         }
         else if (block.TransferCmd is GotoCmd gotoCmd)
         {
           var wlp =
-            HoistAsserts(block, gotoCmd.labelTargets.SelectMany(b => wlps[b]).ToList(), linearRewriter);
+            HoistAsserts(block, gotoCmd.labelTargets.SelectMany(b => wlps[b]).ToList());
           wlps.Add(block, wlp);
         }
         else
@@ -152,9 +152,8 @@ namespace Microsoft.Boogie
       return wlps[impl.Blocks[0]].Select(assertCmd => Forall(impl.LocVars.Union(impl.OutParams), assertCmd)).ToList();
     }
 
-    private static List<AssertCmd> HoistAsserts(Block block, List<AssertCmd> postconditions, LinearRewriter linearRewriter)
+    private static List<AssertCmd> HoistAsserts(Block block, List<AssertCmd> postconditions)
     {
-      block.Cmds = linearRewriter.RewriteCmdSeq(block.Cmds);
       for (int i = block.Cmds.Count - 1; i >= 0; i--)
       {
         var cmd = block.Cmds[i];
@@ -212,8 +211,8 @@ namespace Microsoft.Boogie
 
   public class IntroductionAction : Action
   {
-    public IntroductionAction(Procedure proc, Implementation impl, LayerRange layerRange, LinearRewriter linearRewriter) :
-      base(proc, impl, layerRange, linearRewriter)
+    public IntroductionAction(Procedure proc, Implementation impl, LayerRange layerRange) :
+      base(proc, impl, layerRange)
     {
     }
 
@@ -238,8 +237,8 @@ namespace Microsoft.Boogie
     public Dictionary<Variable, Function> triggerFunctions;
 
     public AtomicAction(Procedure proc, Implementation impl, LayerRange layerRange,
-      MoverType moverType, ConcurrencyOptions options, LinearRewriter linearRewriter) :
-      base(proc, impl, layerRange, linearRewriter)
+      MoverType moverType, ConcurrencyOptions options) :
+      base(proc, impl, layerRange)
     {
       this.moverType = moverType;
       this.options = options;

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Boogie
       {
         var f = triggerFunctions[v];
         program.AddTopLevelDeclaration(f);
-        var assume = CmdHelper.AssumeCmd(ExprHelper.FunctionCall(options, f, Expr.Ident(v)));
+        var assume = CmdHelper.AssumeCmd(ExprHelper.FunctionCall(f, Expr.Ident(v)));
         impl.Blocks[0].Cmds.Insert(0, assume);
       }
     }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Boogie
         new List<Variable>(),
         new List<Variable>(),
         new List<Block> {BlockHelper.Block("init", new List<Cmd>())});
-      SkipAtomicAction = new AtomicAction(skipProcedure, skipImplementation, LayerRange.MinMax, MoverType.Both, Options, linearRewriter);
+      SkipAtomicAction = new AtomicAction(skipProcedure, skipImplementation, LayerRange.MinMax, MoverType.Both, Options);
     }
 
     public string AddNamePrefix(string name)
@@ -365,14 +365,15 @@ namespace Microsoft.Boogie
       foreach (var proc in actionProcs)
       {
         Implementation impl = actionProcToImpl[proc];
+        impl.Blocks.Iter(block => block.Cmds = linearRewriter.RewriteCmdSeq(block.Cmds));
         LayerRange layerRange = actionProcToLayerRange[proc];
         if (proc.HasAttribute(CivlAttributes.INTRO))
         {
-          procToIntroductionAction[proc] = new IntroductionAction(proc, impl, layerRange, linearRewriter);
+          procToIntroductionAction[proc] = new IntroductionAction(proc, impl, layerRange);
         }
         else
         {
-          var action = new AtomicAction(proc, impl, layerRange, GetActionMoverType(proc), Options, linearRewriter);
+          var action = new AtomicAction(proc, impl, layerRange, GetActionMoverType(proc), Options);
           if (proc.HasAttribute(CivlAttributes.IS_INVARIANT))
           {
             procToIsInvariant[proc] = action;

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -55,16 +55,6 @@ namespace Microsoft.Boogie
   // Handy syntactic sugar missing in Expr
   public static class ExprHelper
   {
-    public static NAryExpr FunctionCall(ConcurrencyOptions options, Function f, params Expr[] args)
-    {
-      var expr = new NAryExpr(Token.NoToken, new FunctionCall(f), args);
-      var rc = new ResolutionContext(null, options);
-      rc.StateMode = ResolutionContext.State.Two;
-      expr.Resolve(rc);
-      expr.Typecheck(new TypecheckingContext(null, options));
-      return expr;
-    }
-
     public static NAryExpr FunctionCall(Function f, params Expr[] args)
     {
       return new NAryExpr(Token.NoToken, new FunctionCall(f), args);

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Boogie
 
       List<Cmd> cmds = new List<Cmd>();
       cmds.Add(GetCallCmd(invariantAction));
-      cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(Options, pendingAsync.pendingAsyncCtor.membership, choice)));
+      cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.membership, choice)));
       cmds.Add(CmdHelper.AssumeCmd(Expr.Gt(Expr.Select(PAs, choice), Expr.Literal(0))));
       cmds.Add(RemoveChoice);
 
@@ -121,7 +121,7 @@ namespace Microsoft.Boogie
       List<Expr> inputExprs = new List<Expr>();
       for (int i = 0; i < abs.impl.InParams.Count; i++)
       {
-        var pendingAsyncParam = ExprHelper.FunctionCall(Options, pendingAsync.pendingAsyncCtor.selectors[i], choice);
+        var pendingAsyncParam = ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.selectors[i], choice);
         map[abs.impl.InParams[i]] = pendingAsyncParam;
         inputExprs.Add(pendingAsyncParam);
       }
@@ -141,7 +141,7 @@ namespace Microsoft.Boogie
       }
 
       cmds.Add(GetCheck(GetTransitionRelation(invariantAction)));
-
+      
       return GetCheckerTuple(requires, locals, cmds, "_" + abs.proc.Name);
     }
 
@@ -228,7 +228,7 @@ namespace Microsoft.Boogie
         var expr = Expr.Imp(
           Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0)),
           Expr.And(elim.Keys.Select(a =>
-            Expr.Not(ExprHelper.FunctionCall(civlTypeChecker.Options, a.pendingAsyncCtor.membership, pa)))));
+            Expr.Not(ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa)))));
         expr.Typecheck(new TypecheckingContext(null, civlTypeChecker.Options));
         return ExprHelper.ForallExpr(new List<Variable> { paBound }, expr);
       }
@@ -247,7 +247,7 @@ namespace Microsoft.Boogie
     private Expr ElimPendingAsyncExpr(IdentifierExpr pa)
     {
       return Expr.And(
-        Expr.Or(elim.Keys.Select(a => ExprHelper.FunctionCall(Options, a.pendingAsyncCtor.membership, pa))),
+        Expr.Or(elim.Keys.Select(a => ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa))),
         Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0))
       );
     }
@@ -265,7 +265,7 @@ namespace Microsoft.Boogie
     {
       return AssignCmd.SimpleAssign(Token.NoToken,
         PAs,
-        ExprHelper.FunctionCall(Options, pendingAsyncAdd, PAs, newPAs));
+        ExprHelper.FunctionCall(pendingAsyncAdd, PAs, newPAs));
     }
 
 

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -156,7 +156,7 @@ public class LinearRewriter
       ExprHelper.FunctionCall(lmapConstructor, ExprHelper.FunctionCall(mapConstFunc1, Expr.False),
         ExprHelper.FunctionCall(mapConstFunc2, Default(type)))));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
   
@@ -183,7 +183,7 @@ public class LinearRewriter
     cmdSeq.Add(
       CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),ExprHelper.FunctionCall(mapDiffFunc, Dom(path), k)));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
 
@@ -204,7 +204,7 @@ public class LinearRewriter
         ExprHelper.FunctionCall(mapOrFunc, Dom(path2), Dom(path1)),
         ExprHelper.FunctionCall(mapIteFunc, Dom(path2), Val(path2), Val(path1)))));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
 
@@ -225,7 +225,7 @@ public class LinearRewriter
     var lmapDerefFunc = LmapDeref(type);
     cmdSeq.Add(CmdHelper.AssignCmd(v.Decl, ExprHelper.FunctionCall(lmapDerefFunc, path, k)));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
   
@@ -245,7 +245,7 @@ public class LinearRewriter
 
     cmdSeq.Add(CmdHelper.AssignCmd(CmdHelper.MapAssignLhs(Val(path), new List<Expr>() { k }), v));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
 
@@ -269,7 +269,7 @@ public class LinearRewriter
         ExprHelper.FunctionCall(mapOrFunc, Dom(path), ExprHelper.FunctionCall(mapOneFunc, k)),
         ExprHelper.FunctionCall(mapIteFunc, Dom(path), Val(path), ExprHelper.FunctionCall(mapConstFunc, v)))));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
 
@@ -296,7 +296,7 @@ public class LinearRewriter
       CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),
         ExprHelper.FunctionCall(mapDiffFunc, Dom(path), ExprHelper.FunctionCall(mapOneFunc, k))));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
 
@@ -311,7 +311,7 @@ public class LinearRewriter
     var mapConstFunc = MapConst(type, Type.Bool);
     cmdSeq.Add(CmdHelper.AssignCmd(l, ExprHelper.FunctionCall(lsetConstructor,ExprHelper.FunctionCall(mapConstFunc, Expr.False))));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
   
@@ -338,7 +338,7 @@ public class LinearRewriter
     cmdSeq.Add(
       CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),ExprHelper.FunctionCall(mapDiffFunc, Dom(path), k)));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
 
@@ -356,7 +356,7 @@ public class LinearRewriter
       CmdHelper.ExprToAssignLhs(path2),
       ExprHelper.FunctionCall(lsetConstructor, ExprHelper.FunctionCall(mapOrFunc, Dom(path2), Dom(path1)))));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
   
@@ -380,7 +380,8 @@ public class LinearRewriter
     cmdSeq.Add(
       CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),
         ExprHelper.FunctionCall(mapDiffFunc, Dom(path), ExprHelper.FunctionCall(mapOneFunc, k))));
-    ResolveAndTypecheck(cmdSeq);
+    
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
   
@@ -400,7 +401,7 @@ public class LinearRewriter
       ExprHelper.FunctionCall(lsetConstructor,
         ExprHelper.FunctionCall(mapOrFunc, Dom(path2), ExprHelper.FunctionCall(mapOneFunc, Val(l))))));
     
-    ResolveAndTypecheck(cmdSeq);
+    CivlUtil.ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;
   }
 
@@ -418,16 +419,5 @@ public class LinearRewriter
     lsetConstructor = lsetTypeCtorDecl.Constructors[0];
     var lvalTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lval", actualTypeParams);
     lvalConstructor = lvalTypeCtorDecl.Constructors[0];
-  }
-
-  private void ResolveAndTypecheck(List<Cmd> cmdSeq)
-  {
-    foreach (var cmd in cmdSeq)
-    {
-      var rc = new ResolutionContext(null, options);
-      rc.StateMode = ResolutionContext.State.Two;
-      cmd.Resolve(rc);
-      cmd.Typecheck(new TypecheckingContext(null, options));
-    }
   }
 }

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -73,12 +73,12 @@ namespace Microsoft.Boogie
 
     public Expr MapConstInt(int value)
     {
-      return ExprHelper.FunctionCall(options, mapConstInt, Expr.Literal(value));
+      return ExprHelper.FunctionCall(mapConstInt, Expr.Literal(value));
     }
 
     public Expr MapEqTrue(Expr expr)
     {
-      return Expr.Eq(expr, ExprHelper.FunctionCall(options, mapConstBool, Expr.True));
+      return Expr.Eq(expr, ExprHelper.FunctionCall(mapConstBool, Expr.True));
     }
   }
 
@@ -949,9 +949,8 @@ namespace Microsoft.Boogie
       var domain = linearDomains[domainName];
       foreach (Variable v in scope)
       {
-        Expr expr = ExprHelper.FunctionCall(Options, domain.collectors[v.TypedIdent.Type], Expr.Ident(v));
-        expr.Resolve(new ResolutionContext(null, Options));
-        expr.Typecheck(new TypecheckingContext(null, Options));
+        Expr expr = ExprHelper.FunctionCall(domain.collectors[v.TypedIdent.Type], Expr.Ident(v));
+        CivlUtil.ResolveAndTypecheck(Options, expr);
         yield return expr;
       }
     }
@@ -976,31 +975,29 @@ namespace Microsoft.Boogie
         expr = ExprHelper.ExistsExpr(new List<Variable> {partition}, Expr.And(subsetExprs));
       }
 
-      expr.Resolve(new ResolutionContext(null, Options));
-      expr.Typecheck(new TypecheckingContext(null, Options));
+      CivlUtil.ResolveAndTypecheck(Options, expr);
       return expr;
     }
 
     public Expr UnionExprForPermissions(string domainName, IEnumerable<Expr> permissionExprs)
     {
       var domain = linearDomains[domainName];
-      var expr = ExprHelper.FunctionCall(Options, domain.mapConstBool, Expr.False);
+      var expr = ExprHelper.FunctionCall(domain.mapConstBool, Expr.False);
       foreach (Expr e in permissionExprs)
       {
-        expr = ExprHelper.FunctionCall(Options, domain.mapOr, e, expr);
+        expr = ExprHelper.FunctionCall(domain.mapOr, e, expr);
       }
 
-      expr.Resolve(new ResolutionContext(null, Options));
-      expr.Typecheck(new TypecheckingContext(null, Options));
+      CivlUtil.ResolveAndTypecheck(Options, expr);
       return expr;
     }
 
     private Expr SubsetExpr(LinearDomain domain, Expr ie, Variable partition, int partitionCount)
     {
-      Expr e = ExprHelper.FunctionCall(Options, domain.mapConstInt, Expr.Literal(partitionCount));
-      e = ExprHelper.FunctionCall(Options, domain.mapEqInt, Expr.Ident(partition), e);
-      e = ExprHelper.FunctionCall(Options, domain.mapImp, ie, e);
-      e = Expr.Eq(e, ExprHelper.FunctionCall(Options, domain.mapConstBool, Expr.True));
+      Expr e = ExprHelper.FunctionCall(domain.mapConstInt, Expr.Literal(partitionCount));
+      e = ExprHelper.FunctionCall(domain.mapEqInt, Expr.Ident(partition), e);
+      e = ExprHelper.FunctionCall(domain.mapImp, ie, e);
+      e = Expr.Eq(e, ExprHelper.FunctionCall(domain.mapConstBool, Expr.True));
       return e;
     }
 
@@ -1106,7 +1103,7 @@ namespace Microsoft.Boogie
             // Permissions in linear output variables + linear inputs of a single pending async
             // are a subset of permissions in linear input variables.
             var exactlyOnePA = Expr.And(
-              ExprHelper.FunctionCall(Options, pendingAsync.pendingAsyncCtor.membership, pa1),
+              ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.membership, pa1),
               Expr.Eq(Expr.Select(PAs, pa1), Expr.Literal(1)));
             var outSubsetInExpr = OutPermsSubsetInPerms(domain, inVars, pendingAsyncLinearParams.Union(outVars));
             linearityChecks.Add(new LinearityCheck(
@@ -1119,7 +1116,7 @@ namespace Microsoft.Boogie
             // Third kind
             // If there are two identical pending asyncs, then their input permissions mut be empty.
             var twoIdenticalPAs = Expr.And(
-              ExprHelper.FunctionCall(Options, pendingAsync.pendingAsyncCtor.membership, pa1),
+              ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.membership, pa1),
               Expr.Ge(Expr.Select(PAs, pa1), Expr.Literal(2)));
             var emptyPerms = OutPermsSubsetInPerms(domain, Enumerable.Empty<Expr>(), pendingAsyncLinearParams);
             linearityChecks.Add(new LinearityCheck(
@@ -1152,8 +1149,8 @@ namespace Microsoft.Boogie
               var membership = Expr.And(
                 Expr.Neq(pa1, pa2),
                 Expr.And(
-                  ExprHelper.FunctionCall(Options, pendingAsync1.pendingAsyncCtor.membership, pa1),
-                  ExprHelper.FunctionCall(Options, pendingAsync2.pendingAsyncCtor.membership, pa2)));
+                  ExprHelper.FunctionCall(pendingAsync1.pendingAsyncCtor.membership, pa1),
+                  ExprHelper.FunctionCall(pendingAsync2.pendingAsyncCtor.membership, pa2)));
 
               var existing = Expr.And(
                 Expr.Ge(Expr.Select(PAs, pa1), Expr.Literal(1)),
@@ -1220,11 +1217,13 @@ namespace Microsoft.Boogie
         var inParam = pendingAsync.proc.InParams[i];
         if (FindDomainName(inParam) == domain.domainName && InKinds.Contains(FindLinearKind(inParam)))
         {
-          var pendingAsyncParam = ExprHelper.FunctionCall(Options, pendingAsync.pendingAsyncCtor.selectors[i], pa);
+          var pendingAsyncParam = ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.selectors[i], pa);
           pendingAsyncLinearParams.Add(pendingAsyncParam);
         }
       }
 
+      CivlUtil.ResolveAndTypecheck(Options, pendingAsyncLinearParams);
+      
       return pendingAsyncLinearParams;
     }
 
@@ -1232,15 +1231,15 @@ namespace Microsoft.Boogie
     {
       Expr inMultiset = ExprHelper.Old(PermissionMultiset(domain, ins));
       Expr outMultiset = PermissionMultiset(domain, outs);
-      Expr subsetExpr = ExprHelper.FunctionCall(Options, domain.mapLe, outMultiset, inMultiset);
-      return Expr.Eq(subsetExpr, ExprHelper.FunctionCall(Options, domain.mapConstBool, Expr.True));
+      Expr subsetExpr = ExprHelper.FunctionCall(domain.mapLe, outMultiset, inMultiset);
+      return Expr.Eq(subsetExpr, ExprHelper.FunctionCall(domain.mapConstBool, Expr.True));
     }
 
     private Expr PermissionMultiset(LinearDomain domain, IEnumerable<Expr> exprs)
     {
       var terms = exprs.Select(x =>
-        ExprHelper.FunctionCall(Options, domain.mapIteInt,
-          ExprHelper.FunctionCall(Options, domain.collectors[x.Type], x),
+        ExprHelper.FunctionCall(domain.mapIteInt,
+          ExprHelper.FunctionCall(domain.collectors[x.Type], x),
           domain.MapConstInt(1),
           domain.MapConstInt(0))).ToList<Expr>();
 
@@ -1249,7 +1248,7 @@ namespace Microsoft.Boogie
         return domain.MapConstInt(0);
       }
 
-      return terms.Aggregate((x, y) => ExprHelper.FunctionCall(Options, domain.mapAdd, x, y));
+      return terms.Aggregate((x, y) => ExprHelper.FunctionCall(domain.mapAdd, x, y));
     }
 
     #endregion

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -950,7 +950,6 @@ namespace Microsoft.Boogie
       foreach (Variable v in scope)
       {
         Expr expr = ExprHelper.FunctionCall(domain.collectors[v.TypedIdent.Type], Expr.Ident(v));
-        CivlUtil.ResolveAndTypecheck(Options, expr);
         yield return expr;
       }
     }
@@ -974,8 +973,7 @@ namespace Microsoft.Boogie
 
         expr = ExprHelper.ExistsExpr(new List<Variable> {partition}, Expr.And(subsetExprs));
       }
-
-      CivlUtil.ResolveAndTypecheck(Options, expr);
+      
       return expr;
     }
 
@@ -987,8 +985,7 @@ namespace Microsoft.Boogie
       {
         expr = ExprHelper.FunctionCall(domain.mapOr, e, expr);
       }
-
-      CivlUtil.ResolveAndTypecheck(Options, expr);
+      
       return expr;
     }
 
@@ -1222,6 +1219,7 @@ namespace Microsoft.Boogie
         }
       }
 
+      // These expressions must be typechecked since the types are needed later in PermissionMultiset.
       CivlUtil.ResolveAndTypecheck(Options, pendingAsyncLinearParams);
       
       return pendingAsyncLinearParams;

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Boogie
       };
       foreach (var lemma in civlTypeChecker.commutativityHints.GetLemmas(first, second))
       {
-        cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(Options, lemma.function, lemma.args.ToArray())));
+        cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(lemma.function, lemma.args.ToArray())));
       }
       cmds.Add(commutativityCheck);
 

--- a/Source/Concurrency/PendingAsyncChecker.cs
+++ b/Source/Concurrency/PendingAsyncChecker.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Boogie
           Expr.Imp(
             Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0)),
             Expr.Or(action.pendingAsyncs.Select(a =>
-              ExprHelper.FunctionCall(civlTypeChecker.Options, a.pendingAsyncCtor.membership, pa)))));
+              ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa)))));
 
         CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, nonnegativeExpr);
         CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, correctTypeExpr);

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Boogie
               if (v == varCopies[orig].First() && trc.triggers.ContainsKey(orig))
               {
                 var f = trc.triggers[orig];
-                exprs.Add(ExprHelper.FunctionCall(Options, f, Expr.Ident(existsVarMap[v])));
+                exprs.Add(ExprHelper.FunctionCall(f, Expr.Ident(existsVarMap[v])));
               }
             }
 
@@ -535,7 +535,7 @@ namespace Microsoft.Boogie
             Enumerable.Zip(varToWitnesses.Keys, witnessSet, Tuple.Create))
           {
             CommutativityWitness witness = pair.Item2;
-            witnessSubst[pair.Item1] = ExprHelper.FunctionCall(Options,
+            witnessSubst[pair.Item1] = ExprHelper.FunctionCall(
               witness.function, witness.args.ToArray()
             );
           }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Boogie
 
       if (SummaryHasPendingAsyncParam)
       {
-        var collectedUnionReturned = ExprHelper.FunctionCall(Options, civlTypeChecker.pendingAsyncAdd,
+        var collectedUnionReturned = ExprHelper.FunctionCall(civlTypeChecker.pendingAsyncAdd,
           Expr.Ident(CollectedPAs), Expr.Ident(ReturnedPAs));
         newCmdSeq.Add(CmdHelper.AssignCmd(CollectedPAs, collectedUnionReturned));
       }
@@ -616,7 +616,7 @@ namespace Microsoft.Boogie
           }
         }
 
-        var pa = ExprHelper.FunctionCall(Options, paAction.pendingAsyncCtor, newIns);
+        var pa = ExprHelper.FunctionCall(paAction.pendingAsyncCtor, newIns);
         var inc = Expr.Add(Expr.Select(Expr.Ident(CollectedPAs), pa), Expr.Literal(1));
         var add = CmdHelper.AssignCmd(CollectedPAs, Expr.Store(Expr.Ident(CollectedPAs), pa, inc));
         newCmdSeq.Add(add);


### PR DESCRIPTION
ExprHelper contains a method to create a function call. This method was doing resolution and typechecking on the returned expression even though (1) other expression generators were not and (2) a separate helper method for resolving and typechecking generated Absy's has been provided in CivlUtil.cs. As a result, the situation was confusing, at least for me. This PR eliminates the typechecking from the expression generation leaving it to the caller to make sure things are resolved properly.