### PR TITLE
[Civl] updates to pool instantiation and variable elimination

### DIFF
--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Boogie
       {
         TryElimination(Enumerable.Empty<Variable>());
         TryElimination(trc.allLocVars.Select(v => varCopies[v][0]));
-        TryElimination(trc.allLocVars.Where(v => varCopies[v].Count > 1).Select(v => varCopies[v][1]));
+        TryElimination(trc.allLocVars.Where(v => v.FindAttribute("pool") != null).SelectMany(v => varCopies[v]));
 
         if (trc.ignorePostState)
         {

--- a/Source/VCExpr/QuantifierInstantiationEngine.cs
+++ b/Source/VCExpr/QuantifierInstantiationEngine.cs
@@ -588,7 +588,7 @@ namespace Microsoft.Boogie.VCExprAST
       var skolemizer = new Skolemizer(qiEngine, polarity, vcExpr);
       var skolemizedExpr = skolemizer.Mutate(vcExpr, true);
       LambdaInstanceCollector.CollectInstances(qiEngine, vcExpr);
-      return Factorizer.Factorize(qiEngine, QuantifierCollector.Flip(polarity), skolemizedExpr);
+      return Factorizer.Factorize(qiEngine, skolemizedExpr);
     }
 
     private Skolemizer(QuantifierInstantiationEngine qiEngine, Polarity polarity, VCExpr vcExpr) : base(qiEngine.vcExprGen)
@@ -648,27 +648,21 @@ namespace Microsoft.Boogie.VCExprAST
      */
     
     private QuantifierInstantiationEngine qiEngine;
-    private HashSet<VCExprQuantifier> quantifiers;
 
-    public static VCExpr Factorize(QuantifierInstantiationEngine qiEngine, Polarity polarity, VCExpr vcExpr)
+    public static VCExpr Factorize(QuantifierInstantiationEngine qiEngine, VCExpr vcExpr)
     {
-      var factorizer = new Factorizer(qiEngine, polarity, vcExpr);
+      var factorizer = new Factorizer(qiEngine);
       return factorizer.Mutate(vcExpr, true);
     }
 
-    private Factorizer(QuantifierInstantiationEngine qiEngine, Polarity polarity, VCExpr vcExpr) : base(qiEngine.vcExprGen)
+    private Factorizer(QuantifierInstantiationEngine qiEngine) : base(qiEngine.vcExprGen)
     {
       this.qiEngine = qiEngine;
-      this.quantifiers = QuantifierCollector.CollectQuantifiers(vcExpr, polarity);
     }
 
     public override VCExpr Visit(VCExprQuantifier node, bool arg)
     {
-      if (quantifiers.Contains(node))
-      {
-        return qiEngine.BindQuantifier(node);
-      }
-      return base.Visit(node, arg);
+      return qiEngine.BindQuantifier(node);
     }
   }
   


### PR DESCRIPTION
- Pool instantiation was not collecting all quantifiers that could be instantiated. While skolemization of a quantifier requires knowing the polarity, instantiation can be done on all quantifiers.
- Variable elimination in transition relation computation tries different sets of defined variables one after another. Changed the last attempt to be based on all variables that have a pool associated with them.