### PR TITLE
Fixed binding precedence bug

### DIFF
--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -4061,7 +4061,7 @@ namespace Microsoft.Boogie
 
     public void Emit(IList<Expr> args, TokenTextWriter stream, int contextBindingStrength, bool fragileContext)
     {
-      const int opBindingStrength = 0x90;
+      const int opBindingStrength = 0x68;
       bool parensNeeded = opBindingStrength < contextBindingStrength ||
                           (fragileContext && opBindingStrength == contextBindingStrength);
       stream.SetToken(this);

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -1207,7 +1207,7 @@ MulOp<out IToken/*!*/ x, out BinaryOperator.Opcode op>
 /*------------------------------------------------------------------------*/
 Power<out Expr/*!*/ e0>
 = (.Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; .)
-  UnaryExpression<out e0>
+  IsConstructor<out e0>
   [
     "**"           (. x = t; .)
     /* recurse because exponentation is right-associative */
@@ -1215,26 +1215,31 @@ Power<out Expr/*!*/ e0>
   ]
   .
 
+IsConstructor<out Expr/*!*/ e0>
+= (. Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x, id; .)
+  UnaryExpression<out e0>
+  [ "is"            (. x = t; .)
+    Ident<out id>
+    (. var isConstructor = new IsConstructor(id, id.val);
+       e0 = new NAryExpr(x, isConstructor, new List<Expr> { e0 });
+    .)
+  ]
+  .
+  
 /*------------------------------------------------------------------------*/
 UnaryExpression<out Expr/*!*/ e>
-= (. Contract.Ensures(Contract.ValueAtReturn(out e) != null); IToken/*!*/ x; IsConstructor isConstructor;
+= (. Contract.Ensures(Contract.ValueAtReturn(out e) != null); IToken/*!*/ x;
      e = dummyExpr;
   .)
   ( "-"                        (. x = t; .)
     UnaryExpression<out e>     (. e = Expr.Unary(x, UnaryOperator.Opcode.Neg, e); .)
   | NegOp                      (. x = t; .)
     UnaryExpression<out e>     (. e = Expr.Unary(x, UnaryOperator.Opcode.Not, e); .)
-  | CoercionExpression<out e> [IF(la.val == "is") IsConstructor<out x, out isConstructor> (. e = new NAryExpr(x, isConstructor, new List<Expr> { e }); .)]
+  | CoercionExpression<out e>
   )
   .
 
 NegOp = "!" | '\u00ac'.
-
-IsConstructor<.out IToken x, out IsConstructor isConstructor.>
-= (. Contract.Ensures(Contract.ValueAtReturn(out isConstructor) != null); IToken id; .)
-  "is" (. x = t; .)
-  Ident<out id> (. isConstructor = new IsConstructor(id, id.val); .)
-  .
 
 /*------------------------------------------------------------------------*/
 

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -1656,7 +1656,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 
 	void Power(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; 
-		UnaryExpression(out e0);
+		IsConstructor(out e0);
 		if (la.kind == 82) {
 			Get();
 			x = t; 
@@ -1682,8 +1682,21 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		} else SynErr(134);
 	}
 
+	void IsConstructor(out Expr/*!*/ e0) {
+		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x, id; 
+		UnaryExpression(out e0);
+		if (la.kind == 83) {
+			Get();
+			x = t; 
+			Ident(out id);
+			var isConstructor = new IsConstructor(id, id.val);
+			e0 = new NAryExpr(x, isConstructor, new List<Expr> { e0 });
+			
+		}
+	}
+
 	void UnaryExpression(out Expr/*!*/ e) {
-		Contract.Ensures(Contract.ValueAtReturn(out e) != null); IToken/*!*/ x; IsConstructor isConstructor;
+		Contract.Ensures(Contract.ValueAtReturn(out e) != null); IToken/*!*/ x;
 		e = dummyExpr;
 		
 		if (la.kind == 78) {
@@ -1691,24 +1704,20 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			x = t; 
 			UnaryExpression(out e);
 			e = Expr.Unary(x, UnaryOperator.Opcode.Neg, e); 
-		} else if (la.kind == 83 || la.kind == 84) {
+		} else if (la.kind == 84 || la.kind == 85) {
 			NegOp();
 			x = t; 
 			UnaryExpression(out e);
 			e = Expr.Unary(x, UnaryOperator.Opcode.Not, e); 
 		} else if (StartOf(15)) {
 			CoercionExpression(out e);
-			if (la.val == "is") {
-				IsConstructor(out x, out isConstructor);
-				e = new NAryExpr(x, isConstructor, new List<Expr> { e }); 
-			}
 		} else SynErr(135);
 	}
 
 	void NegOp() {
-		if (la.kind == 83) {
+		if (la.kind == 84) {
 			Get();
-		} else if (la.kind == 84) {
+		} else if (la.kind == 85) {
 			Get();
 		} else SynErr(136);
 	}
@@ -1736,14 +1745,6 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				
 			} else SynErr(137);
 		}
-	}
-
-	void IsConstructor(out IToken x, out IsConstructor isConstructor) {
-		Contract.Ensures(Contract.ValueAtReturn(out isConstructor) != null); IToken id; 
-		Expect(85);
-		x = t; 
-		Ident(out id);
-		isConstructor = new IsConstructor(id, id.val); 
 	}
 
 	void ArrayExpression(out Expr/*!*/ e) {
@@ -2309,14 +2310,14 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_T, _T,_T,_T,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _T,_T,_T,_x, _T,_x,_x,_T, _T,_T,_T,_T, _x,_x,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
 		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x}
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x}
 
 	};
 } // end Parser
@@ -2424,9 +2425,9 @@ public class Errors {
 			case 80: s = "\"mod\" expected"; break;
 			case 81: s = "\"/\" expected"; break;
 			case 82: s = "\"**\" expected"; break;
-			case 83: s = "\"!\" expected"; break;
-			case 84: s = "\"\\u00ac\" expected"; break;
-			case 85: s = "\"is\" expected"; break;
+			case 83: s = "\"is\" expected"; break;
+			case 84: s = "\"!\" expected"; break;
+			case 85: s = "\"\\u00ac\" expected"; break;
 			case 86: s = "\"false\" expected"; break;
 			case 87: s = "\"true\" expected"; break;
 			case 88: s = "\"roundNearestTiesToEven\" expected"; break;

--- a/Source/Core/Scanner.cs
+++ b/Source/Core/Scanner.cs
@@ -549,7 +549,7 @@ public class Scanner {
 			case "par": t.kind = 56; break;
 			case "div": t.kind = 79; break;
 			case "mod": t.kind = 80; break;
-			case "is": t.kind = 85; break;
+			case "is": t.kind = 83; break;
 			case "false": t.kind = 86; break;
 			case "true": t.kind = 87; break;
 			case "roundNearestTiesToEven": t.kind = 88; break;
@@ -893,7 +893,7 @@ public class Scanner {
 			case 88:
 				{t.kind = 82; break;}
 			case 89:
-				{t.kind = 84; break;}
+				{t.kind = 85; break;}
 			case 90:
 				{t.kind = 99; break;}
 			case 91:
@@ -945,9 +945,9 @@ public class Scanner {
 				else if (ch == '{') {AddCh(); goto case 90;}
 				else {t.kind = 57; break;}
 			case 105:
-				recEnd = pos; recKind = 83;
+				recEnd = pos; recKind = 84;
 				if (ch == '=') {AddCh(); goto case 81;}
-				else {t.kind = 83; break;}
+				else {t.kind = 84; break;}
 			case 106:
 				recEnd = pos; recKind = 77;
 				if (ch == '+') {AddCh(); goto case 86;}

--- a/Test/civl/verified-ft.bpl
+++ b/Test/civl/verified-ft.bpl
@@ -322,7 +322,7 @@ procedure {:both} {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shad
    assert shadow.Lock[v2] == tid;
    assert shadow.Lock[ShadowableTid(tid)] == tid;
    assert v1 is ShadowableVar ==> sx.R[v1->x] == SHARED;
-   assert !v2 is ShadowableVar;
+   assert !(v2 is ShadowableVar);
    res := (forall j : int :: {f(j)} 0 <= j && f(j) ==> EpochLeq(VCArrayGet(shadow.VC[v1], j), VCArrayGet(shadow.VC[v2], j)));
 }
 
@@ -369,8 +369,8 @@ modifies shadow.VC;
     assert shadow.Lock[ShadowableTid(tid)] == tid;
     assert shadow.Lock[v1] == tid;
     assert shadow.Lock[v2] == tid;
-    assert !v1 is ShadowableVar;
-    assert !v2 is ShadowableVar;
+    assert !(v1 is ShadowableVar);
+    assert !(v2 is ShadowableVar);
     assert VCRepOk(shadow.VC[v2]);
     assert VCRepOk(shadow.VC[v1]);
     if (*) {
@@ -428,8 +428,8 @@ modifies shadow.VC;
     assert shadow.Lock[ShadowableTid(tid)] == tid;
     assert shadow.Lock[v1] == tid;
     assert shadow.Lock[v2] == tid;
-    assert !v1 is ShadowableVar;
-    assert !v2 is ShadowableVar;
+    assert !(v1 is ShadowableVar);
+    assert !(v2 is ShadowableVar);
     assert VCRepOk(shadow.VC[v2]);
     havoc shadow.VC;
     assume VCRepOk(shadow.VC[v1]);
@@ -487,7 +487,7 @@ modifies shadow.VC;
    assert ValidTid(tid);
    assert shadow.Lock[ShadowableTid(tid)] == tid;
    assert shadow.Lock[v] == tid;
-   assert !v is ShadowableVar;
+   assert !(v is ShadowableVar);
    assert i >= 0;
    assert VCRepOk(shadow.VC[v]);
    shadow.VC[v] := VCArraySetLen(shadow.VC[v], max(VCArrayLen(shadow.VC[v]), i+1));


### PR DESCRIPTION
The recently introduced ```is``` operator was being parsed incorrectly. This PR fixed the bug.