### PR TITLE
Initial refactoring of Civl type checker

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Boogie
 
   public abstract class Action
   {
-    public ActionDecl proc;
+    public ActionDecl proc => (ActionDecl)impl.Proc;
     public Implementation impl;
     public LayerRange layerRange;
     public List<AssertCmd> gate;
@@ -74,9 +74,8 @@ namespace Microsoft.Boogie
     public List<ActionDecl> pendingAsyncs;
     public Function inputOutputRelation;
 
-    protected Action(ActionDecl proc, Implementation impl, LayerRange layerRange, CivlTypeChecker civlTypeChecker)
+    protected Action(Implementation impl, LayerRange layerRange, CivlTypeChecker civlTypeChecker)
     {
-      this.proc = proc;
       this.impl = impl;
       this.layerRange = layerRange;
 
@@ -341,8 +340,8 @@ namespace Microsoft.Boogie
     
     public Dictionary<Variable, Function> triggerFunctions;
 
-    public AtomicAction(ActionDecl proc, Implementation impl, LayerRange layerRange, AtomicAction refinedAction,
-      CivlTypeChecker civlTypeChecker) : base(proc, impl, layerRange, civlTypeChecker)
+    public AtomicAction(Implementation impl, LayerRange layerRange, AtomicAction refinedAction,
+      CivlTypeChecker civlTypeChecker) : base(impl, layerRange, civlTypeChecker)
     {
       this.refinedAction = refinedAction;
     }
@@ -427,8 +426,8 @@ namespace Microsoft.Boogie
   {
     public DatatypeTypeCtorDecl choiceDatatypeTypeCtorDecl;
 
-    public InvariantAction(ActionDecl proc, Implementation impl, LayerRange layerRange, CivlTypeChecker civlTypeChecker)
-      : base(proc, impl, layerRange, civlTypeChecker)
+    public InvariantAction(Implementation impl, LayerRange layerRange, CivlTypeChecker civlTypeChecker)
+      : base(impl, layerRange, civlTypeChecker)
     {
       var choiceDatatypeName = $"Choice_{impl.Name}";
       choiceDatatypeTypeCtorDecl =

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -5,63 +5,6 @@ using Microsoft.Boogie.GraphUtil;
 
 namespace Microsoft.Boogie
 {
-  public class LayerRange
-  {
-    public static int Min = 0;
-    public static int Max = int.MaxValue;
-    public static LayerRange MinMax = new LayerRange(Min, Max);
-
-    public int lowerLayerNum;
-    public int upperLayerNum;
-
-    public LayerRange(int layer) : this(layer, layer)
-    {
-    }
-
-    public LayerRange(int lower, int upper)
-    {
-      Debug.Assert(lower <= upper);
-      this.lowerLayerNum = lower;
-      this.upperLayerNum = upper;
-    }
-
-    public bool Contains(int layerNum)
-    {
-      return lowerLayerNum <= layerNum && layerNum <= upperLayerNum;
-    }
-
-    public bool Subset(LayerRange other)
-    {
-      return other.lowerLayerNum <= lowerLayerNum && upperLayerNum <= other.upperLayerNum;
-    }
-
-    public bool OverlapsWith(LayerRange other)
-    {
-      return lowerLayerNum <= other.upperLayerNum && other.lowerLayerNum <= upperLayerNum;
-    }
-
-    public override string ToString()
-    {
-      return $"[{lowerLayerNum}, {upperLayerNum}]";
-    }
-
-    public override bool Equals(object obj)
-    {
-      LayerRange other = obj as LayerRange;
-      if (obj == null)
-      {
-        return false;
-      }
-
-      return lowerLayerNum == other.lowerLayerNum && upperLayerNum == other.upperLayerNum;
-    }
-
-    public override int GetHashCode()
-    {
-      return (23 * 31 + lowerLayerNum) * 31 + upperLayerNum;
-    }
-  }
-
   public abstract class Action
   {
     public ActionDecl proc => (ActionDecl)impl.Proc;

--- a/Source/Concurrency/CivlRewriter.cs
+++ b/Source/Concurrency/CivlRewriter.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Boogie
       Program program = linearTypeChecker.program;
 
       // Store the original declarations of yielding procedures, which will be removed after desugaring below.
-      var origProc = program.TopLevelDeclarations.OfType<Procedure>()
-        .Where(p => civlTypeChecker.procToYieldingProc.ContainsKey(p));
-      var origImpl = program.TopLevelDeclarations.OfType<Implementation>()
-        .Where(i => civlTypeChecker.procToYieldingProc.ContainsKey(i.Proc));
-      List<Declaration> originalDecls = Enumerable.Union<Declaration>(origProc, origImpl).ToList();
+      var origYieldProcs = program.TopLevelDeclarations.OfType<YieldProcedureDecl>();
+      var origYieldImpls = program.TopLevelDeclarations.OfType<Implementation>()
+        .Where(impl => impl.Proc is YieldProcedureDecl);
+      var origYieldInvariants = program.TopLevelDeclarations.OfType<YieldInvariantDecl>();
+      var originalDecls = origYieldProcs.Union<Declaration>(origYieldImpls).Union(origYieldInvariants).ToHashSet();
 
       // Commutativity checks
       List<Declaration> decls = new List<Declaration>();

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Boogie
         new List<Variable>(),
         new List<Variable>(),
         new List<Block> { BlockHelper.Block("init", new List<Cmd>()) });
-      SkipAtomicAction = new AtomicAction(skipProcedure, skipImplementation, LayerRange.MinMax, null, this);
+      SkipAtomicAction = new AtomicAction(skipImplementation, LayerRange.MinMax, null, this);
       SkipAtomicAction.CompleteInitialization(this);
     }
 
@@ -280,14 +280,6 @@ namespace Microsoft.Boogie
       var actionProcToLayerRange = new Dictionary<ActionDecl, LayerRange>();
       foreach (var proc in actionProcs)
       {
-        Implementation impl = actionProcToImpl[proc];
-        impl.PruneUnreachableBlocks(Options);
-        Graph<Block> cfg = Program.GraphFromImpl(impl);
-        if (!Graph<Block>.Acyclic(cfg))
-        {
-          Error(proc, "Action body cannot have loops");
-          continue;
-        }
         LayerRange layerRange = ToLayerRange(FindLayers(proc.Attributes), proc);
         actionProcToLayerRange.Add(proc, layerRange);
       }
@@ -349,23 +341,23 @@ namespace Microsoft.Boogie
         LayerRange layerRange = actionProcToLayerRange[proc];
         if (proc.actionQualifier == ActionQualifier.Link)
         {
-          procToAtomicAction[proc] = new AtomicAction(proc, impl, layerRange, null, this);
+          procToAtomicAction[proc] = new AtomicAction(impl, layerRange, null, this);
         }
         else if (proc.actionQualifier == ActionQualifier.Invariant)
         {
-          procToInvariantAction[proc] = new InvariantAction(proc, impl, layerRange, this);
+          procToInvariantAction[proc] = new InvariantAction(impl, layerRange, this);
         }
         else if (proc.actionQualifier == ActionQualifier.Abstract)
         {
-          procToAtomicAction[proc] = new AtomicAction(proc, impl, layerRange, null, this);
+          procToAtomicAction[proc] = new AtomicAction(impl, layerRange, null, this);
         }
         else if (proc.actionQualifier == ActionQualifier.Async)
         {
-          procToAtomicAction[proc] = new AtomicAction(proc, impl, layerRange, null, this);
+          procToAtomicAction[proc] = new AtomicAction(impl, layerRange, null, this);
         }
         else
         {
-          procToAtomicAction[proc] = new AtomicAction(proc, impl, layerRange, null, this);
+          procToAtomicAction[proc] = new AtomicAction(impl, layerRange, null, this);
         }
       }
       // Now we create all atomic actions that refine other actions via an inductive sequentialization.
@@ -435,7 +427,7 @@ namespace Microsoft.Boogie
       var refinedAction = procToAtomicAction[refinedProc];
       Implementation impl = actionProcToImpl[proc];
       LayerRange layerRange = actionProcToLayerRange[proc];
-      procToAtomicAction[proc] = new AtomicAction(proc, impl, layerRange, refinedAction, this);
+      procToAtomicAction[proc] = new AtomicAction(impl, layerRange, refinedAction, this);
     }
 
     private void TypeCheckYieldInvariants()

--- a/Source/Concurrency/LinearPermissionInstrumentation.cs
+++ b/Source/Concurrency/LinearPermissionInstrumentation.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Boogie
 
       return civlTypeChecker.linearTypeChecker.AvailableLinearVars(absyMap[absy]).Where(v =>
         !(v is GlobalVariable) &&
-        civlTypeChecker.LocalVariableLayerRange(v).Contains(layerNum));
+        v.layerRange.Contains(layerNum));
     }
 
     private IEnumerable<Variable> FilterInParams(IEnumerable<Variable> locals)
@@ -148,16 +148,14 @@ namespace Microsoft.Boogie
     private IEnumerable<Variable> Filter(IEnumerable<Variable> locals, Predicate<LinearKind> pred)
     {
       return locals.Where(v =>
-        pred(LinearDomainCollector.FindLinearKind(v)) &&
-        civlTypeChecker.LocalVariableLayerRange(v).Contains(layerNum));
+        pred(LinearDomainCollector.FindLinearKind(v)) && v.layerRange.Contains(layerNum));
     }
 
     private IEnumerable<Variable> LinearGlobalVars()
     {
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       return linearTypeChecker.program.GlobalVariables.Where(v =>
-        LinearDomainCollector.FindLinearKind(v) == LinearKind.LINEAR &&
-        civlTypeChecker.GlobalVariableLayerRange(v).Contains(layerNum));
+        LinearDomainCollector.FindLinearKind(v) == LinearKind.LINEAR && v.layerRange.Contains(layerNum));
     }
 
     private Variable MapVariable(Variable v)

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -19,7 +19,7 @@ public class LinearRewriter
   {
     this.civlTypeChecker = civlTypeChecker;
     this.proc = proc;
-    this.layerNum = proc is YieldProcedureDecl decl ? decl.layer : null;
+    this.layerNum = proc is YieldProcedureDecl decl ? decl.Layer : null;
   }
   
   public static bool IsPrimitive(DeclWithFormals decl)

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -23,7 +23,7 @@ public class LinearRewriter
       {
         return null;
       }
-      var layers = civlTypeChecker.FindLayers(proc.Attributes);
+      var layers = ((ICarriesAttributes)proc).FindLayers();
       if (layers.Count == 0)
       {
         return null;

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -17,22 +17,9 @@ public class LinearRewriter
 
   private LinearRewriter(CivlTypeChecker civlTypeChecker, Procedure proc)
   {
-    int? LayerNum()
-    {
-      if (proc is not YieldProcedureDecl)
-      {
-        return null;
-      }
-      var layers = ((ICarriesAttributes)proc).FindLayers();
-      if (layers.Count == 0)
-      {
-        return null;
-      }
-      return layers[0];
-    }
     this.civlTypeChecker = civlTypeChecker;
     this.proc = proc;
-    this.layerNum = LayerNum();
+    this.layerNum = proc is YieldProcedureDecl decl ? decl.layer : null;
   }
   
   public static bool IsPrimitive(DeclWithFormals decl)

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Boogie
       var regularMoverChecks =
         from first in civlTypeChecker.MoverActions
         from second in civlTypeChecker.MoverActions
-        where first.layerRange.OverlapsWith(second.layerRange)
+        where first.LayerRange.OverlapsWith(second.LayerRange)
         where first.IsRightMover || second.IsLeftMover
         select new {first, second};
 
@@ -54,9 +54,9 @@ namespace Microsoft.Boogie
         from IS in civlTypeChecker.inductiveSequentializations
         from leftMover in IS.elim.Values
         from action in civlTypeChecker.MoverActions
-        where action.layerRange.Contains(IS.invariantAction.layerRange.upperLayerNum)
-        let extraAssumption1 = IS.GenerateMoverCheckAssumption(action, action.firstImpl.InParams, leftMover, leftMover.secondImpl.InParams)
-        let extraAssumption2 = IS.GenerateMoverCheckAssumption(action, action.secondImpl.InParams, leftMover, leftMover.firstImpl.InParams)
+        where action.LayerRange.Contains(IS.invariantAction.LayerRange.upperLayerNum)
+        let extraAssumption1 = IS.GenerateMoverCheckAssumption(action, action.FirstImpl.InParams, leftMover, leftMover.SecondImpl.InParams)
+        let extraAssumption2 = IS.GenerateMoverCheckAssumption(action, action.SecondImpl.InParams, leftMover, leftMover.FirstImpl.InParams)
         select new {action, leftMover, extraAssumption1, extraAssumption2};
 
       /*
@@ -124,12 +124,12 @@ namespace Microsoft.Boogie
 
     private CallCmd ActionCallCmd(AtomicAction action, DeclWithFormals paramProvider)
     {
-      return CmdHelper.CallCmd(action.proc, paramProvider.InParams, paramProvider.OutParams);
+      return CmdHelper.CallCmd(action.ActionDecl, paramProvider.InParams, paramProvider.OutParams);
     }
 
     private void CreateCommutativityChecker(AtomicAction first, AtomicAction second, Expr extraAssumption = null)
     {
-      if (first == second && first.firstImpl.InParams.Count == 0 && first.firstImpl.OutParams.Count == 0)
+      if (first == second && first.FirstImpl.InParams.Count == 0 && first.FirstImpl.OutParams.Count == 0)
       {
         return;
       }
@@ -144,20 +144,20 @@ namespace Microsoft.Boogie
         return;
       }
 
-      string checkerName = $"CommutativityChecker_{first.proc.Name}_{second.proc.Name}";
+      string checkerName = $"CommutativityChecker_{first.ActionDecl.Name}_{second.ActionDecl.Name}";
 
       HashSet<Variable> frame = new HashSet<Variable>();
-      frame.UnionWith(first.gateUsedGlobalVars);
-      frame.UnionWith(first.actionUsedGlobalVars);
-      frame.UnionWith(second.gateUsedGlobalVars);
-      frame.UnionWith(second.actionUsedGlobalVars);
+      frame.UnionWith(first.UsedGlobalVarsInGate);
+      frame.UnionWith(first.UsedGlobalVarsInAction);
+      frame.UnionWith(second.UsedGlobalVarsInGate);
+      frame.UnionWith(second.UsedGlobalVarsInAction);
 
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       List<Requires> requires =
         DisjointnessAndWellFormedRequires(
-          first.firstImpl.InParams.Union(second.secondImpl.InParams)
+          first.FirstImpl.InParams.Union(second.SecondImpl.InParams)
             .Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_OUT), frame).ToList();
-      foreach (AssertCmd assertCmd in Enumerable.Union(first.firstGate, second.secondGate))
+      foreach (AssertCmd assertCmd in Enumerable.Union(first.FirstGate, second.SecondGate))
       {
         requires.Add(new Requires(false, assertCmd.Expr));
       }
@@ -169,34 +169,34 @@ namespace Microsoft.Boogie
       var transitionRelation = TransitionRelationComputation.Commutativity(civlTypeChecker, second, first, frame);
 
       var secondInParamsFiltered =
-        second.secondImpl.InParams.Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_IN);
+        second.SecondImpl.InParams.Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_IN);
       IEnumerable<Expr> linearityAssumes = Enumerable.Union(
-        linearTypeChecker.DisjointnessExprForEachDomain(first.firstImpl.OutParams.Union(secondInParamsFiltered)
+        linearTypeChecker.DisjointnessExprForEachDomain(first.FirstImpl.OutParams.Union(secondInParamsFiltered)
           .Union(frame)),
-        linearTypeChecker.DisjointnessExprForEachDomain(first.firstImpl.OutParams.Union(second.secondImpl.OutParams)
+        linearTypeChecker.DisjointnessExprForEachDomain(first.FirstImpl.OutParams.Union(second.SecondImpl.OutParams)
           .Union(frame)));
       // TODO: add further disjointness expressions?
       AssertCmd commutativityCheck = CmdHelper.AssertCmd(
-        first.proc.tok,
+        first.ActionDecl.tok,
         Expr.Imp(Expr.And(linearityAssumes), transitionRelation),
-        $"Commutativity check between {first.proc.Name} and {second.proc.Name} failed");
+        $"Commutativity check between {first.ActionDecl.Name} and {second.ActionDecl.Name} failed");
 
       List<Cmd> cmds = new List<Cmd>
       {
-        ActionCallCmd(first, first.firstImpl),
-        ActionCallCmd(second, second.secondImpl)
+        ActionCallCmd(first, first.FirstImpl),
+        ActionCallCmd(second, second.SecondImpl)
       };
       cmds.Add(commutativityCheck);
 
-      List<Variable> inputs = Enumerable.Union(first.firstImpl.InParams, second.secondImpl.InParams).ToList();
-      List<Variable> outputs = Enumerable.Union(first.firstImpl.OutParams, second.secondImpl.OutParams).ToList();
+      List<Variable> inputs = Enumerable.Union(first.FirstImpl.InParams, second.SecondImpl.InParams).ToList();
+      List<Variable> outputs = Enumerable.Union(first.FirstImpl.OutParams, second.SecondImpl.OutParams).ToList();
 
       AddChecker(checkerName, inputs, outputs, new List<Variable>(), requires, cmds);
     }
 
     private void CreateGatePreservationChecker(AtomicAction first, AtomicAction second, Expr extraAssumption = null)
     {
-      if (!first.gateUsedGlobalVars.Intersect(second.modifiedGlobalVars).Any())
+      if (!first.UsedGlobalVarsInGate.Intersect(second.ModifiedGlobalVars).Any())
       {
         return;
       }
@@ -207,16 +207,16 @@ namespace Microsoft.Boogie
       }
 
       HashSet<Variable> frame = new HashSet<Variable>();
-      frame.UnionWith(first.gateUsedGlobalVars);
-      frame.UnionWith(second.gateUsedGlobalVars);
-      frame.UnionWith(second.actionUsedGlobalVars);
+      frame.UnionWith(first.UsedGlobalVarsInGate);
+      frame.UnionWith(second.UsedGlobalVarsInGate);
+      frame.UnionWith(second.UsedGlobalVarsInAction);
 
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       List<Requires> requires = 
         DisjointnessAndWellFormedRequires(
-          first.firstImpl.InParams.Union(second.secondImpl.InParams)
+          first.FirstImpl.InParams.Union(second.SecondImpl.InParams)
             .Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_OUT), frame).ToList();
-      foreach (AssertCmd assertCmd in first.firstGate.Union(second.secondGate))
+      foreach (AssertCmd assertCmd in first.FirstGate.Union(second.SecondGate))
       {
         requires.Add(new Requires(false, assertCmd.Expr));
       }
@@ -225,23 +225,23 @@ namespace Microsoft.Boogie
         requires.Add(new Requires(false, extraAssumption));
       }
 
-      string checkerName = $"GatePreservationChecker_{first.proc.Name}_{second.proc.Name}";
+      string checkerName = $"GatePreservationChecker_{first.ActionDecl.Name}_{second.ActionDecl.Name}";
 
-      List<Variable> inputs = Enumerable.Union(first.firstImpl.InParams, second.secondImpl.InParams).ToList();
-      List<Variable> outputs = Enumerable.Union(first.firstImpl.OutParams, second.secondImpl.OutParams).ToList();
+      List<Variable> inputs = Enumerable.Union(first.FirstImpl.InParams, second.SecondImpl.InParams).ToList();
+      List<Variable> outputs = Enumerable.Union(first.FirstImpl.OutParams, second.SecondImpl.OutParams).ToList();
 
-      List<Cmd> cmds = new List<Cmd> { ActionCallCmd(second, second.secondImpl) };
+      List<Cmd> cmds = new List<Cmd> { ActionCallCmd(second, second.SecondImpl) };
 
       IEnumerable<Expr> linearityAssumes =
-        linearTypeChecker.DisjointnessExprForEachDomain(first.firstImpl.InParams.Union(second.secondImpl.OutParams)
+        linearTypeChecker.DisjointnessExprForEachDomain(first.FirstImpl.InParams.Union(second.SecondImpl.OutParams)
           .Union(frame));
-      foreach (AssertCmd assertCmd in first.firstGate)
+      foreach (AssertCmd assertCmd in first.FirstGate)
       {
         cmds.Add(
           CmdHelper.AssertCmd(
             assertCmd.tok,
             Expr.Imp(Expr.And(linearityAssumes), assertCmd.Expr),
-            $"Gate of {first.proc.Name} not preserved by {second.proc.Name}"
+            $"Gate of {first.ActionDecl.Name} not preserved by {second.ActionDecl.Name}"
           )
         );
       }
@@ -251,7 +251,7 @@ namespace Microsoft.Boogie
 
     private void CreateFailurePreservationChecker(AtomicAction first, AtomicAction second, Expr extraAssumption = null)
     {
-      if (!first.gateUsedGlobalVars.Intersect(second.modifiedGlobalVars).Any())
+      if (!first.UsedGlobalVarsInGate.Intersect(second.ModifiedGlobalVars).Any())
       {
         return;
       }
@@ -262,19 +262,19 @@ namespace Microsoft.Boogie
       }
 
       HashSet<Variable> frame = new HashSet<Variable>();
-      frame.UnionWith(first.gateUsedGlobalVars);
-      frame.UnionWith(second.gateUsedGlobalVars);
-      frame.UnionWith(second.actionUsedGlobalVars);
+      frame.UnionWith(first.UsedGlobalVarsInGate);
+      frame.UnionWith(second.UsedGlobalVarsInGate);
+      frame.UnionWith(second.UsedGlobalVarsInAction);
 
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       List<Requires> requires = 
         DisjointnessAndWellFormedRequires(
-          first.firstImpl.InParams.Union(second.secondImpl.InParams)
+          first.FirstImpl.InParams.Union(second.SecondImpl.InParams)
             .Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_OUT), frame).ToList();
-      Expr firstNegatedGate = Expr.Not(Expr.And(first.firstGate.Select(a => a.Expr)));
+      Expr firstNegatedGate = Expr.Not(Expr.And(first.FirstGate.Select(a => a.Expr)));
       firstNegatedGate.Type = Type.Bool; // necessary?
       requires.Add(new Requires(false, firstNegatedGate));
-      foreach (AssertCmd assertCmd in second.secondGate)
+      foreach (AssertCmd assertCmd in second.SecondGate)
       {
         requires.Add(new Requires(false, assertCmd.Expr));
       }
@@ -284,20 +284,20 @@ namespace Microsoft.Boogie
       }
 
       IEnumerable<Expr> linearityAssumes =
-        linearTypeChecker.DisjointnessExprForEachDomain(first.firstImpl.InParams.Union(second.secondImpl.OutParams)
+        linearTypeChecker.DisjointnessExprForEachDomain(first.FirstImpl.InParams.Union(second.SecondImpl.OutParams)
           .Union(frame));
       AssertCmd gateFailureCheck = CmdHelper.AssertCmd(
-        first.proc.tok,
+        first.ActionDecl.tok,
         Expr.Imp(Expr.And(linearityAssumes), firstNegatedGate),
-        $"Gate failure of {first.proc.Name} not preserved by {second.proc.Name}");
+        $"Gate failure of {first.ActionDecl.Name} not preserved by {second.ActionDecl.Name}");
 
-      string checkerName = $"FailurePreservationChecker_{first.proc.Name}_{second.proc.Name}";
+      string checkerName = $"FailurePreservationChecker_{first.ActionDecl.Name}_{second.ActionDecl.Name}";
 
-      List<Variable> inputs = Enumerable.Union(first.firstImpl.InParams, second.secondImpl.InParams).ToList();
-      List<Variable> outputs = Enumerable.Union(first.firstImpl.OutParams, second.secondImpl.OutParams).ToList();
+      List<Variable> inputs = Enumerable.Union(first.FirstImpl.InParams, second.SecondImpl.InParams).ToList();
+      List<Variable> outputs = Enumerable.Union(first.FirstImpl.OutParams, second.SecondImpl.OutParams).ToList();
       var cmds = new List<Cmd>
       {
-        ActionCallCmd(second, second.secondImpl),
+        ActionCallCmd(second, second.SecondImpl),
         gateFailureCheck
       };
 
@@ -311,25 +311,25 @@ namespace Microsoft.Boogie
         return;
       }
 
-      string checkerName = $"CooperationChecker_{action.proc.Name}";
+      string checkerName = $"CooperationChecker_{action.ActionDecl.Name}";
 
-      Implementation impl = action.impl;
+      Implementation impl = action.Impl;
       HashSet<Variable> frame = new HashSet<Variable>();
-      frame.UnionWith(action.gateUsedGlobalVars);
-      frame.UnionWith(action.actionUsedGlobalVars);
+      frame.UnionWith(action.UsedGlobalVarsInGate);
+      frame.UnionWith(action.UsedGlobalVarsInAction);
 
       List<Requires> requires =
         DisjointnessAndWellFormedRequires(impl.InParams.Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.LINEAR_OUT),
           frame).ToList();
-      foreach (AssertCmd assertCmd in action.gate)
+      foreach (AssertCmd assertCmd in action.Gate)
       {
         requires.Add(new Requires(false, assertCmd.Expr));
       }
 
       AssertCmd cooperationCheck = CmdHelper.AssertCmd(
-        action.proc.tok,
+        action.ActionDecl.tok,
         TransitionRelationComputation.Cooperation(civlTypeChecker, action, frame),
-        $"Cooperation check for {action.proc.Name} failed");
+        $"Cooperation check for {action.ActionDecl.Name} failed");
 
       AddChecker(checkerName, new List<Variable>(impl.InParams), new List<Variable>(),
         new List<Variable>(), requires, new List<Cmd> { cooperationCheck });

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Boogie
       this.tok = impl.tok;
       this.oldGlobalMap = new Dictionary<Variable, Variable>();
       ActionProc actionProc = civlTypeChecker.procToYieldingProc[originalImpl.Proc] as ActionProc;
-      this.layerNum = actionProc.layer;
+      this.layerNum = actionProc.Layer;
       foreach (Variable v in civlTypeChecker.GlobalVariables)
       {
         var layerRange = v.layerRange;
@@ -114,12 +114,12 @@ namespace Microsoft.Boogie
       // The parameters of an atomic action come from the implementation that denotes the atomic action specification.
       // To use the transition relation computed below in the context of the yielding procedure of the refinement check,
       // we need to substitute the parameters.
-      AtomicAction atomicAction = actionProc.refinedAction;
-      Implementation atomicActionImpl = atomicAction.impl;
+      AtomicAction atomicAction = actionProc.RefinedAction;
+      Implementation atomicActionImpl = atomicAction.Impl;
       Dictionary<Variable, Expr> alwaysMap = new Dictionary<Variable, Expr>();
       for (int i = 0, j = 0; i < impl.InParams.Count; i++)
       {
-        if (civlTypeChecker.FormalRemainsInAction(actionProc, actionProc.proc.InParams[i]))
+        if (civlTypeChecker.FormalRemainsInAction(actionProc, actionProc.Proc.InParams[i]))
         {
           alwaysMap[atomicActionImpl.InParams[j]] = Expr.Ident(impl.InParams[i]);
           j++;
@@ -128,7 +128,7 @@ namespace Microsoft.Boogie
 
       for (int i = 0, j = 0; i < impl.OutParams.Count; i++)
       {
-        if (civlTypeChecker.FormalRemainsInAction(actionProc, actionProc.proc.OutParams[i]))
+        if (civlTypeChecker.FormalRemainsInAction(actionProc, actionProc.Proc.OutParams[i]))
         {
           alwaysMap[atomicActionImpl.OutParams[j]] = Expr.Ident(impl.OutParams[i]);
           j++;
@@ -137,7 +137,7 @@ namespace Microsoft.Boogie
 
       if (atomicAction.HasPendingAsyncs)
       {
-        atomicAction.pendingAsyncs.Iter(decl =>
+        atomicAction.PendingAsyncs.Iter(decl =>
         {
           Variable collectedPAs =
             civlTypeChecker.implToPendingAsyncCollector[originalImpl][decl.PendingAsyncType];
@@ -152,7 +152,7 @@ namespace Microsoft.Boogie
       Substitution forold = Substituter.SubstitutionFromDictionary(foroldMap);
       Expr transitionRelationExpr = GetTransitionRelation(atomicAction);
       transitionRelation = Substituter.ApplyReplacingOldExprs(always, forold, transitionRelationExpr);
-      Expr gateExpr = Expr.And(atomicAction.gate.Select(g => g.Expr));
+      Expr gateExpr = Expr.And(atomicAction.Gate.Select(g => g.Expr));
       gateExpr.Type = Type.Bool;
       gate = Substituter.Apply(always, gateExpr);
     }

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Boogie
       this.layerNum = actionProc.upperLayer;
       foreach (Variable v in civlTypeChecker.GlobalVariables)
       {
-        var layerRange = civlTypeChecker.GlobalVariableLayerRange(v);
+        var layerRange = v.layerRange;
         if (layerRange.lowerLayerNum <= layerNum && layerNum < layerRange.upperLayerNum)
         {
           this.oldGlobalMap[v] = oldGlobalMap[v];

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Boogie
       this.tok = impl.tok;
       this.oldGlobalMap = new Dictionary<Variable, Variable>();
       ActionProc actionProc = civlTypeChecker.procToYieldingProc[originalImpl.Proc] as ActionProc;
-      this.layerNum = actionProc.upperLayer;
+      this.layerNum = actionProc.layer;
       foreach (Variable v in civlTypeChecker.GlobalVariables)
       {
         var layerRange = v.layerRange;

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -82,30 +82,30 @@ namespace Microsoft.Boogie
       AtomicAction first, AtomicAction second,
       HashSet<Variable> frame)
     {
-      var triggers = first.triggerFunctions.Union(second.triggerFunctions).ToDictionary(kv => kv.Key, kv => kv.Value);
+      var triggers = first.TriggerFunctions.Union(second.TriggerFunctions).ToDictionary(kv => kv.Key, kv => kv.Value);
       return ComputeTransitionRelation(
         civlTypeChecker,
-        first.secondImpl, second.firstImpl,
+        first.SecondImpl, second.FirstImpl,
         frame, triggers, false,
-        string.Format("Transition relation of {0} ∘ {1}", first.proc.Name, second.proc.Name));
+        string.Format("Transition relation of {0} ∘ {1}", first.ActionDecl.Name, second.ActionDecl.Name));
     }
 
     public static Expr Refinement(CivlTypeChecker civlTypeChecker, Action action, HashSet<Variable> frame)
     {
       return ComputeTransitionRelation(
         civlTypeChecker,
-        action.impl, null,
+        action.Impl, null,
         frame, null, false,
-        string.Format("Transition relation of {0}", action.proc.Name));
+        string.Format("Transition relation of {0}", action.ActionDecl.Name));
     }
 
     public static Expr Cooperation(CivlTypeChecker civlTypeChecker, Action action, HashSet<Variable> frame)
     {
       return ComputeTransitionRelation(
         civlTypeChecker,
-        action.impl, null,
+        action.Impl, null,
         frame, null, true,
-        string.Format("Cooperation expression of {0}", action.proc.Name));
+        string.Format("Cooperation expression of {0}", action.ActionDecl.Name));
     }
 
     private void EnumeratePaths()

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -411,7 +411,7 @@ namespace Microsoft.Boogie
 
         if (callCmd.Proc is YieldInvariantDecl yieldInvariant)
         {
-          return yieldInvariant.LayerNum == currLayerNum ? Y : P;
+          return yieldInvariant.layer == currLayerNum ? Y : P;
         }
 
         YieldingProc callee = civlTypeChecker.procToYieldingProc[callCmd.Proc];
@@ -480,7 +480,7 @@ namespace Microsoft.Boogie
 
         if (callCmd.Proc is YieldInvariantDecl yieldInvariant)
         {
-          return yieldInvariant.LayerNum == currLayerNum ? Y : P;
+          return yieldInvariant.layer == currLayerNum ? Y : P;
         }
 
         YieldingProc callee = civlTypeChecker.procToYieldingProc[callCmd.Proc];

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Boogie
         Graph<Block> implGraph = Program.GraphFromImpl(impl);
         implGraph.ComputeLoops();
 
-        foreach (int layerNum in civlTypeChecker.allRefinementLayers.Where(l => l <= yieldingProc.upperLayer))
+        foreach (int layerNum in civlTypeChecker.allRefinementLayers.Where(l => l <= yieldingProc.layer))
         {
           new PerLayerYieldSufficiencyTypeChecker(civlTypeChecker, yieldingProc, impl, layerNum, implGraph, moverProcedureCallGraph)
             .TypeCheckLayer();
@@ -120,7 +120,7 @@ namespace Microsoft.Boogie
               continue;
             }
 
-            Debug.Assert(callerProc.upperLayer == calleeProc.upperLayer);
+            Debug.Assert(callerProc.layer == calleeProc.layer);
             moverProcedureCallGraph.AddEdge(callerProc, calleeProc);
           }
         }
@@ -274,7 +274,7 @@ namespace Microsoft.Boogie
 
       private bool IsMoverProcedure
       {
-        get { return yieldingProc is MoverProc && yieldingProc.upperLayer == currLayerNum; }
+        get { return yieldingProc is MoverProc && yieldingProc.layer == currLayerNum; }
       }
 
       private bool CheckAtomicity(Dictionary<Absy, HashSet<int>> simulationRelation)
@@ -417,12 +417,12 @@ namespace Microsoft.Boogie
         YieldingProc callee = civlTypeChecker.procToYieldingProc[callCmd.Proc];
         if (callCmd.IsAsync)
         {
-          if (callee is MoverProc && callee.upperLayer == currLayerNum)
+          if (callee is MoverProc && callee.layer == currLayerNum)
           {
             return MoverTypeToLabel(callee.MoverType);
           }
 
-          if (callee is ActionProc actionProc && callee.upperLayer < currLayerNum && callCmd.HasAttribute(CivlAttributes.SYNC))
+          if (callee is ActionProc actionProc && callee.layer < currLayerNum && callCmd.HasAttribute(CivlAttributes.SYNC))
           {
             return MoverTypeToLabel(actionProc.RefinedActionAtLayer(currLayerNum).proc.moverType);
           }
@@ -431,12 +431,12 @@ namespace Microsoft.Boogie
         }
         else
         {
-          if (callee is MoverProc && callee.upperLayer == currLayerNum)
+          if (callee is MoverProc && callee.layer == currLayerNum)
           {
             return MoverTypeToLabel(callee.MoverType);
           }
 
-          if (callee is ActionProc actionProc && callee.upperLayer < currLayerNum)
+          if (callee is ActionProc actionProc && callee.layer < currLayerNum)
           {
             return MoverTypeToLabel(actionProc.RefinedActionAtLayer(currLayerNum).proc.moverType);
           }
@@ -486,12 +486,12 @@ namespace Microsoft.Boogie
         YieldingProc callee = civlTypeChecker.procToYieldingProc[callCmd.Proc];
         if (callCmd.IsAsync)
         {
-          if (callee is MoverProc && callee.upperLayer == currLayerNum)
+          if (callee is MoverProc && callee.layer == currLayerNum)
           {
             return ModifiesGlobalLabel(callee.proc.Modifies);
           }
 
-          if (callee is ActionProc actionProc && callee.upperLayer < currLayerNum)
+          if (callee is ActionProc actionProc && callee.layer < currLayerNum)
           {
             if (callCmd.HasAttribute(CivlAttributes.SYNC))
             {
@@ -507,12 +507,12 @@ namespace Microsoft.Boogie
         }
         else
         {
-          if (callee is MoverProc && callee.upperLayer == currLayerNum)
+          if (callee is MoverProc && callee.layer == currLayerNum)
           {
             return ModifiesGlobalLabel(callee.proc.Modifies);
           }
 
-          if (callee is ActionProc actionProc && callee.upperLayer < currLayerNum)
+          if (callee is ActionProc actionProc && callee.layer < currLayerNum)
           {
             return ModifiesGlobalLabel(actionProc.RefinedActionAtLayer(currLayerNum).modifiedGlobalVars);
           }

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Boogie
         Graph<Block> implGraph = Program.GraphFromImpl(impl);
         implGraph.ComputeLoops();
 
-        foreach (int layerNum in civlTypeChecker.allRefinementLayers.Where(l => l <= yieldingProc.layer))
+        foreach (int layerNum in civlTypeChecker.allRefinementLayers.Where(l => l <= yieldingProc.Layer))
         {
           new PerLayerYieldSufficiencyTypeChecker(civlTypeChecker, yieldingProc, impl, layerNum, implGraph, moverProcedureCallGraph)
             .TypeCheckLayer();
@@ -120,7 +120,7 @@ namespace Microsoft.Boogie
               continue;
             }
 
-            Debug.Assert(callerProc.layer == calleeProc.layer);
+            Debug.Assert(callerProc.Layer == calleeProc.Layer);
             moverProcedureCallGraph.AddEdge(callerProc, calleeProc);
           }
         }
@@ -274,7 +274,7 @@ namespace Microsoft.Boogie
 
       private bool IsMoverProcedure
       {
-        get { return yieldingProc is MoverProc && yieldingProc.layer == currLayerNum; }
+        get { return yieldingProc is MoverProc && yieldingProc.Layer == currLayerNum; }
       }
 
       private bool CheckAtomicity(Dictionary<Absy, HashSet<int>> simulationRelation)
@@ -403,7 +403,7 @@ namespace Microsoft.Boogie
 
       private string CallCmdLabel(CallCmd callCmd)
       {
-        if (callCmd.Proc is ActionDecl { actionQualifier: ActionQualifier.Link } ||
+        if (callCmd.Proc is ActionDecl { ActionQualifier: ActionQualifier.Link } ||
             callCmd.Proc.IsPure)
         {
           return P;
@@ -411,34 +411,34 @@ namespace Microsoft.Boogie
 
         if (callCmd.Proc is YieldInvariantDecl yieldInvariant)
         {
-          return yieldInvariant.layer == currLayerNum ? Y : P;
+          return yieldInvariant.Layer == currLayerNum ? Y : P;
         }
 
         YieldingProc callee = civlTypeChecker.procToYieldingProc[callCmd.Proc];
         if (callCmd.IsAsync)
         {
-          if (callee is MoverProc && callee.layer == currLayerNum)
+          if (callee is MoverProc && callee.Layer == currLayerNum)
           {
             return MoverTypeToLabel(callee.MoverType);
           }
 
-          if (callee is ActionProc actionProc && callee.layer < currLayerNum && callCmd.HasAttribute(CivlAttributes.SYNC))
+          if (callee is ActionProc actionProc && callee.Layer < currLayerNum && callCmd.HasAttribute(CivlAttributes.SYNC))
           {
-            return MoverTypeToLabel(actionProc.RefinedActionAtLayer(currLayerNum).proc.moverType);
+            return MoverTypeToLabel(actionProc.RefinedActionAtLayer(currLayerNum).ActionDecl.MoverType);
           }
 
           return L;
         }
         else
         {
-          if (callee is MoverProc && callee.layer == currLayerNum)
+          if (callee is MoverProc && callee.Layer == currLayerNum)
           {
             return MoverTypeToLabel(callee.MoverType);
           }
 
-          if (callee is ActionProc actionProc && callee.layer < currLayerNum)
+          if (callee is ActionProc actionProc && callee.Layer < currLayerNum)
           {
-            return MoverTypeToLabel(actionProc.RefinedActionAtLayer(currLayerNum).proc.moverType);
+            return MoverTypeToLabel(actionProc.RefinedActionAtLayer(currLayerNum).ActionDecl.MoverType);
           }
 
           return Y;
@@ -473,29 +473,29 @@ namespace Microsoft.Boogie
 
       private string CallCmdLabelAsync(CallCmd callCmd)
       {
-        if (callCmd.Proc is ActionDecl { actionQualifier: ActionQualifier.Link } || callCmd.Proc.IsPure)
+        if (callCmd.Proc is ActionDecl { ActionQualifier: ActionQualifier.Link } || callCmd.Proc.IsPure)
         {
           return P;
         }
 
         if (callCmd.Proc is YieldInvariantDecl yieldInvariant)
         {
-          return yieldInvariant.layer == currLayerNum ? Y : P;
+          return yieldInvariant.Layer == currLayerNum ? Y : P;
         }
 
         YieldingProc callee = civlTypeChecker.procToYieldingProc[callCmd.Proc];
         if (callCmd.IsAsync)
         {
-          if (callee is MoverProc && callee.layer == currLayerNum)
+          if (callee is MoverProc && callee.Layer == currLayerNum)
           {
-            return ModifiesGlobalLabel(callee.proc.Modifies);
+            return ModifiesGlobalLabel(callee.Proc.Modifies);
           }
 
-          if (callee is ActionProc actionProc && callee.layer < currLayerNum)
+          if (callee is ActionProc actionProc && callee.Layer < currLayerNum)
           {
             if (callCmd.HasAttribute(CivlAttributes.SYNC))
             {
-              return ModifiesGlobalLabel(actionProc.RefinedActionAtLayer(currLayerNum).modifiedGlobalVars);
+              return ModifiesGlobalLabel(actionProc.RefinedActionAtLayer(currLayerNum).ModifiedGlobalVars);
             }
             else
             {
@@ -507,14 +507,14 @@ namespace Microsoft.Boogie
         }
         else
         {
-          if (callee is MoverProc && callee.layer == currLayerNum)
+          if (callee is MoverProc && callee.Layer == currLayerNum)
           {
-            return ModifiesGlobalLabel(callee.proc.Modifies);
+            return ModifiesGlobalLabel(callee.Proc.Modifies);
           }
 
-          if (callee is ActionProc actionProc && callee.layer < currLayerNum)
+          if (callee is ActionProc actionProc && callee.Layer < currLayerNum)
           {
-            return ModifiesGlobalLabel(actionProc.RefinedActionAtLayer(currLayerNum).modifiedGlobalVars);
+            return ModifiesGlobalLabel(actionProc.RefinedActionAtLayer(currLayerNum).ModifiedGlobalVars);
           }
 
           return Y;

--- a/Source/Concurrency/YieldingProcChecker.cs
+++ b/Source/Concurrency/YieldingProcChecker.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Boogie
 
         foreach (var procToYieldingProc in civlTypeChecker.procToYieldingProc)
         {
-          if (procToYieldingProc.Value.layer >= layerNum)
+          if (procToYieldingProc.Value.Layer >= layerNum)
           {
             duplicator.VisitProcedure(procToYieldingProc.Key);
           }
@@ -30,7 +30,7 @@ namespace Microsoft.Boogie
         foreach (Implementation impl in program.Implementations)
         {
           if (civlTypeChecker.procToYieldingProc.TryGetValue(impl.Proc, out var yieldingProc) &&
-              yieldingProc.layer >= layerNum)
+              yieldingProc.Layer >= layerNum)
           {
             duplicator.VisitImplementation(impl);
           }

--- a/Source/Concurrency/YieldingProcChecker.cs
+++ b/Source/Concurrency/YieldingProcChecker.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Boogie
 
         foreach (var procToYieldingProc in civlTypeChecker.procToYieldingProc)
         {
-          if (procToYieldingProc.Value.upperLayer >= layerNum)
+          if (procToYieldingProc.Value.layer >= layerNum)
           {
             duplicator.VisitProcedure(procToYieldingProc.Key);
           }
@@ -30,7 +30,7 @@ namespace Microsoft.Boogie
         foreach (Implementation impl in program.Implementations)
         {
           if (civlTypeChecker.procToYieldingProc.TryGetValue(impl.Proc, out var yieldingProc) &&
-              yieldingProc.upperLayer >= layerNum)
+              yieldingProc.layer >= layerNum)
           {
             duplicator.VisitImplementation(impl);
           }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Boogie
 
       if (newCall.Proc.IsPure)
       {
-        if (civlTypeChecker.FindLayers(newCall.Attributes)[0] == layerNum)
+        if (((ICarriesAttributes)newCall).FindLayers()[0] == layerNum)
         {
           newCmdSeq.Add(newCall);
         }
@@ -269,7 +269,7 @@ namespace Microsoft.Boogie
 
       if (newCall.Proc is YieldInvariantDecl yieldInvariant)
       {
-        if (layerNum == yieldInvariant.LayerNum)
+        if (layerNum == yieldInvariant.layer)
         {
           var parCallCmd = new ParCallCmd(newCall.tok, new List<CallCmd> {newCall});
           absyMap[parCallCmd] = absyMap[newCall];
@@ -391,7 +391,7 @@ namespace Microsoft.Boogie
         else
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
-          if (layerNum == yieldInvariant.LayerNum)
+          if (layerNum == yieldInvariant.layer)
           {
             callCmds.Add(callCmd);
           }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Boogie
       if (!procToDuplicate.ContainsKey(node))
       {
         YieldingProc yieldingProc = civlTypeChecker.procToYieldingProc[node];
-        Debug.Assert(layerNum <= yieldingProc.layer);
+        Debug.Assert(layerNum <= yieldingProc.Layer);
         var proc = new Procedure(
           node.tok,
           civlTypeChecker.AddNamePrefix($"{node.Name}_{layerNum}"),
@@ -53,8 +53,8 @@ namespace Microsoft.Boogie
           VisitVariableSeq(node.OutParams),
           false,
           VisitRequiresSeq(node.Requires),
-          (yieldingProc is MoverProc moverProc && yieldingProc.layer == layerNum
-            ? moverProc.modifiedGlobalVars.Select(g => Expr.Ident(g))
+          (yieldingProc is MoverProc moverProc && yieldingProc.Layer == layerNum
+            ? moverProc.ModifiedGlobalVars.Select(g => Expr.Ident(g))
             : civlTypeChecker.GlobalVariables.Select(v => Expr.Ident(v))).ToList(),
           VisitEnsuresSeq(node.Ensures));
         procToDuplicate[node] = proc;
@@ -115,8 +115,8 @@ namespace Microsoft.Boogie
 
     private Implementation enclosingImpl;
     private YieldingProc enclosingYieldingProc;
-    private bool IsRefinementLayer => layerNum == enclosingYieldingProc.layer;
-    private AtomicAction RefinedAction => ((ActionProc)enclosingYieldingProc).refinedAction;
+    private bool IsRefinementLayer => layerNum == enclosingYieldingProc.Layer;
+    private AtomicAction RefinedAction => ((ActionProc)enclosingYieldingProc).RefinedAction;
     private List<Cmd> newCmdSeq;
 
     private Dictionary<CtorType, Variable> returnedPAs;
@@ -147,7 +147,7 @@ namespace Microsoft.Boogie
       Debug.Assert(civlTypeChecker.procToYieldingProc.ContainsKey(impl.Proc));
       enclosingImpl = impl;
       enclosingYieldingProc = civlTypeChecker.procToYieldingProc[impl.Proc];
-      Debug.Assert(layerNum <= enclosingYieldingProc.layer);
+      Debug.Assert(layerNum <= enclosingYieldingProc.Layer);
 
       returnedPAs = new Dictionary<CtorType, Variable>();
 
@@ -176,7 +176,7 @@ namespace Microsoft.Boogie
 
       if (enclosingYieldingProc is ActionProc && RefinedAction.HasPendingAsyncs && IsRefinementLayer)
       {
-        var assumeExpr = EmptyPendingAsyncMultisetExpr(CollectedPAs, RefinedAction.pendingAsyncs);
+        var assumeExpr = EmptyPendingAsyncMultisetExpr(CollectedPAs, RefinedAction.PendingAsyncs);
         newImpl.LocVars.AddRange(civlTypeChecker.implToPendingAsyncCollector[impl].Values.Except(impl.LocVars));
         newImpl.Blocks.First().Cmds.Insert(0, CmdHelper.AssumeCmd(assumeExpr));
       }
@@ -247,10 +247,10 @@ namespace Microsoft.Boogie
 
     private void ProcessCallCmd(CallCmd newCall)
     {
-      if (newCall.Proc is ActionDecl { actionQualifier: ActionQualifier.Link } actionDecl)
+      if (newCall.Proc is ActionDecl { ActionQualifier: ActionQualifier.Link } actionDecl)
       {
         var linkAction = civlTypeChecker.procToAtomicAction[actionDecl];
-        if (linkAction.LayerNum == layerNum)
+        if (linkAction.LowerLayer == layerNum)
         {
           InjectGate(linkAction, newCall);
           newCmdSeq.Add(newCall);
@@ -269,7 +269,7 @@ namespace Microsoft.Boogie
 
       if (newCall.Proc is YieldInvariantDecl yieldInvariant)
       {
-        if (layerNum == yieldInvariant.layer)
+        if (layerNum == yieldInvariant.Layer)
         {
           var parCallCmd = new ParCallCmd(newCall.tok, new List<CallCmd> {newCall});
           absyMap[parCallCmd] = absyMap[newCall];
@@ -283,7 +283,7 @@ namespace Microsoft.Boogie
 
       if (newCall.IsAsync)
       {
-        if (yieldingProc.layer < layerNum)
+        if (yieldingProc.Layer < layerNum)
         {
           Debug.Assert(yieldingProc is ActionProc);
           var actionProc = (ActionProc)yieldingProc;
@@ -299,7 +299,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          if (yieldingProc is MoverProc && yieldingProc.layer == layerNum)
+          if (yieldingProc is MoverProc && yieldingProc.Layer == layerNum)
           {
             // synchronize the called mover procedure
             AddDuplicateCall(newCall, false);
@@ -320,17 +320,17 @@ namespace Microsoft.Boogie
       // handle synchronous calls to yielding procedures
       if (yieldingProc is MoverProc moverProc)
       {
-        AddDuplicateCall(newCall, moverProc.layer > layerNum);
+        AddDuplicateCall(newCall, moverProc.Layer > layerNum);
       }
       else if (yieldingProc is ActionProc actionProc)
       {
-        if (actionProc.layer < layerNum)
+        if (actionProc.Layer < layerNum)
         {
           AddActionCall(newCall, actionProc);
         }
         else
         {
-          if (IsRefinementLayer && layerNum == actionProc.layer &&
+          if (IsRefinementLayer && layerNum == actionProc.Layer &&
               actionProc.RefinedActionAtLayer(layerNum) != civlTypeChecker.SkipAtomicAction)
           {
             refinementCallCmds[newCall] = (CallCmd) VisitCallCmd(newCall);
@@ -355,8 +355,8 @@ namespace Microsoft.Boogie
         if (civlTypeChecker.procToYieldingProc.ContainsKey(callCmd.Proc))
         {
           var yieldingProc = civlTypeChecker.procToYieldingProc[callCmd.Proc];
-          if (layerNum > yieldingProc.layer && yieldingProc is ActionProc ||
-              layerNum == yieldingProc.layer && yieldingProc is MoverProc)
+          if (layerNum > yieldingProc.Layer && yieldingProc is ActionProc ||
+              layerNum == yieldingProc.Layer && yieldingProc is MoverProc)
           {
             if (callCmds.Count > 0)
             {
@@ -377,7 +377,7 @@ namespace Microsoft.Boogie
           var yieldingProc = civlTypeChecker.procToYieldingProc[callCmd.Proc];
           if (yieldingProc is ActionProc actionProc)
           {
-            if (IsRefinementLayer && layerNum == actionProc.layer &&
+            if (IsRefinementLayer && layerNum == actionProc.Layer &&
                 actionProc.RefinedActionAtLayer(layerNum) != civlTypeChecker.SkipAtomicAction)
             {
               refinementCallCmds[callCmd] = (CallCmd) VisitCallCmd(callCmd);
@@ -391,7 +391,7 @@ namespace Microsoft.Boogie
         else
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
-          if (layerNum == yieldInvariant.layer)
+          if (layerNum == yieldInvariant.Layer)
           {
             callCmds.Add(callCmd);
           }
@@ -411,25 +411,25 @@ namespace Microsoft.Boogie
       var calleeRefinedAction = calleeActionProc.RefinedActionAtLayer(layerNum);
 
       newCall.IsAsync = false;
-      newCall.Proc = calleeRefinedAction.proc;
+      newCall.Proc = calleeRefinedAction.ActionDecl;
       newCall.callee = newCall.Proc.Name;
 
       // We drop the hidden parameters of the procedure from the call to the action.
-      Debug.Assert(newCall.Ins.Count == calleeActionProc.proc.InParams.Count);
-      Debug.Assert(newCall.Outs.Count == calleeActionProc.proc.OutParams.Count);
+      Debug.Assert(newCall.Ins.Count == calleeActionProc.Proc.InParams.Count);
+      Debug.Assert(newCall.Outs.Count == calleeActionProc.Proc.OutParams.Count);
       var newIns = new List<Expr>();
       var newOuts = new List<IdentifierExpr>();
-      for (int i = 0; i < calleeActionProc.proc.InParams.Count; i++)
+      for (int i = 0; i < calleeActionProc.Proc.InParams.Count; i++)
       {
-        if (civlTypeChecker.FormalRemainsInAction(calleeActionProc, calleeActionProc.proc.InParams[i]))
+        if (civlTypeChecker.FormalRemainsInAction(calleeActionProc, calleeActionProc.Proc.InParams[i]))
         {
           newIns.Add(newCall.Ins[i]);
         }
       }
 
-      for (int i = 0; i < calleeActionProc.proc.OutParams.Count; i++)
+      for (int i = 0; i < calleeActionProc.Proc.OutParams.Count; i++)
       {
-        if (civlTypeChecker.FormalRemainsInAction(calleeActionProc, calleeActionProc.proc.OutParams[i]))
+        if (civlTypeChecker.FormalRemainsInAction(calleeActionProc, calleeActionProc.Proc.OutParams[i]))
         {
           newOuts.Add(newCall.Outs[i]);
         }
@@ -443,23 +443,23 @@ namespace Microsoft.Boogie
 
       if (calleeRefinedAction.HasPendingAsyncs)
       {
-        Debug.Assert(newCall.Outs.Count == newCall.Proc.OutParams.Count - calleeRefinedAction.pendingAsyncs.Count);
+        Debug.Assert(newCall.Outs.Count == newCall.Proc.OutParams.Count - calleeRefinedAction.PendingAsyncs.Count);
         CollectReturnedPendingAsyncs(newCall, calleeRefinedAction);
       }
     }
 
     private void InjectGate(Action action, CallCmd callCmd, bool assume = false)
     {
-      if (action.gate.Count == 0)
+      if (action.Gate.Count == 0)
       {
         return;
       }
 
       Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
-      for (int i = 0; i < action.proc.InParams.Count; i++)
+      for (int i = 0; i < action.ActionDecl.InParams.Count; i++)
       {
         // Parameters come from the implementation that defines the action
-        map[action.impl.InParams[i]] = callCmd.Ins[i];
+        map[action.Impl.InParams[i]] = callCmd.Ins[i];
       }
 
       Substitution subst = Substituter.SubstitutionFromDictionary(map);
@@ -467,7 +467,7 @@ namespace Microsoft.Boogie
       // Important: Do not remove CommentCmd!
       // It separates the injected gate from yield assertions.
       newCmdSeq.Add(new CommentCmd("<<< injected gate"));
-      foreach (AssertCmd assertCmd in action.gate)
+      foreach (AssertCmd assertCmd in action.Gate)
       {
         var expr = Substituter.Apply(subst, assertCmd.Expr);
         if (assume)
@@ -477,7 +477,7 @@ namespace Microsoft.Boogie
         else
         {
           newCmdSeq.Add(CmdHelper.AssertCmd(assertCmd.tok, expr,
-            $"this gate of {action.proc.Name} could not be proved"));
+            $"this gate of {action.ActionDecl.Name} could not be proved"));
         }
       }
 
@@ -487,15 +487,15 @@ namespace Microsoft.Boogie
     private void CollectReturnedPendingAsyncs(CallCmd newCall, AtomicAction calleeRefinedAction)
     {
       // Inject pending async collection
-      newCall.Outs.AddRange(calleeRefinedAction.pendingAsyncs.Select(decl => Expr.Ident(ReturnedPAs(decl.PendingAsyncType))));
+      newCall.Outs.AddRange(calleeRefinedAction.PendingAsyncs.Select(decl => Expr.Ident(ReturnedPAs(decl.PendingAsyncType))));
       if (!IsRefinementLayer)
       {
         return;
       }
 
-      calleeRefinedAction.pendingAsyncs.Iter(decl =>
+      calleeRefinedAction.PendingAsyncs.Iter(decl =>
       {
-        if (RefinedAction.pendingAsyncs.Contains(decl))
+        if (RefinedAction.PendingAsyncs.Contains(decl))
         {
           newCmdSeq.Add(CmdHelper.AssignCmd(CollectedPAs(decl.PendingAsyncType),
             ExprHelper.FunctionCall(decl.PendingAsyncAdd, Expr.Ident(CollectedPAs(decl.PendingAsyncType)),
@@ -556,9 +556,9 @@ namespace Microsoft.Boogie
     private void AddPendingAsync(CallCmd newCall, ActionProc calleeProc)
     {
       AtomicAction calleeRefinedAction;
-      if (calleeProc.layer == enclosingYieldingProc.layer)
+      if (calleeProc.Layer == enclosingYieldingProc.Layer)
       {
-        calleeRefinedAction = calleeProc.refinedAction;
+        calleeRefinedAction = calleeProc.RefinedAction;
       }
       else
       {
@@ -570,19 +570,19 @@ namespace Microsoft.Boogie
         return;
       }
 
-      if (RefinedAction.pendingAsyncs.Contains(calleeRefinedAction.proc))
+      if (RefinedAction.PendingAsyncs.Contains(calleeRefinedAction.ActionDecl))
       {
-        Expr[] newIns = new Expr[calleeRefinedAction.proc.InParams.Count];
-        for (int i = 0, j = 0; i < calleeProc.proc.InParams.Count; i++)
+        Expr[] newIns = new Expr[calleeRefinedAction.ActionDecl.InParams.Count];
+        for (int i = 0, j = 0; i < calleeProc.Proc.InParams.Count; i++)
         {
-          if (civlTypeChecker.FormalRemainsInAction(calleeProc, calleeProc.proc.InParams[i]))
+          if (civlTypeChecker.FormalRemainsInAction(calleeProc, calleeProc.Proc.InParams[i]))
           {
             newIns[j] = newCall.Ins[i];
             j++;
           }
         }
-        var collectedPAs = CollectedPAs(calleeRefinedAction.proc.PendingAsyncType);
-        var pa = ExprHelper.FunctionCall(calleeRefinedAction.proc.PendingAsyncCtor, newIns);
+        var collectedPAs = CollectedPAs(calleeRefinedAction.ActionDecl.PendingAsyncType);
+        var pa = ExprHelper.FunctionCall(calleeRefinedAction.ActionDecl.PendingAsyncCtor, newIns);
         var inc = Expr.Add(Expr.Select(Expr.Ident(collectedPAs), pa), Expr.Literal(1));
         var add = CmdHelper.AssignCmd(collectedPAs, Expr.Store(Expr.Ident(collectedPAs), pa, inc));
         newCmdSeq.Add(add);

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Boogie
       {
         return requires;
       }
-
-      if (!civlTypeChecker.absyToLayerNums[node].Contains(layerNum))
+      
+      if (!node.Layers.Contains(layerNum))
       {
         requires.Condition = Expr.True;
       }
@@ -100,8 +100,8 @@ namespace Microsoft.Boogie
       {
         return ensures;
       }
-
-      if (!civlTypeChecker.absyToLayerNums[node].Contains(layerNum))
+      
+      if (!node.Layers.Contains(layerNum))
       {
         ensures.Condition = Expr.True;
       }
@@ -195,7 +195,7 @@ namespace Microsoft.Boogie
     public override Cmd VisitAssertCmd(AssertCmd node)
     {
       AssertCmd assertCmd = (AssertCmd) base.VisitAssertCmd(node);
-      if (!civlTypeChecker.absyToLayerNums[node].Contains(layerNum))
+      if (!node.Layers.Contains(layerNum))
       {
         assertCmd.Expr = Expr.True;
       }
@@ -260,7 +260,7 @@ namespace Microsoft.Boogie
 
       if (newCall.Proc.IsPure)
       {
-        if (((ICarriesAttributes)newCall).FindLayers()[0] == layerNum)
+        if (newCall.Layers[0] == layerNum)
         {
           newCmdSeq.Add(newCall);
         }

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Boogie
         // But this is fine because a mover procedure at its disappearing layer does not have a yield in it.
         linearPermissionInstrumentation.AddDisjointnessAndWellFormedAssumptions(impl);
         var yieldingProc = GetYieldingProc(impl);
-        if (yieldingProc is MoverProc && yieldingProc.upperLayer == layerNum)
+        if (yieldingProc is MoverProc && yieldingProc.layer == layerNum)
         {
           continue;
         }
@@ -360,7 +360,7 @@ namespace Microsoft.Boogie
     {
       // initialize refinementInstrumentation
       var yieldingProc = GetYieldingProc(impl);
-      if (yieldingProc.upperLayer == this.layerNum)
+      if (yieldingProc.layer == this.layerNum)
       {
         refinementInstrumentation = new ActionRefinementInstrumentation(
           civlTypeChecker,

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Boogie
 
       foreach (var yieldInvariant in civlTypeChecker.program.TopLevelDeclarations.OfType<YieldInvariantDecl>())
       {
-        if (layerNum == yieldInvariant.LayerNum)
+        if (layerNum == yieldInvariant.layer)
         {
           noninterferenceCheckerDecls.AddRange(
             NoninterferenceChecker.CreateNoninterferenceCheckers(civlTypeChecker,
@@ -230,7 +230,7 @@ namespace Microsoft.Boogie
       foreach (var callCmd in yieldInvariants)
       {
         var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
-        if (layerNum == yieldInvariant.LayerNum)
+        if (layerNum == yieldInvariant.layer)
         {
           Dictionary<Variable, Expr> map = yieldInvariant.InParams.Zip(callCmd.Ins)
             .ToDictionary(x => x.Item1, x => x.Item2);
@@ -278,7 +278,7 @@ namespace Microsoft.Boogie
         foreach (var callCmd in GetYieldingProc(impl).yieldRequires)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
-          if (layerNum == yieldInvariant.LayerNum)
+          if (layerNum == yieldInvariant.layer)
           {
             Substitution callFormalsToActuals = Substituter.SubstitutionFromDictionary(yieldInvariant.InParams
               .Zip(callCmd.Ins)
@@ -303,7 +303,7 @@ namespace Microsoft.Boogie
         foreach (var callCmd in yieldingProc.yieldRequires)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
-          if (layerNum == yieldInvariant.LayerNum)
+          if (layerNum == yieldInvariant.layer)
           {
             Dictionary<Variable, Expr> map = yieldInvariant.InParams.Zip(callCmd.Ins)
               .ToDictionary(x => x.Item1, x => x.Item2);
@@ -320,7 +320,7 @@ namespace Microsoft.Boogie
         foreach (var callCmd in yieldingProc.yieldEnsures)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
-          if (layerNum == yieldInvariant.LayerNum)
+          if (layerNum == yieldInvariant.layer)
           {
             Dictionary<Variable, Expr> map = yieldInvariant.InParams.Zip(callCmd.Ins)
               .ToDictionary(x => x.Item1, x => x.Item2);

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Boogie
           layers.AddRange(kv.Params.Select(o => ((LiteralExpr)o).asBigNum.ToIntSafe));
         }
       }
-      return layers;
+      return layers.Distinct().OrderBy(l => l).ToList();
     }
   }
 
@@ -2902,6 +2902,8 @@ namespace Microsoft.Boogie
     public readonly bool Free;
 
     private Expr _condition;
+    
+    public List<int> Layers;
 
     public ProofObligationDescription Description { get; set; } = new RequiresDescription();
 
@@ -2996,6 +2998,7 @@ namespace Microsoft.Boogie
     {
       this.Condition.Resolve(rc);
       (this as ICarriesAttributes).ResolveAttributes(rc);
+      Layers = (this as ICarriesAttributes).FindLayers();
     }
 
     public override void Typecheck(TypecheckingContext tc)
@@ -3024,18 +3027,12 @@ namespace Microsoft.Boogie
 
     public Expr Condition
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<Expr>() != null);
-        return this._condition;
-      }
-      set
-      {
-        Contract.Requires(value != null);
-        this._condition = value;
-      }
+      get => this._condition;
+      set => this._condition = value;
     }
-
+    
+    public List<int> Layers;
+    
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
@@ -3112,6 +3109,7 @@ namespace Microsoft.Boogie
     {
       this.Condition.Resolve(rc);
       (this as ICarriesAttributes).ResolveAttributes(rc);
+      Layers = (this as ICarriesAttributes).FindLayers();
     }
 
     public override void Typecheck(TypecheckingContext tc)

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -4240,6 +4240,15 @@ namespace Microsoft.Boogie
       }
       Contract.Assert(tc.Proc == Proc);
       tc.Proc = oldProc;
+
+      if (Proc is ActionDecl)
+      {
+        var cfg = Program.GraphFromImpl(this);
+        if (!Graph<Block>.Acyclic(cfg))
+        {
+          tc.Error(this, "action implementation may not have loops");
+        }
+      }
     }
 
     void MatchFormals(List<Variable> /*!*/ implFormals, List<Variable> /*!*/ procFormals, string /*!*/ inout,

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -3355,6 +3355,8 @@ namespace Microsoft.Boogie
     public DatatypeTypeCtorDecl pendingAsyncCtorDecl;
     public int PendingAsyncStartIndex;
 
+    public Implementation impl; // set when the implementation of this action is resolved
+
     public ActionDecl(IToken tok, string name, MoverType moverType, ActionQualifier actionQualifier,
       List<Variable> inParams, List<Variable> outParams,
       List<ActionDeclRef> creates, ActionDeclRef refinedAction, ActionDeclRef invariantAction,
@@ -4149,6 +4151,10 @@ namespace Microsoft.Boogie
       if (Proc == null)
       {
         rc.Error(this, "implementation given for undeclared procedure: {0}", this.Name);
+      }
+      else if (Proc is ActionDecl actionDecl)
+      {
+        actionDecl.impl = this;
       }
 
       int previousTypeBinderState = rc.TypeBinderState;

--- a/Source/Core/Absy.cs
+++ b/Source/Core/Absy.cs
@@ -1057,7 +1057,7 @@ namespace Microsoft.Boogie
 
     protected LayerRange ToLayerRange(TypecheckingContext tc, LayerRange defaultLayerRange = null)
     {
-      // We return min-max range for invalid declarations in order to proceed with type checking.
+      // We return min-max range for declarations that do not explicitly specify a range
       if (defaultLayerRange == null)
       {
         defaultLayerRange = LayerRange.MinMax;

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -3307,7 +3307,7 @@ namespace Microsoft.Boogie
       if (tc.Yields)
       {
         if (Proc is YieldProcedureDecl || Proc is YieldInvariantDecl || Proc.IsPure ||
-            (Proc is ActionDecl actionDecl && actionDecl.actionQualifier == ActionQualifier.Link))
+            (Proc is ActionDecl actionDecl && actionDecl.ActionQualifier == ActionQualifier.Link))
         {
           // call is fine
         }
@@ -3328,7 +3328,7 @@ namespace Microsoft.Boogie
           var type = TypeProxy.FollowProxy(TypeParameters[Proc.TypeParameters[0]].Expanded);
           if (type is CtorType ctorType && ctorType.Decl is DatatypeTypeCtorDecl datatypeTypeCtorDecl)
           {
-            if (callerActionDecl.creates.All(x => x.actionName != datatypeTypeCtorDecl.Name))
+            if (callerActionDecl.Creates.All(x => x.ActionName != datatypeTypeCtorDecl.Name))
             {
               tc.Error(this, "primitive instantiated on type not in the creates clause of caller");
             }
@@ -3340,13 +3340,13 @@ namespace Microsoft.Boogie
         }
         else if (Proc is ActionDecl calleeActionDecl)
         {
-          if (calleeActionDecl.actionQualifier == ActionQualifier.Invariant)
+          if (calleeActionDecl.ActionQualifier == ActionQualifier.Invariant)
           {
             tc.Error(this, "an invariant action may not be called");
           }
-          foreach (var actionDeclRef in calleeActionDecl.creates)
+          foreach (var actionDeclRef in calleeActionDecl.Creates)
           {
-            if (callerActionDecl.creates.All(x => x.actionDecl != actionDeclRef.actionDecl))
+            if (callerActionDecl.Creates.All(x => x.ActionDecl != actionDeclRef.ActionDecl))
             {
               tc.Error(actionDeclRef, "callee creates a pending async not in the creates clause of caller");
             }

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -1546,6 +1546,8 @@ namespace Microsoft.Boogie
   [ContractClass(typeof(CmdContracts))]
   public abstract class Cmd : Absy
   {
+    public List<int> Layers;
+    
     public byte[] Checksum { get; internal set; }
     public byte[] SugaredCmdChecksum { get; internal set; }
     public bool IrrelevantForChecksumComputation { get; set; }
@@ -3196,6 +3198,8 @@ namespace Microsoft.Boogie
         }
       }
 
+      (this as ICarriesAttributes).ResolveAttributes(rc);
+      Layers = (this as ICarriesAttributes).FindLayers();
       var id = QKeyValue.FindStringAttribute(Attributes, "id");
       if (id != null)
       {
@@ -3840,9 +3844,9 @@ namespace Microsoft.Boogie
 
     public override void Resolve(ResolutionContext rc)
     {
-      //Contract.Requires(rc != null);
       Expr.Resolve(rc);
-
+      (this as ICarriesAttributes).ResolveAttributes(rc);
+      Layers = (this as ICarriesAttributes).FindLayers();
       var id = QKeyValue.FindStringAttribute(Attributes, "id");
       if (id != null)
       {
@@ -3852,7 +3856,6 @@ namespace Microsoft.Boogie
 
     public override void AddAssignedVariables(List<Variable> vars)
     {
-      //Contract.Requires(vars != null);
     }
   }
 

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -3965,7 +3965,6 @@ namespace Microsoft.Boogie
         {
           return verifiedUnder;
         }
-
         verifiedUnder = QKeyValue.FindExprAttribute(Attributes, "verified_under");
         return verifiedUnder;
       }
@@ -3992,37 +3991,26 @@ namespace Microsoft.Boogie
       set { errorDataEnhanced = value; }
     }
 
-    public AssertCmd(IToken /*!*/ tok, Expr /*!*/ expr, ProofObligationDescription description, QKeyValue kv = null)
+    public AssertCmd(IToken tok, Expr expr, ProofObligationDescription description, QKeyValue kv = null)
       : base(tok, expr, kv)
     {
-      Contract.Requires(tok != null);
-      Contract.Requires(expr != null);
       errorDataEnhanced = GenerateBoundVarMiningStrategy(expr);
       Description = description;
     }
 
-    public AssertCmd(IToken /*!*/ tok, Expr /*!*/ expr, QKeyValue kv = null)
+    public AssertCmd(IToken tok, Expr expr, QKeyValue kv = null)
       : this(tok, expr, new AssertionDescription(), kv) { }
 
     public override void Emit(TokenTextWriter stream, int level)
     {
-      //Contract.Requires(stream != null);
       stream.Write(this, level, "assert ");
       EmitAttributes(stream, Attributes);
       this.Expr.Emit(stream);
       stream.WriteLine(";");
     }
 
-    public override void Resolve(ResolutionContext rc)
-    {
-      //Contract.Requires(rc != null);
-      (this as ICarriesAttributes).ResolveAttributes(rc);
-      base.Resolve(rc);
-    }
-
     public override void Typecheck(TypecheckingContext tc)
     {
-      //Contract.Requires(tc != null);
       (this as ICarriesAttributes).TypecheckAttributes(tc);
       Expr.Typecheck(tc);
       Contract.Assert(Expr.Type != null); // follows from Expr.Typecheck postcondition
@@ -4044,7 +4032,7 @@ namespace Microsoft.Boogie
       return new ListOfMiningStrategies(l);
     }
 
-    public static List<MiningStrategy> /*!*/ GenerateBoundVarListForMining(Expr expr, List<MiningStrategy> l)
+    public static List<MiningStrategy> GenerateBoundVarListForMining(Expr expr, List<MiningStrategy> l)
     {
       Contract.Requires(l != null);
       Contract.Requires(expr != null);
@@ -4058,7 +4046,7 @@ namespace Microsoft.Boogie
       else if (expr is NAryExpr)
       {
         NAryExpr e = (NAryExpr) expr;
-        foreach (Expr /*!*/ arg in e.Args)
+        foreach (Expr arg in e.Args)
         {
           Contract.Assert(arg != null);
           l = GenerateBoundVarListForMining(arg, l);
@@ -4096,8 +4084,6 @@ namespace Microsoft.Boogie
 
     public override Absy StdDispatch(StandardVisitor visitor)
     {
-      //Contract.Requires(visitor != null);
-      Contract.Ensures(Contract.Result<Absy>() != null);
       return visitor.VisitAssertCmd(this);
     }
   }

--- a/Source/Core/AbsyCmd.cs
+++ b/Source/Core/AbsyCmd.cs
@@ -1683,24 +1683,6 @@ namespace Microsoft.Boogie
       }
     }
 
-    public static void ResolveAttributes(QKeyValue attributes, ResolutionContext rc)
-    {
-      Contract.Requires(rc != null);
-      for (QKeyValue kv = attributes; kv != null; kv = kv.Next)
-      {
-        kv.Resolve(rc);
-      }
-    }
-
-    public static void TypecheckAttributes(QKeyValue attributes, TypecheckingContext tc)
-    {
-      Contract.Requires(tc != null);
-      for (QKeyValue kv = attributes; kv != null; kv = kv.Next)
-      {
-        kv.Typecheck(tc);
-      }
-    }
-
     [Pure]
     public override string ToString() {
       Contract.Ensures(Contract.Result<string>() != null);
@@ -1883,7 +1865,7 @@ namespace Microsoft.Boogie
 
     public override void Resolve(ResolutionContext rc)
     {
-      ResolveAttributes(Attributes, rc);
+      (this as ICarriesAttributes).ResolveAttributes(rc);
       if (Lhss.Count != Rhss.Count)
       {
         rc.Error(this,
@@ -1956,7 +1938,7 @@ namespace Microsoft.Boogie
     {
       int errorCount = tc.ErrorCount;
 
-      TypecheckAttributes(Attributes, tc);
+      (this as ICarriesAttributes).TypecheckAttributes(tc);
       foreach (AssignLhs /*!*/ e in Lhss)
       {
         Contract.Assert(e != null);
@@ -2435,7 +2417,7 @@ namespace Microsoft.Boogie
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      TypecheckAttributes(Attributes, tc);
+      (this as ICarriesAttributes).TypecheckAttributes(tc);
       lhs.Typecheck(tc);
       rhs.Typecheck(tc);
       this.CheckAssignments(tc);
@@ -2869,7 +2851,7 @@ namespace Microsoft.Boogie
 
     public override void Resolve(ResolutionContext rc)
     {
-      ResolveAttributes(Attributes, rc);
+      (this as ICarriesAttributes).ResolveAttributes(rc);
       foreach (CallCmd callCmd in CallCmds)
       {
         callCmd.Resolve(rc);
@@ -2914,7 +2896,7 @@ namespace Microsoft.Boogie
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      TypecheckAttributes(Attributes, tc);
+      (this as ICarriesAttributes).TypecheckAttributes(tc);
       if (!tc.Options.DoModSetAnalysis)
       {
         if (!tc.Yields)
@@ -3145,7 +3127,7 @@ namespace Microsoft.Boogie
         return;
       }
 
-      ResolveAttributes(Attributes, rc);
+      (this as ICarriesAttributes).ResolveAttributes(rc);
       Proc = rc.LookUpProcedure(callee);
       if (Proc == null)
       {
@@ -3255,7 +3237,7 @@ namespace Microsoft.Boogie
       Contract.Assume(this.Proc !=
                       null); // we assume the CallCmd has been successfully resolved before calling this Typecheck method
 
-      TypecheckAttributes(Attributes, tc);
+      (this as ICarriesAttributes).TypecheckAttributes(tc);
 
       // typecheck in-parameters
       foreach (Expr e in Ins)
@@ -4031,14 +4013,14 @@ namespace Microsoft.Boogie
     public override void Resolve(ResolutionContext rc)
     {
       //Contract.Requires(rc != null);
-      ResolveAttributes(Attributes, rc);
+      (this as ICarriesAttributes).ResolveAttributes(rc);
       base.Resolve(rc);
     }
 
     public override void Typecheck(TypecheckingContext tc)
     {
       //Contract.Requires(tc != null);
-      TypecheckAttributes(Attributes, tc);
+      (this as ICarriesAttributes).TypecheckAttributes(tc);
       Expr.Typecheck(tc);
       Contract.Assert(Expr.Type != null); // follows from Expr.Typecheck postcondition
       if (!Expr.Type.Unify(Type.Bool))
@@ -4239,14 +4221,14 @@ namespace Microsoft.Boogie
     public override void Resolve(ResolutionContext rc)
     {
       //Contract.Requires(rc != null);
-      ResolveAttributes(Attributes, rc);
+      (this as ICarriesAttributes).ResolveAttributes(rc);
       base.Resolve(rc);
     }
 
     public override void Typecheck(TypecheckingContext tc)
     {
       //Contract.Requires(tc != null);
-      TypecheckAttributes(Attributes, tc);
+      (this as ICarriesAttributes).TypecheckAttributes(tc);
       Expr.Typecheck(tc);
       Contract.Assert(Expr.Type != null); // follows from Expr.Typecheck postcondition
       if (!Expr.Type.Unify(Type.Bool))

--- a/Source/Core/AbsyQuant.cs
+++ b/Source/Core/AbsyQuant.cs
@@ -424,6 +424,29 @@ namespace Microsoft.Boogie
         rc.Error(this, "attribute :verified_under accepts only one argument");
       }
 
+      if (Key == CivlAttributes.LAYER)
+      {
+        foreach (var o in Params)
+        {
+          if (o is LiteralExpr l && l.isBigNum)
+          {
+            var n = l.asBigNum;
+            if (n.IsNegative)
+            {
+              rc.Error(this, "layer must be non-negative");
+            }
+            else if (!n.InInt32)
+            {
+              rc.Error(this, "layer is too large (max value is Int32.MaxValue)");
+            }
+          }
+          else
+          {
+            rc.Error(this, "layer must be a non-negative integer");
+          }
+        }
+      }
+
       foreach (object p in Params)
       {
         if (p is Expr)

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -1,9 +1,67 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.Boogie
 {
+  public class LayerRange
+  {
+    public static int Min = 0;
+    public static int Max = int.MaxValue;
+    public static LayerRange MinMax = new LayerRange(Min, Max);
+
+    public int lowerLayerNum;
+    public int upperLayerNum;
+
+    public LayerRange(int layer) : this(layer, layer)
+    {
+    }
+
+    public LayerRange(int lower, int upper)
+    {
+      Debug.Assert(lower <= upper);
+      this.lowerLayerNum = lower;
+      this.upperLayerNum = upper;
+    }
+
+    public bool Contains(int layerNum)
+    {
+      return lowerLayerNum <= layerNum && layerNum <= upperLayerNum;
+    }
+
+    public bool Subset(LayerRange other)
+    {
+      return other.lowerLayerNum <= lowerLayerNum && upperLayerNum <= other.upperLayerNum;
+    }
+
+    public bool OverlapsWith(LayerRange other)
+    {
+      return lowerLayerNum <= other.upperLayerNum && other.lowerLayerNum <= upperLayerNum;
+    }
+
+    public override string ToString()
+    {
+      return $"[{lowerLayerNum}, {upperLayerNum}]";
+    }
+
+    public override bool Equals(object obj)
+    {
+      LayerRange other = obj as LayerRange;
+      if (obj == null)
+      {
+        return false;
+      }
+
+      return lowerLayerNum == other.lowerLayerNum && upperLayerNum == other.upperLayerNum;
+    }
+
+    public override int GetHashCode()
+    {
+      return (23 * 31 + lowerLayerNum) * 31 + upperLayerNum;
+    }
+  }
+
   public static class CivlAttributes
   {
     public const string LAYER = "layer";

--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -528,10 +528,10 @@ namespace Microsoft.Boogie
       var actionDeclRefsInActionDecls = newProgram.TopLevelDeclarations.OfType<ActionDecl>()
         .SelectMany(decl => decl.ActionDeclRefs());
       var actionDeclRefsInYieldProcedureDecls = newProgram.TopLevelDeclarations.OfType<YieldProcedureDecl>()
-        .Select(decl => decl.refinedAction);
+        .Select(decl => decl.RefinedAction);
       foreach (var actionDeclRef in actionDeclRefsInActionDecls.Union(actionDeclRefsInYieldProcedureDecls))
       {
-        actionDeclRef.actionDecl = (ActionDecl)OldToNewProcedureMap[actionDeclRef.actionDecl];
+        actionDeclRef.ActionDecl = (ActionDecl)OldToNewProcedureMap[actionDeclRef.ActionDecl];
       }
 
       OldToNewProcedureMap = null; // This Visitor could be used for other things later so remove the map.

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -649,21 +649,21 @@ namespace Microsoft.Boogie
 
     public virtual Procedure VisitActionDecl(ActionDecl node)
     {
-      for (int i = 0; i < node.creates.Count; i++)
+      for (int i = 0; i < node.Creates.Count; i++)
       {
-        node.creates[i] = VisitActionDeclRef(node.creates[i]);
+        node.Creates[i] = VisitActionDeclRef(node.Creates[i]);
       }
-      node.refinedAction = VisitActionDeclRef(node.refinedAction);
-      node.invariantAction = VisitActionDeclRef(node.invariantAction);
+      node.RefinedAction = VisitActionDeclRef(node.RefinedAction);
+      node.InvariantAction = VisitActionDeclRef(node.InvariantAction);
       return VisitProcedure(node);
     }
 
     public virtual Procedure VisitYieldProcedureDecl(YieldProcedureDecl node)
     {
-      node.yieldEnsures = this.VisitCallCmdSeq(node.yieldEnsures);
-      node.yieldPreserves = this.VisitCallCmdSeq(node.yieldPreserves);
-      node.yieldRequires = this.VisitCallCmdSeq(node.yieldRequires);
-      node.refinedAction = VisitActionDeclRef(node.refinedAction);
+      node.YieldEnsures = this.VisitCallCmdSeq(node.YieldEnsures);
+      node.YieldPreserves = this.VisitCallCmdSeq(node.YieldPreserves);
+      node.YieldRequires = this.VisitCallCmdSeq(node.YieldRequires);
+      node.RefinedAction = VisitActionDeclRef(node.RefinedAction);
       return VisitProcedure(node);
     }
 


### PR DESCRIPTION
The major focus of this PR is to move layer information into AST classes:
- Requires, Ensures, CallCmd, and PredicateCmd get a field called Layers of type List<int>
- GlobalVariable, Variable, and ActionDecl get a field called LayerRange of type LayerRange
- YieldProcedureDecl gets a field called Layer of type int

Additionally, a field called Impl is added to ActionDecl to point to the implementation of the action.

As a result of this movement of information, many tables in CivlTypeChecker and certain fields in the Civl core types Action and YieldingProc became redundant and were dropped.

All of the above is in preparation to move the bulk of Civl type checking together with the rest of Boogie type checking.