### PR TITLE
Eliminate selector and membership functions

### DIFF
--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Boogie
       return new NAryExpr(Token.NoToken, new FieldAccess(Token.NoToken, fieldName), new Expr[] { path });
     }
 
+    public static NAryExpr IsConstructor(Expr path, string constructorName)
+    {
+      return new NAryExpr(Token.NoToken, new IsConstructor(Token.NoToken, constructorName), new Expr[] { path });
+    }
+    
     public static NAryExpr IfThenElse(Expr ifExpr, Expr thenExpr, Expr elseExpr)
     {
       return new NAryExpr(Token.NoToken, new IfThenElse(Token.NoToken),

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Boogie
 
       List<Cmd> cmds = new List<Cmd>();
       cmds.Add(GetCallCmd(invariantAction));
-      cmds.Add(CmdHelper.AssumeCmd(ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.membership, choice)));
+      cmds.Add(CmdHelper.AssumeCmd(ExprHelper.IsConstructor(choice, pendingAsync.pendingAsyncCtor.Name)));
       cmds.Add(CmdHelper.AssumeCmd(Expr.Gt(Expr.Select(PAs, choice), Expr.Literal(0))));
       cmds.Add(RemoveChoice);
 
@@ -121,7 +121,7 @@ namespace Microsoft.Boogie
       List<Expr> inputExprs = new List<Expr>();
       for (int i = 0; i < abs.impl.InParams.Count; i++)
       {
-        var pendingAsyncParam = ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.selectors[i], choice);
+        var pendingAsyncParam = ExprHelper.FieldAccess(choice, pendingAsync.pendingAsyncCtor.InParams[i].Name);
         map[abs.impl.InParams[i]] = pendingAsyncParam;
         inputExprs.Add(pendingAsyncParam);
       }
@@ -228,7 +228,7 @@ namespace Microsoft.Boogie
         var expr = Expr.Imp(
           Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0)),
           Expr.And(elim.Keys.Select(a =>
-            Expr.Not(ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa)))));
+            Expr.Not(ExprHelper.IsConstructor(pa, a.pendingAsyncCtor.Name)))));
         expr.Typecheck(new TypecheckingContext(null, civlTypeChecker.Options));
         return ExprHelper.ForallExpr(new List<Variable> { paBound }, expr);
       }
@@ -247,7 +247,7 @@ namespace Microsoft.Boogie
     private Expr ElimPendingAsyncExpr(IdentifierExpr pa)
     {
       return Expr.And(
-        Expr.Or(elim.Keys.Select(a => ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa))),
+        Expr.Or(elim.Keys.Select(a => ExprHelper.IsConstructor(pa, a.pendingAsyncCtor.Name))),
         Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0))
       );
     }

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -1100,7 +1100,7 @@ namespace Microsoft.Boogie
             // Permissions in linear output variables + linear inputs of a single pending async
             // are a subset of permissions in linear input variables.
             var exactlyOnePA = Expr.And(
-              ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.membership, pa1),
+              ExprHelper.IsConstructor(pa1, pendingAsync.pendingAsyncCtor.Name),
               Expr.Eq(Expr.Select(PAs, pa1), Expr.Literal(1)));
             var outSubsetInExpr = OutPermsSubsetInPerms(domain, inVars, pendingAsyncLinearParams.Union(outVars));
             linearityChecks.Add(new LinearityCheck(
@@ -1113,7 +1113,7 @@ namespace Microsoft.Boogie
             // Third kind
             // If there are two identical pending asyncs, then their input permissions mut be empty.
             var twoIdenticalPAs = Expr.And(
-              ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.membership, pa1),
+              ExprHelper.IsConstructor(pa1, pendingAsync.pendingAsyncCtor.Name),
               Expr.Ge(Expr.Select(PAs, pa1), Expr.Literal(2)));
             var emptyPerms = OutPermsSubsetInPerms(domain, Enumerable.Empty<Expr>(), pendingAsyncLinearParams);
             linearityChecks.Add(new LinearityCheck(
@@ -1146,8 +1146,8 @@ namespace Microsoft.Boogie
               var membership = Expr.And(
                 Expr.Neq(pa1, pa2),
                 Expr.And(
-                  ExprHelper.FunctionCall(pendingAsync1.pendingAsyncCtor.membership, pa1),
-                  ExprHelper.FunctionCall(pendingAsync2.pendingAsyncCtor.membership, pa2)));
+                  ExprHelper.IsConstructor(pa1, pendingAsync1.pendingAsyncCtor.Name),
+                  ExprHelper.IsConstructor(pa2, pendingAsync2.pendingAsyncCtor.Name)));
 
               var existing = Expr.And(
                 Expr.Ge(Expr.Select(PAs, pa1), Expr.Literal(1)),
@@ -1214,7 +1214,7 @@ namespace Microsoft.Boogie
         var inParam = pendingAsync.proc.InParams[i];
         if (FindDomainName(inParam) == domain.domainName && InKinds.Contains(FindLinearKind(inParam)))
         {
-          var pendingAsyncParam = ExprHelper.FunctionCall(pendingAsync.pendingAsyncCtor.selectors[i], pa);
+          var pendingAsyncParam = ExprHelper.FieldAccess(pa, pendingAsync.pendingAsyncCtor.InParams[i].Name);
           pendingAsyncLinearParams.Add(pendingAsyncParam);
         }
       }

--- a/Source/Concurrency/PendingAsyncChecker.cs
+++ b/Source/Concurrency/PendingAsyncChecker.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Boogie
           Expr.Imp(
             Expr.Gt(Expr.Select(PAs, pa), Expr.Literal(0)),
             Expr.Or(action.pendingAsyncs.Select(a =>
-              ExprHelper.FunctionCall(a.pendingAsyncCtor.membership, pa)))));
+              ExprHelper.IsConstructor(pa, a.pendingAsyncCtor.Name)))));
 
         CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, nonnegativeExpr);
         CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, correctTypeExpr);

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -339,9 +339,7 @@ namespace Microsoft.Boogie
           errors.SemErr(func.tok, $"output type of constructor {func.Name} must be a datatype");
           continue;
         }
-        var datatypeTypeCtorDecl = datatypeTypeCtorDecls[outputTypeName];
-        DatatypeConstructor constructor = new DatatypeConstructor(datatypeTypeCtorDecl, func);
-        datatypeTypeCtorDecl.AddConstructor(constructor);
+        datatypeTypeCtorDecls[outputTypeName].AddConstructor(func);
       }
       if (errors.count > 0)
       {
@@ -1416,9 +1414,12 @@ namespace Microsoft.Boogie
       this.accessors = new Dictionary<string, List<DatatypeAccessor>>();
     }
 
-    public void AddConstructor(DatatypeConstructor constructor)
+    public void AddConstructor(Function function)
     {
-      constructor.index = constructors.Count;
+      var constructor = new DatatypeConstructor(this, function)
+      {
+        index = constructors.Count
+      };
       this.constructors.Add(constructor);
       for (int i = 0; i < constructor.InParams.Count; i++)
       {
@@ -2601,6 +2602,7 @@ namespace Microsoft.Boogie
     public DatatypeTypeCtorDecl datatypeTypeCtorDecl;
     public int index;
 
+    // This constructor should only be called by the AddConstructor method in DatatypeTypeCtorDecl
     public DatatypeConstructor(DatatypeTypeCtorDecl datatypeTypeCtorDecl, Function func)
       : base(func.tok, func.Name, func.TypeParameters, func.InParams, func.OutParams[0], func.Comment, func.Attributes)
     {

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Boogie
         var outputTypeName = ((UnresolvedTypeIdentifier)func.OutParams[0].TypedIdent.Type).Name;
         if (!datatypeTypeCtorDecls.ContainsKey(outputTypeName))
         {
-          errors.SemErr(func.tok, $"output type of constructor does not match any datatype name: {func.Name}");
+          errors.SemErr(func.tok, $"output type of constructor {func.Name} must be a datatype");
           continue;
         }
         var datatypeTypeCtorDecl = datatypeTypeCtorDecls[outputTypeName];
@@ -2609,14 +2609,14 @@ namespace Microsoft.Boogie
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      CtorType outputType = this.OutParams[0].TypedIdent.Type as CtorType;
-      if (outputType == null || !outputType.IsDatatype())
+      var outputType = (CtorType)this.OutParams[0].TypedIdent.Type;
+      if (!outputType.Arguments.All(t => t is TypeVariable))
       {
-        tc.Error(tok, "The output type of a constructor must be a datatype");
-      }
-      else if (!outputType.Arguments.All(t => t is TypeVariable))
+        tc.Error(tok, "Each argument of the output type must be a type variable");
+      } 
+      else if (TypeParameters.Count != outputType.Arguments.Count)
       {
-        tc.Error(tok, "Each type argument of the output type of a constructor must be a type variable");
+        tc.Error(tok, "Each type parameter must appear as an argument to the output type");
       }
       base.Typecheck(tc);
     }

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -3860,18 +3860,18 @@ namespace Microsoft.Boogie
     
     // each accessor is specified by a pair comprising a constructor index
     // and a selector index within the constructor corresponding to it
-    public List<Tuple<int, int>> Accessors { get; set; }
+    public List<DatatypeAccessor> Accessors { get; set; }
 
     public DatatypeConstructor Constructor(int index)
     {
       var accessor = Accessors[index];
-      return DatatypeTypeCtorDecl.Constructors[accessor.Item1];
+      return DatatypeTypeCtorDecl.Constructors[accessor.ConstructorIndex];
     }
     
-    private Variable Selector(int index)
+    private Variable Field(int index)
     {
       var accessor = Accessors[index];
-      return DatatypeTypeCtorDecl.Constructors[accessor.Item1].InParams[accessor.Item2];
+      return DatatypeTypeCtorDecl.Constructors[accessor.ConstructorIndex].InParams[accessor.FieldIndex];
     }
 
     public FieldAccess(IToken tok, string fieldName)
@@ -3880,12 +3880,12 @@ namespace Microsoft.Boogie
       this.FieldName = fieldName;
     }
     
-    public FieldAccess(IToken tok, DatatypeTypeCtorDecl datatypeTypeCtorDecl, List<Tuple<int, int>> accessors)
+    public FieldAccess(IToken tok, DatatypeTypeCtorDecl datatypeTypeCtorDecl, List<DatatypeAccessor> accessors)
     {
       this.tok = tok;
       this.DatatypeTypeCtorDecl = datatypeTypeCtorDecl;
       this.Accessors = accessors;
-      this.FieldName = Selector(0).Name;
+      this.FieldName = Field(0).Name;
     }
 
     public string FunctionName => "field-access";
@@ -3966,12 +3966,12 @@ namespace Microsoft.Boogie
       var typeSubst = Constructor(0).TypeParameters.Zip(ctorType.Arguments).ToDictionary(
           x => x.Item1, 
           x => x.Item2);
-      return Selector(0).TypedIdent.Type.Substitute(typeSubst);
+      return Field(0).TypedIdent.Type.Substitute(typeSubst);
     }
 
     public Type ShallowType(IList<Expr> args)
     {
-      return Selector(0).TypedIdent.Type;
+      return Field(0).TypedIdent.Type;
     }
 
     public T Dispatch<T>(IAppliableVisitor<T> visitor)
@@ -4003,7 +4003,7 @@ namespace Microsoft.Boogie
       var constructor = Constructor(index);
       var args = Enumerable.Range(0, constructor.InParams.Count).Select(x =>
       {
-        if (x == Accessors[index].Item2)
+        if (x == Accessors[index].FieldIndex)
         {
           return rhs;
         }

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -3856,13 +3856,13 @@ namespace Microsoft.Boogie
     
     public string FieldName { get; }
 
-    public DatatypeTypeCtorDecl DatatypeTypeCtorDecl { get; set; }
+    public DatatypeTypeCtorDecl DatatypeTypeCtorDecl { get; private set; }
     
     // each accessor is specified by a pair comprising a constructor index
     // and a selector index within the constructor corresponding to it
-    public List<DatatypeAccessor> Accessors { get; set; }
+    public List<DatatypeAccessor> Accessors { get; private set; }
 
-    public DatatypeConstructor Constructor(int index)
+    private DatatypeConstructor Constructor(int index)
     {
       var accessor = Accessors[index];
       return DatatypeTypeCtorDecl.Constructors[accessor.ConstructorIndex];
@@ -4021,9 +4021,9 @@ namespace Microsoft.Boogie
     
     public string ConstructorName { get; }
     
-    public DatatypeTypeCtorDecl DatatypeTypeCtorDecl { get; set; }
+    public DatatypeTypeCtorDecl DatatypeTypeCtorDecl { get; private set; }
     
-    public int ConstructorIndex { get; set; }
+    public int ConstructorIndex { get; private set; }
     
     public IsConstructor(IToken tok, string constructorName)
     {

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -3868,7 +3868,7 @@ namespace Microsoft.Boogie
       return DatatypeTypeCtorDecl.Constructors[accessor.Item1];
     }
     
-    public DatatypeSelector Selector(int index)
+    private DatatypeSelector Selector(int index)
     {
       var accessor = Accessors[index];
       return DatatypeTypeCtorDecl.Constructors[accessor.Item1].selectors[accessor.Item2];
@@ -3997,16 +3997,18 @@ namespace Microsoft.Boogie
       }
       return expr;
     }
-    
+
     private NAryExpr Update(IToken token, Expr record, Expr rhs, int index)
     {
-      var args = Constructor(index).selectors.Select(x =>
+      var constructor = Constructor(index);
+      var args = Enumerable.Range(0, constructor.InParams.Count).Select(x =>
       {
-        if (x == Selector(index))
+        if (x == Accessors[index].Item2)
         {
           return rhs;
         }
-        var fieldAccess = new FieldAccess(tok, DatatypeTypeCtorDecl,  DatatypeTypeCtorDecl.GetAccessors(x.OriginalName));
+        var fieldAccess = new FieldAccess(tok, DatatypeTypeCtorDecl,
+          DatatypeTypeCtorDecl.GetAccessors(constructor.InParams[x].Name));
         return fieldAccess.Select(token, record);
       }).ToList();
       return new NAryExpr(token, new FunctionCall(Constructor(index)), args);
@@ -4023,7 +4025,7 @@ namespace Microsoft.Boogie
     
     public int ConstructorIndex { get; set; }
     
-    public DatatypeMembership Membership => DatatypeTypeCtorDecl.Constructors[ConstructorIndex].membership;
+    private DatatypeMembership Membership => DatatypeTypeCtorDecl.Constructors[ConstructorIndex].membership;
 
     public IsConstructor(IToken tok, string constructorName)
     {

--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -3868,10 +3868,10 @@ namespace Microsoft.Boogie
       return DatatypeTypeCtorDecl.Constructors[accessor.Item1];
     }
     
-    private DatatypeSelector Selector(int index)
+    private Variable Selector(int index)
     {
       var accessor = Accessors[index];
-      return DatatypeTypeCtorDecl.Constructors[accessor.Item1].selectors[accessor.Item2];
+      return DatatypeTypeCtorDecl.Constructors[accessor.Item1].InParams[accessor.Item2];
     }
 
     public FieldAccess(IToken tok, string fieldName)
@@ -3885,7 +3885,7 @@ namespace Microsoft.Boogie
       this.tok = tok;
       this.DatatypeTypeCtorDecl = datatypeTypeCtorDecl;
       this.Accessors = accessors;
-      this.FieldName = Selector(0).OriginalName;
+      this.FieldName = Selector(0).Name;
     }
 
     public string FunctionName => "field-access";
@@ -3962,16 +3962,16 @@ namespace Microsoft.Boogie
         return null;
       }
       Contract.Assert(Accessors.Count > 0);
-      tpInstantiation = SimpleTypeParamInstantiation.From(Selector(0).TypeParameters, ctorType.Arguments);
-      var typeSubst = Selector(0).TypeParameters.Zip(ctorType.Arguments).ToDictionary(
+      tpInstantiation = SimpleTypeParamInstantiation.From(Constructor(0).TypeParameters, ctorType.Arguments);
+      var typeSubst = Constructor(0).TypeParameters.Zip(ctorType.Arguments).ToDictionary(
           x => x.Item1, 
           x => x.Item2);
-      return Selector(0).OutParams[0].TypedIdent.Type.Substitute(typeSubst);
+      return Selector(0).TypedIdent.Type.Substitute(typeSubst);
     }
 
     public Type ShallowType(IList<Expr> args)
     {
-      return Selector(0).OutParams[0].TypedIdent.Type;
+      return Selector(0).TypedIdent.Type;
     }
 
     public T Dispatch<T>(IAppliableVisitor<T> visitor)
@@ -4025,8 +4025,6 @@ namespace Microsoft.Boogie
     
     public int ConstructorIndex { get; set; }
     
-    private DatatypeMembership Membership => DatatypeTypeCtorDecl.Constructors[ConstructorIndex].membership;
-
     public IsConstructor(IToken tok, string constructorName)
     {
       this.tok = tok;
@@ -4116,7 +4114,7 @@ namespace Microsoft.Boogie
         return null;
       }
       ConstructorIndex = constructor.index;
-      tpInstantiation = SimpleTypeParamInstantiation.From(Membership.TypeParameters, ctorType.Arguments);
+      tpInstantiation = SimpleTypeParamInstantiation.From(constructor.TypeParameters, ctorType.Arguments);
       return Type.Bool;
     }
 

--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -54,8 +54,8 @@ function {:inline} Range(from: int, n: int): [int]bool {
   MapDiff(AtLeast(from), AtLeast(from + n))
 }
 
-axiom {:ctor "Vec"} (forall<T> x: Vec T :: {len#Vec(x)}{contents#Vec(x)} MapIte(Range(0, len#Vec(x)), MapConst(Default()), contents#Vec(x)) == MapConst(Default()));
-axiom {:ctor "Vec"} (forall<T> x: Vec T :: {len#Vec(x)} len#Vec(x) >= 0);
+axiom {:ctor "Vec"} (forall<T> x: Vec T :: {x->len}{x->contents} MapIte(Range(0, x->len), MapConst(Default()), x->contents) == MapConst(Default()));
+axiom {:ctor "Vec"} (forall<T> x: Vec T :: {x->len} x->len >= 0);
 
 function {:inline} Vec_Empty<T>(): Vec T
 {
@@ -63,19 +63,19 @@ function {:inline} Vec_Empty<T>(): Vec T
 }
 function {:inline} Vec_Append<T>(v: Vec T, x: T) : Vec T
 {
-  Vec(contents#Vec(v)[len#Vec(v) := x], len#Vec(v) + 1)
+  Vec(v->contents[v->len := x], v->len + 1)
 }
 function {:inline} Vec_Update<T>(v: Vec T, i: int, x: T) : Vec T
 {
-  if (0 <= i && i < len#Vec(v)) then Vec(contents#Vec(v)[i := x], len#Vec(v)) else v
+  if (0 <= i && i < v->len) then Vec(v->contents[i := x], v->len) else v
 }
 function {:inline} Vec_Nth<T>(v: Vec T, i: int): T
 {
-  contents#Vec(v)[i]
+  v->contents[i]
 }
 function {:inline} Vec_Len<T>(v: Vec T): int
 {
-  len#Vec(v)
+  v->len
 }
 
 function {:inline} Vec_Concat<T>(v1: Vec T, v2: Vec T): Vec T {
@@ -91,7 +91,7 @@ function {:inline} Vec_Concat<T>(v1: Vec T, v2: Vec T): Vec T {
 
 function {:inline} Vec_Slice<T>(v: Vec T, i: int, j: int): Vec T {
     (
-        var cond := 0 <= i && i < j && j <= len#Vec(v);
+        var cond := 0 <= i && i < j && j <= v->len;
         Vec(
             (lambda {:pool "Slice"} k: int ::
                 if (cond && 0 <= k && k < j - i) then Vec_Nth(v, k + i)
@@ -103,15 +103,15 @@ function {:inline} Vec_Slice<T>(v: Vec T, i: int, j: int): Vec T {
 
 function {:inline} Vec_Swap<T>(v: Vec T, i: int, j: int): Vec T {
     (
-        var cond := 0 <= i && i < len#Vec(v) && 0 <= j && j < len#Vec(v);
-        Vec(contents#Vec(v)[i := contents#Vec(v)[if (cond) then j else i]][j := contents#Vec(v)[if (cond) then i else j]], len#Vec(v))
+        var cond := 0 <= i && i < v->len && 0 <= j && j < v->len;
+        Vec(v->contents[i := v->contents[if (cond) then j else i]][j := v->contents[if (cond) then i else j]], v->len)
     )
 }
 
 function {:inline} Vec_Remove<T>(v: Vec T): Vec T {
     (
-        var cond, new_len := 0 < len#Vec(v), len#Vec(v) - 1;
-        Vec(contents#Vec(v)[new_len := if (cond) then Default() else contents#Vec(v)[new_len]], if (cond) then new_len else len#Vec(v))
+        var cond, new_len := 0 < v->len, v->len - 1;
+        Vec(v->contents[new_len := if (cond) then Default() else v->contents[new_len]], if (cond) then new_len else v->len)
     )
 }
 
@@ -134,10 +134,10 @@ type {:datatype} Lmap _;
 function {:constructor} Lmap<V>(dom: [Ref V]bool, val: [Ref V]V): Lmap V;
 
 function {:inline} Lmap_Deref<V>(l: Lmap V, k: Ref V): V {
-    val#Lmap(l)[k]
+    l->val[k]
 }
 function {:inline} Lmap_Contains<V>(l: Lmap V, k: Ref V): bool {
-    dom#Lmap(l)[k]
+    l->dom[k]
 }
 procedure Lmap_Empty<V>() returns (l: Lmap V);
 procedure Lmap_Split<V>(path: Lmap V, k: [Ref V]bool) returns (l: Lmap V);
@@ -152,7 +152,7 @@ type {:datatype} Lset _;
 function {:constructor} Lset<V>(dom: [V]bool): Lset V;
 
 function {:inline} Lset_Contains<V>(l: Lset V, k: V): bool {
-    dom#Lset(l)[k]
+    l->dom[k]
 }
 procedure Lset_Empty<V>() returns (l: Lset V);
 procedure Lset_Split<V>(path: Lset V, k: [V]bool) returns (l: Lset V);

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -539,11 +539,7 @@ namespace Microsoft.Boogie
         var newConstructor = new DatatypeConstructor(newDatatypeTypeCtorDecl,
           InstantiateFunctionSignature(constructor, actualTypeParams,
             LinqExtender.Map(constructor.TypeParameters, actualTypeParams)));
-        newConstructor.membership = DatatypeMembership.NewDatatypeMembership(newConstructor);
-        for (int i = 0; i < newConstructor.InParams.Count; i++)
-        {
-          newConstructor.AddSelector(DatatypeSelector.NewDatatypeSelector(newConstructor, i), out _);
-        }
+        newDatatypeTypeCtorDecl.AddConstructor(newConstructor);
       }
 
       private static string MkInstanceName(string name, List<Type> actualTypeParams)
@@ -649,15 +645,7 @@ namespace Microsoft.Boogie
           // to the corresponding instantiated types
           if (functionCall.Func.TypeParameters.Count == 0)
           {
-            if (functionCall.Func is DatatypeMembership membership)
-            {
-              monomorphizationVisitor.VisitTypeCtorDecl(membership.constructor.datatypeTypeCtorDecl);
-            }
-            else if (functionCall.Func is DatatypeSelector selector)
-            {
-              monomorphizationVisitor.VisitTypeCtorDecl(selector.constructor.datatypeTypeCtorDecl);
-            }
-            else if (functionCall.Func is DatatypeConstructor constructor)
+            if (functionCall.Func is DatatypeConstructor constructor)
             {
               monomorphizationVisitor.VisitTypeCtorDecl(constructor.datatypeTypeCtorDecl);
             }
@@ -673,23 +661,7 @@ namespace Microsoft.Boogie
               returnExpr.TypeParameters.FormalTypeParams.Select(x =>
                   TypeProxy.FollowProxy(returnExpr.TypeParameters[x]).Substitute(typeParamInstantiation))
                 .Select(x => LookupType(x)).ToList();
-            if (functionCall.Func is DatatypeMembership membership)
-            {
-              InstantiateTypeCtorDecl(membership.constructor.datatypeTypeCtorDecl, actualTypeParams);
-              var datatypeTypeCtorDecl =
-                (DatatypeTypeCtorDecl) monomorphizationVisitor.typeInstantiations[membership.constructor.datatypeTypeCtorDecl][actualTypeParams];
-              returnExpr.Fun =
-                new FunctionCall(datatypeTypeCtorDecl.Constructors[membership.constructor.index].membership);
-            }
-            else if (functionCall.Func is DatatypeSelector selector)
-            {
-              InstantiateTypeCtorDecl(selector.constructor.datatypeTypeCtorDecl, actualTypeParams);
-              var datatypeTypeCtorDecl =
-                (DatatypeTypeCtorDecl) monomorphizationVisitor.typeInstantiations[selector.constructor.datatypeTypeCtorDecl][actualTypeParams];
-              returnExpr.Fun = new FunctionCall(datatypeTypeCtorDecl.Constructors[selector.constructor.index]
-                .selectors[selector.index]);
-            }
-            else if (functionCall.Func is DatatypeConstructor constructor)
+            if (functionCall.Func is DatatypeConstructor constructor)
             {
               InstantiateTypeCtorDecl(constructor.datatypeTypeCtorDecl, actualTypeParams);
               var datatypeTypeCtorDecl =
@@ -1105,18 +1077,11 @@ namespace Microsoft.Boogie
       visitedTypeCtorDecls.Add(node);
       if (node is DatatypeTypeCtorDecl datatypeTypeCtorDecl)
       {
-        datatypeTypeCtorDecl.Constructors.Iter(constructor => VisitConstructor(constructor));
+        datatypeTypeCtorDecl.Constructors.Iter(constructor => base.VisitFunction(constructor));
       }
       return base.VisitTypeCtorDecl(node);
     }
 
-    private void VisitConstructor(DatatypeConstructor constructor)
-    {
-      base.VisitFunction(constructor);
-      base.VisitFunction(constructor.membership);
-      constructor.selectors.Iter(selector => base.VisitFunction(selector));
-    }
-    
     // this function may be called directly by monomorphizationDuplicator
     // if a non-generic function call is discovered in an expression
     public override Function VisitFunction(Function node)

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -520,6 +520,7 @@ namespace Microsoft.Boogie
               .Add(actualTypeParams, newDatatypeTypeCtorDecl);
             datatypeTypeCtorDecl.Constructors.Iter(constructor =>
               InstantiateDatatypeConstructor(newDatatypeTypeCtorDecl, constructor, actualTypeParams));
+            newDatatypeTypeCtorDecl.Resolve(new ResolutionContext(null, null));
           }
           else
           {

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -519,7 +519,11 @@ namespace Microsoft.Boogie
             monomorphizationVisitor.typeInstantiations[datatypeTypeCtorDecl]
               .Add(actualTypeParams, newDatatypeTypeCtorDecl);
             datatypeTypeCtorDecl.Constructors.Iter(constructor =>
-              InstantiateDatatypeConstructor(newDatatypeTypeCtorDecl, constructor, actualTypeParams));
+            {
+              var function = InstantiateFunctionSignature(constructor, actualTypeParams,
+                LinqExtender.Map(constructor.TypeParameters, actualTypeParams));
+              newDatatypeTypeCtorDecl.AddConstructor(function);
+            });
             newDatatypeTypeCtorDecl.Resolve(new ResolutionContext(null, null));
           }
           else
@@ -532,13 +536,6 @@ namespace Microsoft.Boogie
           }
         }
         return monomorphizationVisitor.typeInstantiations[typeCtorDecl][actualTypeParams];
-      }
-
-      private void InstantiateDatatypeConstructor(DatatypeTypeCtorDecl newDatatypeTypeCtorDecl,
-        DatatypeConstructor constructor, List<Type> actualTypeParams)
-      {
-        newDatatypeTypeCtorDecl.AddConstructor(InstantiateFunctionSignature(constructor, actualTypeParams,
-          LinqExtender.Map(constructor.TypeParameters, actualTypeParams)));
       }
 
       private static string MkInstanceName(string name, List<Type> actualTypeParams)

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -537,10 +537,8 @@ namespace Microsoft.Boogie
       private void InstantiateDatatypeConstructor(DatatypeTypeCtorDecl newDatatypeTypeCtorDecl,
         DatatypeConstructor constructor, List<Type> actualTypeParams)
       {
-        var newConstructor = new DatatypeConstructor(newDatatypeTypeCtorDecl,
-          InstantiateFunctionSignature(constructor, actualTypeParams,
-            LinqExtender.Map(constructor.TypeParameters, actualTypeParams)));
-        newDatatypeTypeCtorDecl.AddConstructor(newConstructor);
+        newDatatypeTypeCtorDecl.AddConstructor(InstantiateFunctionSignature(constructor, actualTypeParams,
+          LinqExtender.Map(constructor.TypeParameters, actualTypeParams)));
       }
 
       private static string MkInstanceName(string name, List<Type> actualTypeParams)

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -785,7 +785,7 @@ namespace Microsoft.Boogie.SMTLib
         var op = (VCExprIsConstructorOp)node.Op;
         var constructor = op.DatatypeTypeCtorDecl.Constructors[op.ConstructorIndex];
         var name = "is-" + constructor.Name;
-        name = ExprLineariser.Namer.GetQuotedName(constructor.membership, name);
+        name = ExprLineariser.Namer.GetQuotedName(name, name);
         WriteApplication(name, node, options);
         return true;
       }

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -769,6 +769,27 @@ namespace Microsoft.Boogie.SMTLib
         return true;
       }
 
+      public bool VisitFieldAccessOp(VCExprNAry node, LineariserOptions options)
+      {
+        var op = (VCExprFieldAccessOp)node.Op;
+        var constructor = op.DatatypeTypeCtorDecl.Constructors[op.ConstructorIndex];
+        Variable v = constructor.InParams[op.SelectorIndex];
+        var name = v.Name + "#" + constructor.Name;
+        name = ExprLineariser.Namer.GetQuotedName(v, name);
+        WriteApplication(name, node, options);
+        return true;
+      }
+
+      public bool VisitIsConstructorOp(VCExprNAry node, LineariserOptions options)
+      {
+        var op = (VCExprIsConstructorOp)node.Op;
+        var constructor = op.DatatypeTypeCtorDecl.Constructors[op.ConstructorIndex];
+        var name = "is-" + constructor.Name;
+        name = ExprLineariser.Namer.GetQuotedName(constructor.membership, name);
+        WriteApplication(name, node, options);
+        return true;
+      }
+
       public bool VisitSelectOp(VCExprNAry node, LineariserOptions options)
       {
         var name = ExprLineariser.SelectOpName(node);
@@ -992,25 +1013,6 @@ namespace Microsoft.Boogie.SMTLib
         return true;
       }
 
-      private string ExtractDatatype(Function func)
-      {
-        if (func is DatatypeSelector)
-        {
-          DatatypeSelector selector = (DatatypeSelector) func;
-          Variable v = selector.constructor.InParams[selector.index];
-          return ExprLineariser.Namer.GetQuotedName(v, v.Name + "#" + selector.constructor.Name);
-        }
-        else if (func is DatatypeMembership)
-        {
-          DatatypeMembership membership = (DatatypeMembership) func;
-          return ExprLineariser.Namer.GetQuotedName(membership, "is-" + membership.constructor.Name);
-        }
-        else
-        {
-          return null;
-        }
-      }
-
       public bool VisitBoogieFunctionOp(VCExprNAry node, LineariserOptions options)
       {
         VCExprBoogieFunctionOp op = (VCExprBoogieFunctionOp) node.Op;
@@ -1018,7 +1020,6 @@ namespace Microsoft.Boogie.SMTLib
         string printedName;
 
         var builtin = ExprLineariser.ExtractBuiltin(op.Func);
-        var datatype = ExtractDatatype(op.Func);
         if (builtin != null)
         {
           printedName = CheckSeqApply(builtin, node);
@@ -1026,10 +1027,6 @@ namespace Microsoft.Boogie.SMTLib
           {
             printedName = CheckMapApply(builtin, node);
           }
-        }
-        else if (datatype != null)
-        {
-          printedName = datatype;
         }
         else
         {

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -773,7 +773,7 @@ namespace Microsoft.Boogie.SMTLib
       {
         var op = (VCExprFieldAccessOp)node.Op;
         var constructor = op.DatatypeTypeCtorDecl.Constructors[op.ConstructorIndex];
-        Variable v = constructor.InParams[op.SelectorIndex];
+        Variable v = constructor.InParams[op.FieldIndex];
         var name = v.Name + "#" + constructor.Name;
         name = ExprLineariser.Namer.GetQuotedName(v, name);
         WriteApplication(name, node, options);

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Boogie.SMTLib
       {
         VCExprBoogieFunctionOp op = node.Op as VCExprBoogieFunctionOp;
         if (op != null &&
-            !(op.Func is DatatypeConstructor) && !(op.Func is DatatypeMembership) && !(op.Func is DatatypeSelector) &&
+            !(op.Func is DatatypeConstructor) &&
             !KnownFunctions.Contains(op.Func))
         {
           Function f = op.Func;

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -1414,7 +1414,7 @@ namespace Microsoft.Boogie.VCExprAST
     public VCExpr Visit(FieldAccess fieldAccess)
     {
       var accessor = fieldAccess.Accessors[0];
-      var expr = Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor.ConstructorIndex, accessor.FieldIndex),
+      var expr = Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor),
         this.args);
       for (int i = 1; i < fieldAccess.Accessors.Count; i++)
       {
@@ -1422,7 +1422,7 @@ namespace Microsoft.Boogie.VCExprAST
         var condExpr = Gen.Function(new VCExprIsConstructorOp(fieldAccess.DatatypeTypeCtorDecl, accessor.ConstructorIndex),
           this.args);
         var thenExpr =
-          Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor.ConstructorIndex, accessor.FieldIndex),
+          Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor),
             this.args);
         expr = Gen.Function(VCExpressionGenerator.IfThenElseOp, new List<VCExpr>() { condExpr, thenExpr, expr });
       }

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -1413,12 +1413,17 @@ namespace Microsoft.Boogie.VCExprAST
     
     public VCExpr Visit(FieldAccess fieldAccess)
     {
-      Contract.Ensures(Contract.Result<VCExpr>() != null);
-      var expr = Gen.Function(fieldAccess.Selector(0), this.args);
+      var accessor = fieldAccess.Accessors[0];
+      var expr = Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor.Item1, accessor.Item2),
+        this.args);
       for (int i = 1; i < fieldAccess.Accessors.Count; i++)
       {
-        var condExpr = Gen.Function(fieldAccess.Constructor(i).membership, this.args);
-        var thenExpr = Gen.Function(fieldAccess.Selector(i), this.args);
+        accessor = fieldAccess.Accessors[i];
+        var condExpr = Gen.Function(new VCExprIsConstructorOp(fieldAccess.DatatypeTypeCtorDecl, accessor.Item1),
+          this.args);
+        var thenExpr =
+          Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor.Item1, accessor.Item2),
+            this.args);
         expr = Gen.Function(VCExpressionGenerator.IfThenElseOp, new List<VCExpr>() { condExpr, thenExpr, expr });
       }
       return expr;
@@ -1426,10 +1431,10 @@ namespace Microsoft.Boogie.VCExprAST
 
     public VCExpr Visit(IsConstructor isConstructor)
     {
-      Contract.Ensures(Contract.Result<VCExpr>() != null);
-      return Gen.Function(isConstructor.Membership, this.args);
+      return Gen.Function(new VCExprIsConstructorOp(isConstructor.DatatypeTypeCtorDecl, isConstructor.ConstructorIndex), this.args);
     }
-
+    
+    
     ///////////////////////////////////////////////////////////////////////////////
 
     private VCExpr TranslateBinaryOperator(BinaryOperator app, List<VCExpr /*!*/> /*!*/ args)

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -1414,15 +1414,15 @@ namespace Microsoft.Boogie.VCExprAST
     public VCExpr Visit(FieldAccess fieldAccess)
     {
       var accessor = fieldAccess.Accessors[0];
-      var expr = Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor.Item1, accessor.Item2),
+      var expr = Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor.ConstructorIndex, accessor.FieldIndex),
         this.args);
       for (int i = 1; i < fieldAccess.Accessors.Count; i++)
       {
         accessor = fieldAccess.Accessors[i];
-        var condExpr = Gen.Function(new VCExprIsConstructorOp(fieldAccess.DatatypeTypeCtorDecl, accessor.Item1),
+        var condExpr = Gen.Function(new VCExprIsConstructorOp(fieldAccess.DatatypeTypeCtorDecl, accessor.ConstructorIndex),
           this.args);
         var thenExpr =
-          Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor.Item1, accessor.Item2),
+          Gen.Function(new VCExprFieldAccessOp(fieldAccess.DatatypeTypeCtorDecl, accessor.ConstructorIndex, accessor.FieldIndex),
             this.args);
         expr = Gen.Function(VCExpressionGenerator.IfThenElseOp, new List<VCExpr>() { condExpr, thenExpr, expr });
       }

--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -988,7 +988,6 @@ namespace Microsoft.Boogie.VCExprAST
     
     public override Type InferType(List<VCExpr> args, List<Type> typeArgs)
     {
-      //return DatatypeTypeCtorDecl.Constructors[ConstructorIndex].selectors[SelectorIndex].OutParams[0].TypedIdent.Type;
       return DatatypeTypeCtorDecl.Constructors[ConstructorIndex].InParams[SelectorIndex].TypedIdent.Type;
     }
     

--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -979,16 +979,21 @@ namespace Microsoft.Boogie.VCExprAST
   public class VCExprFieldAccessOp : VCExprOp
   {
     public DatatypeTypeCtorDecl DatatypeTypeCtorDecl;
+
+    private DatatypeAccessor DatatypeAccessor;
     
-    public int ConstructorIndex;
+    public int ConstructorIndex => DatatypeAccessor.ConstructorIndex;
     
-    public int SelectorIndex;
+    public int FieldIndex => DatatypeAccessor.FieldIndex;
+    
     public override int Arity => 1;
-    public override int TypeParamArity => 0;
+    
+    public override int TypeParamArity => 0; // datatypes work only with monomorphization
     
     public override Type InferType(List<VCExpr> args, List<Type> typeArgs)
     {
-      return DatatypeTypeCtorDecl.Constructors[ConstructorIndex].InParams[SelectorIndex].TypedIdent.Type;
+      Contract.Assert(typeArgs.Count == 0);
+      return DatatypeTypeCtorDecl.Constructors[ConstructorIndex].InParams[FieldIndex].TypedIdent.Type;
     }
     
     public override bool Equals(object that)
@@ -1000,7 +1005,7 @@ namespace Microsoft.Boogie.VCExprAST
       if (that is VCExprFieldAccessOp thatOp)
       {
         return DatatypeTypeCtorDecl.Equals(thatOp.DatatypeTypeCtorDecl) &&
-               ConstructorIndex == thatOp.ConstructorIndex && SelectorIndex == thatOp.SelectorIndex;
+               ConstructorIndex == thatOp.ConstructorIndex && FieldIndex == thatOp.FieldIndex;
       }
       return false;
     }
@@ -1010,11 +1015,10 @@ namespace Microsoft.Boogie.VCExprAST
       return Arity * 1212481;
     }
 
-    internal VCExprFieldAccessOp(DatatypeTypeCtorDecl datatypeTypeCtorDecl, int constructorIndex, int selectorIndex)
+    internal VCExprFieldAccessOp(DatatypeTypeCtorDecl datatypeTypeCtorDecl, DatatypeAccessor datatypeAccessor)
     {
       DatatypeTypeCtorDecl = datatypeTypeCtorDecl;
-      ConstructorIndex = constructorIndex;
-      SelectorIndex = selectorIndex;
+      DatatypeAccessor = datatypeAccessor;
     }
 
     public override Result Accept<Result, Arg>(
@@ -1033,10 +1037,12 @@ namespace Microsoft.Boogie.VCExprAST
     public int ConstructorIndex;
     
     public override int Arity => 1;
-    public override int TypeParamArity => 0;
+    
+    public override int TypeParamArity => 0; // datatypes work only with monomorphization
     
     public override Type InferType(List<VCExpr> args, List<Type> typeArgs)
     {
+      Contract.Assert(typeArgs.Count == 0);
       return Type.Bool;
     }
     

--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -976,6 +976,105 @@ namespace Microsoft.Boogie.VCExprAST
     }
   }
 
+  public class VCExprFieldAccessOp : VCExprOp
+  {
+    public DatatypeTypeCtorDecl DatatypeTypeCtorDecl;
+    
+    public int ConstructorIndex;
+    
+    public int SelectorIndex;
+    public override int Arity => 1;
+    public override int TypeParamArity => 0;
+    
+    public override Type InferType(List<VCExpr> args, List<Type> typeArgs)
+    {
+      //return DatatypeTypeCtorDecl.Constructors[ConstructorIndex].selectors[SelectorIndex].OutParams[0].TypedIdent.Type;
+      return DatatypeTypeCtorDecl.Constructors[ConstructorIndex].InParams[SelectorIndex].TypedIdent.Type;
+    }
+    
+    public override bool Equals(object that)
+    {
+      if (Object.ReferenceEquals(this, that))
+      {
+        return true;
+      }
+      if (that is VCExprFieldAccessOp thatOp)
+      {
+        return DatatypeTypeCtorDecl.Equals(thatOp.DatatypeTypeCtorDecl) &&
+               ConstructorIndex == thatOp.ConstructorIndex && SelectorIndex == thatOp.SelectorIndex;
+      }
+      return false;
+    }
+    
+    public override int GetHashCode()
+    {
+      return Arity * 1212481;
+    }
+
+    internal VCExprFieldAccessOp(DatatypeTypeCtorDecl datatypeTypeCtorDecl, int constructorIndex, int selectorIndex)
+    {
+      DatatypeTypeCtorDecl = datatypeTypeCtorDecl;
+      ConstructorIndex = constructorIndex;
+      SelectorIndex = selectorIndex;
+    }
+
+    public override Result Accept<Result, Arg>(
+      VCExprNAry expr,
+      IVCExprOpVisitor<Result, Arg> visitor,
+      Arg arg)
+    {
+      return visitor.VisitFieldAccessOp(expr, arg);
+    }
+  }
+  
+  public class VCExprIsConstructorOp : VCExprOp
+  {
+    public DatatypeTypeCtorDecl DatatypeTypeCtorDecl;
+    
+    public int ConstructorIndex;
+    
+    public override int Arity => 1;
+    public override int TypeParamArity => 0;
+    
+    public override Type InferType(List<VCExpr> args, List<Type> typeArgs)
+    {
+      return Type.Bool;
+    }
+    
+    public override bool Equals(object that)
+    {
+      if (Object.ReferenceEquals(this, that))
+      {
+        return true;
+      }
+      if (that is VCExprIsConstructorOp thatOp)
+      {
+        return DatatypeTypeCtorDecl.Equals(thatOp.DatatypeTypeCtorDecl) &&
+               ConstructorIndex == thatOp.ConstructorIndex;
+      }
+      return false;
+    }
+    
+    public override int GetHashCode()
+    {
+      return Arity * 1212481;
+    }
+
+    internal VCExprIsConstructorOp(DatatypeTypeCtorDecl datatypeTypeCtorDecl, int constructorIndex)
+    {
+      DatatypeTypeCtorDecl = datatypeTypeCtorDecl;
+      ConstructorIndex = constructorIndex;
+    }
+
+    public override Result Accept<Result, Arg>(
+      VCExprNAry expr,
+      IVCExprOpVisitor<Result, Arg> visitor,
+      Arg arg)
+    {
+      return visitor.VisitIsConstructorOp(expr, arg);
+    }
+  }
+  
   public class VCExprSelectOp : VCExprOp
   {
     private readonly int MapArity;

--- a/Source/VCExpr/VCExprASTPrinter.cs
+++ b/Source/VCExpr/VCExprASTPrinter.cs
@@ -295,6 +295,20 @@ namespace Microsoft.Boogie.VCExprAST
       return PrintNAry("Distinct", node, wr);
     }
 
+    public bool VisitFieldAccessOp(VCExprNAry node, TextWriter wr)
+    {
+      //Contract.Requires(wr != null);
+      //Contract.Requires(node != null);
+      return PrintNAry("FieldAccess", node, wr);
+    }
+    
+    public bool VisitIsConstructorOp(VCExprNAry node, TextWriter wr)
+    {
+      //Contract.Requires(wr != null);
+      //Contract.Requires(node != null);
+      return PrintNAry("IsConstructor", node, wr);
+    }
+    
     public bool VisitSelectOp(VCExprNAry node, TextWriter wr)
     {
       //Contract.Requires(wr != null);

--- a/Source/VCExpr/VCExprASTVisitors.cs
+++ b/Source/VCExpr/VCExprASTVisitors.cs
@@ -66,6 +66,8 @@ namespace Microsoft.Boogie.VCExprAST
     Result VisitOrOp(VCExprNAry node, Arg arg);
     Result VisitImpliesOp(VCExprNAry node, Arg arg);
     Result VisitDistinctOp(VCExprNAry node, Arg arg);
+    Result VisitFieldAccessOp(VCExprNAry node, Arg arg);
+    Result VisitIsConstructorOp(VCExprNAry node, Arg arg);
     Result VisitSelectOp(VCExprNAry node, Arg arg);
     Result VisitStoreOp(VCExprNAry node, Arg arg);
     Result VisitFloatAddOp(VCExprNAry node, Arg arg);
@@ -148,6 +150,18 @@ namespace Microsoft.Boogie.VCExprAST
       throw new NotImplementedException();
     }
 
+    public Result VisitFieldAccessOp(VCExprNAry node, Arg arg)
+    {
+      Contract.Requires(node != null);
+      throw new NotImplementedException();
+    }
+    
+    public Result VisitIsConstructorOp(VCExprNAry node, Arg arg)
+    {
+      Contract.Requires(node != null);
+      throw new NotImplementedException();
+    }
+    
     public Result VisitSelectOp(VCExprNAry node, Arg arg)
     {
       Contract.Requires(node != null);
@@ -1735,6 +1749,18 @@ namespace Microsoft.Boogie.VCExprAST
       return StandardResult(node, arg);
     }
 
+    public virtual Result VisitFieldAccessOp(VCExprNAry node, Arg arg)
+    {
+      //Contract.Requires(node != null);
+      return StandardResult(node, arg);
+    }
+    
+    public virtual Result VisitIsConstructorOp(VCExprNAry node, Arg arg)
+    {
+      //Contract.Requires(node != null);
+      return StandardResult(node, arg);
+    }
+    
     public virtual Result VisitSelectOp(VCExprNAry node, Arg arg)
     {
       //Contract.Requires(node != null);

--- a/Test/datatypes/duplicate_constructor.bpl
+++ b/Test/datatypes/duplicate_constructor.bpl
@@ -1,0 +1,6 @@
+// RUN: %parallel-boogie /monomorphize "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type{:datatype} Split _;
+function{:constructor} Left<T>(i: T): Split T;
+function{:constructor} Left<U>(i: U): Split U;

--- a/Test/datatypes/duplicate_constructor.bpl.expect
+++ b/Test/datatypes/duplicate_constructor.bpl.expect
@@ -1,2 +1,2 @@
-duplicate_constructor.bpl(6,24): error: more than one declaration of datatype constructor name: Left
-1 parse errors detected in duplicate_constructor.bpl
+duplicate_constructor.bpl(6,23): Error: more than one declaration of function name: Left
+1 name resolution errors detected in duplicate_constructor.bpl

--- a/Test/datatypes/duplicate_constructor.bpl.expect
+++ b/Test/datatypes/duplicate_constructor.bpl.expect
@@ -1,0 +1,2 @@
+duplicate_constructor.bpl(6,24): error: more than one declaration of datatype constructor name: Left
+1 parse errors detected in duplicate_constructor.bpl

--- a/Test/datatypes/field_type_error.bpl.expect
+++ b/Test/datatypes/field_type_error.bpl.expect
@@ -1,2 +1,2 @@
 field_type_error.bpl(6,35): Error: type mismatch between field i and identically-named field in constructor Left
-1 name resolution errors detected in field_type_error.bpl
+1 type checking errors detected in field_type_error.bpl


### PR DESCRIPTION
Based on work in previous PRs to add source syntax for field selection and constructor testing, this PR now eliminates the functions that were being automatically generated to account for them. To enable this change, two new VCExprOp's have been introduced. The processing of datatypes in the Boogie pipeline is considerably simplified as a result.