### PR TITLE
add more tests for monomorphization

### DIFF
--- a/Test/monomorphize/polyequality0.bpl
+++ b/Test/monomorphize/polyequality0.bpl
@@ -1,0 +1,22 @@
+// RUN: %parallel-boogie /monomorphize "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Ref;
+type Field _;
+
+function foo<T>(f: Field T) : bool;
+
+procedure equality_boogie_poly_paper() {
+    var age: Field int;
+    var isMarried: Field bool;
+    var fInt: Field int;
+    var fBool: Field bool;
+
+    /* inspired by example from Leino and Ruemmer in 
+     * "A Polymorphic Intermediate Verification Language: Design and Logical Encoding" (TACAS 2010)
+     */
+    assume (forall <T> f: Field T :: (foo(f) || (f == age) || (f == isMarried)));
+    
+    assert foo(fInt) || (fInt == age);
+    assert foo(fBool) || (fBool == isMarried);
+}

--- a/Test/monomorphize/polyequality0.bpl.expect
+++ b/Test/monomorphize/polyequality0.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/monomorphize/polylambda0.bpl
+++ b/Test/monomorphize/polylambda0.bpl
@@ -1,0 +1,21 @@
+// RUN: %parallel-boogie /monomorphize "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Field _;
+type Ref;
+
+var f_int: Field int;
+var f_bool: Field bool;
+var f_field_int: Field (Field int);
+
+function extract<B>(x: Field B, y: int): B;
+
+procedure p(x: Field int) {
+    var m2: <B>[Field B]B;
+    var i: int;
+
+    m2 := (lambda<B> f: Field B :: extract(f, i));
+    assert m2[f_int] == extract(f_int, i);
+    assert m2[f_bool] == extract(f_bool, i);
+    assert m2[f_field_int] == extract(f_field_int, i);
+}

--- a/Test/monomorphize/polylambda0.bpl.expect
+++ b/Test/monomorphize/polylambda0.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/monomorphize/polymap6.bpl
+++ b/Test/monomorphize/polymap6.bpl
@@ -1,0 +1,25 @@
+// RUN: %parallel-boogie /monomorphize "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Field _;
+type Ref;
+
+var f_int: Field int;
+var f_bool: Field bool;
+var f_field_int: Field (Field int);
+
+procedure p(x: Field int) {
+    var m2: <B>[Field B]B;
+    var m1: [Ref](<B>[Field B]B);
+    var r: Ref;
+
+    assume m1[r] == m2;
+    assume m2[f_int] == 5;
+    assume m2[f_bool] == true;
+    assume m2[f_field_int] == f_int;
+
+    assert m2[f_int] > 0;
+    assert m2[f_bool];
+    assert m2[f_field_int] == f_int;
+    assert m1[r] == m2;
+}

--- a/Test/monomorphize/polymap6.bpl.expect
+++ b/Test/monomorphize/polymap6.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
This pull requests adds some more tests for the monomorphization of polymorphic maps and universal type quantification. One of the tests is regarding the liberal typing rule for equality (`a == b` type checks in Boogie even in cases where `a` and `b` may not have the same identical type as long as there is some instantiation of the free type variables that result in the same type). One test is on polymorphic lambdas. One test is on polymorphic maps.