### PR TITLE
[Civl] Add types for Civl concepts

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -5,14 +5,6 @@ using Microsoft.Boogie.GraphUtil;
 
 namespace Microsoft.Boogie
 {
-  public enum MoverType
-  {
-    Non,
-    Right,
-    Left,
-    Both
-  }
-
   public class LayerRange
   {
     public static int Min = 0;

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -744,7 +744,7 @@ namespace Microsoft.Boogie
 
     private void TypeCheckYieldInvariants()
     {
-      foreach (var yieldInvariant in program.TopLevelDeclarations.OfType<YieldInvariant>())
+      foreach (var yieldInvariant in program.TopLevelDeclarations.OfType<YieldInvariantDecl>())
       {
         var layers = FindLayers(yieldInvariant.Attributes);
         if (layers.Count != 1)
@@ -965,7 +965,7 @@ namespace Microsoft.Boogie
               {
                 continue;
               }
-              var yieldInvariant = (YieldInvariant)callCmd.Proc;
+              var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
               var calleeLayerNum = yieldInvariant.LayerNum;
               if (calleeLayerNum <= yieldingLayer)
               {
@@ -1650,7 +1650,7 @@ namespace Microsoft.Boogie
           return;
         }
 
-        var yieldInvariant = civlTypeChecker.program.TopLevelDeclarations.OfType<YieldInvariant>()
+        var yieldInvariant = civlTypeChecker.program.TopLevelDeclarations.OfType<YieldInvariantDecl>()
           .FirstOrDefault(proc => proc.Name == yieldInvariantProcName);
         if (yieldInvariant == null)
         {
@@ -1790,13 +1790,13 @@ namespace Microsoft.Boogie
         {
           yieldRequiresVisitor.Visit(callCmd);
           VisitYieldInvariantCallCmd(callCmd, yieldingProc.upperLayer,
-            ((YieldInvariant)callCmd.Proc).LayerNum);
+            ((YieldInvariantDecl)callCmd.Proc).LayerNum);
         }
 
         foreach (var callCmd in yieldEnsures)
         {
           VisitYieldInvariantCallCmd(callCmd, yieldingProc.upperLayer,
-            ((YieldInvariant)callCmd.Proc).LayerNum);
+            ((YieldInvariantDecl)callCmd.Proc).LayerNum);
         }
 
         yieldingProc = null;
@@ -1988,7 +1988,7 @@ namespace Microsoft.Boogie
           "At most one arm of a parallel call can refine the specification action");
         
         HashSet<Variable> parallelCallInvars = new HashSet<Variable>();
-        foreach (CallCmd callCmd in node.CallCmds.Where(callCmd => callCmd.Proc is not YieldInvariant))
+        foreach (CallCmd callCmd in node.CallCmds.Where(callCmd => callCmd.Proc is not YieldInvariantDecl))
         {
           for (int i = 0; i < callCmd.Proc.InParams.Count; i++)
           {
@@ -2009,7 +2009,7 @@ namespace Microsoft.Boogie
           }
         }
 
-        foreach (CallCmd callCmd in node.CallCmds.Where(callCmd => callCmd.Proc is YieldInvariant))
+        foreach (CallCmd callCmd in node.CallCmds.Where(callCmd => callCmd.Proc is YieldInvariantDecl))
         {
           for (int i = 0; i < callCmd.Proc.InParams.Count; i++)
           {
@@ -2037,7 +2037,7 @@ namespace Microsoft.Boogie
         {
           VisitYieldingProcCallCmd(call, callerProc, civlTypeChecker.procToYieldingProc[call.Proc]);
         }
-        else if (call.Proc is YieldInvariant yieldInvariant)
+        else if (call.Proc is YieldInvariantDecl yieldInvariant)
         {
           VisitYieldInvariantCallCmd(call, callerProc.upperLayer, yieldInvariant.LayerNum);
         }
@@ -2295,7 +2295,7 @@ namespace Microsoft.Boogie
             }
             else
             {
-              Debug.Assert(callCmd.Proc is YieldInvariant ||
+              Debug.Assert(callCmd.Proc is YieldInvariantDecl ||
                            civlTypeChecker.procToLemmaProc.ContainsKey(callCmd.Proc));
             }
 

--- a/Source/Concurrency/NoninterferenceChecker.cs
+++ b/Source/Concurrency/NoninterferenceChecker.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Boogie
       CivlTypeChecker civlTypeChecker,
       int layerNum,
       AbsyMap absyMap,
-      YieldInvariant yieldInvariant,
+      YieldInvariantDecl yieldInvariantDecl,
       List<Variable> declLocalVariables)
     {
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
@@ -36,7 +36,7 @@ namespace Microsoft.Boogie
         domainToHoleVar[domain] = inParam;
       }
 
-      foreach (Variable local in declLocalVariables.Union(yieldInvariant.InParams).Union(yieldInvariant.OutParams))
+      foreach (Variable local in declLocalVariables.Union(yieldInvariantDecl.InParams).Union(yieldInvariantDecl.OutParams))
       {
         var copy = CopyLocal(local);
         locals.Add(copy);
@@ -59,11 +59,11 @@ namespace Microsoft.Boogie
       var linearPermissionInstrumentation = new LinearPermissionInstrumentation(civlTypeChecker,
         layerNum, absyMap, domainToHoleVar, localVarMap);
       var yieldInfos = new List<YieldInfo>();
-      var noninterferenceCheckerName = $"yield_{yieldInvariant.Name}";
-      if (yieldInvariant.Requires.Count > 0)
+      var noninterferenceCheckerName = $"yield_{yieldInvariantDecl.Name}";
+      if (yieldInvariantDecl.Requires.Count > 0)
       {
-        var disjointnessCmds = linearPermissionInstrumentation.ProcDisjointnessAndWellFormedAssumeCmds(yieldInvariant, true);
-        var yieldPredicates = yieldInvariant.Requires.Select(requires =>
+        var disjointnessCmds = linearPermissionInstrumentation.ProcDisjointnessAndWellFormedAssumeCmds(yieldInvariantDecl, true);
+        var yieldPredicates = yieldInvariantDecl.Requires.Select(requires =>
           requires.Free
             ? (PredicateCmd)new AssumeCmd(requires.tok, requires.Condition)
             : (PredicateCmd)new AssertCmd(requires.tok, requires.Condition)).ToList();

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -409,7 +409,7 @@ namespace Microsoft.Boogie
           return P;
         }
 
-        if (callCmd.Proc is YieldInvariant yieldInvariant)
+        if (callCmd.Proc is YieldInvariantDecl yieldInvariant)
         {
           return yieldInvariant.LayerNum == currLayerNum ? Y : P;
         }
@@ -479,7 +479,7 @@ namespace Microsoft.Boogie
           return P;
         }
 
-        if (callCmd.Proc is YieldInvariant yieldInvariant)
+        if (callCmd.Proc is YieldInvariantDecl yieldInvariant)
         {
           return yieldInvariant.LayerNum == currLayerNum ? Y : P;
         }
@@ -539,7 +539,7 @@ namespace Microsoft.Boogie
       private void CheckParCallCmd(ParCallCmd parCallCmd)
       {
         CheckNonMoverCondition(parCallCmd);
-        if (parCallCmd.CallCmds.Any(callCmd => CallCmdLabel(callCmd) == Y && callCmd.Proc is not YieldInvariant))
+        if (parCallCmd.CallCmds.Any(callCmd => CallCmdLabel(callCmd) == Y && callCmd.Proc is not YieldInvariantDecl))
         {
           if (parCallCmd.CallCmds.Any(callCmd => CallCmdLabel(callCmd) == N))
           {
@@ -606,7 +606,7 @@ namespace Microsoft.Boogie
         {
           var label = CallCmdLabel(callCmd);
           Debug.Assert(label != N);
-          if (label == P || label == Y && callCmd.Proc is YieldInvariant)
+          if (label == P || label == Y && callCmd.Proc is YieldInvariantDecl)
           {
             continue;
           }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Boogie
         return;
       }
 
-      if (newCall.Proc is YieldInvariant yieldInvariant)
+      if (newCall.Proc is YieldInvariantDecl yieldInvariant)
       {
         if (layerNum == yieldInvariant.LayerNum)
         {
@@ -398,7 +398,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          var yieldInvariant = (YieldInvariant)callCmd.Proc;
+          var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.LayerNum)
           {
             callCmds.Add(callCmd);

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Boogie
         return;
       }
 
-      foreach (var yieldInvariant in civlTypeChecker.program.TopLevelDeclarations.OfType<YieldInvariant>())
+      foreach (var yieldInvariant in civlTypeChecker.program.TopLevelDeclarations.OfType<YieldInvariantDecl>())
       {
         if (layerNum == yieldInvariant.LayerNum)
         {
@@ -229,7 +229,7 @@ namespace Microsoft.Boogie
       var inlinedYieldInvariants = new List<Cmd>();
       foreach (var callCmd in yieldInvariants)
       {
-        var yieldInvariant = (YieldInvariant)callCmd.Proc;
+        var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
         if (layerNum == yieldInvariant.LayerNum)
         {
           Dictionary<Variable, Expr> map = yieldInvariant.InParams.Zip(callCmd.Ins)
@@ -277,7 +277,7 @@ namespace Microsoft.Boogie
 
         foreach (var callCmd in GetYieldingProc(impl).yieldRequires)
         {
-          var yieldInvariant = (YieldInvariant)callCmd.Proc;
+          var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.LayerNum)
           {
             Substitution callFormalsToActuals = Substituter.SubstitutionFromDictionary(yieldInvariant.InParams
@@ -302,7 +302,7 @@ namespace Microsoft.Boogie
         var yieldingProc = GetYieldingProc(impl);
         foreach (var callCmd in yieldingProc.yieldRequires)
         {
-          var yieldInvariant = (YieldInvariant)callCmd.Proc;
+          var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.LayerNum)
           {
             Dictionary<Variable, Expr> map = yieldInvariant.InParams.Zip(callCmd.Ins)
@@ -319,7 +319,7 @@ namespace Microsoft.Boogie
 
         foreach (var callCmd in yieldingProc.yieldEnsures)
         {
-          var yieldInvariant = (YieldInvariant)callCmd.Proc;
+          var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.LayerNum)
           {
             Dictionary<Variable, Expr> map = yieldInvariant.InParams.Zip(callCmd.Ins)

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -2920,7 +2920,7 @@ namespace Microsoft.Boogie
         foreach (CallCmd callCmd in CallCmds)
         {
           if (!QKeyValue.FindBoolAttribute(callCmd.Proc.Attributes, CivlAttributes.YIELDS) &&
-              callCmd.Proc is not YieldInvariant)
+              callCmd.Proc is not YieldInvariantDecl)
           {
             tc.Error(callCmd, "target procedure of a parallel call must yield");
           }

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -183,7 +183,7 @@ BoogiePL
      Axiom/*!*/ ax;
      List<Declaration/*!*/>/*!*/ ts;
      DatatypeTypeCtorDecl dt;
-     YieldInvariant yi;
+     YieldInvariantDecl yi;
      Procedure/*!*/ pr;
      Implementation im;
      Implementation/*!*/ nnim;
@@ -210,7 +210,7 @@ BoogiePL
                                     Pgm.AddTopLevelDeclaration(v);
                                   }
                                .)
-  | YieldInvariant<out yi> (. Pgm.AddTopLevelDeclaration(yi); .)
+  | YieldInvariantDecl<out yi> (. Pgm.AddTopLevelDeclaration(yi); .)
   | Procedure<out pr, out im>  (. Pgm.AddTopLevelDeclaration(pr);
                                    if (im != null) {
                                      Pgm.AddTopLevelDeclaration(im);
@@ -617,14 +617,14 @@ Constructor<DatatypeTypeCtorDecl datatypeTypeCtorDecl>
   .
 
 /*------------------------------------------------------------------------*/
-YieldInvariant<out YieldInvariant yieldInvariant>
+YieldInvariantDecl<out YieldInvariantDecl yieldInvariant>
 = (. List<Requires> invariants = new List<Requires>(); QKeyValue kv = null; IToken name = null; List<Variable> ins; .)
   "yield" "invariant"
   { Attribute<ref kv> }
   Ident<out name>
   ProcFormals<true, true, out ins> ";"
   { Invariant<invariants> }
-  (. yieldInvariant = new YieldInvariant(name, name.val, ins, invariants, kv); .)
+  (. yieldInvariant = new YieldInvariantDecl(name, name.val, ins, invariants, kv); .)
   .
 
 Invariant<.List<Requires> invariants.>

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -236,7 +236,7 @@ private class BvBounds : Expr {
 		Axiom/*!*/ ax;
 		List<Declaration/*!*/>/*!*/ ts;
 		DatatypeTypeCtorDecl dt;
-		YieldInvariant yi;
+		YieldInvariantDecl yi;
 		Procedure/*!*/ pr;
 		Implementation im;
 		Implementation/*!*/ nnim;
@@ -290,7 +290,7 @@ private class BvBounds : Expr {
 				break;
 			}
 			case 33: {
-				YieldInvariant(out yi);
+				YieldInvariantDecl(out yi);
 				Pgm.AddTopLevelDeclaration(yi); 
 				break;
 			}
@@ -540,7 +540,7 @@ private class BvBounds : Expr {
 		Expect(9);
 	}
 
-	void YieldInvariant(out YieldInvariant yieldInvariant) {
+	void YieldInvariantDecl(out YieldInvariantDecl yieldInvariant) {
 		List<Requires> invariants = new List<Requires>(); QKeyValue kv = null; IToken name = null; List<Variable> ins; 
 		Expect(33);
 		Expect(34);
@@ -553,7 +553,7 @@ private class BvBounds : Expr {
 		while (la.kind == 34) {
 			Invariant(invariants);
 		}
-		yieldInvariant = new YieldInvariant(name, name.val, ins, invariants, kv); 
+		yieldInvariant = new YieldInvariantDecl(name, name.val, ins, invariants, kv); 
 	}
 
 	void Procedure(out Procedure/*!*/ proc, out /*maybe null*/ Implementation impl) {


### PR DESCRIPTION
This PR lays the groundwork for adding syntactic support for actions and yield procedures. 
- New types are added to Absy.cs for the AST representation of action and yield procedures. Parser changes to target these types will be added in a subsequent PR.
- enum MoverType is moved from CivlCoreTypes.cs to Absy.cs to allow a reference from ActionDecl.