### PR TITLE
[Civl] Refactoring linear typechecker

### DIFF
--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -575,7 +575,7 @@ namespace Microsoft.Boogie
         foreach (var param in proc.InParams)
         {
           localVarToLayerRange[param] = new LayerRange(yieldInvariant.LayerNum);
-          var linearKind = linearTypeChecker.FindLinearKind(param);
+          var linearKind = LinearDomainCollector.FindLinearKind(param);
           if (linearKind == LinearKind.LINEAR_IN || linearKind == LinearKind.LINEAR_OUT)
           {
             Error(param, "Parameter to yield invariant can only be :linear");

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1617,7 +1617,7 @@ namespace Microsoft.Boogie
       private YieldInvariantCallChecker(CivlTypeChecker civlTypeChecker, QKeyValue attr, Procedure caller, List<LinearKind> kinds)
         : this(civlTypeChecker, attr,
             new HashSet<Variable>(
-              caller.InParams.Union(caller.OutParams).Where(p => kinds.Contains(civlTypeChecker.linearTypeChecker.FindLinearKind(p)))
+              caller.InParams.Union(caller.OutParams).Where(p => kinds.Contains(LinearDomainCollector.FindLinearKind(p)))
             )
           ) {}
 
@@ -1710,7 +1710,7 @@ namespace Microsoft.Boogie
       {
         foreach (var (actual, formal) in callCmd.Ins.Zip(callCmd.Proc.InParams))
         {
-          if (civlTypeChecker.linearTypeChecker.FindDomainName(formal) != null)
+          if (LinearDomainCollector.FindLinearKind(formal) != LinearKind.ORDINARY)
           {
             var decl = ((IdentifierExpr) actual).Decl;
             if (!availableLinearVars.Contains(decl))

--- a/Source/Concurrency/LinearDomainCollector.cs
+++ b/Source/Concurrency/LinearDomainCollector.cs
@@ -36,18 +36,15 @@ class LinearDomainCollector : ReadOnlyVisitor
     {
       return LinearKind.LINEAR;
     }
-    else if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_IN) != null)
+    if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_IN) != null)
     {
       return LinearKind.LINEAR_IN;
     }
-    else if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_OUT) != null)
+    if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_OUT) != null)
     {
       return LinearKind.LINEAR_OUT;
     }
-    else
-    {
-      return LinearKind.ORDINARY;
-    }
+    return LinearKind.ORDINARY;
   }
 
   public static string FindDomainName(Variable v)
@@ -67,32 +64,34 @@ class LinearDomainCollector : ReadOnlyVisitor
 
   public override Implementation VisitImplementation(Implementation node)
   {
-    if (civlTypeChecker.procToAtomicAction.ContainsKey(node.Proc) ||
-        civlTypeChecker.procToIntroductionAction.ContainsKey(node.Proc) ||
-        civlTypeChecker.procToIsAbstraction.ContainsKey(node.Proc) ||
-        civlTypeChecker.procToIsInvariant.ContainsKey(node.Proc) ||
-        civlTypeChecker.procToLemmaProc.ContainsKey(node.Proc))
+    var proc = node.Proc;
+    if (civlTypeChecker.procToAtomicAction.ContainsKey(proc) ||
+        civlTypeChecker.procToIntroductionAction.ContainsKey(proc) ||
+        civlTypeChecker.procToIsAbstraction.ContainsKey(proc) ||
+        civlTypeChecker.procToIsInvariant.ContainsKey(proc) ||
+        civlTypeChecker.procToLemmaProc.ContainsKey(proc))
     {
       return node;
     }
-    this.VisitVariableSeq(node.LocVars);
-    var proc = node.Proc;
-    this.VisitProcedure(proc);
     for (int i = 0; i < proc.InParams.Count; i++)
     {
-      if (varToLinearQualifier.ContainsKey(proc.InParams[i]))
+      var procInParam = proc.InParams[i];
+      if (procInParam.Attributes != null)
       {
-        varToLinearQualifier[node.InParams[i]] = varToLinearQualifier[proc.InParams[i]];
+        var implInParam = node.InParams[i];
+        implInParam.Attributes = (QKeyValue)procInParam.Attributes.Clone();
       }
     }
     for (int i = 0; i < proc.OutParams.Count; i++)
     {
-      if (varToLinearQualifier.ContainsKey(proc.OutParams[i]))
+      var procOutParam = proc.OutParams[i];
+      if (procOutParam.Attributes != null)
       {
-        varToLinearQualifier[node.OutParams[i]] = varToLinearQualifier[proc.OutParams[i]];
+        var implOutParam = node.OutParams[i];
+        implOutParam.Attributes = (QKeyValue)procOutParam.Attributes.Clone();
       }
     }
-    return node;
+    return base.VisitImplementation(node);
   }
 
   public override Variable VisitVariable(Variable node)

--- a/Source/Concurrency/LinearDomainCollector.cs
+++ b/Source/Concurrency/LinearDomainCollector.cs
@@ -1,249 +1,249 @@
 using System.Collections.Generic;
 using System.Linq;
-namespace Microsoft.Boogie;
 
-class LinearDomainCollector : ReadOnlyVisitor
+
+namespace Microsoft.Boogie
 {
-  private Program program;
-  private CivlTypeChecker civlTypeChecker;
-  private CheckingContext checkingContext;
-  private Dictionary<string, LinearDomain> linearDomains;
-  private Dictionary<Variable, LinearQualifier> varToLinearQualifier;
-
-  public LinearDomainCollector(Program program, CivlTypeChecker civlTypeChecker)
+  class LinearDomainCollector : ReadOnlyVisitor
   {
-    this.program = program;
-    this.civlTypeChecker = civlTypeChecker;
-    this.checkingContext = civlTypeChecker.checkingContext;
-    this.linearDomains = new Dictionary<string, LinearDomain>();
-    this.varToLinearQualifier = new Dictionary<Variable, LinearQualifier>();
-  }
+    public Program program;
+    public CivlTypeChecker civlTypeChecker;
+    public CheckingContext checkingContext;
+    private Dictionary<string, LinearDomain> linearDomains;
 
-  public static (Dictionary<string, LinearDomain>, Dictionary<Variable, LinearQualifier>) Collect(Program program, CivlTypeChecker civlTypeChecker)
-  {
-    var collector = new LinearDomainCollector(program, civlTypeChecker);
-    collector.PopulateLinearDomains();
-    if (civlTypeChecker.checkingContext.ErrorCount == 0)
+    public LinearDomainCollector(Program program, CivlTypeChecker civlTypeChecker)
     {
-      collector.VisitProgram(program);
+      this.program = program;
+      this.civlTypeChecker = civlTypeChecker;
+      this.checkingContext = civlTypeChecker.checkingContext;
+      this.linearDomains = new Dictionary<string, LinearDomain>();
     }
-    return (collector.linearDomains, collector.varToLinearQualifier);
-  }
 
-  public static LinearKind FindLinearKind(Variable v)
-  {
-    if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR) != null)
+    public static Dictionary<string, LinearDomain> Collect(Program program, CivlTypeChecker civlTypeChecker)
     {
-      return LinearKind.LINEAR;
-    }
-    if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_IN) != null)
-    {
-      return LinearKind.LINEAR_IN;
-    }
-    if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_OUT) != null)
-    {
-      return LinearKind.LINEAR_OUT;
-    }
-    return LinearKind.ORDINARY;
-  }
-
-  public static string FindDomainName(Variable v)
-  {
-    string domainName = QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR);
-    if (domainName != null)
-    {
-      return domainName;
-    }
-    domainName = QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_IN);
-    if (domainName != null)
-    {
-      return domainName;
-    }
-    return QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_OUT);
-  }
-
-  public override Implementation VisitImplementation(Implementation node)
-  {
-    var proc = node.Proc;
-    if (civlTypeChecker.procToAtomicAction.ContainsKey(proc) ||
-        civlTypeChecker.procToIntroductionAction.ContainsKey(proc) ||
-        civlTypeChecker.procToIsAbstraction.ContainsKey(proc) ||
-        civlTypeChecker.procToIsInvariant.ContainsKey(proc) ||
-        civlTypeChecker.procToLemmaProc.ContainsKey(proc))
-    {
-      return node;
-    }
-    for (int i = 0; i < proc.InParams.Count; i++)
-    {
-      var procInParam = proc.InParams[i];
-      if (procInParam.Attributes != null)
+      var collector = new LinearDomainCollector(program, civlTypeChecker);
+      collector.PopulateLinearDomains();
+      if (civlTypeChecker.checkingContext.ErrorCount == 0)
       {
-        var implInParam = node.InParams[i];
-        implInParam.Attributes = (QKeyValue)procInParam.Attributes.Clone();
+        collector.VisitProgram(program);
       }
+      return collector.linearDomains;
     }
-    for (int i = 0; i < proc.OutParams.Count; i++)
-    {
-      var procOutParam = proc.OutParams[i];
-      if (procOutParam.Attributes != null)
-      {
-        var implOutParam = node.OutParams[i];
-        implOutParam.Attributes = (QKeyValue)procOutParam.Attributes.Clone();
-      }
-    }
-    return base.VisitImplementation(node);
-  }
 
-  public override Variable VisitVariable(Variable node)
-  {
-    if (varToLinearQualifier.ContainsKey(node))
+    public static LinearKind FindLinearKind(Variable v)
     {
-      return node;
-    }
-    var kind = FindLinearKind(node);
-    if (kind == LinearKind.LINEAR_IN || kind == LinearKind.LINEAR_OUT)
-    {
-      if (node is GlobalVariable || node is LocalVariable || (node is Formal formal && !formal.InComing))
+      if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR) != null)
       {
-        checkingContext.Error(node, "Variable must be declared linear (as opposed to linear_in or linear_out)");
+        return LinearKind.LINEAR;
+      }
+      if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_IN) != null)
+      {
+        return LinearKind.LINEAR_IN;
+      }
+      if (QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_OUT) != null)
+      {
+        return LinearKind.LINEAR_OUT;
+      }
+      return LinearKind.ORDINARY;
+    }
+
+    public static string FindDomainName(Variable v)
+    {
+      string domainName = QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR);
+      if (domainName != null)
+      {
+        return domainName;
+      }
+      domainName = QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_IN);
+      if (domainName != null)
+      {
+        return domainName;
+      }
+      return QKeyValue.FindStringAttribute(v.Attributes, CivlAttributes.LINEAR_OUT);
+    }
+
+    public override Implementation VisitImplementation(Implementation node)
+    {
+      var proc = node.Proc;
+      if (civlTypeChecker.procToAtomicAction.ContainsKey(proc) ||
+          civlTypeChecker.procToIntroductionAction.ContainsKey(proc) ||
+          civlTypeChecker.procToIsAbstraction.ContainsKey(proc) ||
+          civlTypeChecker.procToIsInvariant.ContainsKey(proc) ||
+          civlTypeChecker.procToLemmaProc.ContainsKey(proc))
+      {
         return node;
       }
-    }
-    string domainName;
-    if (kind == LinearKind.LINEAR)
-    {
-      domainName = QKeyValue.FindStringAttribute(node.Attributes, CivlAttributes.LINEAR);
-    }
-    else if (kind == LinearKind.LINEAR_IN)
-    {
-      domainName = QKeyValue.FindStringAttribute(node.Attributes, CivlAttributes.LINEAR_IN);
-    }
-    else if (kind == LinearKind.LINEAR_OUT)
-    {
-      domainName = QKeyValue.FindStringAttribute(node.Attributes, CivlAttributes.LINEAR_OUT);
-    }
-    else
-    {
-      return node;
-    }
-    if (!linearDomains.ContainsKey(domainName))
-    {
-      checkingContext.Error(node, $"Permission type not declared for domain {domainName}");
-      return node;
-    }
-    varToLinearQualifier[node] = new LinearQualifier(linearDomains[domainName], kind);
-    return node;
-  }
-
-  private void PopulateLinearDomains()
-  {
-    var permissionTypes = new Dictionary<string, Type>();
-    foreach (var decl in program.TopLevelDeclarations.Where(decl => decl is TypeCtorDecl || decl is TypeSynonymDecl))
-    {
-      foreach (var domainName in FindDomainNames(decl.Attributes))
+      for (int i = 0; i < proc.InParams.Count; i++)
       {
-        if (permissionTypes.ContainsKey(domainName))
+        var procInParam = proc.InParams[i];
+        if (procInParam.Attributes != null)
         {
-          checkingContext.Error(decl, $"Duplicate permission type for domain {domainName}");
-        }
-        else if (decl is TypeCtorDecl typeCtorDecl)
-        {
-          if (typeCtorDecl.Arity > 0)
-          {
-            checkingContext.Error(decl, "Permission type must be fully instantiated");
-          }
-          else
-          {
-            permissionTypes[domainName] = new CtorType(Token.NoToken, typeCtorDecl, new List<Type>());
-          }
-        }
-        else
-        {
-          permissionTypes[domainName] =
-            new TypeSynonymAnnotation(Token.NoToken, (TypeSynonymDecl)decl, new List<Type>());
+          var implInParam = node.InParams[i];
+          implInParam.Attributes = (QKeyValue)procInParam.Attributes.Clone();
         }
       }
+      for (int i = 0; i < proc.OutParams.Count; i++)
+      {
+        var procOutParam = proc.OutParams[i];
+        if (procOutParam.Attributes != null)
+        {
+          var implOutParam = node.OutParams[i];
+          implOutParam.Attributes = (QKeyValue)procOutParam.Attributes.Clone();
+        }
+      }
+      return base.VisitImplementation(node);
     }
 
-    var domainNameToCollectors = new Dictionary<string, Dictionary<Type, Function>>();
-    foreach (var (domainName, permissionType) in permissionTypes)
+    public override Variable VisitVariable(Variable node)
     {
-      domainNameToCollectors[domainName] = new Dictionary<Type, Function>();
+      var kind = FindLinearKind(node);
+      if (kind == LinearKind.LINEAR_IN || kind == LinearKind.LINEAR_OUT)
       {
-        // add unit collector
-        domainNameToCollectors[domainName][permissionType] =
-          program.monomorphizer.InstantiateFunction("MapUnit",
-            new Dictionary<string, Type>() { { "T", permissionType } });
-      }
-      {
-        // add identity collector
-        var type = new MapType(Token.NoToken, new List<TypeVariable>(), new List<Type> { permissionType }, Type.Bool);
-        domainNameToCollectors[domainName][type] =
-          program.monomorphizer.InstantiateFunction("Id", new Dictionary<string, Type>() { { "T", type } });
-      }
-    }
-
-    foreach (var node in program.TopLevelDeclarations.OfType<Function>())
-    {
-      string domainName = QKeyValue.FindStringAttribute(node.Attributes, CivlAttributes.LINEAR);
-      if (domainName == null)
-      {
-        continue;
-      }
-      if (!domainNameToCollectors.ContainsKey(domainName))
-      {
-        checkingContext.Error(node, "Domain name has not been declared");
-        continue;
-      }
-      if (node.InParams.Count == 1 && node.OutParams.Count == 1)
-      {
-        Type inType = node.InParams[0].TypedIdent.Type;
-        if (domainNameToCollectors[domainName].ContainsKey(inType))
+        if (node is GlobalVariable || node is LocalVariable || (node is Formal formal && !formal.InComing))
         {
-          checkingContext.Error(node, "A collector for domain for input type is already defined");
-          continue;
+          checkingContext.Error(node, "Variable must be declared linear (as opposed to linear_in or linear_out)");
+          return node;
         }
-        var outType = node.OutParams[0].TypedIdent.Type;
-        var expectedType = new MapType(Token.NoToken, new List<TypeVariable>(),
-          new List<Type> { permissionTypes[domainName] }, Type.Bool);
-        if (!outType.Equals(expectedType))
-        {
-          checkingContext.Error(node, "Output of a linear domain collector has unexpected type");
-        }
-        else
-        {
-          domainNameToCollectors[domainName].Add(inType, node);
-        }
+      }
+      string domainName;
+      if (kind == LinearKind.LINEAR)
+      {
+        domainName = QKeyValue.FindStringAttribute(node.Attributes, CivlAttributes.LINEAR);
+      }
+      else if (kind == LinearKind.LINEAR_IN)
+      {
+        domainName = QKeyValue.FindStringAttribute(node.Attributes, CivlAttributes.LINEAR_IN);
+      }
+      else if (kind == LinearKind.LINEAR_OUT)
+      {
+        domainName = QKeyValue.FindStringAttribute(node.Attributes, CivlAttributes.LINEAR_OUT);
       }
       else
       {
-        checkingContext.Error(node, "Linear domain collector should have one input and one output parameter");
+        return node;
       }
+      if (!linearDomains.ContainsKey(domainName))
+      {
+        checkingContext.Error(node, $"Permission type not declared for domain {domainName}");
+        return node;
+      }
+      return node;
     }
 
-    foreach (var (domainName, permissionType) in permissionTypes)
+    private void PopulateLinearDomains()
     {
-      linearDomains.Add(domainName, new LinearDomain(program, domainName, permissionType, domainNameToCollectors[domainName]));
-    }
-  }
-
-  private static List<string> FindDomainNames(QKeyValue kv)
-  {
-    List<string> domains = new List<string>();
-    for (; kv != null; kv = kv.Next)
-    {
-      if (kv.Key != CivlAttributes.LINEAR)
+      var permissionTypes = new Dictionary<string, Type>();
+      foreach (var decl in program.TopLevelDeclarations.Where(decl => decl is TypeCtorDecl || decl is TypeSynonymDecl))
       {
-        continue;
-      }
-      foreach (var o in kv.Params)
-      {
-        if (o is string s)
+        foreach (var domainName in FindDomainNames(decl.Attributes))
         {
-          domains.Add(s);
+          if (permissionTypes.ContainsKey(domainName))
+          {
+            checkingContext.Error(decl, $"Duplicate permission type for domain {domainName}");
+          }
+          else if (decl is TypeCtorDecl typeCtorDecl)
+          {
+            if (typeCtorDecl.Arity > 0)
+            {
+              checkingContext.Error(decl, "Permission type must be fully instantiated");
+            }
+            else
+            {
+              permissionTypes[domainName] = new CtorType(Token.NoToken, typeCtorDecl, new List<Type>());
+            }
+          }
+          else
+          {
+            permissionTypes[domainName] =
+              new TypeSynonymAnnotation(Token.NoToken, (TypeSynonymDecl)decl, new List<Type>());
+          }
         }
       }
+
+      var domainNameToCollectors = new Dictionary<string, Dictionary<Type, Function>>();
+      foreach (var (domainName, permissionType) in permissionTypes)
+      {
+        domainNameToCollectors[domainName] = new Dictionary<Type, Function>();
+        {
+          // add unit collector
+          domainNameToCollectors[domainName][permissionType] =
+            program.monomorphizer.InstantiateFunction("MapUnit",
+              new Dictionary<string, Type>() { { "T", permissionType } });
+        }
+        {
+          // add identity collector
+          var type = new MapType(Token.NoToken, new List<TypeVariable>(), new List<Type> { permissionType }, Type.Bool);
+          domainNameToCollectors[domainName][type] =
+            program.monomorphizer.InstantiateFunction("Id", new Dictionary<string, Type>() { { "T", type } });
+        }
+      }
+
+      foreach (var node in program.TopLevelDeclarations.OfType<Function>())
+      {
+        string domainName = QKeyValue.FindStringAttribute(node.Attributes, CivlAttributes.LINEAR);
+        if (domainName == null)
+        {
+          continue;
+        }
+
+        if (!domainNameToCollectors.ContainsKey(domainName))
+        {
+          checkingContext.Error(node, "Domain name has not been declared");
+          continue;
+        }
+
+        if (node.InParams.Count == 1 && node.OutParams.Count == 1)
+        {
+          Type inType = node.InParams[0].TypedIdent.Type;
+          if (domainNameToCollectors[domainName].ContainsKey(inType))
+          {
+            checkingContext.Error(node, "A collector for domain for input type is already defined");
+            continue;
+          }
+
+          var outType = node.OutParams[0].TypedIdent.Type;
+          var expectedType = new MapType(Token.NoToken, new List<TypeVariable>(),
+            new List<Type> { permissionTypes[domainName] }, Type.Bool);
+          if (!outType.Equals(expectedType))
+          {
+            checkingContext.Error(node, "Output of a linear domain collector has unexpected type");
+          }
+          else
+          {
+            domainNameToCollectors[domainName].Add(inType, node);
+          }
+        }
+        else
+        {
+          checkingContext.Error(node, "Linear domain collector should have one input and one output parameter");
+        }
+      }
+
+      foreach (var (domainName, permissionType) in permissionTypes)
+      {
+        linearDomains.Add(domainName,
+          new LinearDomain(program, domainName, permissionType, domainNameToCollectors[domainName]));
+      }
     }
-    return domains;
+
+    private static List<string> FindDomainNames(QKeyValue kv)
+    {
+      List<string> domains = new List<string>();
+      for (; kv != null; kv = kv.Next)
+      {
+        if (kv.Key != CivlAttributes.LINEAR)
+        {
+          continue;
+        }
+        foreach (var o in kv.Params)
+        {
+          if (o is string s)
+          {
+            domains.Add(s);
+          }
+        }
+      }
+      return domains;
+    }
   }
 }

--- a/Source/Concurrency/LinearDomainCollector.cs
+++ b/Source/Concurrency/LinearDomainCollector.cs
@@ -236,7 +236,6 @@ class LinearDomainCollector : ReadOnlyVisitor
       {
         continue;
       }
-
       foreach (var o in kv.Params)
       {
         if (o is string s)
@@ -245,7 +244,6 @@ class LinearDomainCollector : ReadOnlyVisitor
         }
       }
     }
-
     return domains;
   }
 }

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -698,8 +698,7 @@ namespace Microsoft.Boogie
       {
         int count = 0;
         List<Expr> subsetExprs = new List<Expr>();
-        var domainName = domain.domainName;
-        BoundVariable partition = civlTypeChecker.BoundVariable($"partition_{domainName}", domain.mapTypeInt);
+        BoundVariable partition = civlTypeChecker.BoundVariable($"partition_{domain.domainName}", domain.mapTypeInt);
         foreach (Expr e in permissionsExprs)
         {
           subsetExprs.Add(SubsetExpr(domain, e, partition, count));
@@ -791,15 +790,15 @@ namespace Microsoft.Boogie
       {
         // Linear in vars
         var inVars = inputs.Union(action.modifiedGlobalVars)
-          .Where(x => LinearDomainCollector.FindDomainName(x) == domain.domainName)
           .Where(x => InKinds.Contains(LinearDomainCollector.FindLinearKind(x)))
+          .Where(x => FindDomain(x) == domain)
           .Select(Expr.Ident)
           .ToList();
         
         // Linear out vars
         var outVars = inputs.Union(outputs).Union(action.modifiedGlobalVars)
-          .Where(x => LinearDomainCollector.FindDomainName(x) == domain.domainName)
           .Where(x => OutKinds.Contains(LinearDomainCollector.FindLinearKind(x)))
+          .Where(x => FindDomain(x) == domain)
           .Select(Expr.Ident)
           .ToList();
 
@@ -944,7 +943,7 @@ namespace Microsoft.Boogie
       for (int i = 0; i < pendingAsync.proc.InParams.Count; i++)
       {
         var inParam = pendingAsync.proc.InParams[i];
-        if (LinearDomainCollector.FindDomainName(inParam) == domain.domainName && InKinds.Contains(LinearDomainCollector.FindLinearKind(inParam)))
+        if (InKinds.Contains(LinearDomainCollector.FindLinearKind(inParam)) && FindDomain(inParam) == domain)
         {
           var pendingAsyncParam = ExprHelper.FieldAccess(pa, pendingAsync.pendingAsyncCtor.InParams[i].Name);
           pendingAsyncLinearParams.Add(pendingAsyncParam);

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -647,27 +647,13 @@ namespace Microsoft.Boogie
 
     public IEnumerable<Expr> DisjointnessExprForEachDomain(IEnumerable<Variable> scope)
     {
-      var domainToScope = new Dictionary<LinearDomain, HashSet<Variable>>();
-      foreach (var domainName in linearDomains.Values)
-      {
-        domainToScope[domainName] = new HashSet<Variable>();
-      }
-
-      foreach (Variable v in scope)
-      {
-        if (LinearDomainCollector.FindLinearKind(v) == LinearKind.ORDINARY)
-        {
-          continue;
-        }
-        var domainName = FindDomain(v);
-        domainToScope[domainName].Add(v);
-      }
-
-      foreach (var domainName in domainToScope.Keys)
+      var domainToScope = LinearDomains.ToDictionary(domain => domain, _ => new HashSet<Variable>());
+      scope.Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.ORDINARY).Iter(v => domainToScope[FindDomain(v)].Add(v));
+      foreach (var domain in domainToScope.Keys)
       {
         yield return DisjointnessExprForPermissions(
-          domainName,
-          PermissionExprForEachVariable(domainName, domainToScope[domainName]));
+          domain,
+          PermissionExprForEachVariable(domain, domainToScope[domain]));
       }
     }
 

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Boogie
       {
         DisjointnessRequires(
           first.firstImpl.InParams.Union(second.secondImpl.InParams)
-            .Where(v => linearTypeChecker.FindLinearKind(v) != LinearKind.LINEAR_OUT),
+            .Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_OUT),
           frame)
       };
       foreach (AssertCmd assertCmd in Enumerable.Union(first.firstGate, second.secondGate))
@@ -159,7 +159,7 @@ namespace Microsoft.Boogie
       var transitionRelation = TransitionRelationComputation.Commutativity(civlTypeChecker, second, first, frame, witnesses);
 
       var secondInParamsFiltered =
-        second.secondImpl.InParams.Where(v => linearTypeChecker.FindLinearKind(v) != LinearKind.LINEAR_IN);
+        second.secondImpl.InParams.Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_IN);
       IEnumerable<Expr> linearityAssumes = Enumerable.Union(
         linearTypeChecker.DisjointnessExprForEachDomain(first.firstImpl.OutParams.Union(secondInParamsFiltered)
           .Union(frame)),
@@ -210,7 +210,7 @@ namespace Microsoft.Boogie
       {
         DisjointnessRequires(
           first.firstImpl.InParams.Union(second.secondImpl.InParams)
-            .Where(v => linearTypeChecker.FindLinearKind(v) != LinearKind.LINEAR_OUT), frame)
+            .Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_OUT), frame)
       };
       foreach (AssertCmd assertCmd in first.firstGate.Union(second.secondGate))
       {
@@ -263,7 +263,7 @@ namespace Microsoft.Boogie
       {
         DisjointnessRequires(
           first.firstImpl.InParams.Union(second.secondImpl.InParams)
-            .Where(v => linearTypeChecker.FindLinearKind(v) != LinearKind.LINEAR_OUT), frame)
+            .Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_OUT), frame)
       };
       Expr firstNegatedGate = Expr.Not(Expr.And(first.firstGate.Select(a => a.Expr)));
       firstNegatedGate.Type = Type.Bool; // necessary?
@@ -310,7 +310,7 @@ namespace Microsoft.Boogie
 
       List<Requires> requires = new List<Requires>
       {
-        DisjointnessRequires(impl.InParams.Where(v => civlTypeChecker.linearTypeChecker.FindLinearKind(v) != LinearKind.LINEAR_OUT),
+        DisjointnessRequires(impl.InParams.Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_OUT),
           frame)
       };
       foreach (AssertCmd assertCmd in action.gate)

--- a/Source/Concurrency/NoninterferenceChecker.cs
+++ b/Source/Concurrency/NoninterferenceChecker.cs
@@ -15,16 +15,16 @@ namespace Microsoft.Boogie
       List<Variable> declLocalVariables)
     {
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
-      var domainNameToHoleVar = new Dictionary<LinearDomain, Variable>();
+      var domainToHoleVar = new Dictionary<LinearDomain, Variable>();
       Dictionary<Variable, Variable> localVarMap = new Dictionary<Variable, Variable>();
       Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
       List<Variable> locals = new List<Variable>();
       List<Variable> inputs = new List<Variable>();
-      foreach (var domainName in linearTypeChecker.LinearDomains)
+      foreach (var domain in linearTypeChecker.LinearDomains)
       {
-        var inParam = linearTypeChecker.LinearDomainInFormal(domainName);
+        var inParam = linearTypeChecker.LinearDomainInFormal(domain);
         inputs.Add(inParam);
-        domainNameToHoleVar[domainName] = inParam;
+        domainToHoleVar[domain] = inParam;
       }
 
       foreach (Variable local in declLocalVariables.Union(decl.InParams).Union(decl.OutParams))
@@ -48,7 +48,7 @@ namespace Microsoft.Boogie
       }
 
       var linearPermissionInstrumentation = new LinearPermissionInstrumentation(civlTypeChecker,
-        layerNum, absyMap, domainNameToHoleVar, localVarMap);
+        layerNum, absyMap, domainToHoleVar, localVarMap);
       List<YieldInfo> yieldInfos = null;
       string noninterferenceCheckerName = null;
       if (decl is Implementation impl)

--- a/Source/Concurrency/NoninterferenceChecker.cs
+++ b/Source/Concurrency/NoninterferenceChecker.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Boogie
       List<Variable> declLocalVariables)
     {
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
-      Dictionary<string, Variable> domainNameToHoleVar = new Dictionary<string, Variable>();
+      var domainNameToHoleVar = new Dictionary<LinearDomain, Variable>();
       Dictionary<Variable, Variable> localVarMap = new Dictionary<Variable, Variable>();
       Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
       List<Variable> locals = new List<Variable>();
       List<Variable> inputs = new List<Variable>();
-      foreach (var domainName in linearTypeChecker.linearDomains.Keys)
+      foreach (var domainName in linearTypeChecker.LinearDomains)
       {
         var inParam = linearTypeChecker.LinearDomainInFormal(domainName);
         inputs.Add(inParam);

--- a/Source/Concurrency/NoninterferenceInstrumentation.cs
+++ b/Source/Concurrency/NoninterferenceInstrumentation.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Boogie
     private Procedure yieldProc;
 
     private List<Variable> newLocalVars;
-    private Dictionary<string, Variable> domainNameToHoleVar;
+    private Dictionary<LinearDomain, Variable> domainNameToHoleVar;
 
     public SomeNoninterferenceInstrumentation(
       CivlTypeChecker civlTypeChecker,
@@ -54,8 +54,8 @@ namespace Microsoft.Boogie
       this.oldGlobalMap = oldGlobalMap;
       this.yieldProc = yieldProc;
       this.newLocalVars = new List<Variable>();
-      this.domainNameToHoleVar = new Dictionary<string, Variable>();
-      foreach (string domainName in linearTypeChecker.linearDomains.Keys)
+      this.domainNameToHoleVar = new Dictionary<LinearDomain, Variable>();
+      foreach (var domainName in linearTypeChecker.LinearDomains)
       {
         Variable l = linearTypeChecker.LinearDomainAvailableLocal(domainName);
         domainNameToHoleVar[domainName] = l;
@@ -67,10 +67,10 @@ namespace Microsoft.Boogie
 
     public List<Cmd> CreateInitCmds(Implementation impl)
     {
-      Dictionary<string, Expr> domainNameToExpr = linearPermissionInstrumentation.PermissionExprs(impl);
+      var domainNameToExpr = linearPermissionInstrumentation.PermissionExprs(impl);
       List<IdentifierExpr> lhss = new List<IdentifierExpr>();
       List<Expr> rhss = new List<Expr>();
-      foreach (string domainName in linearTypeChecker.linearDomains.Keys)
+      foreach (var domainName in linearTypeChecker.LinearDomains)
       {
         lhss.Add(Expr.Ident(domainNameToHoleVar[domainName]));
         rhss.Add(domainNameToExpr[domainName]);
@@ -87,10 +87,10 @@ namespace Microsoft.Boogie
 
     public List<Cmd> CreateUpdatesToPermissionCollector(Absy absy)
     {
-      Dictionary<string, Expr> domainNameToExpr = linearPermissionInstrumentation.PermissionExprs(absy);
+      var domainNameToExpr = linearPermissionInstrumentation.PermissionExprs(absy);
       List<IdentifierExpr> lhss = new List<IdentifierExpr>();
       List<Expr> rhss = new List<Expr>();
-      foreach (var domainName in linearTypeChecker.linearDomains.Keys)
+      foreach (var domainName in linearTypeChecker.LinearDomains)
       {
         lhss.Add(Expr.Ident(domainNameToHoleVar[domainName]));
         rhss.Add(domainNameToExpr[domainName]);
@@ -108,7 +108,7 @@ namespace Microsoft.Boogie
     public List<Cmd> CreateCallToYieldProc()
     {
       List<Variable> inputs = new List<Variable>();
-      foreach (string domainName in linearTypeChecker.linearDomains.Keys)
+      foreach (var domainName in linearTypeChecker.LinearDomains)
       {
         inputs.Add(domainNameToHoleVar[domainName]);
       }

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Boogie
 
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       List<Variable> inputs = new List<Variable>();
-      foreach (string domainName in linearTypeChecker.linearDomains.Keys)
+      foreach (var domainName in linearTypeChecker.LinearDomains)
       {
         inputs.Add(linearTypeChecker.LinearDomainInFormal(domainName));
       }
@@ -113,7 +113,7 @@ namespace Microsoft.Boogie
     {
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       List<Variable> inputs = new List<Variable>();
-      foreach (string domainName in linearTypeChecker.linearDomains.Keys)
+      foreach (var domainName in linearTypeChecker.LinearDomains)
       {
         inputs.Add(linearTypeChecker.LinearDomainInFormal(domainName));
       }

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Boogie
 
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       List<Variable> inputs = new List<Variable>();
-      foreach (var domainName in linearTypeChecker.LinearDomains)
+      foreach (var domain in linearTypeChecker.LinearDomains)
       {
-        inputs.Add(linearTypeChecker.LinearDomainInFormal(domainName));
+        inputs.Add(linearTypeChecker.LinearDomainInFormal(domain));
       }
 
       foreach (Variable g in civlTypeChecker.GlobalVariables)
@@ -113,9 +113,9 @@ namespace Microsoft.Boogie
     {
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       List<Variable> inputs = new List<Variable>();
-      foreach (var domainName in linearTypeChecker.LinearDomains)
+      foreach (var domain in linearTypeChecker.LinearDomains)
       {
-        inputs.Add(linearTypeChecker.LinearDomainInFormal(domainName));
+        inputs.Add(linearTypeChecker.LinearDomainInFormal(domain));
       }
 
       foreach (Variable g in civlTypeChecker.GlobalVariables)

--- a/Test/civl/call-yield-invariant-errors.bpl
+++ b/Test/civl/call-yield-invariant-errors.bpl
@@ -18,9 +18,3 @@ p1({:linear "lin"} a: int, {:linear_in "lin"} b: int, c: int)
 
 procedure {:yields} {:layer 1}
 p2({:linear_in "lin"} b: int);
-
-function {:builtin "MapConst"} MapConstBool(bool) : [int]bool;
-function {:inline} {:linear "lin"} TidCollector(x: int) : [int]bool
-{
-  MapConstBool(false)[x := true]
-}

--- a/Test/civl/linear/f1.bpl
+++ b/Test/civl/linear/f1.bpl
@@ -21,11 +21,6 @@ axiom(!b6);
 axiom(!b7);
 axiom(b8);
 
-function {:inline} {:linear "1"} SetCollector1(x: [int]bool) : [int]bool
-{
-  x
-}
-
 procedure main({:linear_in "1"} x_in: [int]bool)
   requires b0 ==> x_in == MapConst(true);
   requires b1 ==> x_in != MapConst(false);

--- a/Test/civl/linear/f1.bpl.expect
+++ b/Test/civl/linear/f1.bpl.expect
@@ -1,5 +1,5 @@
-f1.bpl(40,4): Error: This assertion might not hold.
+f1.bpl(35,4): Error: This assertion might not hold.
 Execution trace:
-    f1.bpl(34,6): anon0
+    f1.bpl(29,6): anon0
 
 Boogie program verifier finished with 1 verified, 1 error

--- a/Test/civl/linear/typecheck.bpl
+++ b/Test/civl/linear/typecheck.bpl
@@ -1,19 +1,8 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+
 type X;
 type {:linear "A", "B", "C", "D", "D2", "x", "", "lin"} Lin = int;
-function {:inline} none() : [int]bool { (lambda i:int :: false) }
-function {:inline} {:linear "A"} A_X_Collector(a: X) : [int]bool { none() }
-function {:inline} {:linear "A"} A_int_Collector(a: int) : [int]bool { none() }
-function {:inline} {:linear "B"} B_X_Collector(a: X) : [int]bool { none() }
-function {:inline} {:linear "B"} B_XSet_Collector(a: [X]bool) : [int]bool { none() }
-function {:inline} {:linear "C"} C_X_Collector(a: X) : [int]bool { none() }
-function {:inline} {:linear "C"} C_XMulSet_Collector(a: [X]int) : [int]bool { none() }
-function {:inline} {:linear "D"} D_X_Collector(a: X) : [int]bool { none() }
-function {:inline} {:linear "D"} D_XSet_Collector(a: [X]bool) : [int]bool { none() }
-function {:inline} {:linear "D2"} A2_X_Collector(a: X) : [int]bool { none() }
-function {:inline} {:linear "x"} x_int_Collector(a: int) : [int]bool { none() }
-function {:inline} {:linear ""} empty_int_Collector(a: int) : [int]bool { none() }
 
 procedure A()
 {

--- a/Test/civl/linear/typecheck.bpl.expect
+++ b/Test/civl/linear/typecheck.bpl.expect
@@ -1,17 +1,17 @@
-typecheck.bpl(46,9): Error: Only simple assignment allowed on linear variable b
-typecheck.bpl(48,6): Error: Only variable can be assigned to linear variable a
-typecheck.bpl(50,6): Error: Only linear variable can be assigned to linear variable a
-typecheck.bpl(54,6): Error: Linear variable of domain D2 cannot be assigned to linear variable of domain D
-typecheck.bpl(60,9): Error: Linear variable x can occur only once in the right-hand-side of an assignment
-typecheck.bpl(64,4): Error: Linear variable a can occur only once as an input parameter
-typecheck.bpl(66,22): Error: Only variable can be passed to linear parameter b
-typecheck.bpl(68,22): Error: The domains of formal and actual parameters must be the same
-typecheck.bpl(70,4): Error: The domains of formal and actual parameters must be the same
-typecheck.bpl(72,19): Error: Only a linear argument can be passed to linear parameter a
-typecheck.bpl(77,4): Error: Linear variable a can occur only once as an input parameter of a parallel call
-typecheck.bpl(86,0): Error: Output variable d must be available at a return
-typecheck.bpl(95,0): Error: Global variable g must be available at a return
-typecheck.bpl(100,7): Error: unavailable source for a linear read
-typecheck.bpl(101,0): Error: Output variable r must be available at a return
-typecheck.bpl(137,2): Error: Linear variable x cannot be an input parameter to both a yield invariant and a procedure in a parallel call
+typecheck.bpl(35,9): Error: Only simple assignment allowed on linear variable b
+typecheck.bpl(37,6): Error: Only variable can be assigned to linear variable a
+typecheck.bpl(39,6): Error: Only linear variable can be assigned to linear variable a
+typecheck.bpl(43,6): Error: Linear variable of domain D2 cannot be assigned to linear variable of domain D
+typecheck.bpl(49,9): Error: Linear variable x can occur only once in the right-hand-side of an assignment
+typecheck.bpl(53,4): Error: Linear variable a can occur only once as an input parameter
+typecheck.bpl(55,22): Error: Only variable can be passed to linear parameter b
+typecheck.bpl(57,22): Error: The domains of formal and actual parameters must be the same
+typecheck.bpl(59,4): Error: The domains of formal and actual parameters must be the same
+typecheck.bpl(61,19): Error: Only a linear argument can be passed to linear parameter a
+typecheck.bpl(66,4): Error: Linear variable a can occur only once as an input parameter of a parallel call
+typecheck.bpl(75,0): Error: Output variable d must be available at a return
+typecheck.bpl(84,0): Error: Global variable g must be available at a return
+typecheck.bpl(89,7): Error: unavailable source for a linear read
+typecheck.bpl(90,0): Error: Output variable r must be available at a return
+typecheck.bpl(126,2): Error: Linear variable x cannot be an input parameter to both a yield invariant and a procedure in a parallel call
 16 type checking errors detected in typecheck.bpl

--- a/Test/civl/treiber-stack.bpl
+++ b/Test/civl/treiber-stack.bpl
@@ -70,15 +70,6 @@ procedure {:yield_invariant} {:layer 1} YieldInv();
 requires BetweenSet(map(Stack), TopOfStack, null)[TopOfStack];
 requires Subset(BetweenSet(map(Stack), TopOfStack, null), Union(Singleton(null), dom(Stack)));
 
-function {:inline} {:linear "Node"} NodeCollector(x: int) : [int]bool
-{
-  MapConst(false)[x := true]
-}
-function {:inline} {:linear "Node"} NodeSetCollector(x: [int]bool) : [int]bool
-{
-  x
-}
-
 procedure {:atomic} {:layer 2} atomic_push(x: int, {:linear_in "Node"} x_lmap: lmap)
 modifies Stack, TopOfStack;
 { assert dom(x_lmap)[x]; Stack := Add(Stack, x, TopOfStack); TopOfStack := x; }

--- a/Test/civl/zeldovich.bpl
+++ b/Test/civl/zeldovich.bpl
@@ -97,9 +97,3 @@ procedure {:yields}{:layer 0}{:refines "RELEASE_Y"} release_y ({:linear "tid"} t
 procedure {:yields}{:layer 0}{:refines "WRITE_X"} write_x ({:linear "tid"} tid:Tid, v:int);
 procedure {:yields}{:layer 0}{:refines "WRITE_Y"} write_y ({:linear "tid"} tid:Tid, v:int);
 procedure {:yields}{:layer 0}{:refines "READ_X"} read_x ({:linear "tid"} tid:Tid) returns (r:int);
-
-function {:builtin "MapConst"} MapConstBool(bool) : [Tid]bool;
-function {:inline}{:linear "tid"} TidCollector(tid:Tid) : [Tid]bool
-{
-  MapConstBool(false)[tid := true]
-}


### PR DESCRIPTION
The goal of this PR is to have clients of LinearTypeChecker use linear domains instead of linear domain names to do their bookkeeping. Thus, later when we have linear variables based on types (and not domain names), the rest of Civl will not have to change. The major aspects of refactoring include:
- splitting out the code for collecting linear domains into a separate class LinearDomainCollector
- eliminating numerous fields in LinearTypeChecker
- propagating changes to the clients

