### PR TITLE
Add  field update expression

### DIFF
--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -991,7 +991,6 @@ FieldAccess<.out IToken x, out FieldAccess fieldAccess.>
   "->" (. x = t; .)
   Ident<out id> (. fieldAccess = new FieldAccess(id, id.val); .)
   .
-
 /*------------------------------------------------------------------------*/
 CallCmd<out Cmd c>
 = (. Contract.Ensures(Contract.ValueAtReturn(out c) != null);
@@ -1288,8 +1287,7 @@ CoercionExpression<out Expr/*!*/ e>
 /*------------------------------------------------------------------------*/
 ArrayExpression<out Expr/*!*/ e>
 = (. Contract.Ensures(Contract.ValueAtReturn(out e) != null); 
-     IToken/*!*/ x;
-     FieldAccess fieldAccess;
+     IToken/*!*/ x, id;
      Expr/*!*/ index0 = dummyExpr; Expr/*!*/ e1;
      bool store; bool bvExtract;
      List<Expr>/*!*/ allArgs = dummyExprSeq;
@@ -1330,7 +1328,16 @@ ArrayExpression<out Expr/*!*/ e>
          e = new NAryExpr(x, new MapSelect(x, allArgs.Count - 1), allArgs);
     .)
     |
-      FieldAccess<out x, out fieldAccess> (. e = new NAryExpr(x, fieldAccess, new List<Expr> { e }); .)
+      "->" (. x = t; .)
+      (
+        Ident<out id> (. e = new NAryExpr(x, new FieldAccess(id, id.val), new List<Expr> { e }); .)
+        |
+        "("
+        Ident<out id>
+        ":=" (. x = t; .)
+        Expression<out e1>
+        ")" (. e = new NAryExpr(x, new FieldUpdate(id, id.val), new List<Expr> { e, e1 }); .)
+      )
   }
   .
 

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -991,6 +991,7 @@ FieldAccess<.out IToken x, out FieldAccess fieldAccess.>
   "->" (. x = t; .)
   Ident<out id> (. fieldAccess = new FieldAccess(id, id.val); .)
   .
+
 /*------------------------------------------------------------------------*/
 CallCmd<out Cmd c>
 = (. Contract.Ensures(Contract.ValueAtReturn(out c) != null);

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -585,6 +585,11 @@ namespace Microsoft.Boogie
             actualTypeParams];
         return new FieldAccess(fieldAccess.tok, instantiatedDatatypeTypeCtorDecl, fieldAccess.Accessors);
       }
+
+      private FieldUpdate InstantiateFieldUpdate(FieldUpdate fieldUpdate, TypeParamInstantiation typeParameters)
+      {
+        return new FieldUpdate(InstantiateFieldAccess(fieldUpdate.FieldAccess, typeParameters));
+      }
       
       public override AssignLhs VisitFieldAssignLhs(FieldAssignLhs node)
       {
@@ -633,6 +638,19 @@ namespace Microsoft.Boogie
           else
           {
             returnExpr.Fun = InstantiateFieldAccess(fieldAccess, returnExpr.TypeParameters);
+            returnExpr.TypeParameters = SimpleTypeParamInstantiation.EMPTY;
+          }
+        }
+        else if (returnExpr.Fun is FieldUpdate fieldUpdate)
+        {
+          var datatypeTypeCtorDecl = fieldUpdate.DatatypeTypeCtorDecl;
+          if (datatypeTypeCtorDecl.Arity == 0)
+          {
+            monomorphizationVisitor.VisitTypeCtorDecl(datatypeTypeCtorDecl);
+          }
+          else
+          {
+            returnExpr.Fun = InstantiateFieldUpdate(fieldUpdate, returnExpr.TypeParameters);
             returnExpr.TypeParameters = SimpleTypeParamInstantiation.EMPTY;
           }
         }

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -1764,8 +1764,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 
 	void ArrayExpression(out Expr/*!*/ e) {
 		Contract.Ensures(Contract.ValueAtReturn(out e) != null); 
-		IToken/*!*/ x;
-		FieldAccess fieldAccess;
+		IToken/*!*/ x, id;
 		Expr/*!*/ index0 = dummyExpr; Expr/*!*/ e1;
 		bool store; bool bvExtract;
 		List<Expr>/*!*/ allArgs = dummyExprSeq;
@@ -1818,8 +1817,20 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				 e = new NAryExpr(x, new MapSelect(x, allArgs.Count - 1), allArgs);
 				
 			} else {
-				FieldAccess(out x, out fieldAccess);
-				e = new NAryExpr(x, fieldAccess, new List<Expr> { e }); 
+				Get();
+				x = t; 
+				if (la.kind == 1) {
+					Ident(out id);
+					e = new NAryExpr(x, new FieldAccess(id, id.val), new List<Expr> { e }); 
+				} else if (la.kind == 10) {
+					Get();
+					Ident(out id);
+					Expect(52);
+					x = t; 
+					Expression(out e1);
+					Expect(11);
+					e = new NAryExpr(x, new FieldUpdate(id, id.val), new List<Expr> { e, e1 }); 
+				} else SynErr(138);
 			}
 		}
 	}
@@ -1936,7 +1947,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 					e = new NAryExpr(x, new FunctionCall(id), es); 
 				} else if (la.kind == 11) {
 					e = new NAryExpr(x, new FunctionCall(id), new List<Expr>()); 
-				} else SynErr(138);
+				} else SynErr(139);
 				Expect(11);
 			}
 			break;
@@ -1996,7 +2007,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				 e = new LambdaExpr(x, typeParams, ds, kv, e); 
 			} else if (la.kind == 8) {
 				LetExpr(out e);
-			} else SynErr(139);
+			} else SynErr(140);
 			Expect(11);
 			break;
 		}
@@ -2009,7 +2020,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			e = new CodeExpr(locals, blocks); 
 			break;
 		}
-		default: SynErr(140); break;
+		default: SynErr(141); break;
 		}
 	}
 
@@ -2021,7 +2032,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		} else if (la.kind == 6) {
 			Get();
 			s = t.val; 
-		} else SynErr(141);
+		} else SynErr(142);
 		try {
 		 n = BigDec.FromString(s);
 		} catch (FormatException) {
@@ -2065,7 +2076,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			Get();
 		} else if (la.kind == 103) {
 			Get();
-		} else SynErr(142);
+		} else SynErr(143);
 	}
 
 	void QuantifierBody(IToken/*!*/ q, out List<TypeVariable>/*!*/ typeParams, out List<Variable>/*!*/ ds,
@@ -2083,7 +2094,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			}
 		} else if (la.kind == 1 || la.kind == 25) {
 			BoundVars(out ds);
-		} else SynErr(143);
+		} else SynErr(144);
 		QSep();
 		while (la.kind == 25) {
 			AttributeOrTrigger(ref kv, ref trig);
@@ -2096,7 +2107,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			Get();
 		} else if (la.kind == 105) {
 			Get();
-		} else SynErr(144);
+		} else SynErr(145);
 	}
 
 	void Lambda() {
@@ -2104,7 +2115,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			Get();
 		} else if (la.kind == 107) {
 			Get();
-		} else SynErr(145);
+		} else SynErr(146);
 	}
 
 	void LetExpr(out Expr/*!*/ letexpr) {
@@ -2207,7 +2218,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			Get();
 			Expression(out e);
 			b = new Block(x,x.val,cs,new ReturnExprCmd(t,e)); 
-		} else SynErr(146);
+		} else SynErr(147);
 		Expect(9);
 	}
 
@@ -2264,7 +2275,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			 trig.AddLast(new Trigger(tok, true, es, null));
 			}
 			
-		} else SynErr(147);
+		} else SynErr(148);
 		Expect(26);
 	}
 
@@ -2279,7 +2290,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		} else if (StartOf(9)) {
 			Expression(out e);
 			o = e; 
-		} else SynErr(148);
+		} else SynErr(149);
 	}
 
 	void QSep() {
@@ -2287,7 +2298,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			Get();
 		} else if (la.kind == 109) {
 			Get();
-		} else SynErr(149);
+		} else SynErr(150);
 	}
 
 	void LetVar(out Variable/*!*/ v) {
@@ -2495,18 +2506,19 @@ public class Errors {
 			case 135: s = "invalid UnaryExpression"; break;
 			case 136: s = "invalid NegOp"; break;
 			case 137: s = "invalid CoercionExpression"; break;
-			case 138: s = "invalid AtomExpression"; break;
+			case 138: s = "invalid ArrayExpression"; break;
 			case 139: s = "invalid AtomExpression"; break;
 			case 140: s = "invalid AtomExpression"; break;
-			case 141: s = "invalid Dec"; break;
-			case 142: s = "invalid Forall"; break;
-			case 143: s = "invalid QuantifierBody"; break;
-			case 144: s = "invalid Exists"; break;
-			case 145: s = "invalid Lambda"; break;
-			case 146: s = "invalid SpecBlock"; break;
-			case 147: s = "invalid AttributeOrTrigger"; break;
-			case 148: s = "invalid AttributeParameter"; break;
-			case 149: s = "invalid QSep"; break;
+			case 141: s = "invalid AtomExpression"; break;
+			case 142: s = "invalid Dec"; break;
+			case 143: s = "invalid Forall"; break;
+			case 144: s = "invalid QuantifierBody"; break;
+			case 145: s = "invalid Exists"; break;
+			case 146: s = "invalid Lambda"; break;
+			case 147: s = "invalid SpecBlock"; break;
+			case 148: s = "invalid AttributeOrTrigger"; break;
+			case 149: s = "invalid AttributeParameter"; break;
+			case 150: s = "invalid QSep"; break;
 
 			default: s = "error " + n; break;
 		}

--- a/Source/Core/TokenTextWriter.cs
+++ b/Source/Core/TokenTextWriter.cs
@@ -226,6 +226,12 @@ namespace Microsoft.Boogie
       this.SetToken(t => expr.tok = t);
     }
     
+    public void SetToken(FieldUpdate expr)
+    {
+      Contract.Requires(expr != null);
+      this.SetToken(t => expr.tok = t);
+    }
+    
     public void SetToken(IsConstructor expr)
     {
       Contract.Requires(expr != null);

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -496,6 +496,11 @@ namespace Microsoft.Boogie.VCExprAST
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
+      if (node.Fun is FieldUpdate fieldUpdate)
+      {
+        return TranslateNAryExpr(fieldUpdate.Update(Token.NoToken, node.Args[0], node.Args[1]));
+      }
+      
       bool flipContextForArg0 = false;
       if (node.Fun is UnaryOperator)
       {
@@ -1435,6 +1440,11 @@ namespace Microsoft.Boogie.VCExprAST
       return expr;
     }
 
+    public VCExpr Visit(FieldUpdate fieldUpdate)
+    {
+      throw new cce.UnreachableException();
+    }
+    
     public VCExpr Visit(IsConstructor isConstructor)
     {
       return Gen.Function(new VCExprIsConstructorOp(isConstructor.DatatypeTypeCtorDecl, isConstructor.ConstructorIndex), this.args);

--- a/Test/datatypes/field_access_correct.bpl
+++ b/Test/datatypes/field_access_correct.bpl
@@ -85,3 +85,23 @@ ensures i == s->i;
   s' := Left(i);
   assert s == s';
 }
+
+procedure P7(p: Pair) returns (q: Pair)
+  requires p->a == 0;
+  ensures  q->a == 1;
+{
+  q := p->(a := 1);
+  assert q->b == p->b;
+  q := q->(b := 1);
+  assert q == Pair(1, 1);
+}
+
+procedure P8<T>(p: GenericPair T) returns (q: GenericPair T)
+  requires p->a == p->b;
+  ensures  q->a == q->b;
+{
+  assert p is GenericPair;
+  q := q->(a := p->b);
+  q := q->(b := p->a);
+  assert q is GenericPair;
+}

--- a/Test/datatypes/field_access_correct.bpl.expect
+++ b/Test/datatypes/field_access_correct.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 7 verified, 0 errors
+Boogie program verifier finished with 9 verified, 0 errors

--- a/Test/datatypes/field_access_type_error.bpl
+++ b/Test/datatypes/field_access_type_error.bpl
@@ -55,3 +55,8 @@ procedure I(p: Pair, a: int)
   var b: int;
   Pair(a, b) := p;
 }
+
+procedure J(p: Pair, x: bool) returns (q: Pair)
+{
+  q := p->(a := x);
+}

--- a/Test/datatypes/field_access_type_error.bpl.expect
+++ b/Test/datatypes/field_access_type_error.bpl.expect
@@ -9,4 +9,5 @@ field_access_type_error.bpl(37,12): Error: mismatched types in assignment comman
 field_access_type_error.bpl(45,13): Error: variable a is assigned more than once in unpack command
 field_access_type_error.bpl(50,13): Error: command assigns to a global variable that is not in the enclosing procedure's modifies clause: g
 field_access_type_error.bpl(56,13): Error: command assigns to an immutable variable: a
-11 type checking errors detected in field_access_type_error.bpl
+field_access_type_error.bpl(61,11): Error: right-hand side in field update with wrong type: bool (expected: int)
+12 type checking errors detected in field_access_type_error.bpl

--- a/Test/datatypes/field_access_verification_error.bpl
+++ b/Test/datatypes/field_access_verification_error.bpl
@@ -51,3 +51,11 @@ ensures i == s->i;
   s' := Left(i);
   assert s == s';
 }
+
+procedure P5(p: Pair) returns (q: Pair)
+  requires p->a == 0;
+  ensures  q->a == 1;
+{
+  q := p->(a := 1);
+  assert q == Pair(1, 1);
+}

--- a/Test/datatypes/field_access_verification_error.bpl.expect
+++ b/Test/datatypes/field_access_verification_error.bpl.expect
@@ -16,5 +16,8 @@ Execution trace:
 field_access_verification_error.bpl(50,11): Error: The precondition for unpack might not hold
 Execution trace:
     field_access_verification_error.bpl(50,11): anon0
+field_access_verification_error.bpl(60,3): Error: This assertion might not hold.
+Execution trace:
+    field_access_verification_error.bpl(59,5): anon0
 
-Boogie program verifier finished with 0 verified, 5 errors
+Boogie program verifier finished with 0 verified, 6 errors


### PR DESCRIPTION
This PR adds a field update expression to Boogie. The syntax is inspired by Dafny. The expression 
```
e1->(f := e2)
```
updates field f of the datatype value computed by e1 with the result from e2. The type of the expression is the same as the type of e1.