### PR TITLE
Fix test for PR #664

### DIFF
--- a/Test/prover/UsedTypes.bpl
+++ b/Test/prover/UsedTypes.bpl
@@ -1,5 +1,6 @@
 // RUN: %parallel-boogie -proverOpt:LOG_FILE="%t.smt2" "%s" > "%t"
-// RUN: ! grep RegEx "%t.smt2"
+// RUN: %OutputCheck "--file-to-check=%t.smt2" "%s"
+// CHECK-NOT-L: RegEx
 
 procedure P(x: int, y: int) {
   assert x*y == y*x;


### PR DESCRIPTION
The test added in PR #664 used a non-standard technique to check for the absence of text in a file, which didn't always work. This uses the more standard `CHECK-NOT-L` directive to `lit`.