### PR TITLE
[Civl] Refinement refactoring

### DIFF
--- a/Source/Concurrency/ConcurrencyOptions.cs
+++ b/Source/Concurrency/ConcurrencyOptions.cs
@@ -7,5 +7,6 @@ public interface ConcurrencyOptions : CoreOptions
   int TrustLayersDownto { get; }
   int TrustLayersUpto { get; }
   bool TrustNoninterference { get; }
+  bool TrustRefinement { get; }
   bool WarnNotEliminatedVars { get; }
 }

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -660,7 +660,13 @@ namespace Microsoft.Boogie
       set => trustNoninterference = value;
     }
 
+    public bool TrustRefinement {
+      get => trustRefinement;
+      set => trustRefinement = value;
+    }
+    
     public int TrustLayersUpto { get; set; } = -1;
+    
     public int TrustLayersDownto { get; set; } = int.MaxValue;
 
     public bool TrustInductiveSequentialization {
@@ -808,6 +814,7 @@ namespace Microsoft.Boogie
     private bool useProverEvaluate;
     private bool trustMoverTypes = false;
     private bool trustNoninterference = false;
+    private bool trustRefinement = false;
     private bool trustInductiveSequentialization = false;
     private bool trace = false;
     private int enhancedErrorMessages = 0;
@@ -1564,6 +1571,7 @@ namespace Microsoft.Boogie
               ps.CheckBooleanFlag("verifySeparately", x => VerifySeparately = x) ||
               ps.CheckBooleanFlag("trustMoverTypes", x => trustMoverTypes = x) ||
               ps.CheckBooleanFlag("trustNoninterference", x => trustNoninterference = x) ||
+              ps.CheckBooleanFlag("trustRefinement", x => trustRefinement = x) ||
               ps.CheckBooleanFlag("trustInductiveSequentialization", x => trustInductiveSequentialization = x) ||
               ps.CheckBooleanFlag("useBaseNameForFileName", x => UseBaseNameForFileName = x) ||
               ps.CheckBooleanFlag("freeVarLambdaLifting", x => FreeVarLambdaLifting = x) ||
@@ -2101,6 +2109,8 @@ namespace Microsoft.Boogie
                 do not verify mover type annotations on atomic action declarations
   /trustNoninterference
                 do not perform noninterference checks
+  /trustRefinement
+                do not perform refinement checks
   /trustLayersUpto:<n>
                 do not verify layers <n> and below
   /trustLayersDownto:<n>

--- a/Test/civl/parallel6.bpl.expect
+++ b/Test/civl/parallel6.bpl.expect
@@ -3,6 +3,7 @@ Execution trace:
     parallel6.bpl(10,5): anon0
     parallel6.bpl(28,7): inline$atomic_incr$0$anon0
     parallel6.bpl(28,7): inline$atomic_incr$1$anon0
+    parallel6.bpl(10,5): anon0$2
     parallel6.bpl(10,5): anon0_0
     parallel6.bpl(28,7): inline$atomic_incr$2$anon0
     parallel6.bpl(28,7): inline$atomic_incr$3$anon0

--- a/Test/civl/refinement.bpl.expect
+++ b/Test/civl/refinement.bpl.expect
@@ -2,6 +2,7 @@ refinement.bpl(7,48): Error: A yield-to-yield fragment modifies layer-2 state su
 Execution trace:
     refinement.bpl(9,3): anon0
     refinement.bpl(53,5): inline$INCR$0$anon0
+    refinement.bpl(9,3): anon0$1
     refinement.bpl(9,3): anon0_0
     refinement.bpl(53,5): inline$INCR$1$anon0
     (0,0): Civl_ReturnChecker
@@ -9,11 +10,13 @@ refinement.bpl(14,48): Error: A yield-to-yield fragment modifies layer-2 state i
 Execution trace:
     refinement.bpl(16,3): anon0
     refinement.bpl(59,5): inline$DECR$0$anon0
+    refinement.bpl(16,3): anon0$1
     (0,0): Civl_RefinementChecker
 refinement.bpl(14,48): Error: A yield-to-yield fragment modifies layer-2 state subsequent to a yield-to-yield fragment that already modified layer-2 state
 Execution trace:
     refinement.bpl(16,3): anon0
     refinement.bpl(59,5): inline$DECR$0$anon0
+    refinement.bpl(16,3): anon0$1
     refinement.bpl(16,3): anon0_0
     refinement.bpl(53,5): inline$INCR$0$anon0
     (0,0): Civl_ReturnChecker
@@ -25,6 +28,7 @@ refinement.bpl(39,48): Error: A yield-to-yield fragment illegally modifies layer
 Execution trace:
     refinement.bpl(41,3): anon0
     refinement.bpl(53,5): inline$INCR$0$anon0
+    refinement.bpl(41,3): anon0$1
     refinement.bpl(41,3): anon0_0
     refinement.bpl(43,3): anon2_LoopHead
     refinement.bpl(53,5): inline$INCR$1$anon0


### PR DESCRIPTION
- Added another variable `eval` in the refinement instrumentation. This variable is used to stash the evaluation of the transition relation so it can be reused in both the asserts and the update assignment to ok. This reduces by half the number of occurrences of the potentially large transition relation.
- Added /trustRefinement option that drops the refinement checking from the generated VCs. Specifically, pc is tracked at most one update to global variables is allowed. Furthermore, the gate is assumed as long as pc is false. But the transition relation does not enter the picture.