### PR TITLE
Prevent Boogie from hanging

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.16.5</Version>
+    <Version>2.16.6</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/VCGeneration/CheckerPool.cs
+++ b/Source/VCGeneration/CheckerPool.cs
@@ -28,12 +28,16 @@ namespace VC
       }
 
       await checkersSemaphore.WaitAsync(cancellationToken);
-      if (!availableCheckers.TryTake(out var checker)) {
-        checker ??= CreateNewChecker();
+      try {
+        if (!availableCheckers.TryTake(out var checker)) {
+          checker ??= CreateNewChecker();
+        }
+        PrepareChecker(vcgen.program, split, checker);
+        return checker;
+      } catch (Exception) {
+        checkersSemaphore.Release();
+        throw;
       }
-
-      PrepareChecker(vcgen.program, split, checker);
-      return checker;
     }
 
     private int createdCheckers;

--- a/Test/commandline/broken_solver_more_impls_than_cores.bpl
+++ b/Test/commandline/broken_solver_more_impls_than_cores.bpl
@@ -1,0 +1,12 @@
+// RUN: ! %boogie /vcsCores:1 "/proverOpt:PROVER_PATH=doesNotExit" "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure first()
+{
+    assume true;
+}
+
+procedure second()
+{
+    assume true;
+}

--- a/Test/commandline/broken_solver_more_impls_than_cores.bpl.expect
+++ b/Test/commandline/broken_solver_more_impls_than_cores.bpl.expect
@@ -1,0 +1,1 @@
+Fatal Error: ProverException: Cannot find specified prover: doesNotExit


### PR DESCRIPTION
Prevent Boogie from hanging when an exception occurs when acquiring a checker, which can occur of the solver path is incorrect or the solver doesn't function correctly