### PR TITLE
[Corral] Make ControlFlowIdMap into a field

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -3,7 +3,7 @@
   <!-- Target framework and package configuration -->
   <PropertyGroup>
     <Version>2.9.5</Version>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>
     <RepositoryUrl>https://github.com/boogie-org/boogie</RepositoryUrl>

--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -345,6 +345,7 @@ namespace VC
     public VCExpr vcexpr;
     public List<VCExprVar> interfaceExprVars;
     public List<VCExprVar> privateExprVars;
+    public ControlFlowIdMap<Absy> absyIds;
     public ModelViewInfo mvInfo;
     public Dictionary<Block, List<CallSite>> callSites;
     public Dictionary<Block, List<CallSite>> recordProcCallSites;
@@ -639,7 +640,7 @@ namespace VC
         PassiveImplInstrumentation(impl);
       }
 
-      var absyIds = new ControlFlowIdMap<Absy>();
+      absyIds = new ControlFlowIdMap<Absy>();
       
       VCGen.CodeExprConversionClosure cc = new VCGen.CodeExprConversionClosure(absyIds, proverInterface.Context);
       translator.SetCodeExprConverter(cc.CodeExprToVerificationCondition);


### PR DESCRIPTION
This PR is part of the effort to update [Corral](https://github.com/Dargones/corral) so that it works with the latest version of Boogie. The idea is to incrementally update this branch of Boogie alongside Corral until a PR could be made to Boogie's main branch.

This particular PR makes to changes:

- Make Boogie 2.9.5 compilable with dotnet6.
- Change a local variable that stores the mapping from AST nodes to Ids into a field of StatifiedInliningInfo, so that Corral can reuse that mapping later on during error-trace parsing.