### PR TITLE
Further refactoring of Civl type checker

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -443,14 +443,10 @@ namespace Microsoft.Boogie
   public abstract class YieldingProc
   {
     public YieldProcedureDecl Proc;
-    public List<CallCmd> YieldRequires;
-    public List<CallCmd> YieldEnsures;
-    
-    public YieldingProc(YieldProcedureDecl proc, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures)
+
+    public YieldingProc(YieldProcedureDecl proc)
     {
       this.Proc = proc;
-      this.YieldRequires = yieldRequires;
-      this.YieldEnsures = yieldEnsures;
     }
 
     public int Layer => Proc.Layer;
@@ -464,8 +460,7 @@ namespace Microsoft.Boogie
 
   public class MoverProc : YieldingProc
   {
-    public MoverProc(YieldProcedureDecl proc, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures)
-      : base(proc, yieldRequires, yieldEnsures)
+    public MoverProc(YieldProcedureDecl proc) : base(proc)
     {
     }
 
@@ -478,8 +473,7 @@ namespace Microsoft.Boogie
   {
     public AtomicAction RefinedAction;
 
-    public ActionProc(YieldProcedureDecl proc, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures, AtomicAction refinedAction)
-      : base(proc, yieldRequires, yieldEnsures)
+    public ActionProc(YieldProcedureDecl proc, AtomicAction refinedAction) : base(proc)
     {
       this.RefinedAction = refinedAction;
     }

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -440,42 +440,6 @@ namespace Microsoft.Boogie
     }
   }
 
-  public abstract class YieldingProc
-  {
-    public YieldProcedureDecl Proc;
-
-    public YieldingProc(YieldProcedureDecl proc)
-    {
-      this.Proc = proc;
-    }
-
-    public int Layer => Proc.Layer;
-
-    public MoverType MoverType => Proc.MoverType;
-
-    public bool IsRightMover => MoverType == MoverType.Right || MoverType == MoverType.Both;
-
-    public bool IsLeftMover => MoverType == MoverType.Left || MoverType == MoverType.Both;
-    
-    public IEnumerable<Variable> ModifiedVars => Proc.ModifiedVars;
-    
-    public HashSet<Variable> HiddenFormals => Proc.HiddenFormals;
-  }
-
-  public class MoverProc : YieldingProc
-  {
-    public MoverProc(YieldProcedureDecl proc) : base(proc)
-    {
-    }
-  }
-
-  public class ActionProc : YieldingProc
-  {
-    public ActionProc(YieldProcedureDecl proc) : base(proc)
-    {
-    }
-  }
-
   /// <summary>
   /// Creates first/second copies of atomic actions used in commutativity checks
   /// (i.e., all non-global variables are prefixed with first_ resp. second_).

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -456,6 +456,10 @@ namespace Microsoft.Boogie
     public bool IsRightMover => MoverType == MoverType.Right || MoverType == MoverType.Both;
 
     public bool IsLeftMover => MoverType == MoverType.Left || MoverType == MoverType.Both;
+    
+    public IEnumerable<Variable> ModifiedVars => Proc.ModifiedVars;
+    
+    public HashSet<Variable> HiddenFormals => Proc.HiddenFormals;
   }
 
   public class MoverProc : YieldingProc
@@ -463,8 +467,6 @@ namespace Microsoft.Boogie
     public MoverProc(YieldProcedureDecl proc) : base(proc)
     {
     }
-
-    public IEnumerable<Variable> ModifiedVars => Proc.ModifiedVars;
   }
 
   public class ActionProc : YieldingProc
@@ -472,8 +474,6 @@ namespace Microsoft.Boogie
     public ActionProc(YieldProcedureDecl proc) : base(proc)
     {
     }
-
-    public HashSet<Variable> HiddenFormals => Proc.HiddenFormals;
   }
 
   /// <summary>

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.Boogie.GraphUtil;
 

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -450,8 +450,8 @@ namespace Microsoft.Boogie
     }
 
     public int Layer => Proc.Layer;
-    
-    public abstract MoverType MoverType { get; }
+
+    public MoverType MoverType => Proc.MoverType;
 
     public bool IsRightMover => MoverType == MoverType.Right || MoverType == MoverType.Both;
 
@@ -464,23 +464,16 @@ namespace Microsoft.Boogie
     {
     }
 
-    public override MoverType MoverType => Proc.MoverType;
-    
     public IEnumerable<Variable> ModifiedVars => Proc.ModifiedVars;
   }
 
   public class ActionProc : YieldingProc
   {
-    public AtomicAction RefinedAction;
-
-    public ActionProc(YieldProcedureDecl proc, AtomicAction refinedAction) : base(proc)
+    public ActionProc(YieldProcedureDecl proc) : base(proc)
     {
-      this.RefinedAction = refinedAction;
     }
 
     public HashSet<Variable> HiddenFormals => Proc.HiddenFormals;
-
-    public override MoverType MoverType => RefinedAction.ActionDecl.MoverType;
   }
 
   /// <summary>

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -487,21 +487,6 @@ namespace Microsoft.Boogie
     public HashSet<Variable> HiddenFormals => Proc.HiddenFormals;
 
     public override MoverType MoverType => RefinedAction.ActionDecl.MoverType;
-
-    public AtomicAction RefinedActionAtLayer(int layer)
-    {
-      Debug.Assert(layer >= base.Layer);
-      var action = RefinedAction;
-      while (action != null)
-      {
-        if (layer <= action.LayerRange.UpperLayer)
-        {
-          return action;
-        }
-        action = action.RefinedAction;
-      }
-      return null;
-    }
   }
 
   /// <summary>

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -464,29 +464,27 @@ namespace Microsoft.Boogie
 
   public class MoverProc : YieldingProc
   {
-    public HashSet<Variable> ModifiedGlobalVars;
-
     public MoverProc(YieldProcedureDecl proc, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures)
       : base(proc, yieldRequires, yieldEnsures)
     {
-      ModifiedGlobalVars = new HashSet<Variable>(proc.Modifies.Select(ie => ie.Decl));
     }
 
     public override MoverType MoverType => Proc.MoverType;
+    
+    public IEnumerable<Variable> ModifiedVars => Proc.ModifiedVars;
   }
 
   public class ActionProc : YieldingProc
   {
     public AtomicAction RefinedAction;
-    public HashSet<Variable> HiddenFormals;
 
-    public ActionProc(YieldProcedureDecl proc, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures,
-      AtomicAction refinedAction, HashSet<Variable> hiddenFormals)
+    public ActionProc(YieldProcedureDecl proc, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures, AtomicAction refinedAction)
       : base(proc, yieldRequires, yieldEnsures)
     {
       this.RefinedAction = refinedAction;
-      this.HiddenFormals = hiddenFormals;
     }
+
+    public HashSet<Variable> HiddenFormals => Proc.HiddenFormals;
 
     public override MoverType MoverType => RefinedAction.ActionDecl.MoverType;
 

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Boogie
     
     public LayerRange LayerRange => ActionDecl.LayerRange;
 
-    public int LowerLayer => LayerRange.lowerLayerNum;
+    public int LowerLayer => LayerRange.LowerLayer;
 
     public bool HasPendingAsyncs => PendingAsyncs.Count > 0;
 
@@ -480,8 +480,8 @@ namespace Microsoft.Boogie
     public AtomicAction RefinedAction;
     public HashSet<Variable> HiddenFormals;
 
-    public ActionProc(YieldProcedureDecl proc, AtomicAction refinedAction, HashSet<Variable> hiddenFormals,
-      List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures)
+    public ActionProc(YieldProcedureDecl proc, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures,
+      AtomicAction refinedAction, HashSet<Variable> hiddenFormals)
       : base(proc, yieldRequires, yieldEnsures)
     {
       this.RefinedAction = refinedAction;
@@ -496,7 +496,7 @@ namespace Microsoft.Boogie
       var action = RefinedAction;
       while (action != null)
       {
-        if (layer <= action.LayerRange.upperLayerNum)
+        if (layer <= action.LayerRange.UpperLayer)
         {
           return action;
         }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Diagnostics;
 using Microsoft.Boogie.GraphUtil;
 
 namespace Microsoft.Boogie
@@ -11,28 +10,20 @@ namespace Microsoft.Boogie
     public ConcurrencyOptions Options { get; }
     public CheckingContext checkingContext;
     public Program program;
-
-    // Don't access directly!
-    // Use public access methods.
-    private string namePrefix;
+    public LinearTypeChecker linearTypeChecker;
+    public List<int> allRefinementLayers;
+    public AtomicAction SkipAtomicAction;
 
     public Dictionary<Block, YieldingLoop> yieldingLoops;
-
     public Dictionary<ActionDecl, AtomicAction> procToAtomicAction;
     private Dictionary<ActionDecl, InvariantAction> procToInvariantAction;
     public Dictionary<Procedure, YieldingProc> procToYieldingProc;
-
     public List<InductiveSequentialization> inductiveSequentializations;
-
     public Dictionary<Implementation, Dictionary<CtorType, Variable>> implToPendingAsyncCollector;
     
-    // These collections are for convenience in later phases and are only initialized at the end of type checking.
-    public List<int> allRefinementLayers;
-    public IEnumerable<Variable> GlobalVariables => program.GlobalVariables;
-    
-    public LinearTypeChecker linearTypeChecker;
+    private string namePrefix;
 
-    public AtomicAction SkipAtomicAction;
+    public IEnumerable<Variable> GlobalVariables => program.GlobalVariables;
 
     public CivlTypeChecker(ConcurrencyOptions options, Program program)
     {
@@ -40,6 +31,10 @@ namespace Microsoft.Boogie
       this.program = program;
       this.Options = options;
       this.linearTypeChecker = new LinearTypeChecker(this);
+      this.allRefinementLayers = program.TopLevelDeclarations.OfType<Implementation>()
+        .Where(impl => impl.Proc is YieldProcedureDecl)
+        .Select(decl => ((YieldProcedureDecl)decl.Proc).Layer)
+        .OrderBy(layer => layer).Distinct().ToList();
 
       this.yieldingLoops = new Dictionary<Block, YieldingLoop>();
       this.procToAtomicAction = new Dictionary<ActionDecl, AtomicAction>();
@@ -65,13 +60,14 @@ namespace Microsoft.Boogie
       var skipProcedure = new ActionDecl(Token.NoToken, AddNamePrefix("Skip"), MoverType.Both, ActionQualifier.None,
         new List<Variable>(), new List<Variable>(), new List<ActionDeclRef>(), null, null, new List<ElimDecl>(),
         new List<IdentifierExpr>(), null, null);
-      skipProcedure.LayerRange = LayerRange.MinMax;
       var skipImplementation = DeclHelper.Implementation(
         skipProcedure,
         new List<Variable>(),
         new List<Variable>(),
         new List<Variable>(),
         new List<Block> { BlockHelper.Block("init", new List<Cmd>()) });
+      skipProcedure.LayerRange = LayerRange.MinMax;
+      skipProcedure.Impl = skipImplementation;
       SkipAtomicAction = new AtomicAction(skipImplementation, null, this);
       SkipAtomicAction.CompleteInitialization(this);
     }
@@ -122,7 +118,6 @@ namespace Microsoft.Boogie
         return;
       }
       
-      TypeCheckYieldInvariants();
       TypeCheckActions();
       if (checkingContext.ErrorCount > 0)
       {
@@ -136,7 +131,6 @@ namespace Microsoft.Boogie
         return;
       }
       
-      TypeCheckYieldingProcedureImpls();
       TypeCheckLoopAnnotations();
       if (checkingContext.ErrorCount > 0)
       {
@@ -155,32 +149,24 @@ namespace Microsoft.Boogie
 
     private void TypeCheckRefinementLayers()
     {
-      // List of all layers where refinement happens
-      var yieldingProcsWithImpls = procToYieldingProc.Keys.Intersect(program.Implementations.Select(i => i.Proc));
-      allRefinementLayers = yieldingProcsWithImpls.Select(p => procToYieldingProc[p].Layer).OrderBy(l => l)
-        .Distinct().ToList();
-
       var allInductiveSequentializationLayers =
         inductiveSequentializations.Select(x => x.invariantAction.LayerRange.UpperLayer).ToList();
-
       var intersect = allRefinementLayers.Intersect(allInductiveSequentializationLayers).ToList();
       if (intersect.Any())
       {
         checkingContext.Error(Token.NoToken,
-          "The following layers mix refinement with IS: " + string.Join(",", intersect));
+          $"procedure refinement and action refinement layers must be disjoint but the following layers mix the two: {string.Join(",", intersect)}");
       }
-
       foreach (var g in GlobalVariables)
       {
         var layerRange = g.LayerRange;
         if (allInductiveSequentializationLayers.Contains(layerRange.LowerLayer))
         {
-          Error(g, $"Global variable {g.Name} cannot be introduced at layer with IS");
+          Error(g, $"global variable {g.Name} cannot be introduced at action refinement layer");
         }
-
         if (allInductiveSequentializationLayers.Contains(layerRange.UpperLayer))
         {
-          Error(g, $"Global variable {g.Name} cannot be hidden at layer with IS");
+          Error(g, $"global variable {g.Name} cannot be hidden at action refinement layer");
         }
       }
     }
@@ -201,28 +187,23 @@ namespace Microsoft.Boogie
 
     private void TypeCheckActions()
     {
-      var actionProcs = program.Procedures.OfType<ActionDecl>().ToHashSet();
-
-      // type check action refinements
-      actionProcs.Where(proc => proc.RefinedAction != null).Iter(proc =>
+      var actionDecls = program.Procedures.OfType<ActionDecl>().ToHashSet();
+      var callGraph = new Graph<Procedure>();
+      foreach (var actionDecl in actionDecls)
       {
-        TypeCheckActionRefinement(proc);
-      });
-      if (checkingContext.ErrorCount > 0)
-      {
-        return;
+        foreach (var block in actionDecl.Impl.Blocks)
+        {
+          foreach (var callCmd in block.Cmds.OfType<CallCmd>())
+          {
+            callGraph.AddEdge(actionDecl, callCmd.Proc);
+          }
+        }
       }
-      
-      // Type check action bodies
-      var actionImplVisitor = new ActionImplVisitor(this);
-      foreach (var proc in actionProcs)
+      if (!Graph<Procedure>.Acyclic(callGraph))
       {
-        actionImplVisitor.VisitImplementation(proc.Impl);
+        Error(program, "call graph over atomic actions must be acyclic");
       }
-      if (!actionImplVisitor.IsCallGraphAcyclic())
-      {
-        Error(program, "Call graph over atomic actions must be acyclic");
-      }
+      actionDecls.Where(proc => proc.RefinedAction != null).Iter(TypeCheckActionRefinement);
       if (checkingContext.ErrorCount > 0)
       {
         return;
@@ -235,10 +216,10 @@ namespace Microsoft.Boogie
       // Fourth, construct the transition and input-output relation for all actions.
       
       // Initialize ActionDecls
-      actionProcs.Iter(proc => proc.Initialize(program.monomorphizer));
+      actionDecls.Iter(proc => proc.Initialize(program.monomorphizer));
       
       // Create all actions
-      foreach (var proc in actionProcs.Where(proc => proc.RefinedAction == null))
+      foreach (var proc in actionDecls.Where(proc => proc.RefinedAction == null))
       {
         // In this loop, we create all link, invariant, and abstraction actions,
         // but only those atomic actions (pending async or otherwise) that do not refine
@@ -268,29 +249,29 @@ namespace Microsoft.Boogie
       // Now we create all atomic actions that refine other actions via an inductive sequentialization.
       // Earlier type checking guarantees that each such action is not a pending async action.
       // Therefore, only the type AtomicAction will be created now.
-      actionProcs.Where(proc => proc.RefinedAction != null).Iter(proc =>
+      actionDecls.Where(proc => proc.RefinedAction != null).Iter(proc =>
       {
         CreateActionsThatRefineAnotherAction(proc);
       });
 
       // Inline atomic actions
       CivlUtil.AddInlineAttribute(SkipAtomicAction.ActionDecl);
-      actionProcs.Iter(proc =>
+      actionDecls.Iter(proc =>
       {
         CivlAttributes.RemoveAttributes(proc, new HashSet<string> { "inline" });
         CivlUtil.AddInlineAttribute(proc);
       });
-      actionProcs.Iter(proc =>
+      actionDecls.Iter(proc =>
       {
         var impl = proc.Impl;
         impl.OriginalBlocks = impl.Blocks;
         impl.OriginalLocVars = impl.LocVars;
       });
-      actionProcs.Iter(proc =>
+      actionDecls.Iter(proc =>
       {
         Inliner.ProcessImplementation(Options, program, proc.Impl);
       });
-      actionProcs.Iter(proc =>
+      actionDecls.Iter(proc =>
       {
         var impl = proc.Impl;
         impl.OriginalBlocks = null;
@@ -308,7 +289,7 @@ namespace Microsoft.Boogie
       });
       
       // Construct inductive sequentializations
-      actionProcs.Where(proc => proc.RefinedAction != null).Iter(proc =>
+      actionDecls.Where(proc => proc.RefinedAction != null).Iter(proc =>
       {
         var action = procToAtomicAction[proc];
         var invariantProc = proc.InvariantAction.ActionDecl;
@@ -331,55 +312,7 @@ namespace Microsoft.Boogie
       Implementation impl = proc.Impl;
       procToAtomicAction[proc] = new AtomicAction(impl, refinedAction, this);
     }
-
-    private void TypeCheckYieldInvariants()
-    {
-      foreach (var yieldInvariant in program.TopLevelDeclarations.OfType<YieldInvariantDecl>())
-      {
-        var visitor = new YieldInvariantVisitor(this, yieldInvariant.Layer);
-        visitor.VisitProcedure(yieldInvariant);
-        foreach (var param in yieldInvariant.InParams)
-        {
-          var linearKind = LinearDomainCollector.FindLinearKind(param);
-          if (linearKind == LinearKind.LINEAR_IN || linearKind == LinearKind.LINEAR_OUT)
-          {
-            Error(param, "parameter to yield invariant may only be :linear");
-          }
-        }
-      }
-    }
-
-    private void TypeCheckYieldingPrePostDecls(YieldProcedureDecl proc, out List<CallCmd> yieldRequires, out List<CallCmd> yieldEnsures)
-    {
-      yieldRequires = new List<CallCmd>();
-      yieldEnsures = new List<CallCmd>();
-      
-      foreach (var callCmd in proc.YieldRequires)
-      {
-        if (YieldInvariantCallChecker.CheckRequires(this, callCmd, proc))
-        {
-          yieldRequires.Add(StripOld(callCmd));
-        }
-      }
-
-      foreach (var callCmd in proc.YieldEnsures)
-      {
-        if (YieldInvariantCallChecker.CheckEnsures(this, callCmd, proc))
-        {
-          yieldEnsures.Add(callCmd);
-        }
-      }
-
-      foreach (var callCmd in proc.YieldPreserves)
-      {
-        if (YieldInvariantCallChecker.CheckPreserves(this, callCmd, proc))
-        {
-          yieldRequires.Add(StripOld(callCmd));
-          yieldEnsures.Add(callCmd);
-        }
-      }
-    }
-
+    
     private static T StripOld<T>(T cmd) where T : Cmd
     {
       var emptySubst = Substituter.SubstitutionFromDictionary(new Dictionary<Variable, Expr>());
@@ -390,34 +323,31 @@ namespace Microsoft.Boogie
     {
       foreach (var proc in program.Procedures.OfType<YieldProcedureDecl>())
       {
-        TypeCheckYieldingPrePostDecls(proc, out var yieldRequires, out var yieldEnsures);
-
+        var yieldRequires = new List<CallCmd>();
+        var yieldEnsures = new List<CallCmd>();
+        foreach (var callCmd in proc.YieldRequires)
+        {
+          yieldRequires.Add(StripOld(callCmd));
+        }
+        foreach (var callCmd in proc.YieldEnsures)
+        {
+          yieldEnsures.Add(callCmd);
+        }
+        foreach (var callCmd in proc.YieldPreserves)
+        {
+          yieldRequires.Add(StripOld(callCmd));
+          yieldEnsures.Add(callCmd);
+        }
+        
         if (proc.RefinedAction != null) // proc is an action procedure
         {
           AtomicAction refinedAction = procToAtomicAction[proc.RefinedAction.ActionDecl];
-          if (!refinedAction.LayerRange.Contains(proc.Layer + 1))
-          {
-            Error(proc, $"refined atomic action must be available at layer {proc.Layer + 1}");
-            continue;
-          }
-          var hiddenFormals =
-            new HashSet<Variable>(proc.InParams.Concat(proc.OutParams).Where(x => x.HasAttribute(CivlAttributes.HIDE)));
-          if (hiddenFormals.Any(x => x.LayerRange.UpperLayer < proc.Layer))
-          {
-            Error(proc, $"all hidden variables must be available at layer {proc.Layer}");
-            continue;
-          }
-          var actionProc = new ActionProc(proc, yieldRequires, yieldEnsures, refinedAction, hiddenFormals);
+          var actionProc = new ActionProc(proc, yieldRequires, yieldEnsures, refinedAction);
           CheckRefinementSignature(actionProc);
           procToYieldingProc[proc] = actionProc;
         }
         else if (proc.MoverType != MoverType.None) // proc is a mover procedure
         {
-          if (!proc.Modifies.All(ie => ie.Decl.LayerRange.Contains(proc.Layer)))
-          {
-            Error(proc, $"all modified variables of a mover procedure must be available at layer {proc.Layer}");
-            continue;
-          }
           procToYieldingProc[proc] = new MoverProc(proc, yieldRequires, yieldEnsures);
         }
         else // proc refines the skip action
@@ -426,14 +356,9 @@ namespace Microsoft.Boogie
           {
             procToAtomicAction[SkipAtomicAction.ActionDecl] = SkipAtomicAction;
           }
-          var hiddenFormals = new HashSet<Variable>(proc.InParams.Concat(proc.OutParams)
-            .Where(x => x.LayerRange.UpperLayer == proc.Layer));
-          var actionProc = new ActionProc(proc, yieldRequires, yieldEnsures, SkipAtomicAction, hiddenFormals);
+          var actionProc = new ActionProc(proc, yieldRequires, yieldEnsures, SkipAtomicAction);
           procToYieldingProc[proc] = actionProc;
         }
-
-        YieldingProcVisitor visitor = new YieldingProcVisitor(this, yieldRequires, yieldEnsures);
-        visitor.VisitProcedure(proc);
       }
 
       if (procToAtomicAction.ContainsKey(SkipAtomicAction.ActionDecl))
@@ -442,16 +367,7 @@ namespace Microsoft.Boogie
         program.AddTopLevelDeclaration(SkipAtomicAction.Impl);
       }
     }
-
-    private void TypeCheckYieldingProcedureImpls()
-    {
-      foreach (var impl in program.Implementations.Where(impl => procToYieldingProc.ContainsKey(impl.Proc)))
-      {
-        YieldingProcVisitor visitor = new YieldingProcVisitor(this);
-        visitor.VisitImplementation(impl);
-      }
-    }
-
+    
     private void TypeCheckLoopAnnotations()
     {
       foreach (var impl in program.Implementations.Where(impl => procToYieldingProc.ContainsKey(impl.Proc)))
@@ -495,7 +411,10 @@ namespace Microsoft.Boogie
           {
             Error(header, "expected :yields attribute on this loop");
           }
-          foreach (var callCmd in yieldInvariants.Where(callCmd => YieldInvariantCallChecker.CheckLoop(this, callCmd, header)))
+
+          var availableLinearVarsAtHeader = new HashSet<Variable>(linearTypeChecker.AvailableLinearVars(header));
+          foreach (var callCmd in yieldInvariants.Where(callCmd =>
+                     linearTypeChecker.CheckLinearParameters(callCmd, availableLinearVarsAtHeader) == 0))
           {
             var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
             var calleeLayerNum = yieldInvariant.Layer;
@@ -504,6 +423,7 @@ namespace Microsoft.Boogie
               Error(callCmd, $"loop must yield at layer {calleeLayerNum} of the called yield invariant");
             }
           }
+
           yieldingLoops[header] = new YieldingLoop(yieldingLayer, yieldInvariants);
 
           foreach (PredicateCmd predCmd in header.Cmds.TakeWhile(cmd => cmd is PredicateCmd))
@@ -519,7 +439,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public class SignatureMatcher
+    private class SignatureMatcher
     {
       public static string IN = "in";
       public static string OUT = "out";
@@ -666,769 +586,7 @@ namespace Microsoft.Boogie
       checkingContext.Error(node, message);
     }
 
-    public bool Require(bool condition, Absy node, string message)
-    {
-      if (!condition)
-      {
-        Error(node, message);
-      }
-
-      return condition;
-    }
-
     #endregion
-
-    private class ActionImplVisitor : ReadOnlyVisitor
-    {
-      private CivlTypeChecker civlTypeChecker;
-      private Graph<Procedure> callGraph;
-      private ActionDecl proc;
-
-      public ActionImplVisitor(CivlTypeChecker civlTypeChecker)
-      {
-        this.civlTypeChecker = civlTypeChecker;
-        this.callGraph = new Graph<Procedure>();
-      }
-
-      public override Procedure VisitProcedure(Procedure node)
-      {
-        // This visitor only has to check the body of action specifications
-        return node;
-      }
-
-      public override Implementation VisitImplementation(Implementation node)
-      {
-        this.proc = (ActionDecl)node.Proc;
-        return base.VisitImplementation(node);
-      }
-      
-      public override Expr VisitIdentifierExpr(IdentifierExpr node)
-      {
-        var layerRange = proc.LayerRange;
-        if (node.Decl is GlobalVariable)
-        {
-          var globalVarLayerRange = node.Decl.LayerRange;
-          if (!layerRange.Subset(globalVarLayerRange) ||
-              globalVarLayerRange.LowerLayer == layerRange.LowerLayer && proc.ActionQualifier != ActionQualifier.Link)
-            // a global variable introduced at layer n is visible to an atomic action only at layer n+1 or higher
-            // thus, a global variable with layer range [n,n] is not accessible by an atomic action
-            // however, a link action may access the global variable at layer n
-          {
-            civlTypeChecker.checkingContext.Error(node, "Global variable {0} is not available in action specification",
-              node.Decl.Name);
-          }
-        }
-        return base.VisitIdentifierExpr(node);
-      }
-
-      public override Cmd VisitCallCmd(CallCmd node)
-      {
-        callGraph.AddEdge(proc, node.Proc);
-        return base.VisitCallCmd(node);
-      }
-
-      public bool IsCallGraphAcyclic()
-      {
-        return Graph<Procedure>.Acyclic(callGraph);
-      }
-    }
-
-    private class YieldInvariantVisitor : ReadOnlyVisitor
-    {
-      private CivlTypeChecker civlTypeChecker;
-      private int layerNum;
-
-      public YieldInvariantVisitor(CivlTypeChecker civlTypeChecker, int layerNum)
-      {
-        this.civlTypeChecker = civlTypeChecker;
-        this.layerNum = layerNum;
-      }
-
-      public override Procedure VisitProcedure(Procedure node)
-      {
-        base.VisitRequiresSeq(node.Requires);
-        return node;
-      }
-
-      public override Expr VisitIdentifierExpr(IdentifierExpr node)
-      {
-        if (node.Decl is GlobalVariable)
-        {
-          civlTypeChecker.Require(node.Decl.LayerRange.Contains(layerNum),
-            node, $"Global variable not available at layer {layerNum}");
-        }
-
-        return base.VisitIdentifierExpr(node);
-      }
-    }
-
-    class YieldInvariantCallChecker : ReadOnlyVisitor
-    {
-      private CivlTypeChecker civlTypeChecker;
-      private int insideOldExpr;
-      private int initialErrorCount;
-      private CallCmd callCmd;
-      private ISet<Variable> availableLinearVars;
-
-      private bool ShouldAbort => civlTypeChecker.checkingContext.ErrorCount != initialErrorCount;
-
-      static List<LinearKind> RequiresAvailable = new List<LinearKind> { LinearKind.LINEAR, LinearKind.LINEAR_IN };
-      static List<LinearKind> EnsuresAvailable = new List<LinearKind> { LinearKind.LINEAR, LinearKind.LINEAR_OUT };
-      static List<LinearKind> PreservesAvailable = new List<LinearKind> { LinearKind.LINEAR };
-
-      private ConcurrencyOptions Options => civlTypeChecker.Options;
-
-      public static bool CheckRequires(CivlTypeChecker civlTypeChecker, CallCmd callCmd, Procedure caller)
-      {
-        var v = new YieldInvariantCallChecker(civlTypeChecker, callCmd, caller, RequiresAvailable);
-        return !v.ShouldAbort;
-      }
-
-      public static bool CheckEnsures(CivlTypeChecker civlTypeChecker, CallCmd callCmd, Procedure caller)
-      {
-        var v = new YieldInvariantCallChecker(civlTypeChecker, callCmd, caller, EnsuresAvailable);
-        return !v.ShouldAbort;
-      }
-
-      public static bool CheckPreserves(CivlTypeChecker civlTypeChecker, CallCmd callCmd, Procedure caller)
-      {
-        var v = new YieldInvariantCallChecker(civlTypeChecker, callCmd, caller, PreservesAvailable);
-        return !v.ShouldAbort;
-      }
-
-      public static bool CheckLoop(CivlTypeChecker civlTypeChecker, CallCmd callCmd, Block loopHeader)
-      {
-        var availableLinearVars = civlTypeChecker.linearTypeChecker.AvailableLinearVars(loopHeader);
-        var v = new YieldInvariantCallChecker(civlTypeChecker, callCmd, availableLinearVars);
-        return !v.ShouldAbort;
-      }
-
-      private YieldInvariantCallChecker(CivlTypeChecker civlTypeChecker, CallCmd callCmd, ISet<Variable> availableLinearVars)
-      {
-        this.civlTypeChecker = civlTypeChecker;
-        this.callCmd = callCmd;
-        this.availableLinearVars = availableLinearVars;
-        this.insideOldExpr = 0;
-        this.initialErrorCount = civlTypeChecker.checkingContext.ErrorCount;
-        Check();
-      }
-
-      private YieldInvariantCallChecker(CivlTypeChecker civlTypeChecker, CallCmd callCmd, Procedure caller, List<LinearKind> kinds)
-        : this(civlTypeChecker, callCmd,
-            new HashSet<Variable>(
-              caller.InParams.Union(caller.OutParams).Where(p => kinds.Contains(LinearDomainCollector.FindLinearKind(p)))
-            )
-          ) {}
-
-      private void Check()
-      {
-        civlTypeChecker.linearTypeChecker.VisitCallCmd(callCmd);
-        if (ShouldAbort) { return; }
-        Visit(callCmd);
-        if (ShouldAbort) { return; }
-        CheckLinearParameters();
-      }
-
-      public override Expr VisitOldExpr(OldExpr node)
-      {
-        insideOldExpr++;
-        base.VisitOldExpr(node);
-        insideOldExpr--;
-        return node;
-      }
-
-      public override Expr VisitIdentifierExpr(IdentifierExpr node)
-      {
-        if (node.Decl is GlobalVariable && insideOldExpr == 0)
-        {
-          civlTypeChecker.Error(node, "global variable must be accessed inside old expression");
-        }
-
-        return node;
-      }
-
-      private void CheckLinearParameters()
-      {
-        foreach (var (actual, formal) in callCmd.Ins.Zip(callCmd.Proc.InParams))
-        {
-          if (LinearDomainCollector.FindLinearKind(formal) != LinearKind.ORDINARY)
-          {
-            var decl = ((IdentifierExpr) actual).Decl;
-            if (!availableLinearVars.Contains(decl))
-            {
-              civlTypeChecker.Error(actual, "argument must be available");
-            }
-          }
-        }
-      }
-    }
-
-    private class YieldingProcVisitor : ReadOnlyVisitor
-    {
-      CivlTypeChecker civlTypeChecker;
-      List<CallCmd> yieldRequires;
-      List<CallCmd> yieldEnsures;
-      YieldingProc yieldingProc;
-      List<IdentifierExpr> globalVariableAccesses;
-      List<IdentifierExpr> localVariableAccesses;
-
-      public YieldingProcVisitor(CivlTypeChecker civlTypeChecker)
-      {
-        this.civlTypeChecker = civlTypeChecker;
-        this.yieldRequires = null;
-        this.yieldEnsures = null;
-        this.yieldingProc = null;
-        this.globalVariableAccesses = null;
-        this.localVariableAccesses = null;
-      }
-
-      public YieldingProcVisitor(CivlTypeChecker civlTypeChecker, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures)
-      {
-        this.civlTypeChecker = civlTypeChecker;
-        this.yieldRequires = yieldRequires;
-        this.yieldEnsures = yieldEnsures;
-        this.yieldingProc = null;
-        this.globalVariableAccesses = null;
-        this.localVariableAccesses = null;
-      }
-
-      public override Implementation VisitImplementation(Implementation node)
-      {
-        Debug.Assert(yieldingProc == null);
-        yieldingProc = civlTypeChecker.procToYieldingProc[node.Proc];
-        var ret = base.VisitImplementation(node);
-        if (civlTypeChecker.checkingContext.ErrorCount == 0)
-        {
-          CheckMoverProcModifiesClause(node);
-        }
-
-        yieldingProc = null;
-        return ret;
-      }
-
-      public override Procedure VisitProcedure(Procedure node)
-      {
-        if (yieldingProc != null)
-        {
-          // We don't want to descend from an implementation into the corresponding procedure,
-          // otherwise the procedure would be visited twice, causing duplicate error messages.
-          return node;
-        }
-
-        yieldingProc = civlTypeChecker.procToYieldingProc[node];
-
-        // Visit procedure except for modifies clause
-        VisitEnsuresSeq(node.Ensures);
-        VisitVariableSeq(node.InParams);
-        VisitVariableSeq(node.OutParams);
-        VisitRequiresSeq(node.Requires);
-        foreach (var callCmd in yieldRequires)
-        {
-          VisitYieldInvariantCallCmd(callCmd, yieldingProc.Layer, ((YieldInvariantDecl)callCmd.Proc).Layer);
-        }
-        foreach (var callCmd in yieldEnsures)
-        {
-          VisitYieldInvariantCallCmd(callCmd, yieldingProc.Layer, ((YieldInvariantDecl)callCmd.Proc).Layer);
-        }
-
-        yieldingProc = null;
-        return node;
-      }
-
-      public override Expr VisitIdentifierExpr(IdentifierExpr node)
-      {
-        if (node.Decl is GlobalVariable)
-        {
-          if (globalVariableAccesses != null)
-          {
-            globalVariableAccesses.Add(node);
-          }
-          else
-          {
-            civlTypeChecker.Error(node, "Global variables cannot be accessed in this context");
-          }
-        }
-        else if (node.Decl is Formal || node.Decl is LocalVariable)
-        {
-          if (localVariableAccesses != null)
-          {
-            localVariableAccesses.Add(node);
-          }
-        }
-
-        return base.VisitIdentifierExpr(node);
-      }
-
-      // All preconditions, postconditions, and assertions are treated similarly:
-      // * VisitSpecPre activates collection of accessed global and local variables
-      // * Call to base visitor actually does the collection
-      // * VisitSpecPost checks the consistency of layer annotations
-
-      public override Ensures VisitEnsures(Ensures ensures)
-      {
-        VisitSpecPre();
-        base.VisitEnsures(ensures);
-        VisitSpecPost(ensures);
-        if (!(yieldingProc is MoverProc && ensures.Layers.All(x => x == yieldingProc.Layer)))
-        {
-          CheckAccessToGlobalVariables(ensures);
-        }
-        return ensures;
-      }
-
-      public override Requires VisitRequires(Requires requires)
-      {
-        VisitSpecPre();
-        base.VisitRequires(requires);
-        VisitSpecPost(requires);
-        if (!(yieldingProc is MoverProc && requires.Layers.All(x => x == yieldingProc.Layer)))
-        {
-          CheckAccessToGlobalVariables(requires);
-        }
-        return requires;
-      }
-
-      private void CheckAccessToGlobalVariables(Absy absy)
-      {
-        if (VariableCollector.Collect(absy, true).OfType<GlobalVariable>().Any())
-        {
-          civlTypeChecker.Error(absy,
-            "specification may not access a global variable since one of its layers is a yielding layer of its procedure");
-        }
-      }
-
-      public override Cmd VisitAssertCmd(AssertCmd assert)
-      {
-        VisitSpecPre();
-        base.VisitAssertCmd(assert);
-        VisitSpecPost(assert);
-        return assert;
-      }
-
-      public override Cmd VisitAssumeCmd(AssumeCmd node)
-      {
-        localVariableAccesses = new List<IdentifierExpr>();
-        var cmd = base.VisitAssumeCmd(node);
-        var fullLayerRange = new LayerRange(LayerRange.Min, yieldingProc.Layer);
-        if (!localVariableAccesses.TrueForAll(x => x.Decl.LayerRange.Equals(fullLayerRange)))
-        {
-          civlTypeChecker.checkingContext.Error(node,
-            "Local variables accessed in assume command must be available at all layers where the enclosing procedure exists");
-        }
-
-        localVariableAccesses = null;
-        return cmd;
-      }
-
-      public override Cmd VisitAssignCmd(AssignCmd node)
-      {
-        var cmd = base.VisitAssignCmd(node);
-        for (int i = 0; i < node.Lhss.Count; i++)
-        {
-          var lhs = node.Lhss[i].DeepAssignedVariable;
-          if (lhs is LocalVariable lhsLocalVariable)
-          {
-            var lhsLayerRange = lhsLocalVariable.LayerRange;
-            localVariableAccesses = new List<IdentifierExpr>();
-            base.Visit(node.Rhss[i]);
-            if (!localVariableAccesses.TrueForAll(x => lhsLayerRange.Subset(x.Decl.LayerRange)))
-            {
-              civlTypeChecker.checkingContext.Error(node,
-                $"Variables accessed in the source of assignment to {lhs} must exist at all layers where {lhs} exists");
-            }
-            localVariableAccesses = null;
-          }
-        }
-        return cmd;
-      }
-
-      public override Cmd VisitUnpackCmd(UnpackCmd node)
-      {
-        var cmd = base.VisitUnpackCmd(node);
-        localVariableAccesses = new List<IdentifierExpr>();
-        base.Visit(node.Rhs);
-        node.UnpackedLhs.Select(ie => ie.Decl).OfType<LocalVariable>().Iter(lhs =>
-        {
-          var lhsLayerRange = lhs.LayerRange;
-          if (!localVariableAccesses.TrueForAll(x => lhsLayerRange.Subset(x.Decl.LayerRange)))
-          {
-            civlTypeChecker.checkingContext.Error(node,
-              $"Variables accessed in the unpacked expression must exist at all layers where {lhs} exists");
-          }
-        });
-        localVariableAccesses = null;
-        return cmd;
-      }
-      
-      public void VisitSpecPre()
-      {
-        globalVariableAccesses = new List<IdentifierExpr>();
-        localVariableAccesses = new List<IdentifierExpr>();
-      }
-
-      public void VisitSpecPost<T>(T node)
-        where T : Absy, ICarriesAttributes
-      {
-        if (node.HasAttribute(CivlAttributes.YIELDS))
-        {
-          return;
-        }
-        var specLayers = node.FindLayers();
-        if (specLayers.Count == 0)
-        {
-          civlTypeChecker.Error(node, "Specification layer(s) not present");
-          return;
-        }
-
-        foreach (var layer in specLayers)
-        {
-          if (layer > yieldingProc.Layer)
-          {
-            civlTypeChecker.checkingContext.Error(node,
-              "Specification layer {0} is greater than enclosing procedure layer {1}", layer, yieldingProc.Layer);
-          }
-
-          foreach (var ie in globalVariableAccesses)
-          {
-            if (!ie.Decl.LayerRange.Contains(layer))
-            {
-              civlTypeChecker.checkingContext.Error(ie, "Global variable {0} is not available at layer {1}", ie.Name,
-                layer);
-            }
-          }
-
-          foreach (var ie in localVariableAccesses)
-          {
-            if (!ie.Decl.LayerRange.Contains(layer))
-            {
-              civlTypeChecker.checkingContext.Error(ie, "Local variable {0} is not available at layer {1}", ie.Name,
-                layer);
-            }
-          }
-        }
-
-        globalVariableAccesses = null;
-        localVariableAccesses = null;
-      }
-
-      public override Cmd VisitParCallCmd(ParCallCmd node)
-      {
-        Require(node.CallCmds.Count(CivlAttributes.IsCallMarked) <= 1, node,
-          "At most one arm of a parallel call can refine the specification action");
-        
-        HashSet<Variable> parallelCallInvars = new HashSet<Variable>();
-        foreach (CallCmd callCmd in node.CallCmds.Where(callCmd => callCmd.Proc is not YieldInvariantDecl))
-        {
-          for (int i = 0; i < callCmd.Proc.InParams.Count; i++)
-          {
-            if (LinearDomainCollector.FindLinearKind(callCmd.Proc.InParams[i]) == LinearKind.ORDINARY)
-            {
-              continue;
-            }
-            IdentifierExpr actual = callCmd.Ins[i] as IdentifierExpr;
-            if (parallelCallInvars.Contains(actual.Decl))
-            {
-              civlTypeChecker.Error(node,
-                $"Linear variable {actual.Decl.Name} can occur only once as an input parameter of a parallel call");
-            }
-            else
-            {
-              parallelCallInvars.Add(actual.Decl);
-            }
-          }
-        }
-
-        foreach (CallCmd callCmd in node.CallCmds.Where(callCmd => callCmd.Proc is YieldInvariantDecl))
-        {
-          for (int i = 0; i < callCmd.Proc.InParams.Count; i++)
-          {
-            if (LinearDomainCollector.FindLinearKind(callCmd.Proc.InParams[i]) == LinearKind.ORDINARY)
-            {
-              continue;
-            }
-            IdentifierExpr actual = callCmd.Ins[i] as IdentifierExpr;
-            if (parallelCallInvars.Contains(actual.Decl))
-            {
-              civlTypeChecker.Error(node,
-                $"Linear variable {actual.Decl.Name} cannot be an input parameter to both a yield invariant and a procedure in a parallel call");
-            }
-          }
-        }
-        
-        return base.VisitParCallCmd(node);
-      }
-
-      public override Cmd VisitCallCmd(CallCmd call)
-      {
-        YieldingProc callerProc = yieldingProc;
-
-        if (call.Proc is YieldProcedureDecl)
-        {
-          VisitYieldingProcCallCmd(call, callerProc, civlTypeChecker.procToYieldingProc[call.Proc]);
-        }
-        else if (call.Proc is YieldInvariantDecl yieldInvariant)
-        {
-          VisitYieldInvariantCallCmd(call, callerProc.Layer, yieldInvariant.Layer);
-        }
-        else if (call.Proc.IsPure)
-        {
-          VisitPureProcCallCmd(call, callerProc.Layer);
-        }
-        else if (call.Proc is ActionDecl { ActionQualifier: ActionQualifier.Link } actionDecl)
-        {
-          VisitLinkActionCallCmd(call, callerProc.Layer, civlTypeChecker.procToAtomicAction[actionDecl]);
-        }
-        else
-        {
-          Debug.Assert(false);
-        }
-        return call;
-      }
-
-      private bool Require(bool condition, Absy absy, string errorMessage)
-      {
-        return civlTypeChecker.Require(condition, absy, errorMessage);
-      }
-
-      private void VisitYieldingProcCallCmd(CallCmd call, YieldingProc callerProc, YieldingProc calleeProc)
-      {
-        if (callerProc.Layer < calleeProc.Layer)
-        {
-          civlTypeChecker.Error(call, "layer of callee must be no more than layer of caller");
-          return;
-        }
-
-        if (calleeProc is ActionProc calleeActionProc)
-        {
-          if (call.IsAsync)
-          {
-            if (call.HasAttribute(CivlAttributes.SYNC))
-            {
-              Require(callerProc.Layer > calleeProc.Layer, call,
-                "layer of callee in synchronized call must be less than layer of caller");
-              Require(calleeProc.IsLeftMover, call, "callee in synchronized call must be a left mover");
-            }
-            else
-            {
-              Require(callerProc is ActionProc, call, "caller must not be a mover procedure");
-              var highestRefinedAction = calleeActionProc.RefinedActionAtLayer(callerProc.Layer + 1);
-              if (highestRefinedAction == null)
-              {
-                civlTypeChecker.Error(call, $"called action is not available at layer {callerProc.Layer + 1}");
-              }
-              else if (highestRefinedAction != civlTypeChecker.SkipAtomicAction)
-              {
-                Require(highestRefinedAction.ActionDecl.ActionQualifier == ActionQualifier.Async, call,
-                  $"action {highestRefinedAction.ActionDecl.Name} refined by callee must be async");
-              }
-            }
-          }
-
-          if (callerProc.Layer > calleeProc.Layer)
-          {
-            var highestRefinedAction = calleeActionProc.RefinedActionAtLayer(callerProc.Layer);
-            if (highestRefinedAction == null)
-            {
-              civlTypeChecker.Error(call, $"called action is not available at layer {callerProc.Layer}");
-            }
-            else if (highestRefinedAction.HasPendingAsyncs)
-            {
-              Require(callerProc is ActionProc, call, "caller must not be a mover procedure");
-            }
-          }
-          else // callerProc.Layer == calleeProc.Layer
-          {
-            Require(callerProc is ActionProc, call, "caller must not be a mover procedure");
-            ActionProc callerActionProc = (ActionProc) callerProc;
-            Require(call.IsAsync || calleeActionProc.RefinedAction.Gate.Count == 0, call,
-              "atomic action refined by callee may not have a gate");
-            HashSet<string> calleeOutputs = new HashSet<string>(call.Outs.Select(ie => ie.Decl.Name));
-            HashSet<string> visibleCallerOutputsAtDisappearingLayer = new HashSet<string>(callerActionProc
-              .Proc.OutParams.Where(x => !callerActionProc.HiddenFormals.Contains(x))
-              .Select(x => x.Name));
-            Require(
-              visibleCallerOutputsAtDisappearingLayer.IsSubsetOf(calleeOutputs) ||
-              !visibleCallerOutputsAtDisappearingLayer.Overlaps(calleeOutputs), call,
-              $"visible outputs of caller at the caller layer must be either subset of or disjoint from call outputs");
-          }
-        }
-        else if (calleeProc is MoverProc)
-        {
-          Require(callerProc.Layer == calleeProc.Layer, call, "layer of caller must be equal to layer of callee");
-          if (call.IsAsync)
-          {
-            Require(call.HasAttribute(CivlAttributes.SYNC), call, "async call to mover procedure must be synchronized");
-            Require(calleeProc.IsLeftMover, call, "callee in synchronized call must be a left mover");
-          }
-        }
-        else
-        {
-          Debug.Assert(false);
-        }
-
-        var hiddenFormals = new HashSet<Variable>();
-        if (calleeProc is ActionProc actionProc)
-        {
-          hiddenFormals = actionProc.HiddenFormals;
-        }
-
-        for (int i = 0; i < call.Ins.Count; i++)
-        {
-          // Visitor checks for global variable accesses and collects accessed local variables
-          localVariableAccesses = new List<IdentifierExpr>();
-          Visit(call.Ins[i]);
-
-          var formal = call.Proc.InParams[i];
-          var formalLayerRange = formal.LayerRange;
-          if (!hiddenFormals.Contains(formal) && calleeProc is ActionProc)
-          {
-            formalLayerRange = new LayerRange(formalLayerRange.LowerLayer, callerProc.Layer);
-          }
-
-          foreach (var ie in localVariableAccesses)
-          {
-            var actualLayerRange = ie.Decl.LayerRange;
-            if (formalLayerRange.Subset(actualLayerRange))
-            {
-              continue;
-            }
-
-            civlTypeChecker.checkingContext.Error(ie,
-              "Variable {0} cannot be used to compute the argument for formal parameter {1}", ie.Decl.Name,
-              formal.Name);
-          }
-
-          localVariableAccesses = null;
-        }
-
-        for (int i = 0; i < call.Outs.Count; i++)
-        {
-          IdentifierExpr actualIdentifierExpr = call.Outs[i];
-          // Visitor only called to check for global variable accesses
-          Visit(actualIdentifierExpr);
-
-          var actualLayerRange = actualIdentifierExpr.Decl.LayerRange;
-          var formal = call.Proc.OutParams[i];
-          var formalLayerRange = formal.LayerRange;
-          if (!hiddenFormals.Contains(formal) && calleeProc is ActionProc)
-          {
-            formalLayerRange = new LayerRange(formalLayerRange.LowerLayer, callerProc.Layer);
-          }
-
-          if (actualLayerRange.Subset(formalLayerRange))
-          {
-            continue;
-          }
-
-          civlTypeChecker.Error(actualIdentifierExpr,
-            "Formal return parameter of call available at fewer layers than the corresponding actual parameter");
-        }
-      }
-
-      private void VisitYieldInvariantCallCmd(CallCmd call, int callerProcLayer, int calleeLayerNum)
-      {
-        Require(calleeLayerNum <= callerProcLayer, call, "layer of callee must be no more than layer of caller");
-        CheckCallInputs(call, calleeLayerNum);
-      }
-
-      private void VisitPureProcCallCmd(CallCmd call, int callerProcLayer)
-      {
-        var calledLayers = call.Layers;
-        if (calledLayers.Count != 1)
-        {
-          civlTypeChecker.checkingContext.Error(call, "call to pure procedure must be annotated with a layer");
-          return;
-        }
-        var calleeLayerNum = calledLayers[0];
-        VisitYieldInvariantCallCmd(call, callerProcLayer, calleeLayerNum);
-        CheckCallOutputs(call, calleeLayerNum);
-      }
-
-      private void VisitLinkActionCallCmd(CallCmd call, int callerProcLayer, AtomicAction linkAction)
-      {
-        var calleeLayerNum = linkAction.LowerLayer;
-        VisitYieldInvariantCallCmd(call, callerProcLayer, calleeLayerNum);
-        CheckCallOutputs(call, calleeLayerNum);
-        Require(callerProcLayer == calleeLayerNum ||
-                linkAction.ModifiedGlobalVars.All(v => v.LayerRange.UpperLayer == calleeLayerNum),
-          call, $"all modified variables of callee must be hidden at layer {calleeLayerNum}");
-      }
-
-      private void CheckCallInputs(CallCmd call, int calleeLayerNum)
-      {
-        globalVariableAccesses = new List<IdentifierExpr>();
-        localVariableAccesses = new List<IdentifierExpr>();
-        foreach (var e in call.Ins)
-        {
-          Visit(e);
-        }
-
-        Require(
-          globalVariableAccesses.All(ie => ie.Decl.LayerRange.Contains(calleeLayerNum)),
-          call,
-          $"A global variable used in input to the call not available at layer {calleeLayerNum}");
-        Require(localVariableAccesses.All(ie => ie.Decl.LayerRange.Contains(calleeLayerNum)),
-          call,
-          $"A local variable used in input to the call not available at layer {calleeLayerNum}");
-        localVariableAccesses = null;
-        globalVariableAccesses = null;
-      }
-
-      private void CheckCallOutputs(CallCmd call, int calleeLayerNum)
-      {
-        Require(call.Outs.All(ie => ie.Decl.LayerRange.LowerLayer == calleeLayerNum),
-          call, $"all output variables must be introduced at layer {calleeLayerNum}");
-        Require(call.Outs.All(ie => ie.Decl.LayerRange.UpperLayer == calleeLayerNum),
-          call, $"all output variables of call must be hidden at layer {calleeLayerNum}");
-      }
-
-      private void CheckMoverProcModifiesClause(Implementation impl)
-      {
-        if (yieldingProc is MoverProc caller)
-        {
-          foreach (var callCmd in impl.Blocks.SelectMany(b => b.Cmds).OfType<CallCmd>())
-          {
-            IEnumerable<Variable> mods = Enumerable.Empty<Variable>();
-            if (civlTypeChecker.procToYieldingProc.TryGetValue(callCmd.Proc, out YieldingProc callee))
-            {
-              if (callee is ActionProc actionProc)
-              {
-                mods = actionProc.RefinedActionAtLayer(caller.Layer).ModifiedGlobalVars;
-              }
-              else if (callee is MoverProc moverProc)
-              {
-                mods = moverProc.ModifiedGlobalVars;
-              }
-              else
-              {
-                Debug.Assert(false);
-              }
-            }
-            else if (callCmd.Proc is ActionDecl { ActionQualifier: ActionQualifier.Link } actionDecl)
-            {
-              var linkAction = civlTypeChecker.procToAtomicAction[actionDecl];
-              if (caller.Layer == linkAction.LowerLayer)
-              {
-                mods = new HashSet<Variable>(callCmd.Proc.Modifies.Select(ie => ie.Decl));
-              }
-            }
-            else
-            {
-              Debug.Assert(callCmd.Proc is YieldInvariantDecl || callCmd.Proc.IsPure);
-            }
-
-            foreach (var mod in mods)
-            {
-              if (!caller.ModifiedGlobalVars.Contains(mod))
-              {
-                civlTypeChecker.Error(callCmd,
-                  $"Modified variable {mod.Name} does not appear in modifies clause of mover procedure");
-              }
-            }
-          }
-        }
-      }
-    }
 
     private class AttributeEraser : ReadOnlyVisitor
     {

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Boogie
     public Dictionary<Block, YieldingLoop> yieldingLoops;
     public Dictionary<ActionDecl, AtomicAction> procToAtomicAction;
     private Dictionary<ActionDecl, InvariantAction> procToInvariantAction;
-    public Dictionary<Procedure, YieldingProc> procToYieldingProc;
     public List<InductiveSequentialization> inductiveSequentializations;
     public Dictionary<Implementation, Dictionary<CtorType, Variable>> implToPendingAsyncCollector;
     
@@ -39,7 +38,6 @@ namespace Microsoft.Boogie
       this.yieldingLoops = new Dictionary<Block, YieldingLoop>();
       this.procToAtomicAction = new Dictionary<ActionDecl, AtomicAction>();
       this.procToInvariantAction = new Dictionary<ActionDecl, InvariantAction>();
-      this.procToYieldingProc = new Dictionary<Procedure, YieldingProc>();
       this.implToPendingAsyncCollector = new Dictionary<Implementation, Dictionary<CtorType, Variable>>();
       this.inductiveSequentializations = new List<InductiveSequentialization>();
 
@@ -325,18 +323,11 @@ namespace Microsoft.Boogie
     
     private void TypeCheckYieldingProcedureDecls()
     {
-      foreach (var proc in program.Procedures.OfType<YieldProcedureDecl>())
+      foreach (var proc in program.Procedures.OfType<YieldProcedureDecl>().Where(proc => !proc.HasMoverType))
       {
-        if (proc.RefinedAction != null) // proc is an action procedure
+        if (proc.RefinedAction != null)
         {
-          AtomicAction refinedAction = procToAtomicAction[proc.RefinedAction.ActionDecl];
-          var actionProc = new ActionProc(proc);
           CheckRefinementSignature(proc);
-          procToYieldingProc[proc] = actionProc;
-        }
-        else if (proc.HasMoverType) // proc is a mover procedure
-        {
-          procToYieldingProc[proc] = new MoverProc(proc);
         }
         else // proc refines the skip action
         {
@@ -344,8 +335,6 @@ namespace Microsoft.Boogie
           {
             procToAtomicAction[SkipAtomicAction.ActionDecl] = SkipAtomicAction;
           }
-          var actionProc = new ActionProc(proc);
-          procToYieldingProc[proc] = actionProc;
         }
       }
 

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -661,15 +661,6 @@ namespace Microsoft.Boogie
           impl.OutParams[i].LayerRange = impl.Proc.OutParams[i].LayerRange;
         }
       }
-
-      // Also copy the layer range of each action to its parameters
-      foreach (var a in procToAtomicAction.Values)
-      {
-        foreach (var v in a.ActionDecl.InParams.Union(a.ActionDecl.OutParams).Union(a.Impl.InParams).Union(a.Impl.OutParams))
-        {
-          v.LayerRange = a.LayerRange;
-        }
-      }
     }
 
     #region Public access methods

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -555,9 +555,9 @@ namespace Microsoft.Boogie
       return layerNum <= yieldingLoops[block].Layer;
     }
 
-    public bool FormalRemainsInAction(ActionProc actionProc, Variable param)
+    public bool FormalRemainsInAction(YieldProcedureDecl yieldProcedureDecl, Variable param)
     {
-      return param.LayerRange.Contains(actionProc.Layer) && !actionProc.HiddenFormals.Contains(param);
+      return param.LayerRange.Contains(yieldProcedureDecl.Layer) && !yieldProcedureDecl.HiddenFormals.Contains(param);
     }
 
     public IEnumerable<AtomicAction> LinkActions =>

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Boogie
           CheckRefinementSignature(proc);
           procToYieldingProc[proc] = actionProc;
         }
-        else if (proc.MoverType != MoverType.None) // proc is a mover procedure
+        else if (proc.HasMoverType) // proc is a mover procedure
         {
           procToYieldingProc[proc] = new MoverProc(proc);
         }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -70,6 +70,16 @@ namespace Microsoft.Boogie
       skipProcedure.Impl = skipImplementation;
       SkipAtomicAction = new AtomicAction(skipImplementation, null, this);
       SkipAtomicAction.CompleteInitialization(this);
+      /*
+      program.TopLevelDeclarations.OfType<YieldProcedureDecl>().Where(decl => decl.RefinedAction == null).Iter(decl =>
+      {
+        decl.RefinedAction = new ActionDeclRef(Token.NoToken, skipProcedure.Name)
+        {
+          ActionDecl = skipProcedure
+        };
+      });
+      procToAtomicAction[skipProcedure] = SkipAtomicAction;
+      */
     }
 
     public string AddNamePrefix(string name)

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Boogie
         if (proc.RefinedAction != null) // proc is an action procedure
         {
           AtomicAction refinedAction = procToAtomicAction[proc.RefinedAction.ActionDecl];
-          var actionProc = new ActionProc(proc, refinedAction);
+          var actionProc = new ActionProc(proc);
           CheckRefinementSignature(proc);
           procToYieldingProc[proc] = actionProc;
         }
@@ -344,7 +344,7 @@ namespace Microsoft.Boogie
           {
             procToAtomicAction[SkipAtomicAction.ActionDecl] = SkipAtomicAction;
           }
-          var actionProc = new ActionProc(proc, SkipAtomicAction);
+          var actionProc = new ActionProc(proc);
           procToYieldingProc[proc] = actionProc;
         }
       }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Boogie.GraphUtil;
 
@@ -326,7 +325,7 @@ namespace Microsoft.Boogie
       Implementation impl = proc.Impl;
       procToAtomicAction[proc] = new AtomicAction(impl, refinedAction, this);
     }
-    
+
     private void TypeCheckYieldingProcedureDecls()
     {
       foreach (var proc in program.Procedures.OfType<YieldProcedureDecl>().Where(proc => proc.RefinedAction != null))
@@ -334,7 +333,7 @@ namespace Microsoft.Boogie
         CheckRefinementSignature(proc);
       }
     }
-    
+
     private void TypeCheckLoopAnnotations()
     {
       foreach (var impl in program.Implementations.Where(impl => impl.Proc is YieldProcedureDecl))

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -323,42 +323,20 @@ namespace Microsoft.Boogie
       procToAtomicAction[proc] = new AtomicAction(impl, refinedAction, this);
     }
     
-    private static T StripOld<T>(T cmd) where T : Cmd
-    {
-      var emptySubst = Substituter.SubstitutionFromDictionary(new Dictionary<Variable, Expr>());
-      return (T) Substituter.ApplyReplacingOldExprs(emptySubst, emptySubst, cmd);
-    }
-
     private void TypeCheckYieldingProcedureDecls()
     {
       foreach (var proc in program.Procedures.OfType<YieldProcedureDecl>())
       {
-        var yieldRequires = new List<CallCmd>();
-        var yieldEnsures = new List<CallCmd>();
-        foreach (var callCmd in proc.YieldRequires)
-        {
-          yieldRequires.Add(StripOld(callCmd));
-        }
-        foreach (var callCmd in proc.YieldEnsures)
-        {
-          yieldEnsures.Add(callCmd);
-        }
-        foreach (var callCmd in proc.YieldPreserves)
-        {
-          yieldRequires.Add(StripOld(callCmd));
-          yieldEnsures.Add(callCmd);
-        }
-        
         if (proc.RefinedAction != null) // proc is an action procedure
         {
           AtomicAction refinedAction = procToAtomicAction[proc.RefinedAction.ActionDecl];
-          var actionProc = new ActionProc(proc, yieldRequires, yieldEnsures, refinedAction);
+          var actionProc = new ActionProc(proc, refinedAction);
           CheckRefinementSignature(proc);
           procToYieldingProc[proc] = actionProc;
         }
         else if (proc.MoverType != MoverType.None) // proc is a mover procedure
         {
-          procToYieldingProc[proc] = new MoverProc(proc, yieldRequires, yieldEnsures);
+          procToYieldingProc[proc] = new MoverProc(proc);
         }
         else // proc refines the skip action
         {
@@ -366,7 +344,7 @@ namespace Microsoft.Boogie
           {
             procToAtomicAction[SkipAtomicAction.ActionDecl] = SkipAtomicAction;
           }
-          var actionProc = new ActionProc(proc, yieldRequires, yieldEnsures, SkipAtomicAction);
+          var actionProc = new ActionProc(proc, SkipAtomicAction);
           procToYieldingProc[proc] = actionProc;
         }
       }

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -358,13 +358,14 @@ namespace Microsoft.Boogie
     
     private void TypeCheckLoopAnnotations()
     {
-      foreach (var impl in program.Implementations.Where(impl => procToYieldingProc.ContainsKey(impl.Proc)))
+      foreach (var impl in program.Implementations.Where(impl => impl.Proc is YieldProcedureDecl))
       {
+        var yieldingProc = (YieldProcedureDecl)impl.Proc;
+        var yieldingLayer = yieldingProc.Layer;
         var graph = Program.GraphFromImpl(impl);
         graph.ComputeLoops();
         foreach (var header in graph.Headers)
         {
-          int yieldingLayer = procToYieldingProc[impl.Proc].Layer;
           var yieldCmd = (PredicateCmd)header.Cmds.FirstOrDefault(cmd =>
             cmd is PredicateCmd predCmd && predCmd.HasAttribute(CivlAttributes.YIELDS));
           if (yieldCmd == null)

--- a/Source/Concurrency/LinearPermissionInstrumentation.cs
+++ b/Source/Concurrency/LinearPermissionInstrumentation.cs
@@ -80,11 +80,6 @@ namespace Microsoft.Boogie
       impl.ComputePredecessorsForBlocks();
       var graph = Program.GraphFromImpl(impl);
       graph.ComputeLoops();
-      if (!graph.Reducible)
-      {
-        throw new Exception("Irreducible flow graphs are unsupported.");
-      }
-
       var loopHeaders = new HashSet<Block>(graph.Headers);
       foreach (var header in loopHeaders)
       {

--- a/Source/Concurrency/LinearPermissionInstrumentation.cs
+++ b/Source/Concurrency/LinearPermissionInstrumentation.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Boogie
 
       return civlTypeChecker.linearTypeChecker.AvailableLinearVars(absyMap[absy]).Where(v =>
         !(v is GlobalVariable) &&
-        v.layerRange.Contains(layerNum));
+        v.LayerRange.Contains(layerNum));
     }
 
     private IEnumerable<Variable> FilterInParams(IEnumerable<Variable> locals)
@@ -148,14 +148,14 @@ namespace Microsoft.Boogie
     private IEnumerable<Variable> Filter(IEnumerable<Variable> locals, Predicate<LinearKind> pred)
     {
       return locals.Where(v =>
-        pred(LinearDomainCollector.FindLinearKind(v)) && v.layerRange.Contains(layerNum));
+        pred(LinearDomainCollector.FindLinearKind(v)) && v.LayerRange.Contains(layerNum));
     }
 
     private IEnumerable<Variable> LinearGlobalVars()
     {
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       return linearTypeChecker.program.GlobalVariables.Where(v =>
-        LinearDomainCollector.FindLinearKind(v) == LinearKind.LINEAR && v.layerRange.Contains(layerNum));
+        LinearDomainCollector.FindLinearKind(v) == LinearKind.LINEAR && v.LayerRange.Contains(layerNum));
     }
 
     private Variable MapVariable(Variable v)

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.Boogie
@@ -26,6 +27,45 @@ namespace Microsoft.Boogie
       program.GlobalVariables.Where(v => LinearDomainCollector.FindLinearKind(v) != LinearKind.ORDINARY);
     
     private Procedure enclosingProc;
+
+    public override Procedure VisitYieldInvariantDecl(YieldInvariantDecl node)
+    {
+      foreach (var v in node.InParams)
+      {
+        var linearKind = LinearDomainCollector.FindLinearKind(v);
+        if (linearKind == LinearKind.LINEAR_IN || linearKind == LinearKind.LINEAR_OUT)
+        {
+          Error(v, "parameter to yield invariant may only be :linear");
+        }
+      }
+      return base.VisitYieldInvariantDecl(node);
+    }
+
+    public override Procedure VisitYieldProcedureDecl(YieldProcedureDecl node)
+    {
+      node.YieldRequires.Iter(callCmd =>
+      {
+        var kinds = new List<LinearKind> { LinearKind.LINEAR, LinearKind.LINEAR_IN };
+        CheckLinearParameters(callCmd,
+          new HashSet<Variable>(node.InParams.Union(node.OutParams)
+            .Where(p => kinds.Contains(LinearDomainCollector.FindLinearKind(p)))));
+      });
+      node.YieldEnsures.Iter(callCmd =>
+      {
+        var kinds = new List<LinearKind> { LinearKind.LINEAR, LinearKind.LINEAR_OUT };
+        CheckLinearParameters(callCmd,
+          new HashSet<Variable>(node.InParams.Union(node.OutParams)
+            .Where(p => kinds.Contains(LinearDomainCollector.FindLinearKind(p)))));
+      });
+      node.YieldPreserves.Iter(callCmd =>
+      {
+        var kinds = new List<LinearKind> { LinearKind.LINEAR };
+        CheckLinearParameters(callCmd,
+          new HashSet<Variable>(node.InParams.Union(node.OutParams)
+            .Where(p => kinds.Contains(LinearDomainCollector.FindLinearKind(p)))));
+      });
+      return base.VisitYieldProcedureDecl(node);
+    }
 
     public override Implementation VisitImplementation(Implementation node)
     {
@@ -497,9 +537,65 @@ namespace Microsoft.Boogie
         Error(node, "linear primitives may not be invoked in a parallel call");
         return node;
       }
+      HashSet<Variable> parallelCallInputVars = new HashSet<Variable>();
+      foreach (CallCmd callCmd in node.CallCmds.Where(callCmd => callCmd.Proc is not YieldInvariantDecl))
+      {
+        for (int i = 0; i < callCmd.Proc.InParams.Count; i++)
+        {
+          if (LinearDomainCollector.FindLinearKind(callCmd.Proc.InParams[i]) == LinearKind.ORDINARY)
+          {
+            continue;
+          }
+          if (callCmd.Ins[i] is IdentifierExpr actual)
+          {
+            if (parallelCallInputVars.Contains(actual.Decl))
+            {
+              Error(node,
+                $"linear variable can occur only once as an input parameter of a parallel call: {actual.Decl.Name}");
+            }
+            else
+            {
+              parallelCallInputVars.Add(actual.Decl);
+            }
+          }
+        }
+      }
+      foreach (CallCmd callCmd in node.CallCmds.Where(callCmd => callCmd.Proc is YieldInvariantDecl))
+      {
+        for (int i = 0; i < callCmd.Proc.InParams.Count; i++)
+        {
+          if (LinearDomainCollector.FindLinearKind(callCmd.Proc.InParams[i]) == LinearKind.ORDINARY)
+          {
+            continue;
+          }
+          if (callCmd.Ins[i] is IdentifierExpr actual && parallelCallInputVars.Contains(actual.Decl))
+          {
+            Error(node,
+              $"linear variable cannot be an input parameter to both a yield invariant and a procedure in a parallel call: {actual.Decl.Name}");
+          }
+        }
+      }
       return base.VisitParCallCmd(node);
     }
 
+    public int CheckLinearParameters(CallCmd callCmd, HashSet<Variable> availableLinearVarsAtCallCmd)
+    {
+      int errorCount = 0;
+      foreach (var (ie, formal) in callCmd.Ins.Zip(callCmd.Proc.InParams))
+      {
+        if (LinearDomainCollector.FindLinearKind(formal) == LinearKind.ORDINARY)
+        {
+          continue;
+        }
+        if (ie is IdentifierExpr actual && !availableLinearVarsAtCallCmd.Contains(actual.Decl))
+        {
+          Error(actual, "argument must be available");
+          errorCount++;
+        }
+      }
+      return errorCount;
+    }
+    
     public override Cmd VisitCallCmd(CallCmd node)
     {
       var isPrimitive = IsPrimitive(node.Proc);

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Boogie
         from IS in civlTypeChecker.inductiveSequentializations
         from leftMover in IS.elim.Values
         from action in civlTypeChecker.MoverActions
-        where action.LayerRange.Contains(IS.invariantAction.LayerRange.upperLayerNum)
+        where action.LayerRange.Contains(IS.invariantAction.LayerRange.UpperLayer)
         let extraAssumption1 = IS.GenerateMoverCheckAssumption(action, action.FirstImpl.InParams, leftMover, leftMover.SecondImpl.InParams)
         let extraAssumption2 = IS.GenerateMoverCheckAssumption(action, action.SecondImpl.InParams, leftMover, leftMover.FirstImpl.InParams)
         select new {action, leftMover, extraAssumption1, extraAssumption2};

--- a/Source/Concurrency/NoninterferenceChecker.cs
+++ b/Source/Concurrency/NoninterferenceChecker.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.Boogie

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -73,8 +73,9 @@ namespace Microsoft.Boogie
       this.civlTypeChecker = civlTypeChecker;
       this.tok = impl.tok;
       this.oldGlobalMap = new Dictionary<Variable, Variable>();
-      ActionProc actionProc = civlTypeChecker.procToYieldingProc[originalImpl.Proc] as ActionProc;
-      this.layerNum = actionProc.Layer;
+      var yieldProcedureDecl = (YieldProcedureDecl)originalImpl.Proc;
+      //ActionProc actionProc = civlTypeChecker.procToYieldingProc[originalImpl.Proc] as ActionProc;
+      this.layerNum = yieldProcedureDecl.Layer;
       foreach (Variable v in civlTypeChecker.GlobalVariables)
       {
         var layerRange = v.LayerRange;
@@ -114,14 +115,14 @@ namespace Microsoft.Boogie
       // The parameters of an atomic action come from the implementation that denotes the atomic action specification.
       // To use the transition relation computed below in the context of the yielding procedure of the refinement check,
       // we need to substitute the parameters.
-      AtomicAction atomicAction = actionProc.Proc.RefinedAction == null
+      AtomicAction atomicAction = yieldProcedureDecl.RefinedAction == null
         ? civlTypeChecker.SkipAtomicAction
-        : civlTypeChecker.procToAtomicAction[actionProc.Proc.RefinedAction.ActionDecl];
+        : civlTypeChecker.procToAtomicAction[yieldProcedureDecl.RefinedAction.ActionDecl];
       Implementation atomicActionImpl = atomicAction.Impl;
       Dictionary<Variable, Expr> alwaysMap = new Dictionary<Variable, Expr>();
       for (int i = 0, j = 0; i < impl.InParams.Count; i++)
       {
-        if (civlTypeChecker.FormalRemainsInAction(actionProc, actionProc.Proc.InParams[i]))
+        if (civlTypeChecker.FormalRemainsInAction(yieldProcedureDecl, yieldProcedureDecl.InParams[i]))
         {
           alwaysMap[atomicActionImpl.InParams[j]] = Expr.Ident(impl.InParams[i]);
           j++;
@@ -130,7 +131,7 @@ namespace Microsoft.Boogie
 
       for (int i = 0, j = 0; i < impl.OutParams.Count; i++)
       {
-        if (civlTypeChecker.FormalRemainsInAction(actionProc, actionProc.Proc.OutParams[i]))
+        if (civlTypeChecker.FormalRemainsInAction(yieldProcedureDecl, yieldProcedureDecl.OutParams[i]))
         {
           alwaysMap[atomicActionImpl.OutParams[j]] = Expr.Ident(impl.OutParams[i]);
           j++;

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Boogie
       this.layerNum = actionProc.Layer;
       foreach (Variable v in civlTypeChecker.GlobalVariables)
       {
-        var layerRange = v.layerRange;
+        var layerRange = v.LayerRange;
         if (layerRange.lowerLayerNum <= layerNum && layerNum < layerRange.upperLayerNum)
         {
           this.oldGlobalMap[v] = oldGlobalMap[v];

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -114,7 +114,9 @@ namespace Microsoft.Boogie
       // The parameters of an atomic action come from the implementation that denotes the atomic action specification.
       // To use the transition relation computed below in the context of the yielding procedure of the refinement check,
       // we need to substitute the parameters.
-      AtomicAction atomicAction = actionProc.RefinedAction;
+      AtomicAction atomicAction = actionProc.Proc.RefinedAction == null
+        ? civlTypeChecker.SkipAtomicAction
+        : civlTypeChecker.procToAtomicAction[actionProc.Proc.RefinedAction.ActionDecl];
       Implementation atomicActionImpl = atomicAction.Impl;
       Dictionary<Variable, Expr> alwaysMap = new Dictionary<Variable, Expr>();
       for (int i = 0, j = 0; i < impl.InParams.Count; i++)

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Boogie
       foreach (Variable v in civlTypeChecker.GlobalVariables)
       {
         var layerRange = v.LayerRange;
-        if (layerRange.lowerLayerNum <= layerNum && layerNum < layerRange.upperLayerNum)
+        if (layerRange.LowerLayer <= layerNum && layerNum < layerRange.UpperLayer)
         {
           this.oldGlobalMap[v] = oldGlobalMap[v];
         }

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -272,10 +272,7 @@ namespace Microsoft.Boogie
         }
       }
 
-      private bool IsMoverProcedure
-      {
-        get { return yieldingProc is MoverProc && yieldingProc.Layer == currLayerNum; }
-      }
+      private bool IsMoverProcedure => yieldingProc is MoverProc && yieldingProc.Layer == currLayerNum;
 
       private bool CheckAtomicity(Dictionary<Absy, HashSet<int>> simulationRelation)
       {

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -298,41 +298,6 @@ namespace Microsoft.Boogie
         return true;
       }
 
-      private bool IsRecursiveMoverProcedureCall(CallCmd call)
-      {
-        MoverProc source = null;
-        if (civlTypeChecker.procToYieldingProc.ContainsKey(call.Proc))
-        {
-          source = civlTypeChecker.procToYieldingProc[call.Proc] as MoverProc;
-        }
-
-        if (source == null)
-        {
-          return false;
-        }
-
-        MoverProc target = (MoverProc) yieldingProc;
-
-        HashSet<MoverProc> frontier = new HashSet<MoverProc> {source};
-        HashSet<MoverProc> visited = new HashSet<MoverProc>();
-
-        while (frontier.Count > 0)
-        {
-          var curr = frontier.First();
-          frontier.Remove(curr);
-          visited.Add(curr);
-
-          if (curr == target)
-          {
-            return true;
-          }
-
-          frontier.UnionWith(moverProcedureCallGraph.Successors(curr).Except(visited));
-        }
-
-        return false;
-      }
-
       private void ComputeGraph()
       {
         atomicityLabels = new Dictionary<Tuple<Absy, Absy>, string>();

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -424,7 +424,9 @@ namespace Microsoft.Boogie
 
           if (callee is ActionProc actionProc && callee.Layer < currLayerNum && callCmd.HasAttribute(CivlAttributes.SYNC))
           {
-            return MoverTypeToLabel(actionProc.RefinedActionAtLayer(currLayerNum).ActionDecl.MoverType);
+            return MoverTypeToLabel(actionProc.Proc.RefinedAction == null
+              ? MoverType.Both
+              : actionProc.Proc.RefinedActionAtLayer(currLayerNum).MoverType);
           }
 
           return L;
@@ -438,7 +440,9 @@ namespace Microsoft.Boogie
 
           if (callee is ActionProc actionProc && callee.Layer < currLayerNum)
           {
-            return MoverTypeToLabel(actionProc.RefinedActionAtLayer(currLayerNum).ActionDecl.MoverType);
+            return MoverTypeToLabel(actionProc.Proc.RefinedAction == null
+              ? MoverType.Both
+              : actionProc.Proc.RefinedActionAtLayer(currLayerNum).MoverType);
           }
 
           return Y;
@@ -495,7 +499,9 @@ namespace Microsoft.Boogie
           {
             if (callCmd.HasAttribute(CivlAttributes.SYNC))
             {
-              return ModifiesGlobalLabel(actionProc.RefinedActionAtLayer(currLayerNum).ModifiedGlobalVars);
+              return ModifiesGlobalLabel(actionProc.Proc.RefinedAction == null
+                ? Enumerable.Empty<Variable>()
+                : actionProc.Proc.RefinedActionAtLayer(currLayerNum).ModifiedVars);
             }
             else
             {
@@ -514,7 +520,9 @@ namespace Microsoft.Boogie
 
           if (callee is ActionProc actionProc && callee.Layer < currLayerNum)
           {
-            return ModifiesGlobalLabel(actionProc.RefinedActionAtLayer(currLayerNum).ModifiedGlobalVars);
+            return ModifiesGlobalLabel(actionProc.Proc.RefinedAction == null
+              ? Enumerable.Empty<Variable>()
+              : actionProc.Proc.RefinedActionAtLayer(currLayerNum).ModifiedVars);
           }
 
           return Y;

--- a/Source/Concurrency/YieldingProcChecker.cs
+++ b/Source/Concurrency/YieldingProcChecker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Boogie
 {
@@ -19,18 +20,18 @@ namespace Microsoft.Boogie
 
         YieldingProcDuplicator duplicator = new YieldingProcDuplicator(civlTypeChecker, layerNum);
 
-        foreach (var procToYieldingProc in civlTypeChecker.procToYieldingProc)
+        foreach (var yieldProcedureDecl in civlTypeChecker.program.TopLevelDeclarations.OfType<YieldProcedureDecl>())
         {
-          if (procToYieldingProc.Value.Layer >= layerNum)
+          if (yieldProcedureDecl.Layer >= layerNum)
           {
-            duplicator.VisitProcedure(procToYieldingProc.Key);
+            duplicator.VisitProcedure(yieldProcedureDecl);
           }
         }
 
-        foreach (Implementation impl in program.Implementations)
+        foreach (Implementation impl in program.Implementations.Where(impl => impl.Proc is YieldProcedureDecl))
         {
-          if (civlTypeChecker.procToYieldingProc.TryGetValue(impl.Proc, out var yieldingProc) &&
-              yieldingProc.Layer >= layerNum)
+          var yieldProcedureDecl = (YieldProcedureDecl)impl.Proc;
+          if (yieldProcedureDecl.Layer >= layerNum)
           {
             duplicator.VisitImplementation(impl);
           }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Boogie
           false,
           VisitRequiresSeq(node.Requires),
           (yieldingProc is MoverProc moverProc && yieldingProc.Layer == layerNum
-            ? moverProc.ModifiedGlobalVars.Select(g => Expr.Ident(g))
+            ? moverProc.ModifiedVars.Select(g => Expr.Ident(g))
             : civlTypeChecker.GlobalVariables.Select(v => Expr.Ident(v))).ToList(),
           VisitEnsuresSeq(node.Ensures));
         procToDuplicate[node] = proc;

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -40,11 +40,10 @@ namespace Microsoft.Boogie
 
     public override Procedure VisitProcedure(Procedure node)
     {
-      Debug.Assert(civlTypeChecker.procToYieldingProc.ContainsKey(node));
       if (!procToDuplicate.ContainsKey(node))
       {
-        YieldingProc yieldingProc = civlTypeChecker.procToYieldingProc[node];
-        Debug.Assert(layerNum <= yieldingProc.Layer);
+        var yieldProcedureDecl = (YieldProcedureDecl)node;
+        Debug.Assert(layerNum <= yieldProcedureDecl.Layer);
         var proc = new Procedure(
           node.tok,
           civlTypeChecker.AddNamePrefix($"{node.Name}_{layerNum}"),
@@ -53,8 +52,8 @@ namespace Microsoft.Boogie
           VisitVariableSeq(node.OutParams),
           false,
           VisitRequiresSeq(node.Requires),
-          (yieldingProc is MoverProc moverProc && yieldingProc.Layer == layerNum
-            ? moverProc.ModifiedVars.Select(g => Expr.Ident(g))
+          (yieldProcedureDecl.HasMoverType && yieldProcedureDecl.Layer == layerNum
+            ? yieldProcedureDecl.ModifiedVars.Select(g => Expr.Ident(g))
             : civlTypeChecker.GlobalVariables.Select(v => Expr.Ident(v))).ToList(),
           VisitEnsuresSeq(node.Ensures));
         procToDuplicate[node] = proc;
@@ -114,18 +113,12 @@ namespace Microsoft.Boogie
     #region Implementation duplication
 
     private Implementation enclosingImpl;
-    private YieldingProc enclosingYieldingProc;
+    private YieldProcedureDecl enclosingYieldingProc;
     private bool IsRefinementLayer => layerNum == enclosingYieldingProc.Layer;
-    private AtomicAction RefinedAction
-    {
-      get
-      {
-        var actionProc = (ActionProc)enclosingYieldingProc;
-        return actionProc.Proc.RefinedAction == null
-          ? civlTypeChecker.SkipAtomicAction
-          : civlTypeChecker.procToAtomicAction[actionProc.Proc.RefinedAction.ActionDecl];
-      }
-    }
+    private AtomicAction RefinedAction =>
+      enclosingYieldingProc.RefinedAction == null
+        ? civlTypeChecker.SkipAtomicAction
+        : civlTypeChecker.procToAtomicAction[enclosingYieldingProc.RefinedAction.ActionDecl];
 
     private List<Cmd> newCmdSeq;
 
@@ -154,9 +147,8 @@ namespace Microsoft.Boogie
 
     public override Implementation VisitImplementation(Implementation impl)
     {
-      Debug.Assert(civlTypeChecker.procToYieldingProc.ContainsKey(impl.Proc));
+      enclosingYieldingProc = (YieldProcedureDecl)impl.Proc;
       enclosingImpl = impl;
-      enclosingYieldingProc = civlTypeChecker.procToYieldingProc[impl.Proc];
       Debug.Assert(layerNum <= enclosingYieldingProc.Layer);
 
       returnedPAs = new Dictionary<CtorType, Variable>();
@@ -169,9 +161,8 @@ namespace Microsoft.Boogie
       {
         var rewrittenCallCmd = kv.Key;
         var originalCallCmd = kv.Value;
-        var actionProc = (ActionProc) civlTypeChecker.procToYieldingProc[originalCallCmd.Proc];
         newCmdSeq = new List<Cmd>();
-        AddActionCall(originalCallCmd, actionProc);
+        AddActionCall(originalCallCmd, (YieldProcedureDecl)originalCallCmd.Proc);
         var block = BlockHelper.Block(
           civlTypeChecker.AddNamePrefix($"call_refinement_{refinementBlocks.Count}"),
           newCmdSeq,
@@ -184,7 +175,7 @@ namespace Microsoft.Boogie
       
       newImpl.LocVars.AddRange(returnedPAs.Values);
 
-      if (enclosingYieldingProc is ActionProc && RefinedAction.HasPendingAsyncs && IsRefinementLayer)
+      if (!enclosingYieldingProc.HasMoverType && RefinedAction.HasPendingAsyncs && IsRefinementLayer)
       {
         var assumeExpr = EmptyPendingAsyncMultisetExpr(CollectedPAs, RefinedAction.PendingAsyncs);
         newImpl.LocVars.AddRange(civlTypeChecker.implToPendingAsyncCollector[impl].Values.Except(impl.LocVars));
@@ -289,27 +280,26 @@ namespace Microsoft.Boogie
       }
 
       // handle calls to yielding procedures in the rest of this method
-      YieldingProc yieldingProc = civlTypeChecker.procToYieldingProc[newCall.Proc];
+      var yieldingProc = (YieldProcedureDecl)newCall.Proc;
 
       if (newCall.IsAsync)
       {
         if (yieldingProc.Layer < layerNum)
         {
-          Debug.Assert(yieldingProc is ActionProc);
-          var actionProc = (ActionProc)yieldingProc;
+          Debug.Assert(!yieldingProc.HasMoverType);
           if (newCall.HasAttribute(CivlAttributes.SYNC))
           {
             // synchronize the called atomic action
-            AddActionCall(newCall, actionProc);
+            AddActionCall(newCall, yieldingProc);
           }
           else if (IsRefinementLayer)
           {
-            AddPendingAsync(newCall, actionProc);
+            AddPendingAsync(newCall, yieldingProc);
           }
         }
         else
         {
-          if (yieldingProc is MoverProc && yieldingProc.Layer == layerNum)
+          if (yieldingProc.HasMoverType && yieldingProc.Layer == layerNum)
           {
             // synchronize the called mover procedure
             AddDuplicateCall(newCall, false);
@@ -319,8 +309,8 @@ namespace Microsoft.Boogie
             DesugarAsyncCall(newCall);
             if (IsRefinementLayer)
             {
-              Debug.Assert(yieldingProc is ActionProc);
-              AddPendingAsync(newCall, (ActionProc)yieldingProc);
+              Debug.Assert(!yieldingProc.HasMoverType);
+              AddPendingAsync(newCall, yieldingProc);
             }
           }
         }
@@ -328,19 +318,19 @@ namespace Microsoft.Boogie
       }
 
       // handle synchronous calls to yielding procedures
-      if (yieldingProc is MoverProc moverProc)
+      if (yieldingProc.HasMoverType)
       {
-        AddDuplicateCall(newCall, moverProc.Layer > layerNum);
+        AddDuplicateCall(newCall, yieldingProc.Layer > layerNum);
       }
-      else if (yieldingProc is ActionProc actionProc)
+      else if (!yieldingProc.HasMoverType)
       {
-        if (actionProc.Layer < layerNum)
+        if (yieldingProc.Layer < layerNum)
         {
-          AddActionCall(newCall, actionProc);
+          AddActionCall(newCall, yieldingProc);
         }
         else
         {
-          if (IsRefinementLayer && layerNum == actionProc.Layer && actionProc.Proc.RefinedAction != null)
+          if (IsRefinementLayer && layerNum == yieldingProc.Layer && yieldingProc.RefinedAction != null)
           {
             refinementCallCmds[newCall] = (CallCmd) VisitCallCmd(newCall);
           }
@@ -361,11 +351,11 @@ namespace Microsoft.Boogie
       var callCmds = new List<CallCmd>();
       foreach (var callCmd in newParCall.CallCmds)
       {
-        if (civlTypeChecker.procToYieldingProc.ContainsKey(callCmd.Proc))
+        if (callCmd.Proc is YieldProcedureDecl)
         {
-          var yieldingProc = civlTypeChecker.procToYieldingProc[callCmd.Proc];
-          if (layerNum > yieldingProc.Layer && yieldingProc is ActionProc ||
-              layerNum == yieldingProc.Layer && yieldingProc is MoverProc)
+          var yieldingProc = (YieldProcedureDecl)callCmd.Proc;
+          if (layerNum > yieldingProc.Layer && !yieldingProc.HasMoverType ||
+              layerNum == yieldingProc.Layer && yieldingProc.HasMoverType)
           {
             if (callCmds.Count > 0)
             {
@@ -382,11 +372,10 @@ namespace Microsoft.Boogie
 
         if (procToDuplicate.ContainsKey(callCmd.Proc))
         {
-          Debug.Assert(civlTypeChecker.procToYieldingProc.ContainsKey(callCmd.Proc));
-          var yieldingProc = civlTypeChecker.procToYieldingProc[callCmd.Proc];
-          if (yieldingProc is ActionProc actionProc)
+          var yieldingProc = (YieldProcedureDecl)callCmd.Proc;
+          if (!yieldingProc.HasMoverType)
           {
-            if (IsRefinementLayer && layerNum == actionProc.Layer && actionProc.Proc.RefinedAction != null)
+            if (IsRefinementLayer && layerNum == yieldingProc.Layer && yieldingProc.RefinedAction != null)
             {
               refinementCallCmds[callCmd] = (CallCmd) VisitCallCmd(callCmd);
             }
@@ -414,32 +403,32 @@ namespace Microsoft.Boogie
       }
     }
 
-    private void AddActionCall(CallCmd newCall, ActionProc calleeActionProc)
+    private void AddActionCall(CallCmd newCall, YieldProcedureDecl calleeActionProc)
     {
-      var calleeRefinedAction = calleeActionProc.Proc.RefinedAction == null
+      var calleeRefinedAction = calleeActionProc.RefinedAction == null
         ? civlTypeChecker.SkipAtomicAction
-        : civlTypeChecker.procToAtomicAction[calleeActionProc.Proc.RefinedActionAtLayer(layerNum)];
+        : civlTypeChecker.procToAtomicAction[calleeActionProc.RefinedActionAtLayer(layerNum)];
 
       newCall.IsAsync = false;
       newCall.Proc = calleeRefinedAction.ActionDecl;
       newCall.callee = newCall.Proc.Name;
 
       // We drop the hidden parameters of the procedure from the call to the action.
-      Debug.Assert(newCall.Ins.Count == calleeActionProc.Proc.InParams.Count);
-      Debug.Assert(newCall.Outs.Count == calleeActionProc.Proc.OutParams.Count);
+      Debug.Assert(newCall.Ins.Count == calleeActionProc.InParams.Count);
+      Debug.Assert(newCall.Outs.Count == calleeActionProc.OutParams.Count);
       var newIns = new List<Expr>();
       var newOuts = new List<IdentifierExpr>();
-      for (int i = 0; i < calleeActionProc.Proc.InParams.Count; i++)
+      for (int i = 0; i < calleeActionProc.InParams.Count; i++)
       {
-        if (civlTypeChecker.FormalRemainsInAction(calleeActionProc, calleeActionProc.Proc.InParams[i]))
+        if (civlTypeChecker.FormalRemainsInAction(calleeActionProc, calleeActionProc.InParams[i]))
         {
           newIns.Add(newCall.Ins[i]);
         }
       }
 
-      for (int i = 0; i < calleeActionProc.Proc.OutParams.Count; i++)
+      for (int i = 0; i < calleeActionProc.OutParams.Count; i++)
       {
-        if (civlTypeChecker.FormalRemainsInAction(calleeActionProc, calleeActionProc.Proc.OutParams[i]))
+        if (civlTypeChecker.FormalRemainsInAction(calleeActionProc, calleeActionProc.OutParams[i]))
         {
           newOuts.Add(newCall.Outs[i]);
         }
@@ -563,22 +552,22 @@ namespace Microsoft.Boogie
       newCmdSeq.Add(newCall);
     }
 
-    private void AddPendingAsync(CallCmd newCall, ActionProc calleeProc)
+    private void AddPendingAsync(CallCmd newCall, YieldProcedureDecl calleeProc)
     {
-      if (calleeProc.Proc.RefinedAction == null)
+      if (calleeProc.RefinedAction == null)
       {
         return;
       }
       var calleeRefinedAction = calleeProc.Layer == enclosingYieldingProc.Layer
-        ? calleeProc.Proc.RefinedAction.ActionDecl
-        : calleeProc.Proc.RefinedActionAtLayer(layerNum);
+        ? calleeProc.RefinedAction.ActionDecl
+        : calleeProc.RefinedActionAtLayer(layerNum);
 
       if (RefinedAction.PendingAsyncs.Contains(calleeRefinedAction))
       {
         Expr[] newIns = new Expr[calleeRefinedAction.InParams.Count];
-        for (int i = 0, j = 0; i < calleeProc.Proc.InParams.Count; i++)
+        for (int i = 0, j = 0; i < calleeProc.InParams.Count; i++)
         {
-          if (civlTypeChecker.FormalRemainsInAction(calleeProc, calleeProc.Proc.InParams[i]))
+          if (civlTypeChecker.FormalRemainsInAction(calleeProc, calleeProc.InParams[i]))
           {
             newIns[j] = newCall.Ins[i];
             j++;

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -116,7 +116,17 @@ namespace Microsoft.Boogie
     private Implementation enclosingImpl;
     private YieldingProc enclosingYieldingProc;
     private bool IsRefinementLayer => layerNum == enclosingYieldingProc.Layer;
-    private AtomicAction RefinedAction => ((ActionProc)enclosingYieldingProc).RefinedAction;
+    private AtomicAction RefinedAction
+    {
+      get
+      {
+        var actionProc = (ActionProc)enclosingYieldingProc;
+        return actionProc.Proc.RefinedAction == null
+          ? civlTypeChecker.SkipAtomicAction
+          : civlTypeChecker.procToAtomicAction[actionProc.Proc.RefinedAction.ActionDecl];
+      }
+    }
+
     private List<Cmd> newCmdSeq;
 
     private Dictionary<CtorType, Variable> returnedPAs;

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -406,7 +406,9 @@ namespace Microsoft.Boogie
 
     private void AddActionCall(CallCmd newCall, ActionProc calleeActionProc)
     {
-      var calleeRefinedAction = calleeActionProc.RefinedActionAtLayer(layerNum);
+      var calleeRefinedAction = calleeActionProc.Proc.RefinedAction == null
+        ? civlTypeChecker.SkipAtomicAction
+        : civlTypeChecker.procToAtomicAction[calleeActionProc.Proc.RefinedActionAtLayer(layerNum)];
 
       newCall.IsAsync = false;
       newCall.Proc = calleeRefinedAction.ActionDecl;

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -151,10 +151,10 @@ namespace Microsoft.Boogie
       return civlTypeChecker.LocalVariable($"global_old_{v.Name}", v.TypedIdent.Type);
     }
     
-    private YieldingProc GetYieldingProc(Implementation impl)
+    private YieldProcedureDecl GetYieldingProc(Implementation impl)
     {
       var originalImpl = absyMap.Original(impl);
-      return civlTypeChecker.procToYieldingProc[originalImpl.Proc];
+      return (YieldProcedureDecl)originalImpl.Proc;
     }
 
     private Implementation WrapperNoninterferenceCheckerImpl()
@@ -275,7 +275,7 @@ namespace Microsoft.Boogie
         impl.Proc.Requires.ForEach(req =>
           initCmds.Add(new AssumeCmd(req.tok, Substituter.Apply(procToImplInParams, req.Condition))));
 
-        foreach (var callCmd in GetYieldingProc(impl).Proc.DesugaredYieldRequires)
+        foreach (var callCmd in GetYieldingProc(impl).DesugaredYieldRequires)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.Layer)
@@ -300,7 +300,7 @@ namespace Microsoft.Boogie
       foreach (var impl in absyMap.Keys.OfType<Implementation>())
       {
         var yieldingProc = GetYieldingProc(impl);
-        foreach (var callCmd in yieldingProc.Proc.DesugaredYieldRequires)
+        foreach (var callCmd in yieldingProc.DesugaredYieldRequires)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.Layer)
@@ -317,7 +317,7 @@ namespace Microsoft.Boogie
           }
         }
 
-        foreach (var callCmd in yieldingProc.Proc.DesugaredYieldEnsures)
+        foreach (var callCmd in yieldingProc.DesugaredYieldEnsures)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.Layer)
@@ -347,7 +347,7 @@ namespace Microsoft.Boogie
         // But this is fine because a mover procedure at its disappearing layer does not have a yield in it.
         linearPermissionInstrumentation.AddDisjointnessAndWellFormedAssumptions(impl);
         var yieldingProc = GetYieldingProc(impl);
-        if (yieldingProc is MoverProc && yieldingProc.Layer == layerNum)
+        if (yieldingProc.HasMoverType && yieldingProc.Layer == layerNum)
         {
           continue;
         }

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Boogie
         impl.Proc.Requires.ForEach(req =>
           initCmds.Add(new AssumeCmd(req.tok, Substituter.Apply(procToImplInParams, req.Condition))));
 
-        foreach (var callCmd in GetYieldingProc(impl).YieldRequires)
+        foreach (var callCmd in GetYieldingProc(impl).Proc.DesugaredYieldRequires)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.Layer)
@@ -300,7 +300,7 @@ namespace Microsoft.Boogie
       foreach (var impl in absyMap.Keys.OfType<Implementation>())
       {
         var yieldingProc = GetYieldingProc(impl);
-        foreach (var callCmd in yieldingProc.YieldRequires)
+        foreach (var callCmd in yieldingProc.Proc.DesugaredYieldRequires)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.Layer)
@@ -317,7 +317,7 @@ namespace Microsoft.Boogie
           }
         }
 
-        foreach (var callCmd in yieldingProc.YieldEnsures)
+        foreach (var callCmd in yieldingProc.Proc.DesugaredYieldEnsures)
         {
           var yieldInvariant = (YieldInvariantDecl)callCmd.Proc;
           if (layerNum == yieldInvariant.Layer)

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -2916,7 +2916,7 @@ namespace Microsoft.Boogie
       {
         rc.Error(this, $"async action may not have output parameters");
       }
-      if (MoverType != MoverType.None)
+      if (HasMoverType)
       {
         if (ActionQualifier == ActionQualifier.Invariant)
         {
@@ -3103,6 +3103,8 @@ namespace Microsoft.Boogie
       return Creates.Append(RefinedAction).Append(InvariantAction);
     }
 
+    public bool HasMoverType => MoverType != MoverType.None;
+    
     public bool IsRightMover => MoverType == MoverType.Right || MoverType == MoverType.Both;
 
     public bool IsLeftMover => MoverType == MoverType.Left || MoverType == MoverType.Both;
@@ -3195,7 +3197,7 @@ namespace Microsoft.Boogie
       rc.StateMode = oldStateMode;
       rc.Proc = null;
 
-      if (MoverType == MoverType.None)
+      if (!HasMoverType)
       {
         HiddenFormals = RefinedAction != null
           ? new HashSet<Variable>(InParams.Concat(OutParams)
@@ -3208,7 +3210,7 @@ namespace Microsoft.Boogie
         RefinedAction.Resolve(rc);
       }
 
-      if (MoverType == MoverType.None)
+      if (!HasMoverType)
       {
         if (Modifies.Any())
         {
@@ -3231,7 +3233,7 @@ namespace Microsoft.Boogie
         tc.Error(this, $"refined atomic action must be available at layer {Layer + 1}");
       }
 
-      if (MoverType != MoverType.None)
+      if (HasMoverType)
       {
         Modifies.Where(ie => !ie.Decl.LayerRange.Contains(Layer)).Iter(ie =>
         {
@@ -3259,6 +3261,8 @@ namespace Microsoft.Boogie
       return YieldEnsures.Union(YieldPreserves).Union(YieldRequires);
     }
 
+    public bool HasMoverType => MoverType != MoverType.None;
+    
     public bool IsRightMover => MoverType == MoverType.Right || MoverType == MoverType.Both;
 
     public bool IsLeftMover => MoverType == MoverType.Left || MoverType == MoverType.Both;

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -1524,8 +1524,7 @@ namespace Microsoft.Boogie
     }
 
     /// <summary>
-    /// Given a sequence of Formal declarations, returns sequence of Formals like the given one but without where clauses
-    /// and without any attributes.
+    /// Given a sequence of Formal declarations, returns sequence of Formals like the given one but without where clauses.
     /// The Type of each Formal is cloned.
     /// </summary>
     public static List<Variable> StripWhereClauses(List<Variable> w)
@@ -1538,7 +1537,7 @@ namespace Microsoft.Boogie
         Contract.Assert(v != null);
         Formal f = (Formal) v;
         TypedIdent ti = f.TypedIdent;
-        s.Add(new Formal(f.tok, new TypedIdent(ti.tok, ti.Name, ti.Type.CloneUnresolved()), f.InComing, null));
+        s.Add(new Formal(f.tok, new TypedIdent(ti.tok, ti.Name, ti.Type.CloneUnresolved()), f.InComing, v.Attributes));
       }
 
       return s;

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -1755,10 +1755,9 @@ namespace Microsoft.Boogie
   {
     public QKeyValue Attributes { get; set; }
 
-    private List<AssignLhs /*!*/> /*!*/
-      _lhss;
+    private List<AssignLhs> _lhss;
 
-    public IList<AssignLhs /*!*/> /*!*/ Lhss
+    public IList<AssignLhs> Lhss
     {
       get
       {
@@ -1781,10 +1780,9 @@ namespace Microsoft.Boogie
       this._lhss[index] = lhs;
     }
 
-    private List<Expr /*!*/> /*!*/
-      _rhss;
+    private List<Expr> _rhss;
 
-    public IList<Expr /*!*/> /*!*/ Rhss
+    public IList<Expr> Rhss
     {
       get
       {
@@ -1814,9 +1812,7 @@ namespace Microsoft.Boogie
       Contract.Invariant(cce.NonNullElements(this._rhss));
     }
 
-
-    public AssignCmd(IToken tok, IList<AssignLhs /*!*/> /*!*/ lhss,
-      IList<Expr /*!*/> /*!*/ rhss, QKeyValue kv)
+    public AssignCmd(IToken tok, IList<AssignLhs> lhss, IList<Expr> rhss, QKeyValue kv)
       : base(tok)
     {
       Contract.Requires(tok != null);
@@ -1827,7 +1823,7 @@ namespace Microsoft.Boogie
       this.Attributes = kv;
     }
 
-    public AssignCmd(IToken tok, IList<AssignLhs /*!*/> /*!*/ lhss, IList<Expr /*!*/> /*!*/ rhss)
+    public AssignCmd(IToken tok, IList<AssignLhs> lhss, IList<Expr> rhss)
       : base(tok)
     {
       Contract.Requires(tok != null);
@@ -1941,16 +1937,32 @@ namespace Microsoft.Boogie
       int errorCount = tc.ErrorCount;
 
       (this as ICarriesAttributes).TypecheckAttributes(tc);
+
+      var expectedLayerRanges = new List<LayerRange>();
+      if (tc.Proc is YieldProcedureDecl)
+      {
+        foreach (var e in Lhss.Where(e => e.DeepAssignedVariable is GlobalVariable))
+        {
+          tc.Error(e, $"global variable directly modified in a yield procedure: {e.DeepAssignedVariable.Name}");
+        }
+        expectedLayerRanges = Lhss.Select(e => e.DeepAssignedVariable.LayerRange).ToList();
+      }
+
       foreach (AssignLhs /*!*/ e in Lhss)
       {
         Contract.Assert(e != null);
         e.Typecheck(tc);
       }
 
-      foreach (Expr /*!*/ e in Rhss)
+      for (int i = 0; i < Rhss.Count; i++)
       {
+        var e = Rhss[i];
         Contract.Assert(e != null);
+        tc.GlobalAccessOnlyInOld = true;
+        tc.ExpectedLayerRange = tc.Proc is YieldProcedureDecl ? expectedLayerRanges[i] : null;
         e.Typecheck(tc);
+        tc.GlobalAccessOnlyInOld = false;
+        tc.ExpectedLayerRange = null;
       }
 
       if (tc.ErrorCount > errorCount)
@@ -2420,8 +2432,28 @@ namespace Microsoft.Boogie
     public override void Typecheck(TypecheckingContext tc)
     {
       (this as ICarriesAttributes).TypecheckAttributes(tc);
+
+      LayerRange expectedLayerRange = null;
+      if (tc.Proc is YieldProcedureDecl)
+      {
+        UnpackedLhs.Select(ie => ie.Decl).Iter(v =>
+        {
+          if (v is GlobalVariable)
+          {
+            tc.Error(v, $"global variable directly modified in a yield procedure: {v.Name}");
+          }
+        });
+        expectedLayerRange = LayerRange.Union(UnpackedLhs.Select(ie => ie.Decl.LayerRange).ToList());
+      }
+
       lhs.Typecheck(tc);
+      
+      tc.GlobalAccessOnlyInOld = true;
+      tc.ExpectedLayerRange = expectedLayerRange;
       rhs.Typecheck(tc);
+      tc.GlobalAccessOnlyInOld = false;
+      tc.ExpectedLayerRange = null;
+      
       this.CheckAssignments(tc);
       Type ltype = lhs.Type;
       Type rtype = rhs.Type;
@@ -2894,6 +2926,10 @@ namespace Microsoft.Boogie
           }
         }
       }
+      if (CallCmds.Count(CivlAttributes.IsCallMarked) > 1)
+      {
+        rc.Error(this, "at most one arm of a parallel call may be annotated with :mark");
+      }
     }
 
     public override void Typecheck(TypecheckingContext tc)
@@ -3065,7 +3101,6 @@ namespace Microsoft.Boogie
 
     public override void Emit(TokenTextWriter stream, int level)
     {
-      //Contract.Requires(stream != null);
       stream.Write(this, level, "");
       if (IsFree)
       {
@@ -3122,7 +3157,6 @@ namespace Microsoft.Boogie
 
     public override void Resolve(ResolutionContext rc)
     {
-      //Contract.Requires(rc != null);
       if (Proc != null)
       {
         // already resolved
@@ -3200,10 +3234,340 @@ namespace Microsoft.Boogie
 
       (this as ICarriesAttributes).ResolveAttributes(rc);
       Layers = (this as ICarriesAttributes).FindLayers();
+
       var id = QKeyValue.FindStringAttribute(Attributes, "id");
       if (id != null)
       {
         rc.AddStatementId(tok, id);
+      }
+      
+      if (rc.Proc.GetType() == typeof(Procedure))
+      {
+        if (Proc.GetType() != typeof(Procedure))
+        {
+          rc.Error(this, "a procedure may only call other procedures");
+        }
+      }
+      if (rc.Proc.IsPure && !Proc.IsPure)
+      {
+        rc.Error(this, "pure procedure may only call a pure procedure");
+      }
+      if (rc.Proc is YieldProcedureDecl)
+      {
+        if (Proc is YieldProcedureDecl || Proc is YieldInvariantDecl ||
+            Proc is ActionDecl { ActionQualifier: ActionQualifier.Link } || Proc.IsPure)
+        {
+          // call ok
+        }
+        else
+        {
+          rc.Error(this,
+            "a yielding procedure may only call yield procedures, yield invariants, link actions, or pure procedures");
+        }
+      }
+      if (IsAsync)
+      {
+        if (rc.Proc is not YieldProcedureDecl)
+        {
+          rc.Error(this, "calling procedure of an async call must yield");
+        }
+        if (Proc is not YieldProcedureDecl)
+        {
+          rc.Error(this, "target procedure of an async call must yield");
+        }
+      }
+      // checking calls from atomic actions need type information, hence postponed to type checking
+    }
+
+    private List<LayerRange> TypecheckCallCmdInYieldProcedureDecl(TypecheckingContext tc)
+    {
+      if (tc.Proc is not YieldProcedureDecl callerDecl)
+      {
+        return null;
+      }
+      
+      var callerModifiedVars = new HashSet<Variable>(callerDecl.ModifiedVars);
+
+      void CheckModifies(IEnumerable<Variable> modifiedVars)
+      {
+        if (callerDecl.MoverType == MoverType.None)
+        {
+          return;
+        }
+        foreach (var v in modifiedVars.Where(v => !callerModifiedVars.Contains(v)))
+        {
+          tc.Error(this, $"modified variable does not appear in modifies clause of mover procedure: {v.Name}");
+        }
+      }
+      
+      LayerRange FormalLayerRange(Variable formal)
+      {
+        LayerRange formalLayerRange;
+        switch (Proc)
+        {
+          case YieldInvariantDecl yieldInvariantDecl:
+            formalLayerRange = new LayerRange(yieldInvariantDecl.Layer);
+            break;
+          case ActionDecl { ActionQualifier: ActionQualifier.Link } actionDecl:
+            formalLayerRange = new LayerRange(actionDecl.LayerRange.LowerLayer);
+            break;
+          case YieldProcedureDecl calleeDecl:
+          {
+            formalLayerRange = formal.LayerRange;
+            if (calleeDecl.MoverType == MoverType.None && formalLayerRange.UpperLayer == calleeDecl.Layer &&
+                !calleeDecl.HiddenFormals.Contains(formal))
+            {
+              formalLayerRange = new LayerRange(formalLayerRange.LowerLayer, callerDecl.Layer);
+            }
+            break;
+          }
+          default:
+            Debug.Assert(Proc.IsPure);
+            formalLayerRange = new LayerRange(Layers[0]);
+            break;
+        }
+        return formalLayerRange;
+      }
+
+      // check layers
+      if (Proc is YieldProcedureDecl calleeDecl)
+      {
+        var isSynchronized = this.HasAttribute(CivlAttributes.SYNC);
+        if (calleeDecl.Layer > callerDecl.Layer)
+        {
+          tc.Error(this, "layer of callee must not be more than layer of caller");
+        }
+        else if (calleeDecl.MoverType == MoverType.None)
+        {
+          if (callerDecl.Layer > calleeDecl.Layer)
+          {
+            if (calleeDecl.RefinedAction != null)
+            {
+              var highestRefinedActionDecl = calleeDecl.RefinedActionAtLayer(callerDecl.Layer);
+              if (highestRefinedActionDecl == null)
+              {
+                tc.Error(this, $"called action is not available at layer {callerDecl.Layer}");
+              }
+              else
+              {
+                CheckModifies(highestRefinedActionDecl.ModifiedVars);
+                if (highestRefinedActionDecl.Creates.Any())
+                {
+                  if (callerDecl.MoverType != MoverType.None)
+                  {
+                    tc.Error(this, "caller must not be a mover procedure");
+                  }
+                }
+                else if (IsAsync && isSynchronized)
+                {
+                  // check that entire chain of refined actions all the way to highestRefinedAction is comprised of left movers
+                  var actionDeclRef = calleeDecl.RefinedAction;
+                  while (actionDeclRef != null)
+                  {
+                    var actionDecl = actionDeclRef.ActionDecl;
+                    if (!actionDecl.IsLeftMover)
+                    {
+                      tc.Error(this,
+                        $"callee abstraction in synchronized call must be a left mover: {actionDecl.Name}");
+                    }
+                    else if (actionDecl != highestRefinedActionDecl)
+                    {
+                      actionDeclRef = actionDecl.RefinedAction;
+                    }
+                    else
+                    {
+                      actionDeclRef = null;
+                    }
+                  }
+                }
+              }
+            }
+          }
+          else // callerDecl.Layer == calleeDecl.Layer
+          {
+            if (callerDecl.MoverType != MoverType.None)
+            {
+              tc.Error(this, "caller must not be a mover procedure");
+            }
+            else if (!IsAsync)
+            {
+              if (calleeDecl.RefinedAction != null)
+              {
+                calleeDecl.OutParams.Where(x => calleeDecl.HiddenFormals.Contains(x)).Iter(x =>
+                {
+                  tc.Error(this,
+                    $"hidden output variable not allowed for callee with the same layer as caller: {x.Name}");
+                });
+              }
+            }
+            else if (isSynchronized)
+            {
+              tc.Error(this, "layer of callee in synchronized call must be less than layer of caller");
+            }
+          }
+
+          if (IsAsync && !isSynchronized)
+          {
+            if (callerDecl.MoverType != MoverType.None)
+            {
+              tc.Error(this, "caller must not be a mover procedure");
+            }
+            else if (calleeDecl.RefinedAction != null)
+            {
+              var highestRefinedAction = calleeDecl.RefinedActionAtLayer(callerDecl.Layer + 1);
+              if (highestRefinedAction == null)
+              {
+                tc.Error(this, $"called action is not available at layer {callerDecl.Layer + 1}");
+              }
+              else if (highestRefinedAction.ActionQualifier != ActionQualifier.Async)
+              {
+                tc.Error(this, $"action {highestRefinedAction.Name} refined by callee must be async");
+              }
+            }
+          }
+        }
+        else // calleeDecl.MoverType != MoverType.None
+        {
+          if (callerDecl.Layer > calleeDecl.Layer)
+          {
+            tc.Error(this, "layer of caller must be equal to layer of callee");
+          }
+          else
+          {
+            CheckModifies(calleeDecl.ModifiedVars);
+            if (IsAsync)
+            {
+              if (!isSynchronized)
+              {
+                tc.Error(this, "async call to mover procedure must be synchronized");
+              }
+              else if (!calleeDecl.IsLeftMover)
+              {
+                tc.Error(this, "callee in synchronized call must be a left mover");
+              }
+            }
+          }
+        }
+      }
+      else if (Proc is YieldInvariantDecl yieldInvariantDecl)
+      {
+        if (yieldInvariantDecl.Layer > callerDecl.Layer)
+        {
+          tc.Error(this, "layer of callee must not be more than layer of caller");
+        }
+      }
+      else if (Proc is ActionDecl { ActionQualifier: ActionQualifier.Link } actionDecl)
+      {
+        var calleeLayer = actionDecl.LayerRange.LowerLayer;
+        if (calleeLayer > callerDecl.Layer)
+        {
+          tc.Error(this, "layer of callee must not be more than layer of caller");
+        }
+        else if (calleeLayer < callerDecl.Layer)
+        {
+          actionDecl.Modifies.Iter(ie =>
+          {
+            if (ie.Decl.LayerRange.UpperLayer != calleeLayer)
+            {
+              tc.Error(this, $"modified variable of callee must be hidden at layer {calleeLayer}: {ie.Decl.Name}");
+            }
+          });
+        }
+        else
+        {
+          CheckModifies(actionDecl.ModifiedVars);
+        }
+      }
+      else
+      {
+        Debug.Assert(Proc.IsPure);
+        if (Layers.Count != 1)
+        {
+          tc.Error(this, "call to pure procedure must be annotated with a layer");
+        }
+        else
+        {
+          if (Layers[0] > callerDecl.Layer)
+          {
+            tc.Error(this, "layer of callee must not be more than layer of caller");
+          }
+        }
+      }
+      
+      var expectedLayerRanges = Proc.InParams.Select(FormalLayerRange).ToList();
+      for (int i = 0; i < Proc.OutParams.Count; i++)
+      {
+        var formal = Proc.OutParams[i];
+        var actual = Outs[i];
+        if (actual.Decl is GlobalVariable)
+        {
+          tc.Error(actual, $"global variable directly modified in a yield procedure: {actual.Decl.Name}");
+        }
+        else
+        {
+          var formalLayerRange = FormalLayerRange(formal);
+          if (!actual.Decl.LayerRange.Subset(formalLayerRange))
+          {
+            tc.Error(this, $"variable must be available only within layers in {formalLayerRange}: {actual.Decl.Name}");
+          }
+        }
+      }
+      return expectedLayerRanges;
+    }
+
+    private void TypecheckCallCmdInActionDecl(TypecheckingContext tc)
+    {
+      if (tc.Proc is not ActionDecl callerActionDecl)
+      {
+        return;
+      }
+
+      if (CivlPrimitives.Linear.Contains(Proc.Name))
+      {
+        // ok
+      }
+      else if (CivlPrimitives.Async.Contains(Proc.Name))
+      {
+        var type = TypeProxy.FollowProxy(TypeParameters[Proc.TypeParameters[0]].Expanded);
+        if (type is CtorType ctorType && ctorType.Decl is DatatypeTypeCtorDecl datatypeTypeCtorDecl)
+        {
+          if (callerActionDecl.Creates.All(x => x.ActionName != datatypeTypeCtorDecl.Name))
+          {
+            tc.Error(this, "primitive instantiated on type not in the creates clause of caller");
+          }
+        }
+        else
+        {
+          tc.Error(this, "type parameter to primitive call must be instantiated with a pending async type");
+        }
+      }
+      else if (Proc is ActionDecl calleeActionDecl)
+      {
+        if (calleeActionDecl.ActionQualifier == ActionQualifier.Invariant)
+        {
+          tc.Error(this, "an invariant action may not be called");
+        }
+        foreach (var actionDeclRef in calleeActionDecl.Creates)
+        {
+          if (callerActionDecl.Creates.All(x => x.ActionDecl != actionDeclRef.ActionDecl))
+          {
+            tc.Error(actionDeclRef, "callee creates a pending async not in the creates clause of caller");
+          }
+        }
+        if (!callerActionDecl.LayerRange.Subset(calleeActionDecl.LayerRange))
+        {
+          tc.Error(this, "caller layer range must be subset of callee layer range");
+        }
+        else if (callerActionDecl.LayerRange.LowerLayer == calleeActionDecl.LayerRange.LowerLayer &&
+                 calleeActionDecl.ActionQualifier == ActionQualifier.Link &&
+                 callerActionDecl.ActionQualifier != ActionQualifier.Link)
+        {
+          tc.Error(this, "lower layer of caller must be greater than lower layer of callee");
+        }
+      }
+      else
+      {
+        tc.Error(this, "an action may only call actions or pending async primitives");
       }
     }
 
@@ -3237,23 +3601,30 @@ namespace Microsoft.Boogie
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      //Contract.Requires(tc != null);
       Contract.Assume(this.Proc !=
                       null); // we assume the CallCmd has been successfully resolved before calling this Typecheck method
 
       (this as ICarriesAttributes).TypecheckAttributes(tc);
 
+      List<LayerRange> expectedLayerRanges = TypecheckCallCmdInYieldProcedureDecl(tc);
+      
       // typecheck in-parameters
-      foreach (Expr e in Ins)
+      for (int i = 0; i < Ins.Count; i++)
       {
+        var e = Ins[i];
         if (e != null)
         {
+          tc.GlobalAccessOnlyInOld = tc.Proc is YieldProcedureDecl && Proc is YieldProcedureDecl;
+          tc.ExpectedLayerRange = expectedLayerRanges?[i];
           e.Typecheck(tc);
+          tc.GlobalAccessOnlyInOld = false;
+          tc.ExpectedLayerRange = null;
         }
       }
 
-      foreach (Expr e in Outs)
+      for (int i = 0; i < Outs.Count; i++)
       {
+        var e = Outs[i];
         if (e != null)
         {
           e.Typecheck(tc);
@@ -3300,92 +3671,7 @@ namespace Microsoft.Boogie
       TypeParameters = SimpleTypeParamInstantiation.From(Proc.TypeParameters,
         actualTypeParams);
 
-      if (tc.Proc.IsPure && !Proc.IsPure)
-      {
-        tc.Error(this, "pure procedure may only call a pure procedure");
-      }
-      if (tc.Yields)
-      {
-        if (Proc is YieldProcedureDecl || Proc is YieldInvariantDecl || Proc.IsPure ||
-            (Proc is ActionDecl actionDecl && actionDecl.ActionQualifier == ActionQualifier.Link))
-        {
-          // call is fine
-        }
-        else
-        {
-          tc.Error(this,
-            "a yielding procedure may only call yield procedures, yield invariants, pure procedures, or link actions");
-        }
-      }
-      else if (tc.Proc is ActionDecl callerActionDecl)
-      {
-        if (CivlPrimitives.Linear.Contains(Proc.Name))
-        {
-          // ok
-        }
-        else if (CivlPrimitives.Async.Contains(Proc.Name))
-        {
-          var type = TypeProxy.FollowProxy(TypeParameters[Proc.TypeParameters[0]].Expanded);
-          if (type is CtorType ctorType && ctorType.Decl is DatatypeTypeCtorDecl datatypeTypeCtorDecl)
-          {
-            if (callerActionDecl.Creates.All(x => x.ActionName != datatypeTypeCtorDecl.Name))
-            {
-              tc.Error(this, "primitive instantiated on type not in the creates clause of caller");
-            }
-          }
-          else
-          {
-            tc.Error(this, "type parameter to primitive call must be instantiated with a pending async type");
-          }
-        }
-        else if (Proc is ActionDecl calleeActionDecl)
-        {
-          if (calleeActionDecl.ActionQualifier == ActionQualifier.Invariant)
-          {
-            tc.Error(this, "an invariant action may not be called");
-          }
-          foreach (var actionDeclRef in calleeActionDecl.Creates)
-          {
-            if (callerActionDecl.Creates.All(x => x.ActionDecl != actionDeclRef.ActionDecl))
-            {
-              tc.Error(actionDeclRef, "callee creates a pending async not in the creates clause of caller");
-            }
-          }
-          if (!callerActionDecl.LayerRange.Subset(calleeActionDecl.LayerRange))
-          {
-            tc.Error(this, "caller layer range must be subset of callee layer range");
-          }
-          else if (callerActionDecl.LayerRange.LowerLayer == calleeActionDecl.LayerRange.LowerLayer &&
-                   calleeActionDecl.ActionQualifier == ActionQualifier.Link &&
-                   callerActionDecl.ActionQualifier != ActionQualifier.Link)
-          {
-            tc.Error(this, "lower layer of caller must be greater than lower layer of callee");
-          }
-        }
-        else
-        {
-          tc.Error(this, "an action may only call actions or pending async primitives");
-        }
-      }
-      else
-      {
-        Debug.Assert(tc.Proc.GetType() == typeof(Procedure));
-        if (Proc.GetType() != typeof(Procedure))
-        {
-          tc.Error(this, "a procedure may only call other procedures");
-        }
-      }
-      if (IsAsync)
-      {
-        if (!tc.Yields)
-        {
-          tc.Error(this, "calling procedure of an async call must yield");
-        }
-        if (Proc is not YieldProcedureDecl)
-        {
-          tc.Error(this, "target procedure of an async call must yield");
-        }
-      }
+      TypecheckCallCmdInActionDecl(tc);
     }
 
     private IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ TypeParamSubstitution()
@@ -3857,6 +4143,17 @@ namespace Microsoft.Boogie
       Expr.Resolve(rc);
       (this as ICarriesAttributes).ResolveAttributes(rc);
       Layers = (this as ICarriesAttributes).FindLayers();
+      if (rc.Proc is YieldProcedureDecl yieldProcedureDecl && this is AssertCmd && !this.HasAttribute(CivlAttributes.YIELDS))
+      {
+        if (Layers.Count == 0)
+        {
+          rc.Error(this, "expected layers");
+        }
+        else if (Layers[^1] > yieldProcedureDecl.Layer)
+        {
+          rc.Error(this, $"each layer must not be more than {yieldProcedureDecl.Layer}");
+        }
+      }
       var id = QKeyValue.FindStringAttribute(Attributes, "id");
       if (id != null)
       {
@@ -4022,7 +4319,9 @@ namespace Microsoft.Boogie
     public override void Typecheck(TypecheckingContext tc)
     {
       (this as ICarriesAttributes).TypecheckAttributes(tc);
+      tc.ExpectedLayerRange = Layers == null || Layers.Count == 0 ? null : new LayerRange(Layers[0], Layers[^1]);
       Expr.Typecheck(tc);
+      tc.ExpectedLayerRange = null;
       Contract.Assert(Expr.Type != null); // follows from Expr.Typecheck postcondition
       if (!Expr.Type.Unify(Type.Bool))
       {
@@ -4219,16 +4518,18 @@ namespace Microsoft.Boogie
 
     public override void Resolve(ResolutionContext rc)
     {
-      //Contract.Requires(rc != null);
       (this as ICarriesAttributes).ResolveAttributes(rc);
       base.Resolve(rc);
     }
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      //Contract.Requires(tc != null);
       (this as ICarriesAttributes).TypecheckAttributes(tc);
+      tc.ExpectedLayerRange = tc.Proc is YieldProcedureDecl decl ? new LayerRange(0, decl.Layer) : null;
+      tc.GlobalAccessOnlyInOld = true;
       Expr.Typecheck(tc);
+      tc.ExpectedLayerRange = null;
+      tc.GlobalAccessOnlyInOld = false;
       Contract.Assert(Expr.Type != null); // follows from Expr.Typecheck postcondition
       if (!Expr.Type.Unify(Type.Bool))
       {
@@ -4238,8 +4539,6 @@ namespace Microsoft.Boogie
 
     public override Absy StdDispatch(StandardVisitor visitor)
     {
-      //Contract.Requires(visitor != null);
-      Contract.Ensures(Contract.Result<Absy>() != null);
       return visitor.VisitAssumeCmd(this);
     }
   }

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -3290,7 +3290,7 @@ namespace Microsoft.Boogie
 
       void CheckModifies(IEnumerable<Variable> modifiedVars)
       {
-        if (callerDecl.MoverType == MoverType.None)
+        if (!callerDecl.HasMoverType)
         {
           return;
         }
@@ -3314,7 +3314,7 @@ namespace Microsoft.Boogie
           case YieldProcedureDecl calleeDecl:
           {
             formalLayerRange = formal.LayerRange;
-            if (calleeDecl.MoverType == MoverType.None && formalLayerRange.UpperLayer == calleeDecl.Layer &&
+            if (!calleeDecl.HasMoverType && formalLayerRange.UpperLayer == calleeDecl.Layer &&
                 !calleeDecl.HiddenFormals.Contains(formal))
             {
               formalLayerRange = new LayerRange(formalLayerRange.LowerLayer, callerDecl.Layer);
@@ -3337,7 +3337,7 @@ namespace Microsoft.Boogie
         {
           tc.Error(this, "layer of callee must not be more than layer of caller");
         }
-        else if (calleeDecl.MoverType == MoverType.None)
+        else if (!calleeDecl.HasMoverType)
         {
           if (callerDecl.Layer > calleeDecl.Layer)
           {
@@ -3353,7 +3353,7 @@ namespace Microsoft.Boogie
                 CheckModifies(highestRefinedActionDecl.ModifiedVars);
                 if (highestRefinedActionDecl.Creates.Any())
                 {
-                  if (callerDecl.MoverType != MoverType.None)
+                  if (callerDecl.HasMoverType)
                   {
                     tc.Error(this, "caller must not be a mover procedure");
                   }
@@ -3385,7 +3385,7 @@ namespace Microsoft.Boogie
           }
           else // callerDecl.Layer == calleeDecl.Layer
           {
-            if (callerDecl.MoverType != MoverType.None)
+            if (callerDecl.HasMoverType)
             {
               tc.Error(this, "caller must not be a mover procedure");
             }
@@ -3397,7 +3397,7 @@ namespace Microsoft.Boogie
 
           if (IsAsync && !isSynchronized)
           {
-            if (callerDecl.MoverType != MoverType.None)
+            if (callerDecl.HasMoverType)
             {
               tc.Error(this, "caller must not be a mover procedure");
             }
@@ -3415,7 +3415,7 @@ namespace Microsoft.Boogie
             }
           }
         }
-        else // calleeDecl.MoverType != MoverType.None
+        else // calleeDecl.HasMoverType
         {
           if (callerDecl.Layer > calleeDecl.Layer)
           {

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -3359,7 +3359,7 @@ namespace Microsoft.Boogie
                    calleeActionDecl.ActionQualifier == ActionQualifier.Link &&
                    callerActionDecl.ActionQualifier != ActionQualifier.Link)
           {
-            tc.Error(this, "lower layer of caller must be greater that lower layer of callee");
+            tc.Error(this, "lower layer of caller must be greater than lower layer of callee");
           }
         }
         else

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -3389,18 +3389,7 @@ namespace Microsoft.Boogie
             {
               tc.Error(this, "caller must not be a mover procedure");
             }
-            else if (!IsAsync)
-            {
-              if (calleeDecl.RefinedAction != null)
-              {
-                calleeDecl.OutParams.Where(x => calleeDecl.HiddenFormals.Contains(x)).Iter(x =>
-                {
-                  tc.Error(this,
-                    $"hidden output variable not allowed for callee with the same layer as caller: {x.Name}");
-                });
-              }
-            }
-            else if (isSynchronized)
+            else if (IsAsync && isSynchronized)
             {
               tc.Error(this, "layer of callee in synchronized call must be less than layer of caller");
             }

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -3351,6 +3351,16 @@ namespace Microsoft.Boogie
               tc.Error(actionDeclRef, "callee creates a pending async not in the creates clause of caller");
             }
           }
+          if (!callerActionDecl.LayerRange.Subset(calleeActionDecl.LayerRange))
+          {
+            tc.Error(this, "caller layer range must be subset of callee layer range");
+          }
+          else if (callerActionDecl.LayerRange.lowerLayerNum == calleeActionDecl.LayerRange.lowerLayerNum &&
+                   calleeActionDecl.ActionQualifier == ActionQualifier.Link &&
+                   callerActionDecl.ActionQualifier != ActionQualifier.Link)
+          {
+            tc.Error(this, "lower layer of caller must be greater that lower layer of callee");
+          }
         }
         else
         {

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -3355,7 +3355,7 @@ namespace Microsoft.Boogie
           {
             tc.Error(this, "caller layer range must be subset of callee layer range");
           }
-          else if (callerActionDecl.LayerRange.lowerLayerNum == calleeActionDecl.LayerRange.lowerLayerNum &&
+          else if (callerActionDecl.LayerRange.LowerLayer == calleeActionDecl.LayerRange.LowerLayer &&
                    calleeActionDecl.ActionQualifier == ActionQualifier.Link &&
                    callerActionDecl.ActionQualifier != ActionQualifier.Link)
           {

--- a/Source/Core/AST/AbsyExpr.cs
+++ b/Source/Core/AST/AbsyExpr.cs
@@ -1346,6 +1346,51 @@ namespace Microsoft.Boogie
         }
 
         Type = Decl.TypedIdent.Type;
+        if (Decl is Constant || Decl is BoundVariable)
+        {
+          return;
+        }
+
+        // Decl is GlobalVariable or LocalVariable or Formal
+        if (tc.Proc is ActionDecl actionDecl)
+        {
+          if (Decl is GlobalVariable)
+          {
+            var globalVarLayerRange = Decl.LayerRange;
+            if (actionDecl.ActionQualifier != ActionQualifier.Link)
+            {
+              // a global variable introduced at layer n is visible to an action only at layer n+1 or higher
+              // unless the action is a link action
+              globalVarLayerRange =
+                new LayerRange(globalVarLayerRange.LowerLayer + 1, globalVarLayerRange.UpperLayer);
+            }
+            if (!actionDecl.LayerRange.Subset(globalVarLayerRange))
+            {
+              tc.Error(this, $"variable not available across layers in {actionDecl.LayerRange}: {Decl.Name}");
+            }
+          }
+        }
+        else if (tc.Proc is YieldInvariantDecl yieldInvariantDecl)
+        {
+          if (Decl is GlobalVariable)
+          {
+            if (!Decl.LayerRange.Contains(yieldInvariantDecl.Layer))
+            {
+              tc.Error(this, $"variable not available at layer {yieldInvariantDecl.Layer}: {Decl.Name}");
+            }
+          }
+        }
+        else if (tc.Proc is YieldProcedureDecl)
+        {
+          if (Decl is GlobalVariable && !tc.GlobalAccessOk)
+          {
+            tc.Error(this, $"global variable must be accessed inside old expression: {Decl.Name}");
+          }
+          if (tc.ExpectedLayerRange != null && !tc.ExpectedLayerRange.Subset(Decl.LayerRange))
+          {
+            tc.Error(this, $"variable not available across layers in {tc.ExpectedLayerRange}: {Decl.Name}");
+          }
+        }
       }
     }
 
@@ -1514,8 +1559,9 @@ namespace Microsoft.Boogie
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      //Contract.Requires(tc != null);
+      tc.InsideOld++;
       Expr.Typecheck(tc);
+      tc.InsideOld--;
       Type = Expr.Type;
     }
 

--- a/Source/Core/AST/AbsyExpr.cs
+++ b/Source/Core/AST/AbsyExpr.cs
@@ -1297,7 +1297,6 @@ namespace Microsoft.Boogie
 
     public override void Resolve(ResolutionContext rc)
     {
-      //Contract.Requires(rc != null);
       if (Decl != null)
       {
         // already resolved, but re-resolve type just in case it came from an unresolved type
@@ -1327,14 +1326,12 @@ namespace Microsoft.Boogie
 
     public override void ComputeFreeVariables(Set /*Variable*/ freeVars)
     {
-      //Contract.Requires(freeVars != null);
       Contract.Assume(this.Decl != null);
       freeVars.Add(Decl);
     }
 
     public override void Typecheck(TypecheckingContext tc)
     {
-      //Contract.Requires(tc != null);
       if (this.Decl != null)
       {
         // sanity check

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Boogie
     public static int Max = int.MaxValue;
     public static LayerRange MinMax = new LayerRange(Min, Max);
 
-    public int lowerLayerNum;
-    public int upperLayerNum;
+    public int LowerLayer;
+    public int UpperLayer;
 
     public LayerRange(int layer) : this(layer, layer)
     {
@@ -21,28 +21,28 @@ namespace Microsoft.Boogie
     public LayerRange(int lower, int upper)
     {
       Debug.Assert(lower <= upper);
-      this.lowerLayerNum = lower;
-      this.upperLayerNum = upper;
+      this.LowerLayer = lower;
+      this.UpperLayer = upper;
     }
 
     public bool Contains(int layerNum)
     {
-      return lowerLayerNum <= layerNum && layerNum <= upperLayerNum;
+      return LowerLayer <= layerNum && layerNum <= UpperLayer;
     }
 
     public bool Subset(LayerRange other)
     {
-      return other.lowerLayerNum <= lowerLayerNum && upperLayerNum <= other.upperLayerNum;
+      return other.LowerLayer <= LowerLayer && UpperLayer <= other.UpperLayer;
     }
 
     public bool OverlapsWith(LayerRange other)
     {
-      return lowerLayerNum <= other.upperLayerNum && other.lowerLayerNum <= upperLayerNum;
+      return LowerLayer <= other.UpperLayer && other.LowerLayer <= UpperLayer;
     }
 
     public override string ToString()
     {
-      return $"[{lowerLayerNum}, {upperLayerNum}]";
+      return $"[{LowerLayer}, {UpperLayer}]";
     }
 
     public override bool Equals(object obj)
@@ -53,12 +53,12 @@ namespace Microsoft.Boogie
         return false;
       }
 
-      return lowerLayerNum == other.lowerLayerNum && upperLayerNum == other.upperLayerNum;
+      return LowerLayer == other.LowerLayer && UpperLayer == other.UpperLayer;
     }
 
     public override int GetHashCode()
     {
-      return (23 * 31 + lowerLayerNum) * 31 + upperLayerNum;
+      return (23 * 31 + LowerLayer) * 31 + UpperLayer;
     }
   }
 

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -40,6 +40,22 @@ namespace Microsoft.Boogie
       return LowerLayer <= other.UpperLayer && other.LowerLayer <= UpperLayer;
     }
 
+    public static LayerRange Union(LayerRange first, LayerRange second)
+    {
+      return new LayerRange(Math.Min(first.LowerLayer, second.LowerLayer), Math.Max(first.UpperLayer, second.UpperLayer));
+    }
+    
+    public static LayerRange Union(List<LayerRange> layerRanges)
+    {
+      Debug.Assert(layerRanges.Any());
+      var unionLayerRange = layerRanges.First();
+      foreach (var layerRange in layerRanges)
+      {
+        unionLayerRange = Union(unionLayerRange, layerRange);
+      }
+      return unionLayerRange;
+    }
+    
     public override string ToString()
     {
       return $"[{LowerLayer}, {UpperLayer}]";

--- a/Source/Core/ResolutionContext.cs
+++ b/Source/Core/ResolutionContext.cs
@@ -739,6 +739,8 @@ namespace Microsoft.Boogie
         cce.EndExpose();
       }
     }
+
+    public Procedure Proc;
   }
 
   public class TypecheckingContext : CheckingContext

--- a/Source/Core/ResolutionContext.cs
+++ b/Source/Core/ResolutionContext.cs
@@ -747,6 +747,9 @@ namespace Microsoft.Boogie
   {
     public CoreOptions Options { get; }
     public Procedure Proc;
+    public LayerRange ExpectedLayerRange;
+    public bool GlobalAccessOnlyInOld;
+    public int InsideOld;
 
     public TypecheckingContext(IErrorSink errorSink, CoreOptions options)
       : base(errorSink)
@@ -760,5 +763,7 @@ namespace Microsoft.Boogie
     }
 
     public bool Yields => Proc is YieldProcedureDecl;
+
+    public bool GlobalAccessOk => !GlobalAccessOnlyInOld || 0 < InsideOld;
   }
 }

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -667,6 +667,11 @@ namespace Microsoft.Boogie
       return VisitProcedure(node);
     }
 
+    public virtual Procedure VisitYieldInvariantDecl(YieldInvariantDecl node)
+    {
+      return VisitProcedure(node);
+    }
+    
     public virtual Program VisitProgram(Program node)
     {
       Contract.Requires(node != null);

--- a/Test/civl/call-yield-invariant-errors.bpl.expect
+++ b/Test/civl/call-yield-invariant-errors.bpl.expect
@@ -1,3 +1,3 @@
-call-yield-invariant-errors.bpl(15,2): Error: Linear variable x can occur only once as an input parameter of a parallel call
-call-yield-invariant-errors.bpl(22,2): Error: Linear variable x cannot be an input parameter to both a yield invariant and a procedure in a parallel call
+call-yield-invariant-errors.bpl(15,2): Error: linear variable can occur only once as an input parameter of a parallel call: x
+call-yield-invariant-errors.bpl(22,2): Error: linear variable cannot be an input parameter to both a yield invariant and a procedure in a parallel call: x
 2 type checking errors detected in call-yield-invariant-errors.bpl

--- a/Test/civl/intro-inline-check.bpl.expect
+++ b/Test/civl/intro-inline-check.bpl.expect
@@ -1,2 +1,2 @@
-intro-inline-check.bpl(9,4): Error: lower layer of caller must be greater that lower layer of callee
+intro-inline-check.bpl(9,4): Error: lower layer of caller must be greater than lower layer of callee
 1 type checking errors detected in intro-inline-check.bpl

--- a/Test/civl/intro-inline-check.bpl.expect
+++ b/Test/civl/intro-inline-check.bpl.expect
@@ -1,2 +1,2 @@
-intro-inline-check.bpl(9,4): Error: Lower layer of caller must be greater that lower layer of callee
+intro-inline-check.bpl(9,4): Error: lower layer of caller must be greater that lower layer of callee
 1 type checking errors detected in intro-inline-check.bpl

--- a/Test/civl/local-layers.bpl.expect
+++ b/Test/civl/local-layers.bpl.expect
@@ -1,3 +1,3 @@
-local-layers.bpl(9,9): Error: Variables accessed in the source of assignment to y must exist at all layers where y exists
-local-layers.bpl(10,4): Error: Local variables accessed in assume command must be available at all layers where the enclosing procedure exists
+local-layers.bpl(9,15): Error: variable not available across layers in [0, 5]: x
+local-layers.bpl(10,11): Error: variable not available across layers in [0, 5]: x
 2 type checking errors detected in local-layers.bpl

--- a/Test/civl/yield-requires-ensures-errors-3.bpl.expect
+++ b/Test/civl/yield-requires-ensures-errors-3.bpl.expect
@@ -1,2 +1,3 @@
+yield-requires-ensures-errors-3.bpl(12,29): Error: argument must be available
 yield-requires-ensures-errors-3.bpl(12,9): Error: Only linear variable can be passed to linear parameter: a
-1 type checking errors detected in yield-requires-ensures-errors-3.bpl
+2 type checking errors detected in yield-requires-ensures-errors-3.bpl

--- a/Test/civl/yield-requires-ensures-errors-4.bpl
+++ b/Test/civl/yield-requires-ensures-errors-4.bpl
@@ -1,0 +1,17 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type {:linear "lin"} X = int;
+
+var {:layer 0,1} x:int;
+
+yield invariant {:layer 1} linear_yield_x({:linear "lin"} n: int);
+invariant x >= n;
+
+yield procedure {:layer 1}
+p3({:linear "lin"} a: int, {:linear_in "lin"} b: int, {:linear_out "lin"} c: int);
+requires call linear_yield_x(a);
+ensures call linear_yield_x(a);
+requires call linear_yield_x(c);
+ensures call linear_yield_x(b);
+preserves call linear_yield_x(c);

--- a/Test/civl/yield-requires-ensures-errors-4.bpl.expect
+++ b/Test/civl/yield-requires-ensures-errors-4.bpl.expect
@@ -1,0 +1,4 @@
+yield-requires-ensures-errors-4.bpl(15,29): Error: argument must be available
+yield-requires-ensures-errors-4.bpl(16,28): Error: argument must be available
+yield-requires-ensures-errors-4.bpl(17,30): Error: argument must be available
+3 type checking errors detected in yield-requires-ensures-errors-4.bpl

--- a/Test/civl/yield-requires-ensures-errors.bpl
+++ b/Test/civl/yield-requires-ensures-errors.bpl
@@ -8,19 +8,8 @@ var {:layer 0,1} x:int;
 yield invariant {:layer 1} yield_x(n: int);
 invariant x >= n;
 
-yield invariant {:layer 1} linear_yield_x({:linear "lin"} n: int);
-invariant x >= n;
-
 yield procedure {:layer 1} p2({:layer 0,0} a: int) returns (c: int)
 requires call yield_x(a);
 ensures call yield_x(a + c);
 {
 }
-
-yield procedure {:layer 1}
-p3({:linear "lin"} a: int, {:linear_in "lin"} b: int, {:linear_out "lin"} c: int);
-requires call linear_yield_x(a);
-ensures call linear_yield_x(a);
-requires call linear_yield_x(c);
-ensures call linear_yield_x(b);
-preserves call linear_yield_x(c);

--- a/Test/civl/yield-requires-ensures-errors.bpl.expect
+++ b/Test/civl/yield-requires-ensures-errors.bpl.expect
@@ -1,6 +1,3 @@
-yield-requires-ensures-errors.bpl(15,9): Error: A local variable used in input to the call not available at layer 1
-yield-requires-ensures-errors.bpl(16,8): Error: A local variable used in input to the call not available at layer 1
-yield-requires-ensures-errors.bpl(24,29): Error: argument must be available
-yield-requires-ensures-errors.bpl(25,28): Error: argument must be available
-yield-requires-ensures-errors.bpl(26,30): Error: argument must be available
-5 type checking errors detected in yield-requires-ensures-errors.bpl
+yield-requires-ensures-errors.bpl(12,22): Error: variable not available across layers in [1, 1]: a
+yield-requires-ensures-errors.bpl(13,21): Error: variable not available across layers in [1, 1]: a
+2 type checking errors detected in yield-requires-ensures-errors.bpl

--- a/Test/civl/yield-requires-ensures-errors.bpl.expect
+++ b/Test/civl/yield-requires-ensures-errors.bpl.expect
@@ -1,6 +1,6 @@
 yield-requires-ensures-errors.bpl(15,9): Error: A local variable used in input to the call not available at layer 1
 yield-requires-ensures-errors.bpl(16,8): Error: A local variable used in input to the call not available at layer 1
-yield-requires-ensures-errors.bpl(24,29): Error: Argument must be available
-yield-requires-ensures-errors.bpl(25,28): Error: Argument must be available
-yield-requires-ensures-errors.bpl(26,30): Error: Argument must be available
+yield-requires-ensures-errors.bpl(24,29): Error: argument must be available
+yield-requires-ensures-errors.bpl(25,28): Error: argument must be available
+yield-requires-ensures-errors.bpl(26,30): Error: argument must be available
 5 type checking errors detected in yield-requires-ensures-errors.bpl

--- a/Test/test1/Pure.bpl.expect
+++ b/Test/test1/Pure.bpl.expect
@@ -1,2 +1,2 @@
 Pure.bpl(7,4): Error: pure procedure may only call a pure procedure
-1 type checking errors detected in Pure.bpl
+1 name resolution errors detected in Pure.bpl


### PR DESCRIPTION
This PR further refactors the Civl type checker primarily caused by the adding of layer information to ASTs introduced for Civl.