### PR TITLE
Refactor TypeAttr field in MapAssignLhs and FieldAssignLhs

### DIFF
--- a/Source/Core/AbsyExpr.cs
+++ b/Source/Core/AbsyExpr.cs
@@ -3976,6 +3976,14 @@ namespace Microsoft.Boogie
       return Field(0).TypedIdent.Type.Substitute(typeSubst);
     }
 
+    public Type Type(CtorType ctorType)
+    {
+      var typeSubst = Constructor(0).TypeParameters.Zip(ctorType.Arguments).ToDictionary(
+        x => x.Item1, 
+        x => x.Item2);
+      return Field(0).TypedIdent.Type.Substitute(typeSubst);
+    }
+
     public Type ShallowType(IList<Expr> args)
     {
       return Field(0).TypedIdent.Type;

--- a/Test/floats/TypeMismatch2.bpl.expect
+++ b/Test/floats/TypeMismatch2.bpl.expect
@@ -1,4 +1,4 @@
-TypeMismatch2.bpl(14,2): Error: mismatched types in assignment command (cannot assign double to float)
+TypeMismatch2.bpl(14,2): Error: mismatched types in assignment command (cannot assign double to float24e8)
 TypeMismatch2.bpl(15,9): Error: invalid argument types (double and float24e8) to binary operator *
 TypeMismatch2.bpl(16,9): Error: invalid argument types (double and float24e8) to binary operator +
 3 type checking errors detected in TypeMismatch2.bpl

--- a/Test/test1/Arrays.bpl.expect
+++ b/Test/test1/Arrays.bpl.expect
@@ -16,9 +16,7 @@ Arrays.bpl(48,15): Error: invalid type for argument 1 in map select: int (expect
 Arrays.bpl(52,6): Error: invalid type for argument 0 in map assignment: bool (expected: int)
 Arrays.bpl(53,6): Error: invalid type for argument 0 in map assignment: int (expected: bool)
 Arrays.bpl(53,8): Error: invalid type for argument 1 in map assignment: int (expected: ref)
-Arrays.bpl(53,5): Error: mismatched types in assignment command (cannot assign ref to int)
 Arrays.bpl(54,7): Error: invalid type for argument 0 in map assignment: bool (expected: int)
-Arrays.bpl(54,5): Error: mismatched types in assignment command (cannot assign int to bool)
 Arrays.bpl(55,12): Error: invalid type for argument 1 in map assignment: bool (expected: ref)
 Arrays.bpl(115,11): Error: invalid type for argument 0 in map select: name (expected: [int,int]bool)
 Arrays.bpl(116,4): Error: mismatched types in assignment command (cannot assign [int,int]bool to [[int,int]bool,[name]name]int)
@@ -50,4 +48,4 @@ Arrays.bpl(217,4): Error: mismatched types in assignment command (cannot assign 
 Arrays.bpl(218,4): Error: mismatched types in assignment command (cannot assign any to int)
 Arrays.bpl(220,24): Error: invalid type for argument 0 in call to AnyMethod: any (expected: int)
 Arrays.bpl(220,9): Error: invalid type for out-parameter 0 in call to AnyMethod: int (expected: any)
-52 type checking errors detected in Arrays.bpl
+50 type checking errors detected in Arrays.bpl

--- a/Test/test1/Lambda.bpl.expect
+++ b/Test/test1/Lambda.bpl.expect
@@ -1,6 +1,5 @@
 Lambda.bpl(7,2): Error: mismatched types in assignment command (cannot assign [int]int to [int,int]int)
 Lambda.bpl(8,2): Error: mismatched types in assignment command (cannot assign [int]int to [int]bool)
 Lambda.bpl(14,8): Error: the type variable T does not occur in types of the lambda parameters
-Lambda.bpl(14,2): Error: mismatched types in assignment command (cannot assign <T>[int]int to [int]int)
 Lambda.bpl(20,27): Error: invalid argument types (bool and int) to binary operator +
-5 type checking errors detected in Lambda.bpl
+4 type checking errors detected in Lambda.bpl

--- a/Test/test1/MapsTypeErrors.bpl.expect
+++ b/Test/test1/MapsTypeErrors.bpl.expect
@@ -12,5 +12,5 @@ MapsTypeErrors.bpl(97,2): Error: mismatched types in assignment command (cannot 
 MapsTypeErrors.bpl(106,2): Error: mismatched types in assignment command (cannot assign bv20 to bv32)
 MapsTypeErrors.bpl(112,56): Error: invalid type for argument 1 in application of Same: bv18 (expected: T)
 MapsTypeErrors.bpl(122,4): Error: mismatched types in assignment command (cannot assign [?, ?]? to [int,int]bool)
-MapsTypeErrors.bpl(124,4): Error: mismatched types in assignment command (cannot assign [?, ?]? to HeapType)
+MapsTypeErrors.bpl(124,4): Error: mismatched types in assignment command (cannot assign [?, ?]? to <a>[ref,Field a]a)
 15 type checking errors detected in MapsTypeErrors.bpl


### PR DESCRIPTION
The type hierarchy for AssignLhs comprising SimpleAssignLhs, FieldAssignLhs and MapAssignLhs supports method Type() to retrieve the type of the lhs.  The implementation of this method had an asymmtery earlier. While SimpleAssignLhs was "stateless" because it could query the underlying IdentifierExpr, FieldAssignLhs and MapAssignLhs stashed the type in a field TypeAttr which is returned by Type(). This PR refactors TypeAttr so it becomes simply a caching optimization bringing parity to the Type implementation across the type hierarchy.

The only downside to this refactor is that during type checking of an assignment, type checking must stop if either the lhs or the rhs are not well-typed. With this PR, type checking of the assignment stops if the individual elements of an assignment are not well-typed.