### PR TITLE
[Civl] Fix to heuristic for variable elimination in transition relation computation

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -299,6 +299,24 @@ namespace Microsoft.Boogie
         var assume = CmdHelper.AssumeCmd(ExprHelper.FunctionCall(f, Expr.Ident(v)));
         impl.Blocks[0].Cmds.Insert(0, assume);
       }
+      impl.Blocks.Iter(block =>
+      {
+        block.Cmds = block.Cmds.SelectMany(cmd =>
+        {
+          var newCmds = new List<Cmd> { cmd };
+          if (cmd is HavocCmd havocCmd)
+          {
+            var havocVars = new HashSet<Variable>(havocCmd.Vars.Select(x => x.Decl));
+            foreach (var v in impl.LocVars.Intersect(havocVars))
+            {
+              var f = triggerFunctions[v];
+              var assume = CmdHelper.AssumeCmd(ExprHelper.FunctionCall(f, Expr.Ident(v)));
+              newCmds.Add(assume);
+            }
+          }
+          return newCmds;
+        }).ToList();
+      });
     }
   }
 

--- a/Source/Concurrency/CivlRewriter.cs
+++ b/Source/Concurrency/CivlRewriter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Boogie
       foreach (AtomicAction action in civlTypeChecker.procToAtomicAction.Values.Union(civlTypeChecker
         .procToIsAbstraction.Values))
       {
-        action.AddTriggerAssumes(program);
+        action.AddTriggerAssumes(program, options);
       }
 
       // Remove original declarations and add new checkers generated above

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Boogie
         // The first attempt eliminates temporaries using the defined variables set up in SetDefinedVariables above.
         TryElimination(Enumerable.Empty<Variable>());
 
-        // The second attempt eliminates temporaries considering as defined the subset that is defined by assignments.
+        // The second attempt eliminates temporaries considering as defined the subset that is not defined by assignments.
         TryElimination(trc.allLocVars.SelectMany(v => varCopies[v]).Except(assignments.Select(x => x.Var)));
 
         // The third attempt eliminates temporaties considering as defined the subset that has pool annotations.

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -415,7 +415,7 @@ namespace Microsoft.Boogie
             foreach (var v in existsVarMap.Keys)
             {
               var orig = copyToOriginalVar[v];
-              if (v == varCopies[orig].First() && trc.triggers.ContainsKey(orig))
+              if (trc.triggers.ContainsKey(orig))
               {
                 var f = trc.triggers[orig];
                 exprs.Add(ExprHelper.FunctionCall(f, Expr.Ident(existsVarMap[v])));

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -348,7 +348,14 @@ namespace Microsoft.Boogie
       private void EliminateIntermediateVariables()
       {
         TryElimination(Enumerable.Empty<Variable>());
-        TryElimination(trc.allLocVars.Select(v => varCopies[v][0]));
+        if (trc.allLocVars.Count > 0)
+        {
+          for (int i = 1; i <= trc.allLocVars.Select(v => varCopies[v].Count).Max(); i++)
+          {
+            TryElimination(trc.allLocVars.SelectMany(v =>
+              varCopies[v].GetRange(0, i <= varCopies[v].Count ? i : varCopies[v].Count)));
+          }
+        }
         TryElimination(trc.allLocVars.Where(v => v.FindAttribute("pool") != null).SelectMany(v => varCopies[v]));
 
         if (trc.ignorePostState)

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -347,15 +347,13 @@ namespace Microsoft.Boogie
 
       private void EliminateIntermediateVariables()
       {
+        // The first attempt eliminates temporaries using the defined variables set up in SetDefinedVariables above.
         TryElimination(Enumerable.Empty<Variable>());
-        if (trc.allLocVars.Count > 0)
-        {
-          for (int i = 1; i <= trc.allLocVars.Select(v => varCopies[v].Count).Max(); i++)
-          {
-            TryElimination(trc.allLocVars.SelectMany(v =>
-              varCopies[v].GetRange(0, i <= varCopies[v].Count ? i : varCopies[v].Count)));
-          }
-        }
+
+        // The second attempt eliminates temporaries considering as defined the subset that is defined by assignments.
+        TryElimination(trc.allLocVars.SelectMany(v => varCopies[v]).Except(assignments.Select(x => x.Var)));
+
+        // The third attempt eliminates temporaties considering as defined the subset that has pool annotations.
         TryElimination(trc.allLocVars.Where(v => v.FindAttribute("pool") != null).SelectMany(v => varCopies[v]));
 
         if (trc.ignorePostState)

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Boogie
         // The second attempt eliminates temporaries considering as defined the subset that is not defined by assignments.
         TryElimination(trc.allLocVars.SelectMany(v => varCopies[v]).Except(assignments.Select(x => x.Var)));
 
-        // The third attempt eliminates temporaties considering as defined the subset that has pool annotations.
+        // The third attempt eliminates temporaries considering as defined the subset that has pool annotations.
         TryElimination(trc.allLocVars.Where(v => v.FindAttribute("pool") != null).SelectMany(v => varCopies[v]));
 
         if (trc.ignorePostState)

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -784,8 +784,8 @@ namespace Microsoft.Boogie.SMTLib
       {
         var op = (VCExprIsConstructorOp)node.Op;
         var constructor = op.DatatypeTypeCtorDecl.Constructors[op.ConstructorIndex];
-        var name = "is-" + constructor.Name;
-        name = ExprLineariser.Namer.GetQuotedName(name, name);
+        var constructorName = ExprLineariser.Namer.GetQuotedName(constructor, constructor.Name);
+        var name = "is-" + constructorName;
         WriteApplication(name, node, options);
         return true;
       }

--- a/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl
+++ b/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl
@@ -47,13 +47,12 @@ function max(CH:[val]int) : val;
 function card(CH:[val]int) : int;
 
 axiom card(MultisetEmpty) == 0;
-axiom (forall v:val :: card(MultisetSingleton(v)) == 1);
 axiom (forall CH:[val]int, v:val :: card(MultisetPlus(CH, MultisetSingleton(v))) == card(CH) + 1);
-axiom (forall CH:[val]int, v:val :: {CH[v := CH[v] + 1]} card(CH[v := CH[v] + 1]) == card(CH) + 1);
-axiom (forall m:[val]int, m':[val]int :: {card(m), card(m')} MultisetSubsetEq(m, m') && card(m) == card(m') ==> m == m');
+axiom (forall CH:[val]int, v:val, x:int :: card(CH[v := x]) == card(CH) + x - CH[v]);
+axiom (forall m:[val]int, m':[val]int :: MultisetSubsetEq(m, m') && card(m) == card(m') ==> m == m');
 
 axiom (forall v:val :: max(MultisetSingleton(v)) == v);
-axiom (forall CH:[val]int, v:val :: { CH[v := CH[v] + 1] } max(CH[v := CH[v] + 1]) == (if v > max(CH) then v else max(CH)));
+axiom (forall CH:[val]int, v:val, x:int :: max(CH[v := x]) == (if v > max(CH) && x > 0 then v else max(CH)));
 
 function value_card(v:val, value:[pid]val, i:pid, j:pid) : int
 {

--- a/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl
+++ b/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl
@@ -47,12 +47,11 @@ function max(CH:[val]int) : val;
 function card(CH:[val]int) : int;
 
 axiom card(MultisetEmpty) == 0;
-axiom (forall CH:[val]int, v:val :: card(MultisetPlus(CH, MultisetSingleton(v))) == card(CH) + 1);
 axiom (forall CH:[val]int, v:val, x:int :: card(CH[v := x]) == card(CH) + x - CH[v]);
 axiom (forall m:[val]int, m':[val]int :: MultisetSubsetEq(m, m') && card(m) == card(m') ==> m == m');
 
 axiom (forall v:val :: max(MultisetSingleton(v)) == v);
-axiom (forall CH:[val]int, v:val, x:int :: max(CH[v := x]) == (if v > max(CH) && x > 0 then v else max(CH)));
+axiom (forall CH:[val]int, v:val, x:int :: x > 0 ==> max(CH[v := x]) == (if v > max(CH) then v else max(CH)));
 
 function value_card(v:val, value:[pid]val, i:pid, j:pid) : int
 {

--- a/Test/civl/inductive-sequentialization/ChangRoberts_pendingAsyncs.bpl
+++ b/Test/civl/inductive-sequentialization/ChangRoberts_pendingAsyncs.bpl
@@ -104,40 +104,8 @@ P' ({:linear_in "pid"} pid:int)
 returns ({:pending_async "P"} PAs:[PA]int)
 modifies channel, pendingAsyncs, leader;
 {
-  var msg:int;
-
-  assert pid(pid);
-  assert pendingAsyncs[P(pid)] > 0;
-  assert (forall m:int :: channel[pid][m] > 0 ==> m <= id[max(id)]);
-
   assert (forall j:int :: pid(j) && between(max(id), j, pid) ==> pendingAsyncs[P(j)] == 0);
-
-  if (*)
-  {
-    PAs := NoPAs();
-  }
-  else
-  {
-    assume channel[pid][msg] > 0;
-    channel[pid][msg] := channel[pid][msg] - 1;
-
-    if (msg == id[pid])
-    {
-      leader[pid] := true;
-      PAs := NoPAs();
-    }
-    else
-    {
-      if (msg > id[pid])
-      {
-        channel[next(pid)][msg] := channel[next(pid)][msg] + 1;
-      }
-      PAs := NoPAs()[P(pid) := 1];
-    }
-  }
-
-  pendingAsyncs := MapAdd(pendingAsyncs, PAs);
-  pendingAsyncs := MapSub(pendingAsyncs, SingletonPA(P(pid)));
+  call PAs := P(pid);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Test/civl/inductive-sequentialization/NBuyer.bpl
+++ b/Test/civl/inductive-sequentialization/NBuyer.bpl
@@ -341,8 +341,8 @@ procedure {:atomic}{:layer 2,4}
 MiddleBuyer ({:linear_in "pid"} pid:int)
 modifies QuoteCH, RemCH, contribution;
 {
-  var {:pool "rem"} rem:int;
-  var {:pool "amount"} amount:int;
+  var rem:int;
+  var amount:int;
 
   assert middleBuyerID(pid);
   assert (forall q:int :: QuoteCH[pid][q] > 0 ==> q == price);
@@ -356,10 +356,7 @@ modifies QuoteCH, RemCH, contribution;
 
   if (*) { amount := min(wallet, rem); } else { amount := 0; }
   contribution[pid] := amount;
-  assume
-  {:add_to_pool "contribution", contribution}
-  {:add_to_pool "rem", rem}
-  {:add_to_pool "amount", amount} true;
+  assume {:add_to_pool "contribution", contribution} true;
   rem := rem - amount;
   RemCH[nextBuyer(pid)][rem] := RemCH[nextBuyer(pid)][rem] + 1;
 }
@@ -368,8 +365,8 @@ procedure {:atomic}{:layer 2,4}
 LastBuyer ({:linear_in "pid"} pid:int)
 modifies QuoteCH, RemCH, DecCH, contribution;
 {
-  var {:pool "rem"} rem:int;
-  var {:pool "amount"} amount:int;
+  var rem:int;
+  var amount:int;
 
   assert lastBuyerID(pid);
   assert (forall q:int :: QuoteCH[pid][q] > 0 ==> q == price);
@@ -383,10 +380,7 @@ modifies QuoteCH, RemCH, DecCH, contribution;
 
   if (*) { amount := min(wallet, rem); } else { amount := 0; }
   contribution[pid] := amount;
-  assume
-  {:add_to_pool "contribution", contribution}
-  {:add_to_pool "rem", rem}
-  {:add_to_pool "amount", amount} true;
+  assume {:add_to_pool "contribution", contribution} true;
   if (amount == rem)
   {
       DecCH[true] := DecCH[true] + 1;

--- a/Test/civl/inductive-sequentialization/NBuyer.bpl
+++ b/Test/civl/inductive-sequentialization/NBuyer.bpl
@@ -33,7 +33,7 @@ function {:constructor} SellerInit(pid:int) : PA;
 function {:constructor} SellerFinish(pid:int) : PA;
 
 function {:inline} NoPAs () : [PA]int
-{ (lambda pa:PA :: 0) }
+{ MapConst(0) }
 
 function {:inline} SingletonPA (pa:PA) : [PA]int
 { NoPAs()[pa := 1] }
@@ -61,10 +61,10 @@ function {:inline} Init(pids:[int]bool, ReqCH:int, QuoteCH:[int][int]int,
 {
   pids == MapConst(true) &&
   ReqCH == 0 &&
-  QuoteCH == (lambda i:int :: (lambda q:int :: 0)) &&
-  RemCH == (lambda i:int :: (lambda r:int :: 0)) &&
-  DecCH == (lambda b:bool :: 0) &&
-  contribution == (lambda i:int :: 0)
+  QuoteCH == (lambda i:int :: MapConst(0)) &&
+  RemCH == (lambda i:int :: MapConst(0)) &&
+  DecCH == MapConst(0) &&
+  contribution == MapConst(0)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -86,7 +86,7 @@ modifies DecCH, contribution;
   havoc contribution;
   if (*)
   {
-    DecCH := (lambda b:bool :: if b == (sum(contribution, 1, n) == price) then 1 else 0);
+    DecCH := MapConst(0)[(sum(contribution, 1, n) == price) := 1];
     PAs := SingletonPA(SellerFinish(0));
   }
   else
@@ -101,8 +101,8 @@ modifies DecCH;
 {
   var dec:bool;
   assert sellerID(pid);
-  assert DecCH == (lambda b:bool :: if b == (sum(contribution, 1, n) == price) then 1 else 0);
   dec := (sum(contribution, 1, n) == price);
+  assert DecCH == MapConst(0)[dec := 1];
   DecCH[dec] := DecCH[dec] - 1;
 }
 
@@ -116,7 +116,7 @@ modifies DecCH, contribution;
 {
   assert Init(pids, ReqCH, QuoteCH, RemCH, DecCH, contribution);
   havoc contribution;
-  DecCH := (lambda b:bool :: if b == (sum(contribution, 1, n) == price) then 1 else 0);
+  DecCH := MapConst(0)[(sum(contribution, 1, n) == price) := 1];
   PAs := SingletonPA(SellerFinish(0));
 }
 
@@ -126,37 +126,38 @@ returns ({:pending_async "SellerFinish","FirstBuyer","MiddleBuyer","LastBuyer"} 
 modifies QuoteCH, RemCH, DecCH, contribution;
 {
   var {:pool "INV3"} k: int;
+  var {:pool "contribution"} c: [int]int;
 
   assert Init(pids, ReqCH, QuoteCH, RemCH, DecCH, contribution);
 
-  havoc contribution;
+  contribution := c;
 
   assume {:add_to_pool "INV3", 0, 1, k, k+1, n} true;
   if (*)
   {
-    QuoteCH := (lambda i:int :: (lambda q:int :: if buyerID(i) && q == price then 1 else 0));
+    QuoteCH := (lambda i:int :: if buyerID(i) then MapConst(0)[price := 1] else MapConst(0));
     PAs := MapAddPA4(SellerFinish(0), FirstBuyer(1), LastBuyer(n), (lambda pa:PA :: if pa is MiddleBuyer && middleBuyerID(pa->pid) then 1 else 0));
     choice := FirstBuyer(1);
   }
   else if (*)
   {
     assume 1 <= k && k < n && 0 <= sum(contribution, 1, k) && sum(contribution, 1, k) <= price;
-    QuoteCH := (lambda i:int :: (lambda q:int :: if buyerID(i) && i > k && q == price then 1 else 0));
-    RemCH := (lambda i:int :: (lambda r:int :: if i == k+1 && r == price - sum(contribution, 1, k) then 1 else 0));
+    QuoteCH := (lambda i:int :: if buyerID(i) && i > k then MapConst(0)[price := 1] else MapConst(0));
+    RemCH := (lambda i:int :: if i == k+1 then MapConst(0)[(price - sum(contribution, 1, k)) := 1] else MapConst(0));
     PAs := MapAddPA3(SellerFinish(0), LastBuyer(n), (lambda pa:PA :: if pa is MiddleBuyer && middleBuyerID(pa->pid) && pa->pid > k then 1 else 0));
     choice := if lastBuyerID(k+1) then LastBuyer(k+1) else MiddleBuyer(k+1);
   }
   else if (*)
   {
-    QuoteCH := (lambda i:int :: (lambda q:int :: if lastBuyerID(i) && q == price then 1 else 0));
+    QuoteCH := (lambda i:int :: if lastBuyerID(i) then MapConst(0)[price := 1] else MapConst(0));
     assume 0 <= sum(contribution, 1, n-1) && sum(contribution, 1, n-1) <= price;
-    RemCH := (lambda i:int :: (lambda r:int :: if i == n && r == price - sum(contribution, 1, n-1) then 1 else 0));
+    RemCH := (lambda i:int :: if i == n then MapConst(0)[(price - sum(contribution, 1, n-1)) := 1] else MapConst(0));
     PAs := MapAddPA(SingletonPA(SellerFinish(0)), SingletonPA(LastBuyer(n)));
     choice := LastBuyer(n);
   }
   else
   {
-    DecCH := (lambda b:bool :: if b == (sum(contribution, 1, n) == price) then 1 else 0);
+    DecCH := MapConst(0)[(sum(contribution, 1, n) == price) := 1];
     PAs := SingletonPA(SellerFinish(0));
   }
 }
@@ -165,85 +166,35 @@ procedure {:IS_abstraction}{:layer 4}
 FirstBuyer' ({:linear_in "pid"} pid:int)
 modifies QuoteCH, RemCH, contribution;
 {
-  var rem:int;
-  var amount:int;
-
-  assert firstBuyerID(pid);
-  assert (forall q:int :: QuoteCH[pid][q] > 0 ==> q == price);
-
-  assert DecCH == (lambda b:bool :: 0);
-  assert (forall i:int :: i != pid ==> RemCH[i] == (lambda r:int :: 0));
-
+  assert DecCH == MapConst(0);
+  assert (forall i:int :: i != pid ==> RemCH[i] == MapConst(0));
   assert QuoteCH[pid][price] > 0;
-  QuoteCH[pid][price] := QuoteCH[pid][price] - 1;
-
-  rem := price;
-  if (*) { amount := min(wallet, rem); } else { amount := 0; }
-  contribution[pid] := amount;
-  rem := rem - amount;
-  RemCH[nextBuyer(pid)][rem] := RemCH[nextBuyer(pid)][rem] + 1;
+  call FirstBuyer(pid);
 }
 
 procedure {:IS_abstraction}{:layer 4}
 MiddleBuyer' ({:linear_in "pid"} pid:int)
 modifies QuoteCH, RemCH, contribution;
 {
-  var rem:int;
-  var amount:int;
-
-  assert middleBuyerID(pid);
-  assert (forall q:int :: QuoteCH[pid][q] > 0 ==> q == price);
-  assert (forall r:int :: RemCH[pid][r] > 0 ==> 0 <= r && r <= price);
   assert (forall r:int :: RemCH[pid][r] > 0 ==> r == price - sum(contribution, 1, pid - 1));
   assert RemCH[pid][price - sum(contribution, 1, pid - 1)] > 0;
-  assert DecCH == (lambda b:bool :: 0);
-  assert (forall i:int :: i < pid ==> QuoteCH[i] == (lambda r:int :: 0));
-  assert (forall i:int :: i != pid ==> RemCH[i] == (lambda r:int :: 0));
-
+  assert DecCH == MapConst(0);
+  assert (forall i:int :: i < pid ==> QuoteCH[i] == MapConst(0));
+  assert (forall i:int :: i != pid ==> RemCH[i] == MapConst(0));
   assert QuoteCH[pid][price] > 0;
-  assume RemCH[pid][rem] > 0;
-
-  QuoteCH[pid][price] := QuoteCH[pid][price] - 1;
-  RemCH[pid][rem] := RemCH[pid][rem] - 1;
-
-  if (*) { amount := min(wallet, rem); } else { amount := 0; }
-  contribution[pid] := amount;
-  rem := rem - amount;
-  RemCH[nextBuyer(pid)][rem] := RemCH[nextBuyer(pid)][rem] + 1;
+  call MiddleBuyer(pid);
 }
 
 procedure {:IS_abstraction}{:layer 4}
 LastBuyer' ({:linear_in "pid"} pid:int)
 modifies QuoteCH, RemCH, DecCH, contribution;
 {
-  var rem:int;
-  var amount:int;
-
-  assert lastBuyerID(pid);
-  assert (forall q:int :: QuoteCH[pid][q] > 0 ==> q == price);
-  assert (forall r:int :: RemCH[pid][r] > 0 ==> 0 <= r && r <= price);
   assert (forall r:int :: RemCH[pid][r] > 0 ==> r == price - sum(contribution, 1, pid - 1));
   assert RemCH[n][price - sum(contribution, 1, n-1)] > 0;
-  assert DecCH == (lambda b:bool :: 0);
-  assert (forall i:int :: i < pid ==> QuoteCH[i] == (lambda r:int :: 0));
-
+  assert DecCH == MapConst(0);
+  assert (forall i:int :: i < pid ==> QuoteCH[i] == MapConst(0));
   assert QuoteCH[pid][price] > 0;
-  assume RemCH[pid][rem] > 0;
-
-  QuoteCH[pid][price] := QuoteCH[pid][price] - 1;
-  RemCH[pid][rem] := RemCH[pid][rem] - 1;
-
-  if (*) { amount := min(wallet, rem); } else { amount := 0; }
-  contribution[pid] := amount;
-
-  if (amount == rem)
-  {
-    DecCH[true] := DecCH[true] + 1;
-  }
-  else
-  {
-    DecCH[false] := DecCH[false] + 1;
-  }
+  call LastBuyer(pid);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -255,7 +206,8 @@ returns ({:pending_async "SellerFinish","FirstBuyer","MiddleBuyer","LastBuyer"} 
 modifies QuoteCH;
 {
   assert Init(pids, ReqCH, QuoteCH, RemCH, DecCH, contribution);
-  QuoteCH := (lambda i:int :: (lambda q:int :: if buyerID(i) && q == price then 1 else 0));
+  assume {:add_to_pool "contribution", contribution} true;
+  QuoteCH := (lambda i:int :: if buyerID(i) then MapConst(0)[price := 1] else MapConst(0));
   PAs := MapAddPA4(SellerFinish(0), FirstBuyer(1), LastBuyer(n), (lambda pa:PA :: if pa is MiddleBuyer && middleBuyerID(pa->pid) then 1 else 0));
 }
 
@@ -272,7 +224,7 @@ modifies ReqCH, QuoteCH;
   }
   else
   {
-    QuoteCH := (lambda i:int :: (lambda q:int :: if buyerID(i) && q == price then 1 else 0));
+    QuoteCH := (lambda i:int :: if buyerID(i) then MapConst(0)[price := 1] else MapConst(0));
     PAs := MapAddPA4(SellerFinish(0), FirstBuyer(1), LastBuyer(n), (lambda pa:PA :: if pa is MiddleBuyer && middleBuyerID(pa->pid) then 1 else 0));
   }
 }
@@ -282,14 +234,9 @@ SellerInit' ({:linear_in "pid"} pid:int)
 returns ({:pending_async "SellerFinish"} PAs:[PA]int)
 modifies ReqCH, QuoteCH;
 {
-  assert sellerID(pid);
-  assert QuoteCH == (lambda i:int :: (lambda q:int :: 0)); // To discharge gate failure preservation for FirstBuyer/MiddleBuyer/LastBuyer
-
+  assert QuoteCH == (lambda i:int :: MapConst(0)); // To discharge gate failure preservation for FirstBuyer/MiddleBuyer/LastBuyer
   assert ReqCH > 0;
-  ReqCH := ReqCH - 1;
-
-  QuoteCH := (lambda i:int :: (lambda q:int :: if buyerID(i) && q == price then QuoteCH[i][q] + 1 else QuoteCH[i][q]));
-  PAs := SingletonPA(SellerFinish(pid));
+  call PAs := SellerInit(pid);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -385,6 +332,7 @@ modifies QuoteCH, RemCH, contribution;
   rem := price;
   if (*) { amount := min(wallet, rem); } else { amount := 0; }
   contribution[pid] := amount;
+  assume {:add_to_pool "contribution", contribution} true;
   rem := rem - amount;
   RemCH[nextBuyer(pid)][rem] := RemCH[nextBuyer(pid)][rem] + 1;
 }
@@ -393,8 +341,8 @@ procedure {:atomic}{:layer 2,4}
 MiddleBuyer ({:linear_in "pid"} pid:int)
 modifies QuoteCH, RemCH, contribution;
 {
-  var rem:int;
-  var amount:int;
+  var {:pool "rem"} rem:int;
+  var {:pool "amount"} amount:int;
 
   assert middleBuyerID(pid);
   assert (forall q:int :: QuoteCH[pid][q] > 0 ==> q == price);
@@ -408,6 +356,10 @@ modifies QuoteCH, RemCH, contribution;
 
   if (*) { amount := min(wallet, rem); } else { amount := 0; }
   contribution[pid] := amount;
+  assume
+  {:add_to_pool "contribution", contribution}
+  {:add_to_pool "rem", rem}
+  {:add_to_pool "amount", amount} true;
   rem := rem - amount;
   RemCH[nextBuyer(pid)][rem] := RemCH[nextBuyer(pid)][rem] + 1;
 }
@@ -416,8 +368,8 @@ procedure {:atomic}{:layer 2,4}
 LastBuyer ({:linear_in "pid"} pid:int)
 modifies QuoteCH, RemCH, DecCH, contribution;
 {
-  var rem:int;
-  var amount:int;
+  var {:pool "rem"} rem:int;
+  var {:pool "amount"} amount:int;
 
   assert lastBuyerID(pid);
   assert (forall q:int :: QuoteCH[pid][q] > 0 ==> q == price);
@@ -431,7 +383,10 @@ modifies QuoteCH, RemCH, DecCH, contribution;
 
   if (*) { amount := min(wallet, rem); } else { amount := 0; }
   contribution[pid] := amount;
-
+  assume
+  {:add_to_pool "contribution", contribution}
+  {:add_to_pool "rem", rem}
+  {:add_to_pool "amount", amount} true;
   if (amount == rem)
   {
       DecCH[true] := DecCH[true] + 1;

--- a/Test/civl/inductive-sequentialization/NBuyer.bpl.expect
+++ b/Test/civl/inductive-sequentialization/NBuyer.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 130 verified, 0 errors
+Boogie program verifier finished with 132 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/paxos/Paxos.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/Paxos.bpl
@@ -96,7 +96,7 @@ function {:inline} JoinPermissions(r: Round) : [Permission]bool
 
 function {:inline} ProposePermissions(r: Round) : [Permission]bool
 {
-  (lambda p:Permission :: if (p is VotePerm && p->r == r) || (p is ConcludePerm && p->r == r) then true else false)
+  (lambda {:pool "Permission"} p:Permission :: if (p is VotePerm && p->r == r) || (p is ConcludePerm && p->r == r) then true else false)
 }
 
 function {:inline} VotePermissions(r: Round) : [Permission]bool
@@ -163,22 +163,12 @@ function {:inline} InitLow (
 
 function {:inline}{:linear "perm"} RoundCollector (round: Round) : [Permission]bool
 {
-  (lambda p: Permission ::
-    if (p is JoinPerm && round == p->r) ||
-       (p is VotePerm && round == p->r) ||
-       (p is ConcludePerm && round == p->r)
-    then true else false
-  )
+  (lambda {:pool "Permission"} p: Permission :: round == p->r)
 }
 
 function {:inline}{:linear "perm"} RoundSetCollector (rounds: [Round]bool) : [Permission]bool
 {
-  (lambda p: Permission ::
-    if (p is JoinPerm && rounds[p->r]) ||
-       (p is VotePerm && rounds[p->r]) ||
-       (p is ConcludePerm && rounds[p->r])
-    then true else false
-  )
+  (lambda {:pool "Permission"} p: Permission :: rounds[p->r])
 }
 
 function {:inline}{:linear "perm"} JoinResponseChannelCollector (permJoinChannel: JoinResponseChannel) : [Permission]bool

--- a/Test/civl/inductive-sequentialization/paxos/PaxosAbstractions.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosAbstractions.bpl
@@ -66,86 +66,31 @@ modifies voteInfo, pendingAsyncs;
 procedure {:IS_abstraction}{:layer 2} A_Conclude'(r: Round, v: Value, {:linear_in "perm"} p: Permission)
 modifies decision, pendingAsyncs;
 {
-  var q: NodeSet;
-
-  assert Round(r);
-  assert pendingAsyncs[A_Conclude(r, v, p)] > 0;
-  assert p == ConcludePerm(r);
-  assert voteInfo[r] is Some;
-  assert voteInfo[r]->t->value == v;
-
-  /**************************************************************************/
   assert (forall n': Node, v': Value, p': Permission :: pendingAsyncs[A_Vote(r, n', v', p')] == 0);
-  /**************************************************************************/
 
-  assume 
-    {:add_to_pool "Round", r}
-    true;
-
-  if (*) {
-    assume IsSubset(q, voteInfo[r]->t->ns) && IsQuorum(q);
-    decision[r] := Some(v);
-  }
-
-  pendingAsyncs := MapSub(pendingAsyncs, SingletonPA(A_Conclude(r, v, p)));
+  call A_Conclude(r, v, p);
 }
 
 procedure {:IS_abstraction}{:layer 2} A_Join'(r: Round, n: Node, {:linear_in "perm"} p: Permission)
 modifies joinedNodes, pendingAsyncs;
 {
-  assert Round(r);
-  assert pendingAsyncs[A_Join(r, n, p)] > 0;
-  assert p == JoinPerm(r, n);
-
-  /**************************************************************************/
   assert (forall r': Round :: r' <= r ==> pendingAsyncs[A_StartRound(r', r')] == 0);
   assert (forall r': Round, n': Node, p': Permission :: r' < r ==> pendingAsyncs[A_Join(r', n', p')] == 0);
   assert (forall r': Round, p': [Permission]bool :: r' < r ==> pendingAsyncs[A_Propose(r', p')] == 0);
   assert (forall r': Round, n': Node, v': Value, p': Permission :: r' < r ==> pendingAsyncs[A_Vote(r', n', v', p')] == 0);
-  /**************************************************************************/
 
-  assume
-    {:add_to_pool "Round", r, r-1}
-    {:add_to_pool "Node", n}
-    true;
-
-  if (*) {
-    assume (forall r': Round :: Round(r') && joinedNodes[r'][n] ==> r' < r);
-    joinedNodes[r][n] := true;
-  }
-
-  pendingAsyncs := MapSub(pendingAsyncs, SingletonPA(A_Join(r, n, p)));
+  call A_Join(r, n, p);
 }
 
 procedure {:IS_abstraction}{:layer 2} A_Vote'(r: Round, n: Node, v: Value, {:linear_in "perm"} p: Permission)
 modifies joinedNodes, voteInfo, pendingAsyncs;
 {
-  assert Round(r);
-  assert p == VotePerm(r, n);
-  assert pendingAsyncs[A_Vote(r, n, v, p)] > 0;
-  assert voteInfo[r] is Some;
-  assert voteInfo[r]->t->value == v;
-  assert !voteInfo[r]->t->ns[n];
-
-  /**************************************************************************/
   assert (forall r': Round :: r' <= r ==> pendingAsyncs[A_StartRound(r', r')] == 0);
   assert (forall r': Round, n': Node, p': Permission :: r' <= r ==> pendingAsyncs[A_Join(r', n', p')] == 0);
   assert (forall r': Round, p': [Permission]bool :: r' <= r ==> pendingAsyncs[A_Propose(r', p')] == 0);
   assert (forall r': Round, n': Node, v': Value, p': Permission :: r' < r ==> pendingAsyncs[A_Vote(r', n', v', p')] == 0);
-  /**************************************************************************/
 
-  assume
-    {:add_to_pool "Round", r, r-1}
-    {:add_to_pool "Node", n}
-    true;
-
-  if (*) {
-    assume (forall r': Round :: Round(r') && joinedNodes[r'][n] ==> r' <= r);
-    voteInfo[r] := Some(VoteInfo(v, voteInfo[r]->t->ns[n := true]));
-    joinedNodes[r][n] := true;
-  }
-
-  pendingAsyncs := MapSub(pendingAsyncs, SingletonPA(A_Vote(r, n, v, p)));
+  call A_Vote(r, n, v, p);
 }
 
 // Local Variables:

--- a/Test/civl/inductive-sequentialization/paxos/PaxosActions.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosActions.bpl
@@ -6,6 +6,12 @@ modifies pendingAsyncs;
   assert Round(r);
   assert pendingAsyncs[A_StartRound(r, r_lin)] > 0;
 
+  assume 
+    {:add_to_pool "Round", r-1}
+    {:add_to_pool "Node", 0}
+    {:add_to_pool "Permission", ConcludePerm(r)}
+    true;
+
   PAs := MapAdd(JoinPAs(r), SingletonPA(A_Propose(r, ProposePermissions(r))));
 
   pendingAsyncs := MapAdd(pendingAsyncs, PAs);
@@ -26,7 +32,10 @@ modifies voteInfo, pendingAsyncs;
   assert voteInfo[r] is None;
 
   assume
+    {:add_to_pool "Round", r, r-1}
+    {:add_to_pool "Node", 0}
     {:add_to_pool "NodeSet", ns}
+    {:add_to_pool "Permission", ConcludePerm(r)}
     true;
 
   if (*) {
@@ -57,6 +66,10 @@ modifies decision, pendingAsyncs;
   assert voteInfo[r] is Some;
   assert voteInfo[r]->t->value == v;
 
+  assume 
+    {:add_to_pool "Round", r}
+    true;
+
   if (*) {
     assume IsSubset(q, voteInfo[r]->t->ns) && IsQuorum(q);
     decision[r] := Some(v);
@@ -71,6 +84,11 @@ modifies joinedNodes, pendingAsyncs;
   assert Round(r);
   assert pendingAsyncs[A_Join(r, n, p)] > 0;
   assert p == JoinPerm(r, n);
+
+  assume
+    {:add_to_pool "Round", r, r-1}
+    {:add_to_pool "Node", n}
+    true;
 
   if (*) {
     assume (forall r': Round :: Round(r') && joinedNodes[r'][n] ==> r' < r);

--- a/Test/civl/inductive-sequentialization/paxos/PaxosSeq.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosSeq.bpl
@@ -9,7 +9,7 @@ modifies joinedNodes, voteInfo, decision, pendingAsyncs;
 
 procedure {:atomic}{:layer 2}
 {:IS "A_Paxos'","INV"}
-{:elim "A_StartRound","A_StartRound'"}
+{:elim "A_StartRound"}
 {:elim "A_Propose","A_Propose'"}
 {:elim "A_Conclude","A_Conclude'"}
 {:elim "A_Join","A_Join'"}

--- a/Test/civl/inductive-sequentialization/paxos/is.sh.expect
+++ b/Test/civl/inductive-sequentialization/paxos/is.sh.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 116 verified, 0 errors
+Boogie program verifier finished with 115 verified, 0 errors


### PR DESCRIPTION
The investigation behind this PR started when I attempted to eliminate the duplication between the abstract and concrete actions used in the IS proof of NBuyer. I wanted to simply call the concrete atomic action from the abstract one right after the extra asserts had been added. I discovered that the refactored code did not verify due to proof flakiness. The changes to  the sample were my efforts (not all of which may have been necessary) to reduce the flakiness while still achieving no duplication of code. In the process, I also attempted to generalize the heuristic for variable elimination in computation of transition relations. The revised (more powerful) heuristic is needed for the revised version of NBuyer.bpl otherwise the cooperation check for MiddleBuyer' does not verify.

The change to transition relation computation is in the second attempt to eliminate temporaries. Before this PR, the second attempt used as defined only the initial incarnations of locals. The PR changes this logic to allow as defined any incarnation that does not have a definition among assignments. Thus, all incarnations generated by havocs are also considered as defined.

While working on this PR, I discovered that the computation of transition relation of atomic actions also uses patterns. The triggers for these patterns are injected in the body of atomic actions. The instantiation induced by these triggers is more precise than what is achievable today via pools. Furthermore, the triggers appear to be needed for the verification of commutativity checks. This PR also modifies the trigger generation. Before this PR, triggers were being generated only for the initial incarnation of local variables. This PR adds trigger generation for incarnations created due to havoc commands as well. Live variable analysis is done over the body of atomic actions to avoid adding triggers for incarnations that are not live. This optimization appears to be important for the commutativity check between A_Propose and A_Propose'. This check quickly starts to become expensive with more instantiations, either due to triggers or due to pools. This explosive growth in running time is a ticking time bomb in the scalability of Civl.

The overall effect of this PR is to eliminate the duplication between concrete and abstract actions across our entire set of benchmarks.