### PR TITLE
[Civl] Small fixes

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -209,14 +209,19 @@ namespace Microsoft.Boogie
     }
   }
 
+    /*
+     * An introduction action may have a layer range which allows it to be called
+     * from other atomic actions. But its lower layer is special because the variables
+     * it can modify must have been introduced at that layer.
+     */
   public class IntroductionAction : Action
   {
     public IntroductionAction(Procedure proc, Implementation impl, LayerRange layerRange) :
       base(proc, impl, layerRange)
     {
     }
-
-    public int LayerNum => layerRange.lowerLayerNum; // layerRange.lowerLayerNum == layerRange.upperLayerNum
+    
+    public int LayerNum => layerRange.lowerLayerNum;
   }
 
   public class AtomicAction : Action

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -290,10 +290,6 @@ namespace Microsoft.Boogie
           {
             Error(proc, "Action must be either an atomic action or introduction action");
           }
-          else if (layerRange.lowerLayerNum != layerRange.upperLayerNum)
-          {
-            Error(proc, "Layer range of an introduction action should be singleton");
-          }
           else if (proc.Modifies.Any(ie => GlobalVariableLayerRange(ie.Decl).lowerLayerNum != layerRange.lowerLayerNum))
           {
             Error(proc, "Introduction actions can modify a global variable only on its introduction layer");

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -367,6 +367,12 @@ namespace Microsoft.Boogie
             rc.ErrorCount = e;
             continue;
           }
+          if (d is DatatypeConstructor)
+          {
+            // resolving a constructor adds it to its datatype declaration
+            // so we remove it from TopLevelDeclarations
+            continue;
+          }
         }
         prunedTopLevelDeclarations.Add(d);
       }


### PR DESCRIPTION
- Allow introduction actions to have a layer range.
- Remove datatype constructors from TopLevelDeclarations once resolution is done.