### PR TITLE
fix: AlwaysAssume test had previously passed for the wrong reason

### DIFF
--- a/Test/test0/AlwaysAssume.bpl
+++ b/Test/test0/AlwaysAssume.bpl
@@ -1,24 +1,40 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-procedure reqDef()
+procedure reqDef0()
   free requires false;
   requires false;  // fails
-  free requires {:alwaysAssume} false;
+  free requires {:always_assume} false; // this always_assumes comes too late to be useful to the previous line
+{
+}
+
+procedure testReq0()
+  ensures false;
+{
+  call reqDef0();
+}
+
+procedure reqDef1()
+  free requires {:always_assume} false;
   requires false;
 {
 }
 
-procedure testReq()
+procedure testReq1()
   ensures false;
 {
-  call reqDef();
+  call reqDef1();
 }
 
-procedure ensDef()
+procedure ensDef0()
   free ensures false;
   ensures false;  // fails
-  free ensures {:alwaysAssume} false;
+  free ensures {:always_assume} false; // this always_assumes comes too late to be useful to the previous line
+{
+}
+
+procedure ensDef1()
+  free ensures {:always_assume} false;
   ensures false;
 {
 }

--- a/Test/test0/AlwaysAssume.bpl.expect
+++ b/Test/test0/AlwaysAssume.bpl.expect
@@ -1,10 +1,10 @@
-AlwaysAssume.bpl(15,3): Error: a precondition for this call could not be proved
+AlwaysAssume.bpl(14,3): Error: a precondition for this call could not be proved
 AlwaysAssume.bpl(6,3): Related location: this is the precondition that could not be proved
 Execution trace:
-    AlwaysAssume.bpl(15,3): anon0
-AlwaysAssume.bpl(24,1): Error: a postcondition could not be proved on this return path
-AlwaysAssume.bpl(20,3): Related location: this is the postcondition that could not be proved
+    AlwaysAssume.bpl(14,3): anon0
+AlwaysAssume.bpl(34,1): Error: a postcondition could not be proved on this return path
+AlwaysAssume.bpl(31,3): Related location: this is the postcondition that could not be proved
 Execution trace:
-    AlwaysAssume.bpl(24,1): anon0
+    AlwaysAssume.bpl(34,1): anon0
 
-Boogie program verifier finished with 1 verified, 2 errors
+Boogie program verifier finished with 4 verified, 2 errors


### PR DESCRIPTION
This PR fixes two problems with the test file for `:always_assume`.

The first problem is that the test was structured like

``` boogie
procedure P()
  free ensures false;                         // L0
  ensures false;  // fails                    // L1
  free ensures {:always_assume} false;        // L2
  ensures false; // succeeds                  // L3
```

In the checking context of procedure `P`, these postconditions turn into:

``` boogie
  /* skip */      // L0
  assert false;   // L1
  assume false;   // L2
  assert false;   // L3
```

Indeed, L1 fails and L3 succeeds. However, the reason L3 succeeds is already because of L1, regardless of whether L2 is skipped or assumed.

This first problem is fixed by splitting test `P` into two, the first containing L0+L1 and the second containing L2+L3.

The second problem fixed by this PR is that the test file didn't write `:always_assume` but `:alwaysAssume`, which had been the name in the prototype before the name style was made consistent with other Boogie attributes. So, the original test file didn't actually mention the attribute that was intended as the subject of test.

Fortunately, the `:always_assume` attribute appears to work as intended, so this PR is just fixing the test file.