### PR TITLE
[Civl] Linear refactor

### DIFF
--- a/Source/Concurrency/CivlRewriter.cs
+++ b/Source/Concurrency/CivlRewriter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Boogie
       YieldingProcChecker.AddCheckers(civlTypeChecker, decls);
 
       // Linear type checks
-      civlTypeChecker.linearTypeChecker.AddCheckers(decls);
+      LinearityChecker.AddCheckers(civlTypeChecker, decls);
 
       if (!options.TrustInductiveSequentialization)
       {

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -143,14 +143,11 @@ namespace Microsoft.Boogie
 
     public void TypeCheck()
     {
-      var (domainNameToLinearDomain, linearTypeToLinearDomain) =
-        LinearDomainCollector.Collect(program, checkingContext);
+      linearTypeChecker.TypeCheck();
       TypeCheckGlobalVariables();
       TypeCheckLemmaProcedures();
       TypeCheckYieldInvariants();
       TypeCheckActions();
-      // linear type checking is not performed inside those decls that are accumulated so far
-      linearTypeChecker.TypeCheck(domainNameToLinearDomain, linearTypeToLinearDomain);
       TypeCheckPendingAsyncMachinery();
       if (checkingContext.ErrorCount > 0)
       {
@@ -1112,7 +1109,7 @@ namespace Microsoft.Boogie
 
     #region Helpers for attribute parsing
 
-    private bool IsYieldingProcedure(Procedure proc)
+    public bool IsYieldingProcedure(Procedure proc)
     {
       return proc.HasAttribute(CivlAttributes.YIELDS);
     }
@@ -1131,7 +1128,7 @@ namespace Microsoft.Boogie
       return !proc.HasAttribute(CivlAttributes.YIELDS) && proc.HasAttribute(CivlAttributes.LEMMA);
     }
 
-    private bool IsYieldInvariant(Procedure proc)
+    public bool IsYieldInvariant(Procedure proc)
     {
       return proc.HasAttribute(CivlAttributes.YIELD_INVARIANT);
     }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1117,7 +1117,7 @@ namespace Microsoft.Boogie
       return proc.HasAttribute(CivlAttributes.YIELDS);
     }
 
-    private bool IsAction(Procedure proc)
+    public bool IsAction(Procedure proc)
     {
       return !proc.HasAttribute(CivlAttributes.YIELDS) &&
              (GetMoverType(proc) != null ||
@@ -1126,7 +1126,7 @@ namespace Microsoft.Boogie
               proc.HasAttribute(CivlAttributes.IS_ABSTRACTION));
     }
 
-    private bool IsLemmaProcedure(Procedure proc)
+    public bool IsLemmaProcedure(Procedure proc)
     {
       return !proc.HasAttribute(CivlAttributes.YIELDS) && proc.HasAttribute(CivlAttributes.LEMMA);
     }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -143,12 +143,14 @@ namespace Microsoft.Boogie
 
     public void TypeCheck()
     {
+      var (domainNameToLinearDomain, linearTypeToLinearDomain) =
+        LinearDomainCollector.Collect(program, checkingContext);
       TypeCheckGlobalVariables();
       TypeCheckLemmaProcedures();
       TypeCheckYieldInvariants();
       TypeCheckActions();
       // linear type checking is not performed inside those decls that are accumulated so far
-      linearTypeChecker.TypeCheck();
+      linearTypeChecker.TypeCheck(domainNameToLinearDomain, linearTypeToLinearDomain);
       TypeCheckPendingAsyncMachinery();
       if (checkingContext.ErrorCount > 0)
       {

--- a/Source/Concurrency/LinearDomainCollector.cs
+++ b/Source/Concurrency/LinearDomainCollector.cs
@@ -262,13 +262,11 @@ namespace Microsoft.Boogie
       {
         domainNameToCollectors[domainName] = new Dictionary<Type, Function>();
         {
-          // add unit collector
           domainNameToCollectors[domainName][permissionType] =
-            program.monomorphizer.InstantiateFunction("MapUnit",
+            program.monomorphizer.InstantiateFunction("MapOne",
               new Dictionary<string, Type>() { { "T", permissionType } });
         }
         {
-          // add identity collector
           var type = new MapType(Token.NoToken, new List<TypeVariable>(), new List<Type> { permissionType }, Type.Bool);
           domainNameToCollectors[domainName][type] =
             program.monomorphizer.InstantiateFunction("Id", new Dictionary<string, Type>() { { "T", type } });

--- a/Source/Concurrency/LinearDomainCollector.cs
+++ b/Source/Concurrency/LinearDomainCollector.cs
@@ -66,6 +66,10 @@ namespace Microsoft.Boogie
     {
       return Expr.Eq(expr, ExprHelper.FunctionCall(mapConstBool, Expr.True));
     }
+
+    public bool IsNameDomain => domainName != null;
+
+    public bool IsTypeDomain => domainName == null;
   }
   
   class LinearDomainCollector : ReadOnlyVisitor

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -3,18 +3,6 @@ using System.Linq;
 
 namespace Microsoft.Boogie
 {
-  /// <summary>
-  /// Type checker for linear type annotations.
-  /// 
-  /// The functionality is basically grouped into four parts (see #region's).
-  /// 1) TypeCheck parses linear type attributes, sets up the data structures,
-  ///    and performs a dataflow check on procedure implementations.
-  /// 2) Useful public methods to generate expressions for permissions, their disjointness,
-  ///    and their union.
-  /// 3) Generation of linearity-invariant checker procedures for atomic actions.
-  /// 4) Erasure procedure to remove all linearity attributes
-  ///    (invoked after all other Civl transformations).
-  /// </summary>
   public class LinearTypeChecker : ReadOnlyVisitor
   {
     public Program program;
@@ -31,39 +19,6 @@ namespace Microsoft.Boogie
       this.checkingContext = civlTypeChecker.checkingContext;
       this.availableLinearVars = new Dictionary<Absy, HashSet<Variable>>();
     }
-
-    public IEnumerable<LinearDomain> LinearDomains => domainNameToLinearDomain.Values.Union(linearTypeToLinearDomain.Values);
-    
-    public LinearDomain FindDomain(Variable v)
-    {
-      var domainName = LinearDomainCollector.FindDomainName(v);
-      if (domainName == null)
-      {
-        return linearTypeToLinearDomain[v.TypedIdent.Type];
-      }
-      return domainNameToLinearDomain[domainName];
-    }
-
-    public Formal LinearDomainInFormal(LinearDomain domain)
-    {
-      return civlTypeChecker.Formal("linear_" + domain.DomainName + "_in", domain.mapTypeBool, true);
-    }
-
-    public LocalVariable LinearDomainAvailableLocal(LinearDomain domain)
-    {
-      return civlTypeChecker.LocalVariable("linear_" + domain.DomainName + "_available", domain.mapTypeBool);
-    }
-
-    public void TypeCheck(Dictionary<string, LinearDomain> domainNameToLinearDomain, Dictionary<Type, LinearDomain> linearTypeToLinearDomain)
-    {
-      this.domainNameToLinearDomain = domainNameToLinearDomain;
-      this.linearTypeToLinearDomain = linearTypeToLinearDomain;
-      this.VisitProgram(program);
-      foreach (var absy in this.availableLinearVars.Keys)
-      {
-        availableLinearVars[absy].RemoveWhere(v => v is GlobalVariable);
-      }
-    }
     
     #region Visitor Implementation
 
@@ -72,13 +27,9 @@ namespace Microsoft.Boogie
 
     public override Implementation VisitImplementation(Implementation node)
     {
-      var linearGlobalVariables = LinearGlobalVariables;
-      
-      if (civlTypeChecker.procToAtomicAction.ContainsKey(node.Proc) ||
-          civlTypeChecker.procToIntroductionAction.ContainsKey(node.Proc) ||
-          civlTypeChecker.procToIsAbstraction.ContainsKey(node.Proc) ||
-          civlTypeChecker.procToIsInvariant.ContainsKey(node.Proc) ||
-          civlTypeChecker.procToLemmaProc.ContainsKey(node.Proc))
+      var proc = node.Proc;
+      if (civlTypeChecker.IsAction(proc) ||
+          civlTypeChecker.IsLemmaProcedure(proc))
       {
         return node;
       }
@@ -88,6 +39,7 @@ namespace Microsoft.Boogie
       GraphUtil.Graph<Block> graph = Program.GraphFromImpl(node);
       graph.ComputeLoops();
 
+      var linearGlobalVariables = LinearGlobalVariables;
       HashSet<Variable> start = new HashSet<Variable>(linearGlobalVariables.Union(node.InParams.Where(v =>
       {
         var kind = LinearDomainCollector.FindLinearKind(v);
@@ -444,6 +396,42 @@ namespace Microsoft.Boogie
     #endregion
 
     #region Useful public methods
+    
+    public IEnumerable<LinearDomain> NamedLinearDomains => domainNameToLinearDomain.Values;
+
+    public IEnumerable<LinearDomain> LinearDomains => domainNameToLinearDomain.Values.Union(linearTypeToLinearDomain.Values);
+    
+    public LinearDomain FindDomain(Variable v)
+    {
+      var domainName = LinearDomainCollector.FindDomainName(v);
+      if (domainName == null)
+      {
+        return linearTypeToLinearDomain[v.TypedIdent.Type];
+      }
+      return domainNameToLinearDomain[domainName];
+    }
+
+    public Formal LinearDomainInFormal(LinearDomain domain)
+    {
+      return civlTypeChecker.Formal("linear_" + domain.DomainName + "_in", domain.mapTypeBool, true);
+    }
+
+    public LocalVariable LinearDomainAvailableLocal(LinearDomain domain)
+    {
+      return civlTypeChecker.LocalVariable("linear_" + domain.DomainName + "_available", domain.mapTypeBool);
+    }
+
+    public void TypeCheck(Dictionary<string, LinearDomain> domainNameToLinearDomain, Dictionary<Type, LinearDomain> linearTypeToLinearDomain)
+    {
+      this.domainNameToLinearDomain = domainNameToLinearDomain;
+      this.linearTypeToLinearDomain = linearTypeToLinearDomain;
+      this.VisitProgram(program);
+      foreach (var absy in this.availableLinearVars.Keys)
+      {
+        availableLinearVars[absy].RemoveWhere(v => v is GlobalVariable);
+      }
+    }
+
     public ISet<Variable> AvailableLinearVars(Absy absy)
     {
       if (availableLinearVars.ContainsKey(absy))
@@ -515,257 +503,6 @@ namespace Microsoft.Boogie
       e = ExprHelper.FunctionCall(domain.mapImp, ie, e);
       e = Expr.Eq(e, ExprHelper.FunctionCall(domain.mapConstBool, Expr.True));
       return e;
-    }
-
-    #endregion
-
-    #region Linearity Invariant Checker
-
-    public void AddCheckers(List<Declaration> decls)
-    {
-      foreach (var action in Enumerable.Concat<Action>(civlTypeChecker.procToAtomicAction.Values,
-        civlTypeChecker.procToIntroductionAction.Values))
-      {
-        AddChecker(action, decls);
-      }
-    }
-
-    private static LinearKind[] InKinds = {LinearKind.LINEAR, LinearKind.LINEAR_IN};
-    private static LinearKind[] OutKinds = {LinearKind.LINEAR, LinearKind.LINEAR_OUT};
-
-    private class LinearityCheck
-    {
-      public string domainName;
-      public Expr assume;
-      public Expr assert;
-      public string message;
-      public string checkName;
-
-      public LinearityCheck(string domainName, Expr assume, Expr assert, string message, string checkName)
-      {
-        this.domainName = domainName;
-        this.assume = assume;
-        this.assert = assert;
-        this.message = message;
-        this.checkName = checkName;
-      }
-    }
-
-    private void AddChecker(Action action, List<Declaration> decls)
-    {
-      // Note: The implementation should be used as the variables in the
-      //       gate are bound to implementation and not to the procedure.
-      Implementation impl = action.impl;
-      List<Variable> inputs = impl.InParams;
-      List<Variable> outputs = impl.OutParams;
-
-      List<Variable> locals = new List<Variable>(2);
-      var paLocal1 = civlTypeChecker.LocalVariable("pa1", civlTypeChecker.pendingAsyncType);
-      var paLocal2 = civlTypeChecker.LocalVariable("pa2", civlTypeChecker.pendingAsyncType);
-      var pa1 = Expr.Ident(paLocal1);
-      var pa2 = Expr.Ident(paLocal2);
-      
-      if (civlTypeChecker.pendingAsyncType != null)
-      {
-        locals.Add(paLocal1);
-        locals.Add(paLocal2);
-      }
-
-      List<Requires> requires = action.gate.Select(a => new Requires(false, a.Expr)).ToList();
-      List<LinearityCheck> linearityChecks = new List<LinearityCheck>();
-
-      foreach (var domain in domainNameToLinearDomain.Values)
-      {
-        // Linear in vars
-        var inVars = inputs.Union(action.modifiedGlobalVars)
-          .Where(x => InKinds.Contains(LinearDomainCollector.FindLinearKind(x)))
-          .Where(x => FindDomain(x) == domain)
-          .Select(Expr.Ident)
-          .ToList();
-        
-        // Linear out vars
-        var outVars = inputs.Union(outputs).Union(action.modifiedGlobalVars)
-          .Where(x => OutKinds.Contains(LinearDomainCollector.FindLinearKind(x)))
-          .Where(x => FindDomain(x) == domain)
-          .Select(Expr.Ident)
-          .ToList();
-
-        // First kind
-        // Permissions in linear output variables are a subset of permissions in linear input variables.
-        if (outVars.Count > 0)
-        {
-          linearityChecks.Add(new LinearityCheck(
-            domain.DomainName,
-            null,
-            OutPermsSubsetInPerms(domain, inVars, outVars),
-            $"Potential linearity violation in outputs for domain {domain.DomainName}.",
-            "variables"));
-        }
-
-        if (action is AtomicAction atomicAction && atomicAction.HasPendingAsyncs)
-        {
-          var PAs = Expr.Ident(atomicAction.impl.OutParams.Last());
-          
-          foreach (var pendingAsync in atomicAction.pendingAsyncs)
-          {
-            var pendingAsyncLinearParams = PendingAsyncLinearParams(domain, pendingAsync, pa1);
-
-            if (pendingAsyncLinearParams.Count == 0)
-            {
-              continue;
-            }
-
-            // Second kind
-            // Permissions in linear output variables + linear inputs of a single pending async
-            // are a subset of permissions in linear input variables.
-            var exactlyOnePA = Expr.And(
-              ExprHelper.IsConstructor(pa1, pendingAsync.pendingAsyncCtor.Name),
-              Expr.Eq(Expr.Select(PAs, pa1), Expr.Literal(1)));
-            var outSubsetInExpr = OutPermsSubsetInPerms(domain, inVars, pendingAsyncLinearParams.Union(outVars));
-            linearityChecks.Add(new LinearityCheck(
-              domain.DomainName,
-              exactlyOnePA,
-              outSubsetInExpr,
-              $"Potential linearity violation in outputs and pending async of {pendingAsync.proc.Name} for domain {domain.DomainName}.",
-              $"single_{pendingAsync.proc.Name}"));
-
-            // Third kind
-            // If there are two identical pending asyncs, then their input permissions mut be empty.
-            var twoIdenticalPAs = Expr.And(
-              ExprHelper.IsConstructor(pa1, pendingAsync.pendingAsyncCtor.Name),
-              Expr.Ge(Expr.Select(PAs, pa1), Expr.Literal(2)));
-            var emptyPerms = OutPermsSubsetInPerms(domain, Enumerable.Empty<Expr>(), pendingAsyncLinearParams);
-            linearityChecks.Add(new LinearityCheck(
-              domain.DomainName,
-              twoIdenticalPAs,
-              emptyPerms,
-              $"Potential linearity violation in identical pending asyncs of {pendingAsync.proc.Name} for domain {domain.DomainName}.",
-              $"identical_{pendingAsync.proc.Name}"));
-          }
-
-          var pendingAsyncs = atomicAction.pendingAsyncs.ToList();
-          for (int i = 0; i < pendingAsyncs.Count; i++)
-          {
-            var pendingAsync1 = pendingAsyncs[i];
-            for (int j = i; j < pendingAsyncs.Count; j++)
-            {
-              var pendingAsync2 = pendingAsyncs[j];
-
-              var pendingAsyncLinearParams1 = PendingAsyncLinearParams(domain, pendingAsync1, pa1);
-              var pendingAsyncLinearParams2 = PendingAsyncLinearParams(domain, pendingAsync2, pa2);
-              
-              if (pendingAsyncLinearParams1.Count == 0 || pendingAsyncLinearParams2.Count == 0)
-              {
-                continue;
-              }
-
-              // Fourth kind
-              // Input permissions of two non-identical pending asyncs (possibly of the same action)
-              // are a subset of permissions in linear input variables.
-              var membership = Expr.And(
-                Expr.Neq(pa1, pa2),
-                Expr.And(
-                  ExprHelper.IsConstructor(pa1, pendingAsync1.pendingAsyncCtor.Name),
-                  ExprHelper.IsConstructor(pa2, pendingAsync2.pendingAsyncCtor.Name)));
-
-              var existing = Expr.And(
-                Expr.Ge(Expr.Select(PAs, pa1), Expr.Literal(1)),
-                Expr.Ge(Expr.Select(PAs, pa2), Expr.Literal(1)));
-
-              var noDuplication = OutPermsSubsetInPerms(domain, inVars, pendingAsyncLinearParams1.Union(pendingAsyncLinearParams2));
-
-              linearityChecks.Add(new LinearityCheck(
-                domain.DomainName,
-                Expr.And(membership, existing),
-                noDuplication,
-                $"Potential lnearity violation in pending asyncs of {pendingAsync1.proc.Name} and {pendingAsync2.proc.Name} for domain {domain.DomainName}.",
-                $"distinct_{pendingAsync1.proc.Name}_{pendingAsync2.proc.Name}"));
-            }
-          }
-        }
-      }
-
-      if (linearityChecks.Count == 0)
-      {
-        return;
-      }
-
-      // Create checker blocks
-      List<Block> checkerBlocks = new List<Block>(linearityChecks.Count);
-      foreach (var lc in linearityChecks)
-      {
-        List<Cmd> cmds = new List<Cmd>(2);
-        if (lc.assume != null)
-        {
-          cmds.Add(CmdHelper.AssumeCmd(lc.assume));
-        }
-        cmds.Add(CmdHelper.AssertCmd(action.proc.tok, lc.assert, lc.message));
-        var block = BlockHelper.Block($"{lc.domainName}_{lc.checkName}", cmds);
-        CivlUtil.ResolveAndTypecheck(Options, block, ResolutionContext.State.Two);
-        checkerBlocks.Add(block);
-      }
-      
-      // Create init blocks
-      List<Block> blocks = new List<Block>(linearityChecks.Count + 1);
-      blocks.Add(
-        BlockHelper.Block(
-          "init",
-          new List<Cmd> { CmdHelper.CallCmd(action.proc, inputs, outputs) },
-          checkerBlocks));
-      blocks.AddRange(checkerBlocks);
-
-      // Create the whole check procedure
-      string checkerName = civlTypeChecker.AddNamePrefix($"LinearityChecker_{action.proc.Name}");
-      Procedure linCheckerProc = DeclHelper.Procedure(checkerName,
-        inputs, outputs, requires, action.proc.Modifies, new List<Ensures>());
-      Implementation linCheckImpl = DeclHelper.Implementation(linCheckerProc,
-        inputs, outputs, locals, blocks);
-      decls.Add(linCheckImpl);
-      decls.Add(linCheckerProc);
-    }
-
-    private List<Expr> PendingAsyncLinearParams(LinearDomain domain, AtomicAction pendingAsync, IdentifierExpr pa)
-    {
-      var pendingAsyncLinearParams = new List<Expr>();
-
-      for (int i = 0; i < pendingAsync.proc.InParams.Count; i++)
-      {
-        var inParam = pendingAsync.proc.InParams[i];
-        if (InKinds.Contains(LinearDomainCollector.FindLinearKind(inParam)) && FindDomain(inParam) == domain)
-        {
-          var pendingAsyncParam = ExprHelper.FieldAccess(pa, pendingAsync.pendingAsyncCtor.InParams[i].Name);
-          pendingAsyncLinearParams.Add(pendingAsyncParam);
-        }
-      }
-
-      // These expressions must be typechecked since the types are needed later in PermissionMultiset.
-      CivlUtil.ResolveAndTypecheck(Options, pendingAsyncLinearParams);
-      
-      return pendingAsyncLinearParams;
-    }
-
-    private Expr OutPermsSubsetInPerms(LinearDomain domain, IEnumerable<Expr> ins, IEnumerable<Expr> outs)
-    {
-      Expr inMultiset = ExprHelper.Old(PermissionMultiset(domain, ins));
-      Expr outMultiset = PermissionMultiset(domain, outs);
-      Expr subsetExpr = ExprHelper.FunctionCall(domain.mapLe, outMultiset, inMultiset);
-      return Expr.Eq(subsetExpr, ExprHelper.FunctionCall(domain.mapConstBool, Expr.True));
-    }
-
-    private Expr PermissionMultiset(LinearDomain domain, IEnumerable<Expr> exprs)
-    {
-      var terms = exprs.Select(x =>
-        ExprHelper.FunctionCall(domain.mapIteInt,
-          ExprHelper.FunctionCall(domain.collectors[x.Type], x),
-          domain.MapConstInt(1),
-          domain.MapConstInt(0))).ToList<Expr>();
-
-      if (terms.Count == 0)
-      {
-        return domain.MapConstInt(0);
-      }
-
-      return terms.Aggregate((x, y) => ExprHelper.FunctionCall(domain.mapAdd, x, y));
     }
 
     #endregion

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Boogie
       this.civlTypeChecker = civlTypeChecker;
       this.program = civlTypeChecker.program;
       this.checkingContext = civlTypeChecker.checkingContext;
-      this.availableLinearVars = new Dictionary<Absy, HashSet<Variable>>();
+      // other fields are initialized in the TypeCheck method
     }
     
     #region Visitor Implementation
@@ -421,10 +421,10 @@ namespace Microsoft.Boogie
       return civlTypeChecker.LocalVariable("linear_" + domain.DomainName + "_available", domain.mapTypeBool);
     }
 
-    public void TypeCheck(Dictionary<string, LinearDomain> domainNameToLinearDomain, Dictionary<Type, LinearDomain> linearTypeToLinearDomain)
+    public void TypeCheck()
     {
-      this.domainNameToLinearDomain = domainNameToLinearDomain;
-      this.linearTypeToLinearDomain = linearTypeToLinearDomain;
+      (this.domainNameToLinearDomain, this.linearTypeToLinearDomain) = LinearDomainCollector.Collect(program, checkingContext);
+      this.availableLinearVars = new Dictionary<Absy, HashSet<Variable>>();
       this.VisitProgram(program);
       foreach (var absy in this.availableLinearVars.Keys)
       {

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Boogie
       this.availableLinearVars = new Dictionary<Absy, HashSet<Variable>>();
     }
 
-    public IEnumerable<LinearDomain> LinearDomains => domainNameToLinearDomain.Values;
+    public IEnumerable<LinearDomain> LinearDomains => domainNameToLinearDomain.Values.Union(linearTypeToLinearDomain.Values);
     
     public LinearDomain FindDomain(Variable v)
     {
@@ -46,21 +46,20 @@ namespace Microsoft.Boogie
 
     public Formal LinearDomainInFormal(LinearDomain domain)
     {
-      var domainName = domain.DomainName;
-      return civlTypeChecker.Formal("linear_" + domainName + "_in", domainNameToLinearDomain[domainName].mapTypeBool, true);
+      return civlTypeChecker.Formal("linear_" + domain.DomainName + "_in", domain.mapTypeBool, true);
     }
 
     public LocalVariable LinearDomainAvailableLocal(LinearDomain domain)
     {
-      var domainName = domain.DomainName;
-      return civlTypeChecker.LocalVariable("linear_" + domainName + "_available", domainNameToLinearDomain[domainName].mapTypeBool);
+      return civlTypeChecker.LocalVariable("linear_" + domain.DomainName + "_available", domain.mapTypeBool);
     }
 
-    public void TypeCheck()
+    public void TypeCheck(Dictionary<string, LinearDomain> domainNameToLinearDomain, Dictionary<Type, LinearDomain> linearTypeToLinearDomain)
     {
-      (this.domainNameToLinearDomain, this.linearTypeToLinearDomain) = LinearDomainCollector.Collect(program, civlTypeChecker);
+      this.domainNameToLinearDomain = domainNameToLinearDomain;
+      this.linearTypeToLinearDomain = linearTypeToLinearDomain;
       this.VisitProgram(program);
-      foreach (Absy absy in this.availableLinearVars.Keys)
+      foreach (var absy in this.availableLinearVars.Keys)
       {
         availableLinearVars[absy].RemoveWhere(v => v is GlobalVariable);
       }

--- a/Source/Concurrency/LinearityChecker.cs
+++ b/Source/Concurrency/LinearityChecker.cs
@@ -66,7 +66,7 @@ class LinearityChecker
       List<Requires> requires = action.gate.Select(a => new Requires(false, a.Expr)).ToList();
       List<LinearityCheck> linearityChecks = new List<LinearityCheck>();
 
-      foreach (var domain in linearTypeChecker.NamedLinearDomains)
+      foreach (var domain in linearTypeChecker.NameLinearDomains)
       {
         // Linear in vars
         var inVars = inputs.Union(action.modifiedGlobalVars)

--- a/Source/Concurrency/LinearityChecker.cs
+++ b/Source/Concurrency/LinearityChecker.cs
@@ -1,0 +1,262 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Boogie;
+class LinearityChecker 
+{
+    private CivlTypeChecker civlTypeChecker;
+    private LinearTypeChecker linearTypeChecker => civlTypeChecker.linearTypeChecker;
+
+    private LinearityChecker(CivlTypeChecker civlTypeChecker)
+    {
+        this.civlTypeChecker = civlTypeChecker;
+    }
+
+    public static void AddCheckers(CivlTypeChecker civlTypeChecker, List<Declaration> decls)
+    {
+      var linearityChecker = new LinearityChecker(civlTypeChecker);
+      foreach (var action in Enumerable.Concat<Action>(civlTypeChecker.procToAtomicAction.Values,
+        civlTypeChecker.procToIntroductionAction.Values))
+      {
+        linearityChecker.AddChecker(action, decls);
+      }
+    }
+
+    private static LinearKind[] InKinds = {LinearKind.LINEAR, LinearKind.LINEAR_IN};
+    private static LinearKind[] OutKinds = {LinearKind.LINEAR, LinearKind.LINEAR_OUT};
+
+    private class LinearityCheck
+    {
+      public string domainName;
+      public Expr assume;
+      public Expr assert;
+      public string message;
+      public string checkName;
+
+      public LinearityCheck(string domainName, Expr assume, Expr assert, string message, string checkName)
+      {
+        this.domainName = domainName;
+        this.assume = assume;
+        this.assert = assert;
+        this.message = message;
+        this.checkName = checkName;
+      }
+    }
+
+    private void AddChecker(Action action, List<Declaration> decls)
+    {
+      // Note: The implementation should be used as the variables in the
+      //       gate are bound to implementation and not to the procedure.
+      Implementation impl = action.impl;
+      List<Variable> inputs = impl.InParams;
+      List<Variable> outputs = impl.OutParams;
+
+      List<Variable> locals = new List<Variable>(2);
+      var paLocal1 = civlTypeChecker.LocalVariable("pa1", civlTypeChecker.pendingAsyncType);
+      var paLocal2 = civlTypeChecker.LocalVariable("pa2", civlTypeChecker.pendingAsyncType);
+      var pa1 = Expr.Ident(paLocal1);
+      var pa2 = Expr.Ident(paLocal2);
+      
+      if (civlTypeChecker.pendingAsyncType != null)
+      {
+        locals.Add(paLocal1);
+        locals.Add(paLocal2);
+      }
+
+      List<Requires> requires = action.gate.Select(a => new Requires(false, a.Expr)).ToList();
+      List<LinearityCheck> linearityChecks = new List<LinearityCheck>();
+
+      foreach (var domain in linearTypeChecker.NamedLinearDomains)
+      {
+        // Linear in vars
+        var inVars = inputs.Union(action.modifiedGlobalVars)
+          .Where(x => InKinds.Contains(LinearDomainCollector.FindLinearKind(x)))
+          .Where(x => linearTypeChecker.FindDomain(x) == domain)
+          .Select(Expr.Ident)
+          .ToList();
+        
+        // Linear out vars
+        var outVars = inputs.Union(outputs).Union(action.modifiedGlobalVars)
+          .Where(x => OutKinds.Contains(LinearDomainCollector.FindLinearKind(x)))
+          .Where(x => linearTypeChecker.FindDomain(x) == domain)
+          .Select(Expr.Ident)
+          .ToList();
+
+        // First kind
+        // Permissions in linear output variables are a subset of permissions in linear input variables.
+        if (outVars.Count > 0)
+        {
+          linearityChecks.Add(new LinearityCheck(
+            domain.DomainName,
+            null,
+            OutPermsSubsetInPerms(domain, inVars, outVars),
+            $"Potential linearity violation in outputs for domain {domain.DomainName}.",
+            "variables"));
+        }
+
+        if (action is AtomicAction atomicAction && atomicAction.HasPendingAsyncs)
+        {
+          var PAs = Expr.Ident(atomicAction.impl.OutParams.Last());
+          
+          foreach (var pendingAsync in atomicAction.pendingAsyncs)
+          {
+            var pendingAsyncLinearParams = PendingAsyncLinearParams(domain, pendingAsync, pa1);
+
+            if (pendingAsyncLinearParams.Count == 0)
+            {
+              continue;
+            }
+
+            // Second kind
+            // Permissions in linear output variables + linear inputs of a single pending async
+            // are a subset of permissions in linear input variables.
+            var exactlyOnePA = Expr.And(
+              ExprHelper.IsConstructor(pa1, pendingAsync.pendingAsyncCtor.Name),
+              Expr.Eq(Expr.Select(PAs, pa1), Expr.Literal(1)));
+            var outSubsetInExpr = OutPermsSubsetInPerms(domain, inVars, pendingAsyncLinearParams.Union(outVars));
+            linearityChecks.Add(new LinearityCheck(
+              domain.DomainName,
+              exactlyOnePA,
+              outSubsetInExpr,
+              $"Potential linearity violation in outputs and pending async of {pendingAsync.proc.Name} for domain {domain.DomainName}.",
+              $"single_{pendingAsync.proc.Name}"));
+
+            // Third kind
+            // If there are two identical pending asyncs, then their input permissions mut be empty.
+            var twoIdenticalPAs = Expr.And(
+              ExprHelper.IsConstructor(pa1, pendingAsync.pendingAsyncCtor.Name),
+              Expr.Ge(Expr.Select(PAs, pa1), Expr.Literal(2)));
+            var emptyPerms = OutPermsSubsetInPerms(domain, Enumerable.Empty<Expr>(), pendingAsyncLinearParams);
+            linearityChecks.Add(new LinearityCheck(
+              domain.DomainName,
+              twoIdenticalPAs,
+              emptyPerms,
+              $"Potential linearity violation in identical pending asyncs of {pendingAsync.proc.Name} for domain {domain.DomainName}.",
+              $"identical_{pendingAsync.proc.Name}"));
+          }
+
+          var pendingAsyncs = atomicAction.pendingAsyncs.ToList();
+          for (int i = 0; i < pendingAsyncs.Count; i++)
+          {
+            var pendingAsync1 = pendingAsyncs[i];
+            for (int j = i; j < pendingAsyncs.Count; j++)
+            {
+              var pendingAsync2 = pendingAsyncs[j];
+
+              var pendingAsyncLinearParams1 = PendingAsyncLinearParams(domain, pendingAsync1, pa1);
+              var pendingAsyncLinearParams2 = PendingAsyncLinearParams(domain, pendingAsync2, pa2);
+              
+              if (pendingAsyncLinearParams1.Count == 0 || pendingAsyncLinearParams2.Count == 0)
+              {
+                continue;
+              }
+
+              // Fourth kind
+              // Input permissions of two non-identical pending asyncs (possibly of the same action)
+              // are a subset of permissions in linear input variables.
+              var membership = Expr.And(
+                Expr.Neq(pa1, pa2),
+                Expr.And(
+                  ExprHelper.IsConstructor(pa1, pendingAsync1.pendingAsyncCtor.Name),
+                  ExprHelper.IsConstructor(pa2, pendingAsync2.pendingAsyncCtor.Name)));
+
+              var existing = Expr.And(
+                Expr.Ge(Expr.Select(PAs, pa1), Expr.Literal(1)),
+                Expr.Ge(Expr.Select(PAs, pa2), Expr.Literal(1)));
+
+              var noDuplication = OutPermsSubsetInPerms(domain, inVars, pendingAsyncLinearParams1.Union(pendingAsyncLinearParams2));
+
+              linearityChecks.Add(new LinearityCheck(
+                domain.DomainName,
+                Expr.And(membership, existing),
+                noDuplication,
+                $"Potential lnearity violation in pending asyncs of {pendingAsync1.proc.Name} and {pendingAsync2.proc.Name} for domain {domain.DomainName}.",
+                $"distinct_{pendingAsync1.proc.Name}_{pendingAsync2.proc.Name}"));
+            }
+          }
+        }
+      }
+
+      if (linearityChecks.Count == 0)
+      {
+        return;
+      }
+
+      // Create checker blocks
+      List<Block> checkerBlocks = new List<Block>(linearityChecks.Count);
+      foreach (var lc in linearityChecks)
+      {
+        List<Cmd> cmds = new List<Cmd>(2);
+        if (lc.assume != null)
+        {
+          cmds.Add(CmdHelper.AssumeCmd(lc.assume));
+        }
+        cmds.Add(CmdHelper.AssertCmd(action.proc.tok, lc.assert, lc.message));
+        var block = BlockHelper.Block($"{lc.domainName}_{lc.checkName}", cmds);
+        CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, block, ResolutionContext.State.Two);
+        checkerBlocks.Add(block);
+      }
+      
+      // Create init blocks
+      List<Block> blocks = new List<Block>(linearityChecks.Count + 1);
+      blocks.Add(
+        BlockHelper.Block(
+          "init",
+          new List<Cmd> { CmdHelper.CallCmd(action.proc, inputs, outputs) },
+          checkerBlocks));
+      blocks.AddRange(checkerBlocks);
+
+      // Create the whole check procedure
+      string checkerName = civlTypeChecker.AddNamePrefix($"LinearityChecker_{action.proc.Name}");
+      Procedure linCheckerProc = DeclHelper.Procedure(checkerName,
+        inputs, outputs, requires, action.proc.Modifies, new List<Ensures>());
+      Implementation linCheckImpl = DeclHelper.Implementation(linCheckerProc,
+        inputs, outputs, locals, blocks);
+      decls.Add(linCheckImpl);
+      decls.Add(linCheckerProc);
+    }
+
+    private List<Expr> PendingAsyncLinearParams(LinearDomain domain, AtomicAction pendingAsync, IdentifierExpr pa)
+    {
+      var pendingAsyncLinearParams = new List<Expr>();
+
+      for (int i = 0; i < pendingAsync.proc.InParams.Count; i++)
+      {
+        var inParam = pendingAsync.proc.InParams[i];
+        if (InKinds.Contains(LinearDomainCollector.FindLinearKind(inParam)) && linearTypeChecker.FindDomain(inParam) == domain)
+        {
+          var pendingAsyncParam = ExprHelper.FieldAccess(pa, pendingAsync.pendingAsyncCtor.InParams[i].Name);
+          pendingAsyncLinearParams.Add(pendingAsyncParam);
+        }
+      }
+
+      // These expressions must be typechecked since the types are needed later in PermissionMultiset.
+      CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, pendingAsyncLinearParams);
+      
+      return pendingAsyncLinearParams;
+    }
+
+    private Expr OutPermsSubsetInPerms(LinearDomain domain, IEnumerable<Expr> ins, IEnumerable<Expr> outs)
+    {
+      Expr inMultiset = ExprHelper.Old(PermissionMultiset(domain, ins));
+      Expr outMultiset = PermissionMultiset(domain, outs);
+      Expr subsetExpr = ExprHelper.FunctionCall(domain.mapLe, outMultiset, inMultiset);
+      return Expr.Eq(subsetExpr, ExprHelper.FunctionCall(domain.mapConstBool, Expr.True));
+    }
+
+    private Expr PermissionMultiset(LinearDomain domain, IEnumerable<Expr> exprs)
+    {
+      var terms = exprs.Select(x =>
+        ExprHelper.FunctionCall(domain.mapIteInt,
+          ExprHelper.FunctionCall(domain.collectors[x.Type], x),
+          domain.MapConstInt(1),
+          domain.MapConstInt(0))).ToList<Expr>();
+
+      if (terms.Count == 0)
+      {
+        return domain.MapConstInt(0);
+      }
+
+      return terms.Aggregate((x, y) => ExprHelper.FunctionCall(domain.mapAdd, x, y));
+    }
+}

--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -12,10 +12,6 @@ function {:inline} MapDiff<T>(a: [T]bool, b: [T]bool) : [T]bool
 {
   MapAnd(a, MapNot(b))
 }
-function {:inline} MapOne<T>(a: T) : [T]bool
-{
-  MapConst(false)[a := true]
-}
 
 function {:builtin "MapAdd"} MapAdd<T>([T]int, [T]int) : [T]int;
 function {:builtin "MapSub"} MapSub<T>([T]int, [T]int) : [T]int;
@@ -27,7 +23,7 @@ function {:builtin "MapGe"} MapGe<T>([T]int, [T]int) : [T]bool;
 function {:builtin "MapLt"} MapLt<T>([T]int, [T]int) : [T]bool;
 function {:builtin "MapLe"} MapLe<T>([T]int, [T]int) : [T]bool;
 
-function {:inline} MapUnit<T>(t: T): [T]bool
+function {:inline} MapOne<T>(t: T): [T]bool
 {
   MapConst(false)[t := true]
 }

--- a/Source/Core/LibraryDefinitions.bpl
+++ b/Source/Core/LibraryDefinitions.bpl
@@ -133,11 +133,14 @@ type Ref _;
 type {:datatype} Lmap _;
 function {:constructor} Lmap<V>(dom: [Ref V]bool, val: [Ref V]V): Lmap V;
 
-function {:inline} Lmap_Deref<V>(l: Lmap V, k: Ref V): V {
-    l->val[k]
+function {:inline} Lmap_Collector<V>(l: Lmap V): [Ref V]bool {
+    l->dom
 }
 function {:inline} Lmap_Contains<V>(l: Lmap V, k: Ref V): bool {
     l->dom[k]
+}
+function {:inline} Lmap_Deref<V>(l: Lmap V, k: Ref V): V {
+    l->val[k]
 }
 procedure Lmap_Empty<V>() returns (l: Lmap V);
 procedure Lmap_Split<V>(path: Lmap V, k: [Ref V]bool) returns (l: Lmap V);
@@ -151,6 +154,9 @@ procedure Lmap_Remove<V>(path: Lmap V, k: Ref V) returns (v: V);
 type {:datatype} Lset _;
 function {:constructor} Lset<V>(dom: [V]bool): Lset V;
 
+function {:inline} Lset_Collector<V>(l: Lset V): [V]bool {
+    l->dom
+}
 function {:inline} Lset_Contains<V>(l: Lset V, k: V): bool {
     l->dom[k]
 }
@@ -162,5 +168,8 @@ procedure Lset_Transfer<V>(path1: Lset V, path2: Lset V);
 type {:datatype} Lval _;
 function {:constructor} Lval<V>(val: V): Lval V;
 
+function {:inline} Lval_Collector<V>(l: Lval V): [V]bool {
+    MapConst(false)[l->val := true]
+}
 procedure Lval_Split<V>(path: Lset V, k: V) returns (l: Lval V);
 procedure Lval_Transfer<V>(l: Lval V, path: Lset V);

--- a/Test/civl/zeldovich2.bpl
+++ b/Test/civl/zeldovich2.bpl
@@ -1,0 +1,99 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Tid;
+const nil: Tid;
+
+var {:layer 0,1} lock_x: Tid;
+var {:layer 0,1} lock_y: Tid;
+var {:layer 0,2} x: int;
+var {:layer 0,2} y: int;
+
+procedure {:atomic}{:layer 2} GET_X (tid: Lval Tid) returns (v: int)
+{
+  v := x;
+}
+
+procedure {:atomic}{:layer 2} SET_BOTH (tid: Lval Tid, v: int, w: int)
+modifies x, y;
+{
+  x := v;
+  y := w;
+}
+
+procedure {:layer 1}{:yields}{:refines "GET_X"} get_x (tid: Lval Tid) returns (v: int)
+requires {:layer 1} tid->val != nil;
+{
+  call acquire_x(tid);
+  call v := read_x(tid);
+  call release_x(tid);
+}
+
+procedure {:layer 1}{:yields}{:refines "SET_BOTH"} set_both (tid: Lval Tid, v: int, w: int)
+requires {:layer 1} tid->val != nil;
+{
+  call acquire_x(tid);
+  call acquire_y(tid);
+  call write_x(tid, v);
+  call release_x(tid); // early release of lock_x
+  call write_y(tid, w);
+  call release_y(tid);
+}
+
+procedure {:right}{:layer 1} ACQUIRE_X (tid: Lval Tid)
+modifies lock_x;
+{
+  assert tid->val != nil;
+  assume lock_x == nil;
+  lock_x := tid->val;
+}
+
+procedure {:left}{:layer 1} RELEASE_X (tid: Lval Tid)
+modifies lock_x;
+{
+  assert tid->val != nil && lock_x == tid->val;
+  lock_x := nil;
+}
+
+procedure {:right}{:layer 1} ACQUIRE_Y (tid: Lval Tid)
+modifies lock_y;
+{
+  assert tid->val != nil;
+  assume lock_y == nil;
+  lock_y := tid->val;
+}
+
+procedure {:left}{:layer 1} RELEASE_Y (tid: Lval Tid)
+modifies lock_y;
+{
+  assert tid->val != nil && lock_y == tid->val;
+  lock_y := nil;
+}
+
+procedure {:both}{:layer 1} WRITE_X (tid: Lval Tid, v: int)
+modifies x;
+{
+  assert tid->val != nil && lock_x == tid->val;
+  x := v;
+}
+
+procedure {:both}{:layer 1} WRITE_Y (tid: Lval Tid, v: int)
+modifies y;
+{
+  assert tid->val != nil && lock_y == tid->val;
+  y := v;
+}
+
+procedure {:both}{:layer 1} READ_X (tid: Lval Tid) returns (r: int)
+{
+  assert tid->val != nil && lock_x == tid->val;
+  r := x;
+}
+
+procedure {:yields}{:layer 0}{:refines "ACQUIRE_X"} acquire_x (tid: Lval Tid);
+procedure {:yields}{:layer 0}{:refines "ACQUIRE_Y"} acquire_y (tid: Lval Tid);
+procedure {:yields}{:layer 0}{:refines "RELEASE_X"} release_x (tid: Lval Tid);
+procedure {:yields}{:layer 0}{:refines "RELEASE_Y"} release_y (tid: Lval Tid);
+procedure {:yields}{:layer 0}{:refines "WRITE_X"} write_x (tid: Lval Tid, v: int);
+procedure {:yields}{:layer 0}{:refines "WRITE_Y"} write_y (tid: Lval Tid, v: int);
+procedure {:yields}{:layer 0}{:refines "READ_X"} read_x (tid: Lval Tid) returns (r: int);

--- a/Test/civl/zeldovich2.bpl.expect
+++ b/Test/civl/zeldovich2.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 27 verified, 0 errors


### PR DESCRIPTION
- Added linear domains for linear types
- Split out VC generation for linearity checking into a separate class and file
- Break dependency between LinearTypeChecker and the population of various tables related to atomic actions and lemma procedures in CivlTypeChecker. This is achieved by examining the attributes instead of the tables in LinearTypeChecker.
- Allow the type checker to run on the code of either actions or yielding procedures by selectively disabling a few checks.