### PR TITLE
Set prover options outside (push) in batch mode

### DIFF
--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Boogie.SMTLib
           await currentLogFile.WriteAsync(common.ToString());
         }
 
+        SendVCOptions();
         PrepareCommon();
         FlushAxioms();
 
@@ -87,7 +88,10 @@ namespace Microsoft.Boogie.SMTLib
         FlushAxioms();
 
         Push();
-        SendVCAndOptions(descriptiveName, vcString);
+        if (this.libOptions.EmitDebugInformation) {
+          SendThisVC("(set-info :boogie-vc-id " + SmtLibNameUtils.QuoteId(descriptiveName) + ")");
+        }
+        SendThisVC(vcString);
         SendOptimizationRequests();
 
         FlushLogFile();

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -88,9 +88,7 @@ namespace Microsoft.Boogie.SMTLib
         FlushAxioms();
 
         Push();
-        if (this.libOptions.EmitDebugInformation) {
-          SendThisVC("(set-info :boogie-vc-id " + SmtLibNameUtils.QuoteId(descriptiveName) + ")");
-        }
+        SendVCId(descriptiveName);
         SendThisVC(vcString);
         SendOptimizationRequests();
 

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -102,7 +102,9 @@ namespace Microsoft.Boogie.SMTLib
         DeclCollector.Push();
         string vcString = "(assert (not\n" + VCExpr2String(vc, 1) + "\n))";
         FlushAxioms();
-        SendVCAndOptions(descriptiveName, vcString);
+        SendVCId(descriptiveName);
+        SendVCOptions();
+        SendThisVC(vcString);
 
         SendOptimizationRequests();
 

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -428,11 +428,8 @@ namespace Microsoft.Boogie.SMTLib
       //FlushPushedAssertions();
     }
 
-    protected void SendVCAndOptions(string descriptiveName, String vcString)
+    protected void SendVCOptions()
     {
-      if (this.libOptions.EmitDebugInformation) {
-        SendThisVC("(set-info :boogie-vc-id " + SmtLibNameUtils.QuoteId(descriptiveName) + ")");
-      }
       if (options.Solver == SolverKind.Z3 || options.Solver == SolverKind.NoOpWithZ3Options)
       {
         SendThisVC("(set-option :" + Z3.TimeoutOption + " " + options.TimeLimit + ")");
@@ -442,6 +439,14 @@ namespace Microsoft.Boogie.SMTLib
           SendThisVC("(set-option :" + Z3.SatRandomSeed + " " + options.RandomSeed.Value + ")");
         }
       }
+    }
+
+    protected void SendVCAndOptions(string descriptiveName, String vcString)
+    {
+      if (this.libOptions.EmitDebugInformation) {
+        SendThisVC("(set-info :boogie-vc-id " + SmtLibNameUtils.QuoteId(descriptiveName) + ")");
+      }
+      SendVCOptions();
       SendThisVC(vcString);
     }
 

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -441,13 +441,11 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    protected void SendVCAndOptions(string descriptiveName, String vcString)
+    protected void SendVCId(string descriptiveName)
     {
       if (this.libOptions.EmitDebugInformation) {
         SendThisVC("(set-info :boogie-vc-id " + SmtLibNameUtils.QuoteId(descriptiveName) + ")");
       }
-      SendVCOptions();
-      SendThisVC(vcString);
     }
 
     protected void CloseLogFile()

--- a/Test/prover/cvc5-offline.bpl
+++ b/Test/prover/cvc5-offline.bpl
@@ -1,0 +1,8 @@
+// RUN: %boogie /trace /proverOpt:BATCH_MODE=true /proverLog:cvc5-offline.smt2 "%s" > "%t"
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+// CHECK: Boogie program verifier finished with 1 verified, 0 errors
+// RUN: cvc5 --incremental cvc5-offline.smt2
+
+procedure P(x: int, y: int) {
+  assert x*y == y*x;
+}


### PR DESCRIPTION
This makes files generated for Z3 slightly more compatible with CVC5. Although CVC5 is supported in a separate mode, it can be useful for SMT files generated when running with Z3 to be as compatible as possible with other solvers.