### PR TITLE
Renamed Lmap type to Lheap

### DIFF
--- a/Source/Concurrency/LinearDomainCollector.cs
+++ b/Source/Concurrency/LinearDomainCollector.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Boogie
         {
           var originalDecl = program.monomorphizer.GetOriginalDecl(datatypeTypeCtorDecl);
           var originalDeclName = originalDecl.Name;
-          if (originalDeclName == "Lmap" || originalDeclName == "Lset" || originalDeclName == "Lval")
+          if (originalDeclName == "Lheap" || originalDeclName == "Lset" || originalDeclName == "Lval")
           {
             permissionTypes.Add(type);
             linearTypes.Add(type);
@@ -168,7 +168,7 @@ namespace Microsoft.Boogie
       var originalTypeCtorDecl = program.monomorphizer.GetOriginalDecl(typeCtorDecl);
       var actualTypeParams = program.monomorphizer.GetTypeInstantiation(typeCtorDecl);
       return 
-        originalTypeCtorDecl.Name == "Lmap"
+        originalTypeCtorDecl.Name == "Lheap"
           ? new CtorType(Token.NoToken, program.monomorphizer.InstantiateTypeCtorDecl("Ref", actualTypeParams),
             new List<Type>())
           : actualTypeParams[0];
@@ -190,8 +190,8 @@ namespace Microsoft.Boogie
         if (!permissionTypeToCollectors[permissionType].ContainsKey(type))
         {
           var collector = 
-            originalTypeCtorDecl.Name == "Lmap" 
-              ? program.monomorphizer.InstantiateFunction("Lmap_Collector",
+            originalTypeCtorDecl.Name == "Lheap"
+              ? program.monomorphizer.InstantiateFunction("Lheap_Collector",
                 new Dictionary<string, Type> { { "V", actualTypeParams[0] } }) :
               originalTypeCtorDecl.Name == "Lset" 
                 ? program.monomorphizer.InstantiateFunction("Lset_Collector",

--- a/Source/Concurrency/LinearPermissionInstrumentation.cs
+++ b/Source/Concurrency/LinearPermissionInstrumentation.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Boogie
         ? FilterInParams(proc.InParams)
         : FilterInOutParams(proc.InParams.Union(proc.OutParams));
       return DisjointnessExprs(availableVars)
-        .Union(civlTypeChecker.linearTypeChecker.LmapWellFormedExpressions(availableVars))
+        .Union(civlTypeChecker.linearTypeChecker.LheapWellFormedExpressions(availableVars))
         .Select(expr => CmdHelper.AssumeCmd(expr)).ToList<Cmd>();
     }
 
@@ -54,7 +54,7 @@ namespace Microsoft.Boogie
     {
       var availableVars = AvailableLinearLocalVars(absy).Union(addGlobals ? LinearGlobalVars() : new List<Variable>());
       return DisjointnessExprs(availableVars)
-        .Union(civlTypeChecker.linearTypeChecker.LmapWellFormedExpressions(availableVars))
+        .Union(civlTypeChecker.linearTypeChecker.LheapWellFormedExpressions(availableVars))
         .Select(expr => CmdHelper.AssumeCmd(expr)).ToList<Cmd>();
     }
     

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -365,12 +365,12 @@ namespace Microsoft.Boogie
         if (nAryExpr.Fun is MapSelect)
         {
           var mapExpr = nAryExpr.Args[0];
-          if (mapExpr is NAryExpr lmapValExpr &&
-              lmapValExpr.Fun is FieldAccess &&
-              lmapValExpr.Args[0].Type is CtorType ctorType &&
-              program.monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lmap")
+          if (mapExpr is NAryExpr lheapValExpr &&
+              lheapValExpr.Fun is FieldAccess &&
+              lheapValExpr.Args[0].Type is CtorType ctorType &&
+              program.monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lheap")
           {
-            return ExtractRootFromAccessPathExpr(lmapValExpr.Args[0]);
+            return ExtractRootFromAccessPathExpr(lheapValExpr.Args[0]);
           }
         }
       }
@@ -381,19 +381,19 @@ namespace Microsoft.Boogie
     {
       switch (program.monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
       {
-        case "Lmap_Empty":
+        case "Lheap_Empty":
           return null;
-        case "Lmap_Split":
+        case "Lheap_Split":
           return ExtractRootFromAccessPathExpr(callCmd.Ins[1]);
-        case "Lmap_Transfer":
+        case "Lheap_Transfer":
           return ExtractRootFromAccessPathExpr(callCmd.Ins[1]);
-        case "Lmap_Read":
+        case "Lheap_Read":
           return null;
-        case "Lmap_Write":
+        case "Lheap_Write":
           return ExtractRootFromAccessPathExpr(callCmd.Ins[0]);
-        case "Lmap_Add":
+        case "Lheap_Add":
           return ExtractRootFromAccessPathExpr(callCmd.Ins[0]);
-        case "Lmap_Remove":
+        case "Lheap_Remove":
           return ExtractRootFromAccessPathExpr(callCmd.Ins[0]);
         case "Lset_Empty":
           return null;
@@ -701,7 +701,7 @@ namespace Microsoft.Boogie
       return expr;
     }
 
-    public IEnumerable<Expr> LmapWellFormedExpressions(IEnumerable<Variable> availableVars)
+    public IEnumerable<Expr> LheapWellFormedExpressions(IEnumerable<Variable> availableVars)
     {
       var monomorphizer = civlTypeChecker.program.monomorphizer;
       if (monomorphizer == null)
@@ -709,11 +709,11 @@ namespace Microsoft.Boogie
         return Enumerable.Empty<Expr>();
       }
       return availableVars.Where(v =>
-        v.TypedIdent.Type is CtorType ctorType && monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lmap").Select(
+        v.TypedIdent.Type is CtorType ctorType && monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lheap").Select(
         v =>
         {
           var ctorType = (CtorType)v.TypedIdent.Type;
-          var func = monomorphizer.InstantiateFunction("Lmap_WellFormed",
+          var func = monomorphizer.InstantiateFunction("Lheap_WellFormed",
             new Dictionary<string, Type>() { { "V", monomorphizer.GetTypeInstantiation(ctorType.Decl)[0] } });
           return ExprHelper.FunctionCall(func, Expr.Ident(v));
         });

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Boogie
     {
       var availableVars = paramVars.Union(frame);
       return civlTypeChecker.linearTypeChecker.DisjointnessExprForEachDomain(availableVars)
-        .Union(civlTypeChecker.linearTypeChecker.LmapWellFormedExpressions(availableVars))
+        .Union(civlTypeChecker.linearTypeChecker.LheapWellFormedExpressions(availableVars))
         .Select(expr => new Requires(false, expr));
     }
 

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -126,28 +126,28 @@ function {:builtin "seq.extract"} Seq_Extract<T>(a: Seq T, pos: int, length: int
 
 /// linear maps
 type Ref _;
-type {:datatype} Lmap _;
-function {:constructor} Lmap<V>(dom: [Ref V]bool, val: [Ref V]V): Lmap V;
+type {:datatype} Lheap _;
+function {:constructor} Lheap<V>(dom: [Ref V]bool, val: [Ref V]V): Lheap V;
 
-function {:inline} Lmap_WellFormed<V>(l: Lmap V): bool {
+function {:inline} Lheap_WellFormed<V>(l: Lheap V): bool {
     l->val == MapIte(l->dom, l->val, MapConst(Default())) 
 }
-function {:inline} Lmap_Collector<V>(l: Lmap V): [Ref V]bool {
+function {:inline} Lheap_Collector<V>(l: Lheap V): [Ref V]bool {
     l->dom
 }
-function {:inline} Lmap_Contains<V>(l: Lmap V, k: Ref V): bool {
+function {:inline} Lheap_Contains<V>(l: Lheap V, k: Ref V): bool {
     l->dom[k]
 }
-function {:inline} Lmap_Deref<V>(l: Lmap V, k: Ref V): V {
+function {:inline} Lheap_Deref<V>(l: Lheap V, k: Ref V): V {
     l->val[k]
 }
-procedure Lmap_Empty<V>() returns (l: Lmap V);
-procedure Lmap_Split<V>(k: [Ref V]bool, path: Lmap V) returns (l: Lmap V);
-procedure Lmap_Transfer<V>({:linear_in} path1: Lmap V, path2: Lmap V);
-procedure Lmap_Read<V>(path: V) returns (v: V);
-procedure Lmap_Write<V>(path: V, v: V);
-procedure Lmap_Add<V>(path: Lmap V, v: V) returns (k: Ref V);
-procedure Lmap_Remove<V>(path: Lmap V, k: Ref V) returns (v: V);
+procedure Lheap_Empty<V>() returns (l: Lheap V);
+procedure Lheap_Split<V>(k: [Ref V]bool, path: Lheap V) returns (l: Lheap V);
+procedure Lheap_Transfer<V>({:linear_in} path1: Lheap V, path2: Lheap V);
+procedure Lheap_Read<V>(path: V) returns (v: V);
+procedure Lheap_Write<V>(path: V, v: V);
+procedure Lheap_Add<V>(path: Lheap V, v: V) returns (k: Ref V);
+procedure Lheap_Remove<V>(path: Lheap V, k: Ref V) returns (v: V);
 
 /// linear sets
 type {:datatype} Lset _;

--- a/Test/civl/linear_types.bpl
+++ b/Test/civl/linear_types.bpl
@@ -1,24 +1,24 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-procedure {:atomic} {:layer 1, 2} A0({:linear_in} path: Lmap int, k: [Ref int]bool) returns (path': Lmap int, l: Lmap int) {
-    call path' := Lmap_Empty();
-    call Lmap_Transfer(path, path');
-    call l := Lmap_Split(k, path');
+procedure {:atomic} {:layer 1, 2} A0({:linear_in} path: Lheap int, k: [Ref int]bool) returns (path': Lheap int, l: Lheap int) {
+    call path' := Lheap_Empty();
+    call Lheap_Transfer(path, path');
+    call l := Lheap_Split(k, path');
 }
 
-procedure {:atomic} {:layer 1, 2} A1({:linear_in} path: Lmap int, k: Ref int, v: int) returns (path': Lmap int, v': int) {
-    call path' := Lmap_Empty();
-    call Lmap_Transfer(path, path');
-    call Lmap_Write(path'->val[k], v);
-    call v' := Lmap_Read(path'->val[k]);
+procedure {:atomic} {:layer 1, 2} A1({:linear_in} path: Lheap int, k: Ref int, v: int) returns (path': Lheap int, v': int) {
+    call path' := Lheap_Empty();
+    call Lheap_Transfer(path, path');
+    call Lheap_Write(path'->val[k], v);
+    call v' := Lheap_Read(path'->val[k]);
 }
 
-procedure {:atomic} {:layer 1, 2} A2(v: int) returns (path': Lmap int, v': int) {
+procedure {:atomic} {:layer 1, 2} A2(v: int) returns (path': Lheap int, v': int) {
     var k: Ref int;
-    call path' := Lmap_Empty();
-    call k := Lmap_Add(path', v);
-    call v' := Lmap_Remove(path', k);
+    call path' := Lheap_Empty();
+    call k := Lheap_Add(path', v);
+    call v' := Lheap_Remove(path', k);
 }
 
 procedure {:atomic} {:layer 1, 2} A3({:linear_in} path: Lset int, {:linear_out} l: Lset int) returns (path': Lset int) {
@@ -34,28 +34,28 @@ procedure {:atomic} {:layer 1, 2} A4({:linear_in} path: Lset int, l: Lval int) r
     call Lval_Split(l, path');
 }
 
-procedure {:atomic} {:layer 1, 2} A5({:linear_in} path: Lmap int) returns (path': Lmap int) {
+procedure {:atomic} {:layer 1, 2} A5({:linear_in} path: Lheap int) returns (path': Lheap int) {
     path' := path;
 }
 
-var {:layer 0, 2} g: Lmap int;
+var {:layer 0, 2} g: Lheap int;
 
-procedure {:atomic} {:layer 1, 2} A6({:linear_in} path: Lmap int) returns (path': Lmap int)
+procedure {:atomic} {:layer 1, 2} A6({:linear_in} path: Lheap int) returns (path': Lheap int)
 modifies g;
 {
     path' := path;
-    call Lmap_Transfer(g, path');
-    call g := Lmap_Empty();
+    call Lheap_Transfer(g, path');
+    call g := Lheap_Empty();
 }
 
 type {:datatype} Foo;
-function {:constructor} Foo(f: Lmap int): Foo;
+function {:constructor} Foo(f: Lheap int): Foo;
 
-procedure {:atomic} {:layer 1, 2} A7({:linear_in} path: Lmap Foo, x: Ref Foo, y: Ref int) returns (path': Lmap Foo)
+procedure {:atomic} {:layer 1, 2} A7({:linear_in} path: Lheap Foo, x: Ref Foo, y: Ref int) returns (path': Lheap Foo)
 {
-    var l: Lmap int;
+    var l: Lheap int;
     path' := path;
-    call l := Lmap_Split(MapOne(y), path'->val[x]->f);
+    call l := Lheap_Split(MapOne(y), path'->val[x]->f);
 }
 
 procedure {:atomic} {:layer 1, 2} A8({:linear_out} l: Lval int, {:linear_in} path: Lset int) returns (path': Lset int)
@@ -64,15 +64,15 @@ procedure {:atomic} {:layer 1, 2} A8({:linear_out} l: Lval int, {:linear_in} pat
     call Lval_Split(l, path');
 }
 
-procedure {:atomic} {:layer 1, 2} A9({:linear_in} path1: Lmap int, x: Ref Foo) returns (path2: Lmap Foo)
+procedure {:atomic} {:layer 1, 2} A9({:linear_in} path1: Lheap int, x: Ref Foo) returns (path2: Lheap Foo)
 {
-    call path2 := Lmap_Empty();
-    call Lmap_Transfer(path1, path2->val[x]->f);
+    call path2 := Lheap_Empty();
+    call Lheap_Transfer(path1, path2->val[x]->f);
 }
 
 procedure {:atomic} {:layer 1, 2} A10({:linear_in} a: Foo) returns (b: Foo)
 {
-    var x: Lmap int;
+    var x: Lheap int;
     Foo(x) := a;
     b := Foo(x);
 }

--- a/Test/civl/linear_types_error.bpl
+++ b/Test/civl/linear_types_error.bpl
@@ -1,79 +1,79 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-procedure {:atomic} {:layer 1, 2} A0(path: Lmap int) returns (l: Lmap int) { }
+procedure {:atomic} {:layer 1, 2} A0(path: Lheap int) returns (l: Lheap int) { }
 
-procedure {:atomic} {:layer 1, 2} A1(path: Lmap int) returns (path': Lmap int) {
+procedure {:atomic} {:layer 1, 2} A1(path: Lheap int) returns (path': Lheap int) {
     path' := path;
 }
 
-procedure {:atomic} {:layer 1, 2} A2(path: Lmap int) returns (path': Lmap int) {
-    call path' := Lmap_Empty();
-    call Lmap_Transfer(path, path');
+procedure {:atomic} {:layer 1, 2} A2(path: Lheap int) returns (path': Lheap int) {
+    call path' := Lheap_Empty();
+    call Lheap_Transfer(path, path');
 }
 
-var {:layer 0, 2} g: Lmap int;
+var {:layer 0, 2} g: Lheap int;
 
-procedure {:atomic} {:layer 1, 2} A3({:linear_in} path: Lmap int) returns (path': Lmap int)
+procedure {:atomic} {:layer 1, 2} A3({:linear_in} path: Lheap int) returns (path': Lheap int)
 {
     path' := path;
-    call Lmap_Transfer(g, path');
+    call Lheap_Transfer(g, path');
 }
 
 type {:datatype} Foo;
-function {:constructor} Foo(f: Lmap int): Foo;
+function {:constructor} Foo(f: Lheap int): Foo;
 
-procedure {:atomic} {:layer 1, 2} A4({:linear_in} path: Lmap Foo, x: Ref Foo, {:linear_in} l: Lmap int) returns (path': Lmap Foo, l': Lmap int)
+procedure {:atomic} {:layer 1, 2} A4({:linear_in} path: Lheap Foo, x: Ref Foo, {:linear_in} l: Lheap int) returns (path': Lheap Foo, l': Lheap int)
 {
     path' := path;
     l' := l;
-    call Lmap_Transfer(path'->val[x]->f, l');
+    call Lheap_Transfer(path'->val[x]->f, l');
 }
 
-procedure {:atomic} {:layer 1, 2} A5({:linear_out} path: Lmap int) { }
+procedure {:atomic} {:layer 1, 2} A5({:linear_out} path: Lheap int) { }
 
-procedure {:atomic} {:layer 1, 2} A6({:linear_in} path: Lmap int) returns (path': Lmap int)
+procedure {:atomic} {:layer 1, 2} A6({:linear_in} path: Lheap int) returns (path': Lheap int)
 {
     path' := path;
-    call Lmap_Transfer(path', path');
+    call Lheap_Transfer(path', path');
 }
 
-procedure {:atomic} {:layer 1, 2} A7(path1: Lmap int, {:linear_in} path2: Lmap int) returns (path': Lmap int)
+procedure {:atomic} {:layer 1, 2} A7(path1: Lheap int, {:linear_in} path2: Lheap int) returns (path': Lheap int)
 {
     path' := path2;
-    call Lmap_Transfer(path1, path');
+    call Lheap_Transfer(path1, path');
 }
 
-procedure {:atomic} {:layer 1, 2} A8({:linear_in} path1: Lmap int, x: Ref Foo) returns (path2: Lmap Foo)
+procedure {:atomic} {:layer 1, 2} A8({:linear_in} path1: Lheap int, x: Ref Foo) returns (path2: Lheap Foo)
 {
-    call Lmap_Transfer(path1, path2->val[x]->f);
+    call Lheap_Transfer(path1, path2->val[x]->f);
 }
 
-procedure {:atomic} {:layer 1, 2} A9({:linear_in} l: Lmap int)
+procedure {:atomic} {:layer 1, 2} A9({:linear_in} l: Lheap int)
 {
-    call Lmap_Transfer(l, g);
+    call Lheap_Transfer(l, g);
 }
 
-procedure {:atomic} {:layer 1, 2} A10({:linear_in} l: Lmap int, l': Lmap int)
+procedure {:atomic} {:layer 1, 2} A10({:linear_in} l: Lheap int, l': Lheap int)
 {
-    call Lmap_Transfer(l, l');
+    call Lheap_Transfer(l, l');
 }
 
 procedure {:atomic} {:layer 1, 2} A11({:linear_in} a: Foo) returns (b: Foo)
 {
-    var x: Lmap int;
+    var x: Lheap int;
     Foo(x) := a;
 }
 
 procedure {:atomic} {:layer 1, 2} A12({:linear_in} a: Foo) returns (b: Foo)
 {
-    var x: Lmap int;
+    var x: Lheap int;
     b := a;
     Foo(x) := a;
 }
 
 procedure {:atomic} {:layer 1, 2} A13({:linear_in} a: Foo) returns (b: Foo)
 {
-    var x: Lmap int;
+    var x: Lheap int;
     b := Foo(x);
 }

--- a/Test/civl/linear_types_error.bpl.expect
+++ b/Test/civl/linear_types_error.bpl.expect
@@ -1,12 +1,12 @@
-linear_types_error.bpl(4,77): Error: Output variable l must be available at a return
+linear_types_error.bpl(4,79): Error: Output variable l must be available at a return
 linear_types_error.bpl(8,0): Error: Input variable path must be available at a return
 linear_types_error.bpl(13,0): Error: Input variable path must be available at a return
 linear_types_error.bpl(21,0): Error: Global variable g must be available at a return
 linear_types_error.bpl(30,4): Error: Only variable can be passed to linear parameter: path'->val[x]->f
-linear_types_error.bpl(33,69): Error: Input variable path must be available at a return
+linear_types_error.bpl(33,70): Error: Input variable path must be available at a return
 linear_types_error.bpl(38,4): Error: Linear variable path' can occur only once as an input parameter
 linear_types_error.bpl(45,0): Error: Input variable path1 must be available at a return
-linear_types_error.bpl(49,30): Error: unavailable source path2 for linear parameter at position 1
+linear_types_error.bpl(49,31): Error: unavailable source path2 for linear parameter at position 1
 linear_types_error.bpl(50,0): Error: Output variable path2 must be available at a return
 linear_types_error.bpl(54,4): Error: Primitive assigns to a global variable that is not in the enclosing procedure's modifies clause: g
 linear_types_error.bpl(59,4): Error: Primitive assigns to input variable: l'

--- a/Test/datatypes/node-client.bpl
+++ b/Test/datatypes/node-client.bpl
@@ -2,11 +2,11 @@
 // RUN: %diff "%s.expect" "%t"
 
 type {:datatype} Treiber T;
-function {:constructor} Treiber<T>(top: RefNode T, stack: Lmap (Node T)): Treiber T;
+function {:constructor} Treiber<T>(top: RefNode T, stack: Lheap (Node T)): Treiber T;
 type RefTreiber T = Ref (Treiber T);
 
 type X; 
-var ts: Lmap (Treiber X);
+var ts: Lheap (Treiber X);
 
 procedure YieldInv(ref_t: RefTreiber X)
 requires ts->dom[ref_t];
@@ -29,7 +29,7 @@ modifies ts;
   assert ts->dom[ref_t];
   assume ts->val[ref_t]->top != Nil() && ts->val[ref_t]->stack->dom[ts->val[ref_t]->top];
   Node(ref_n, x) := ts->val[ref_t]->stack->val[ts->val[ref_t]->top];
-  call Lmap_Write(ts->val[ref_t]->top, ref_n);
+  call Lheap_Write(ts->val[ref_t]->top, ref_n);
 }
 
 procedure {:inline 1} AtomicPushIntermediate(ref_t: RefTreiber X, x: X)
@@ -37,6 +37,6 @@ modifies ts;
 {
   var ref_n: RefNode X;
   assert ts->dom[ref_t];
-  call ref_n := Lmap_Add(ts->val[ref_t]->stack, Node(ts->val[ref_t]->top, x));
-  call Lmap_Write(ts->val[ref_t]->top, ref_n);
+  call ref_n := Lheap_Add(ts->val[ref_t]->stack, Node(ts->val[ref_t]->top, x));
+  call Lheap_Write(ts->val[ref_t]->top, ref_n);
 }


### PR DESCRIPTION
Lmap was introduced in the base library as a linear type several PRs back. I realized that this type is better named Lheap. This PR performs the renaming.