### PR TITLE
Another round of refactoring in the Civl type checker

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -18,26 +18,26 @@ namespace Microsoft.Boogie
     {
       this.ActionDecl = actionDecl;
       this.PendingAsyncs = ActionDecl.Creates.Select(x => x.ActionDecl).ToList();
-      var lhss = new List<IdentifierExpr>();
-      var rhss = new List<Expr>();
-      PendingAsyncs.Iter(decl =>
-      {
-        var pa = civlTypeChecker.Formal($"PAs_{decl.Name}", decl.PendingAsyncMultisetType, false);
-        ActionDecl.OutParams.Add(pa);
-        Impl.OutParams.Add(pa);
-        lhss.Add(Expr.Ident(pa));
-        rhss.Add(ExprHelper.FunctionCall(decl.PendingAsyncConst, Expr.Literal(0)));
-        var paLocal = civlTypeChecker.LocalVariable($"local_PAs_{decl.Name}", decl.PendingAsyncMultisetType);
-        Impl.LocVars.Add(paLocal);
-      });
       if (PendingAsyncs.Any())
       {
+        var lhss = new List<IdentifierExpr>();
+        var rhss = new List<Expr>();
+        PendingAsyncs.Iter(decl =>
+        {
+          var pa = civlTypeChecker.Formal($"PAs_{decl.Name}", decl.PendingAsyncMultisetType, false);
+          ActionDecl.OutParams.Add(pa);
+          Impl.OutParams.Add(pa);
+          lhss.Add(Expr.Ident(pa));
+          rhss.Add(ExprHelper.FunctionCall(decl.PendingAsyncConst, Expr.Literal(0)));
+          var paLocal = civlTypeChecker.LocalVariable($"local_PAs_{decl.Name}", decl.PendingAsyncMultisetType);
+          Impl.LocVars.Add(paLocal);
+        });
         var tc = new TypecheckingContext(null, civlTypeChecker.Options);
         var assignCmd = CmdHelper.AssignCmd(lhss, rhss);
         assignCmd.Typecheck(tc);
         Impl.Blocks[0].Cmds.Insert(0, assignCmd);
+        DesugarCreateAsyncs(civlTypeChecker);
       }
-      DesugarCreateAsyncs(civlTypeChecker);
     }
 
     public Implementation Impl => ActionDecl.Impl;

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Boogie
       }
     }
 
+    public IToken tok => ActionDecl.tok;
+
+    public string Name => ActionDecl.Name;
+
     public Implementation Impl => ActionDecl.Impl;
     
     public LayerRange LayerRange => ActionDecl.LayerRange;
@@ -92,7 +96,7 @@ namespace Microsoft.Boogie
         Substituter.ApplyReplacingOldExprs(always, forold, ExprHelper.Old(assertCmd.Expr)));
       var transitionRelationInputs = Impl.InParams.Concat(Impl.OutParams)
         .Select(key => alwaysMap[key]).OfType<IdentifierExpr>().Select(ie => ie.Decl).ToList();
-      InputOutputRelation = new Function(Token.NoToken, $"Civl_InputOutputRelation_{ActionDecl.Name}",
+      InputOutputRelation = new Function(Token.NoToken, $"Civl_InputOutputRelation_{Name}",
         new List<TypeVariable>(),
         transitionRelationInputs, VarHelper.Formal(TypedIdent.NoName, Type.Bool, false), null,
         new QKeyValue(Token.NoToken, "inline", new List<object>(), null));
@@ -354,7 +358,7 @@ namespace Microsoft.Boogie
 
     public InvariantAction(ActionDecl actionDecl, CivlTypeChecker civlTypeChecker) : base(actionDecl, civlTypeChecker)
     {
-      var choiceDatatypeName = $"Choice_{ActionDecl.Name}";
+      var choiceDatatypeName = $"Choice_{Name}";
       ChoiceDatatypeTypeCtorDecl =
         new DatatypeTypeCtorDecl(Token.NoToken, choiceDatatypeName, new List<TypeVariable>(), null);
       PendingAsyncs.Iter(elim =>

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Boogie
       });
       civlTypeChecker.program.AddTopLevelDeclaration(ChoiceDatatypeTypeCtorDecl);
       var choice = VarHelper.Formal("choice", TypeHelper.CtorType(ChoiceDatatypeTypeCtorDecl), false);
-      ActionDecl.OutParams.Add(choice);
+      Impl.Proc.OutParams.Add(choice);
       Impl.OutParams.Add(choice);
       DesugarSetChoice(civlTypeChecker, choice);
     }

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Boogie
           DesugarSetChoice(civlTypeChecker, choice);
         }
       }
+      CompleteInitialization(civlTypeChecker);
     }
 
     public IToken tok => ActionDecl.tok;
@@ -112,7 +113,7 @@ namespace Microsoft.Boogie
     // The flag initializeInputOutputRelation is added just so the Boogie function representing the input-output relation
     // of SkipAtomicAction (not needed) is not injected into TopLevelDeclarations. This trick ensures that if the input
     // program does not use Civl features then the program is not modified.
-    public virtual void CompleteInitialization(CivlTypeChecker civlTypeChecker)
+    public void CompleteInitialization(CivlTypeChecker civlTypeChecker)
     {
       Gate = HoistAsserts(Impl, civlTypeChecker.Options);
       UsedGlobalVarsInGate = new HashSet<Variable>(VariableCollector.Collect(Gate).Where(x => x is GlobalVariable));

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Boogie
       Gate = HoistAsserts(Impl, civlTypeChecker.Options);
       UsedGlobalVarsInGate = new HashSet<Variable>(VariableCollector.Collect(Gate).Where(x => x is GlobalVariable));
       UsedGlobalVarsInAction = new HashSet<Variable>(VariableCollector.Collect(Impl).Where(x => x is GlobalVariable));
-      ModifiedGlobalVars = new HashSet<Variable>(ActionDecl.Modifies.Select(x => x.Decl));
+      ModifiedGlobalVars = new HashSet<Variable>(Impl.Proc.Modifies.Select(x => x.Decl));
       
       var alwaysMap = new Dictionary<Variable, Expr>();
       var foroldMap = new Dictionary<Variable, Expr>();

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -415,13 +415,6 @@ namespace Microsoft.Boogie
     }
   }
 
-  public class InvariantAction : Action
-  {
-    public InvariantAction(ActionDecl actionDecl, CivlTypeChecker civlTypeChecker) : base(actionDecl, civlTypeChecker)
-    {
-    }
-  }
-
   /// <summary>
   /// Creates first/second copies of atomic actions used in commutativity checks
   /// (i.e., all non-global variables are prefixed with first_ resp. second_).

--- a/Source/Concurrency/CivlRewriter.cs
+++ b/Source/Concurrency/CivlRewriter.cs
@@ -28,11 +28,6 @@ namespace Microsoft.Boogie
         decls.Add(x.Impl);
         decls.Add(x.Impl.Proc);
       });
-      civlTypeChecker.InvariantActions.Iter(x =>
-      {
-        decls.Add(x.Impl);
-        decls.Add(x.Impl.Proc);
-      });
 
       if (!options.TrustMoverTypes)
       {

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -400,8 +400,8 @@ namespace Microsoft.Boogie
     public IEnumerable<AtomicAction> LinkActions =>
       procToAtomicAction.Values.Where(action => action.ActionDecl.ActionQualifier == ActionQualifier.Link);
 
-    public IEnumerable<AtomicAction> MoverActions => procToAtomicAction.Values.Where(action =>
-      action.ActionDecl.ActionQualifier != ActionQualifier.Abstract && action.ActionDecl.ActionQualifier != ActionQualifier.Link);
+    public IEnumerable<AtomicAction> MoverActions => procToAtomicAction.Keys
+      .Where(actionDecl => actionDecl.HasMoverType).Select(actionDecl => procToAtomicAction[actionDecl]);
 
     public IEnumerable<AtomicAction> AtomicActions => procToAtomicAction.Values;
 

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -400,6 +400,8 @@ namespace Microsoft.Boogie
 
     public IEnumerable<AtomicAction> AtomicActions => procToAtomicAction.Values;
 
+    public IEnumerable<InvariantAction> InvariantActions => procToInvariantAction.Values;
+
     public void Error(Absy node, string message)
     {
       checkingContext.Error(node, message);

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -65,7 +65,6 @@ namespace Microsoft.Boogie
       skipProcedure.LayerRange = LayerRange.MinMax;
       skipProcedure.Impl = skipImplementation;
       SkipAtomicAction = new AtomicAction(skipProcedure, null, this);
-      SkipAtomicAction.CompleteInitialization(this);
       if (program.TopLevelDeclarations.OfType<YieldProcedureDecl>().Any())
       {
         procToAtomicAction[skipProcedure] = SkipAtomicAction;
@@ -236,11 +235,11 @@ namespace Microsoft.Boogie
       // Construct transition and input-output relation
       procToAtomicAction.Values.Iter(action =>
       {
-        action.CompleteInitialization(this, true);
+        action.CompleteInitialization(this);
       });
       procToInvariantAction.Values.Iter(action =>
       {
-        action.CompleteInitialization(this, true);
+        action.CompleteInitialization(this);
       });
       
       // Construct inductive sequentializations

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Boogie
       var outputVars = new List<Variable>(invariantAction.Impl.OutParams.Take(invariantAction.ActionDecl.PendingAsyncStartIndex));
       outputVars.AddRange(inputAction.PendingAsyncs.Select(action =>
         invariantAction.Impl.OutParams[pendingAsyncTypeToOutputParamIndex[action.PendingAsyncType]]));
-      cmds.Add(CmdHelper.CallCmd(inputAction.ActionDecl, invariantAction.Impl.InParams, outputVars));
+      cmds.Add(CmdHelper.CallCmd(inputAction.Impl.Proc, invariantAction.Impl.InParams, outputVars));
       
       // Assign empty multiset to the rest
       var remainderPendingAsyncs = invariantAction.PendingAsyncs.Except(inputAction.PendingAsyncs);
@@ -123,7 +123,7 @@ namespace Microsoft.Boogie
           outputExprs.Add(ie);
         });
       }
-      cmds.Add(CmdHelper.CallCmd(abs.ActionDecl, inputExprs, outputExprs));
+      cmds.Add(CmdHelper.CallCmd(abs.Impl.Proc, inputExprs, outputExprs));
       if (abs.HasPendingAsyncs)
       {
         var lhss = abs.PendingAsyncs.Select(decl => new SimpleAssignLhs(Token.NoToken, PAs(decl.PendingAsyncType)))
@@ -231,7 +231,7 @@ namespace Microsoft.Boogie
 
     private CallCmd GetInvariantCallCmd()
     {
-      return CmdHelper.CallCmd(invariantAction.ActionDecl, invariantAction.Impl.InParams,
+      return CmdHelper.CallCmd(invariantAction.Impl.Proc, invariantAction.Impl.InParams,
         invariantAction.Impl.OutParams);
     }
 
@@ -405,7 +405,7 @@ namespace Microsoft.Boogie
         $"Abstraction {abs.Name} fails gate of {action.Name}").ToList<Cmd>();
       cmds.Add(
         CmdHelper.CallCmd(
-          action.ActionDecl,
+          action.Impl.Proc,
           abs.Impl.InParams,
           abs.Impl.OutParams
         ));
@@ -423,7 +423,7 @@ namespace Microsoft.Boogie
         abs.Impl.InParams,
         abs.Impl.OutParams,
         requires,
-        action.ActionDecl.Modifies,
+        action.Impl.Proc.Modifies,
         new List<Ensures>());
       var impl = DeclHelper.Implementation(
         proc,

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Boogie
       List<Cmd> cmds = GetGateAsserts(invariantAction, null,
           $"Gate of {invariantAction.ActionDecl.Name} fails in IS conclusion check against {outputAction.ActionDecl.Name}")
         .ToList<Cmd>();
-      cmds.Add(GetCallCmd(invariantAction));
+      cmds.Add(GetInvariantCallCmd());
       cmds.Add(CmdHelper.AssumeCmd(NoPendingAsyncs));
       cmds.Add(GetCheck(inputAction.ActionDecl.tok, Substituter.Apply(subst, GetTransitionRelation(outputAction)),
         $"IS conclusion of {inputAction.ActionDecl.Name} failed"));
@@ -94,7 +94,7 @@ namespace Microsoft.Boogie
       var requires = invariantAction.Gate.Select(g => new Requires(false, g.Expr)).ToList();
       var locals = new List<Variable>();
       List<Cmd> cmds = new List<Cmd>();
-      cmds.Add(GetCallCmd(invariantAction));
+      cmds.Add(GetInvariantCallCmd());
       cmds.Add(CmdHelper.AssumeCmd(ChoiceTest(pendingAsyncType)));
       cmds.Add(CmdHelper.AssumeCmd(Expr.Gt(Expr.Select(PAs(pendingAsyncType), Choice(pendingAsyncType)),
         Expr.Literal(0))));
@@ -229,13 +229,10 @@ namespace Microsoft.Boogie
         Expr.And(new[] { invariantTransitionRelationExpr, actionExpr, leftMoverExpr }));
     }
 
-    private CallCmd GetCallCmd(Action callee)
+    private CallCmd GetInvariantCallCmd()
     {
-      return CmdHelper.CallCmd(
-        callee.ActionDecl,
-        invariantAction.Impl.InParams,
-        invariantAction.Impl.OutParams.GetRange(0, callee.Impl.OutParams.Count)
-      );
+      return CmdHelper.CallCmd(invariantAction.ActionDecl, invariantAction.Impl.InParams,
+        invariantAction.Impl.OutParams);
     }
 
     private AssertCmd GetCheck(IToken tok, Expr expr, string msg)

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Boogie
   {
     public CivlTypeChecker civlTypeChecker;
     public AtomicAction targetAction;
-    public InvariantAction invariantAction;
+    public AtomicAction invariantAction;
     public Dictionary<AtomicAction, AtomicAction> elim;
 
     private HashSet<Variable> frame;
@@ -19,7 +19,7 @@ namespace Microsoft.Boogie
     private ConcurrencyOptions Options => civlTypeChecker.Options;
 
     public InductiveSequentialization(CivlTypeChecker civlTypeChecker, AtomicAction targetAction,
-      InvariantAction invariantAction, Dictionary<AtomicAction, AtomicAction> elim)
+      AtomicAction invariantAction, Dictionary<AtomicAction, AtomicAction> elim)
     {
       this.civlTypeChecker = civlTypeChecker;
       this.targetAction = targetAction;

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Boogie
       
       var subst = GetSubstitution(inputAction, invariantAction);
       List<Cmd> cmds = GetGateAsserts(inputAction, subst,
-          $"Gate of {inputAction.ActionDecl.Name} fails in IS base check against invariant {invariantAction.ActionDecl.Name}")
+          $"Gate of {inputAction.Name} fails in IS base check against invariant {invariantAction.Name}")
         .ToList<Cmd>();
 
       // Construct call to inputAction
@@ -64,10 +64,10 @@ namespace Microsoft.Boogie
         cmds.Add(CmdHelper.AssignCmd(lhss, rhss));
       }
       
-      cmds.Add(GetCheck(inputAction.ActionDecl.tok, GetTransitionRelation(invariantAction),
-        $"IS base of {inputAction.ActionDecl.Name} failed"));
+      cmds.Add(GetCheck(inputAction.tok, GetTransitionRelation(invariantAction),
+        $"IS base of {inputAction.Name} failed"));
 
-      return GetCheckerTuple($"IS_base_{inputAction.ActionDecl.Name}", requires, new List<Variable>(), cmds);
+      return GetCheckerTuple($"IS_base_{inputAction.Name}", requires, new List<Variable>(), cmds);
     }
 
     public Tuple<Procedure, Implementation> GenerateConclusionChecker(AtomicAction inputAction)
@@ -77,14 +77,14 @@ namespace Microsoft.Boogie
       var requires = outputAction.Gate.Select(g => new Requires(false, Substituter.Apply(subst, g.Expr))).ToList();
 
       List<Cmd> cmds = GetGateAsserts(invariantAction, null,
-          $"Gate of {invariantAction.ActionDecl.Name} fails in IS conclusion check against {outputAction.ActionDecl.Name}")
+          $"Gate of {invariantAction.Name} fails in IS conclusion check against {outputAction.Name}")
         .ToList<Cmd>();
       cmds.Add(GetInvariantCallCmd());
       cmds.Add(CmdHelper.AssumeCmd(NoPendingAsyncs));
-      cmds.Add(GetCheck(inputAction.ActionDecl.tok, Substituter.Apply(subst, GetTransitionRelation(outputAction)),
-        $"IS conclusion of {inputAction.ActionDecl.Name} failed"));
+      cmds.Add(GetCheck(inputAction.tok, Substituter.Apply(subst, GetTransitionRelation(outputAction)),
+        $"IS conclusion of {inputAction.Name} failed"));
 
-      return GetCheckerTuple($"IS_conclusion_{inputAction.ActionDecl.Name}", requires, new List<Variable>(), cmds);
+      return GetCheckerTuple($"IS_conclusion_{inputAction.Name}", requires, new List<Variable>(), cmds);
     }
 
     public Tuple<Procedure, Implementation> GenerateStepChecker(AtomicAction pendingAsync)
@@ -111,7 +111,7 @@ namespace Microsoft.Boogie
       }
       var subst = Substituter.SubstitutionFromDictionary(map);
       cmds.AddRange(GetGateAsserts(abs, subst,
-        $"Gate of {abs.ActionDecl.Name} fails in IS induction step for invariant {invariantAction.ActionDecl.Name}"));
+        $"Gate of {abs.Name} fails in IS induction step for invariant {invariantAction.Name}"));
 
       List<IdentifierExpr> outputExprs = new List<IdentifierExpr>();
       if (abs.HasPendingAsyncs)
@@ -133,10 +133,10 @@ namespace Microsoft.Boogie
         cmds.Add(new AssignCmd(Token.NoToken, lhss, rhss));
       }
 
-      cmds.Add(GetCheck(invariantAction.ActionDecl.tok, GetTransitionRelation(invariantAction),
-        $"IS step of {invariantAction.ActionDecl.Name} with {abs.ActionDecl.Name} failed"));
+      cmds.Add(GetCheck(invariantAction.tok, GetTransitionRelation(invariantAction),
+        $"IS step of {invariantAction.Name} with {abs.Name} failed"));
       
-      return GetCheckerTuple($"IS_step_{invariantAction.ActionDecl.Name}_{abs.ActionDecl.Name}", requires, locals, cmds);
+      return GetCheckerTuple($"IS_step_{invariantAction.Name}_{abs.Name}", requires, locals, cmds);
     }
 
     /*
@@ -217,7 +217,7 @@ namespace Microsoft.Boogie
 
       var invariantFormalMap =
         invariantAction.Impl.InParams.Concat(invariantAction.Impl.OutParams).ToDictionary(v => v,
-          v => (Expr)Expr.Ident(civlTypeChecker.BoundVariable($"{invariantAction.ActionDecl.Name}_{v.Name}",
+          v => (Expr)Expr.Ident(civlTypeChecker.BoundVariable($"{invariantAction.Name}_{v.Name}",
             v.TypedIdent.Type)));
       var invariantFormalSubst = Substituter.SubstitutionFromDictionary(invariantFormalMap);
       actionExpr = Substituter.Apply(invariantFormalSubst, actionExpr);
@@ -402,7 +402,7 @@ namespace Microsoft.Boogie
 
       var subst = InductiveSequentialization.GetSubstitution(action, abs);
       List<Cmd> cmds = InductiveSequentialization.GetGateAsserts(action, subst,
-        $"Abstraction {abs.ActionDecl.Name} fails gate of {action.ActionDecl.Name}").ToList<Cmd>();
+        $"Abstraction {abs.Name} fails gate of {action.Name}").ToList<Cmd>();
       cmds.Add(
         CmdHelper.CallCmd(
           action.ActionDecl,
@@ -411,15 +411,15 @@ namespace Microsoft.Boogie
         ));
       cmds.Add(
         CmdHelper.AssertCmd(
-          abs.ActionDecl.tok,
+          abs.tok,
           TransitionRelationComputation.Refinement(civlTypeChecker, abs, frame),
-          $"Abstraction {abs.ActionDecl.Name} does not summarize {action.ActionDecl.Name}"
+          $"Abstraction {abs.Name} does not summarize {action.Name}"
         ));
 
       var blocks = new List<Block> { BlockHelper.Block("init", cmds) };
 
       var proc = DeclHelper.Procedure(
-        civlTypeChecker.AddNamePrefix($"AbstractionCheck_{action.ActionDecl.Name}_{abs.ActionDecl.Name}"),
+        civlTypeChecker.AddNamePrefix($"AbstractionCheck_{action.Name}_{abs.Name}"),
         abs.Impl.InParams,
         abs.Impl.OutParams,
         requires,

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Boogie
   public class InductiveSequentialization
   {
     public CivlTypeChecker civlTypeChecker;
-    public AtomicAction targetAction;
-    public AtomicAction invariantAction;
-    public Dictionary<AtomicAction, AtomicAction> elim;
+    public Action targetAction;
+    public Action invariantAction;
+    public Dictionary<Action, Action> elim;
 
     private HashSet<Variable> frame;
     private IdentifierExpr choice;
@@ -18,8 +18,8 @@ namespace Microsoft.Boogie
 
     private ConcurrencyOptions Options => civlTypeChecker.Options;
 
-    public InductiveSequentialization(CivlTypeChecker civlTypeChecker, AtomicAction targetAction,
-      AtomicAction invariantAction, Dictionary<AtomicAction, AtomicAction> elim)
+    public InductiveSequentialization(CivlTypeChecker civlTypeChecker, Action targetAction,
+      Action invariantAction, Dictionary<Action, Action> elim)
     {
       this.civlTypeChecker = civlTypeChecker;
       this.targetAction = targetAction;
@@ -35,7 +35,7 @@ namespace Microsoft.Boogie
         decl => (Variable)civlTypeChecker.LocalVariable($"newPAs_{decl.Name}", decl.PendingAsyncMultisetType));
     }
 
-    public Tuple<Procedure, Implementation> GenerateBaseCaseChecker(AtomicAction inputAction)
+    public Tuple<Procedure, Implementation> GenerateBaseCaseChecker(Action inputAction)
     {
       var requires = invariantAction.Gate.Select(g => new Requires(false, g.Expr)).ToList();
       
@@ -70,7 +70,7 @@ namespace Microsoft.Boogie
       return GetCheckerTuple($"IS_base_{inputAction.Name}", requires, new List<Variable>(), cmds);
     }
 
-    public Tuple<Procedure, Implementation> GenerateConclusionChecker(AtomicAction inputAction)
+    public Tuple<Procedure, Implementation> GenerateConclusionChecker(Action inputAction)
     {
       var outputAction = inputAction.RefinedAction;
       var subst = GetSubstitution(outputAction, invariantAction);
@@ -87,7 +87,7 @@ namespace Microsoft.Boogie
       return GetCheckerTuple($"IS_conclusion_{inputAction.Name}", requires, new List<Variable>(), cmds);
     }
 
-    public Tuple<Procedure, Implementation> GenerateStepChecker(AtomicAction pendingAsync)
+    public Tuple<Procedure, Implementation> GenerateStepChecker(Action pendingAsync)
     {
       var pendingAsyncType = pendingAsync.ActionDecl.PendingAsyncType;
       var pendingAsyncCtor = pendingAsync.ActionDecl.PendingAsyncCtor;
@@ -100,7 +100,7 @@ namespace Microsoft.Boogie
         Expr.Literal(0))));
       cmds.Add(RemoveChoice(pendingAsyncType));
 
-      AtomicAction abs = elim[pendingAsync];
+      Action abs = elim[pendingAsync];
       Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
       List<Expr> inputExprs = new List<Expr>();
       for (int i = 0; i < abs.Impl.InParams.Count; i++)
@@ -155,7 +155,7 @@ namespace Microsoft.Boogie
      *   (1) the permissions in the invocation are disjoint from the permissions in the invariant invocation, or
      *   (2) the permissions in the invocation is contained in the permissions of one of the pending asyncs created by the invariant invocation.
      */
-    public Expr GenerateMoverCheckAssumption(AtomicAction action, List<Variable> actionArgs, AtomicAction leftMover, List<Variable> leftMoverArgs)
+    public Expr GenerateMoverCheckAssumption(Action action, List<Variable> actionArgs, Action leftMover, List<Variable> leftMoverArgs)
     {
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       Expr actionExpr = Expr.True;
@@ -394,7 +394,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    private static Tuple<Procedure, Implementation> GenerateAbstractionChecker(CivlTypeChecker civlTypeChecker, AtomicAction action, AtomicAction abs)
+    private static Tuple<Procedure, Implementation> GenerateAbstractionChecker(CivlTypeChecker civlTypeChecker, Action action, Action abs)
     {
       var requires = abs.Gate.Select(g => new Requires(false, g.Expr)).ToList();
       // The type checker ensures that the modified set of abs is a subset of the modified set of action.

--- a/Source/Concurrency/LinearityChecker.cs
+++ b/Source/Concurrency/LinearityChecker.cs
@@ -42,7 +42,7 @@ class LinearityChecker
       }
     }
 
-    private IdentifierExpr PAs(AtomicAction action, int pendingAsyncIndex)
+    private IdentifierExpr PAs(Action action, int pendingAsyncIndex)
     {
       return Expr.Ident(action.Impl.OutParams[action.ActionDecl.PendingAsyncStartIndex + pendingAsyncIndex]);
     }
@@ -58,7 +58,7 @@ class LinearityChecker
       var locals = new List<Variable>();
       var ctorTypeToFirstPA = new Dictionary<CtorType, IdentifierExpr>();
       var ctorTypeToSecondPA = new Dictionary<CtorType, IdentifierExpr>();
-      if (action is AtomicAction x && x.HasPendingAsyncs)
+      if (action is Action x && x.HasPendingAsyncs)
       {
         x.PendingAsyncs.Iter(y =>
         {
@@ -96,7 +96,7 @@ class LinearityChecker
             "variables"));
         }
 
-        if (action is AtomicAction atomicAction && atomicAction.HasPendingAsyncs)
+        if (action is Action atomicAction && atomicAction.HasPendingAsyncs)
         {
           var pendingAsyncs = atomicAction.PendingAsyncs;
           

--- a/Source/Concurrency/LinearityChecker.cs
+++ b/Source/Concurrency/LinearityChecker.cs
@@ -207,14 +207,14 @@ class LinearityChecker
       blocks.Add(
         BlockHelper.Block(
           "init",
-          new List<Cmd> { CmdHelper.CallCmd(action.ActionDecl, inputs, outputs) },
+          new List<Cmd> { CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs) },
           checkerBlocks));
       blocks.AddRange(checkerBlocks);
 
       // Create the whole check procedure
       string checkerName = civlTypeChecker.AddNamePrefix($"LinearityChecker_{action.Name}");
       Procedure linCheckerProc = DeclHelper.Procedure(checkerName,
-        inputs, outputs, requires, action.ActionDecl.Modifies, new List<Ensures>());
+        inputs, outputs, requires, action.Impl.Proc.Modifies, new List<Ensures>());
       Implementation linCheckImpl = DeclHelper.Implementation(linCheckerProc,
         inputs, outputs, locals, blocks);
       decls.Add(linCheckImpl);

--- a/Source/Concurrency/LinearityChecker.cs
+++ b/Source/Concurrency/LinearityChecker.cs
@@ -196,7 +196,7 @@ class LinearityChecker
         {
           cmds.Add(CmdHelper.AssumeCmd(lc.assume));
         }
-        cmds.Add(CmdHelper.AssertCmd(action.ActionDecl.tok, lc.assert, lc.message));
+        cmds.Add(CmdHelper.AssertCmd(action.tok, lc.assert, lc.message));
         var block = BlockHelper.Block($"{lc.domainName}_{lc.checkName}", cmds);
         CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, block, ResolutionContext.State.Two);
         checkerBlocks.Add(block);
@@ -212,7 +212,7 @@ class LinearityChecker
       blocks.AddRange(checkerBlocks);
 
       // Create the whole check procedure
-      string checkerName = civlTypeChecker.AddNamePrefix($"LinearityChecker_{action.ActionDecl.Name}");
+      string checkerName = civlTypeChecker.AddNamePrefix($"LinearityChecker_{action.Name}");
       Procedure linCheckerProc = DeclHelper.Procedure(checkerName,
         inputs, outputs, requires, action.ActionDecl.Modifies, new List<Ensures>());
       Implementation linCheckImpl = DeclHelper.Implementation(linCheckerProc,

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Boogie
         return;
       }
 
-      string checkerName = $"CommutativityChecker_{first.ActionDecl.Name}_{second.ActionDecl.Name}";
+      string checkerName = $"CommutativityChecker_{first.Name}_{second.Name}";
 
       HashSet<Variable> frame = new HashSet<Variable>();
       frame.UnionWith(first.UsedGlobalVarsInGate);
@@ -177,9 +177,9 @@ namespace Microsoft.Boogie
           .Union(frame)));
       // TODO: add further disjointness expressions?
       AssertCmd commutativityCheck = CmdHelper.AssertCmd(
-        first.ActionDecl.tok,
+        first.tok,
         Expr.Imp(Expr.And(linearityAssumes), transitionRelation),
-        $"Commutativity check between {first.ActionDecl.Name} and {second.ActionDecl.Name} failed");
+        $"Commutativity check between {first.Name} and {second.Name} failed");
 
       List<Cmd> cmds = new List<Cmd>
       {
@@ -225,7 +225,7 @@ namespace Microsoft.Boogie
         requires.Add(new Requires(false, extraAssumption));
       }
 
-      string checkerName = $"GatePreservationChecker_{first.ActionDecl.Name}_{second.ActionDecl.Name}";
+      string checkerName = $"GatePreservationChecker_{first.Name}_{second.Name}";
 
       List<Variable> inputs = Enumerable.Union(first.FirstImpl.InParams, second.SecondImpl.InParams).ToList();
       List<Variable> outputs = Enumerable.Union(first.FirstImpl.OutParams, second.SecondImpl.OutParams).ToList();
@@ -241,7 +241,7 @@ namespace Microsoft.Boogie
           CmdHelper.AssertCmd(
             assertCmd.tok,
             Expr.Imp(Expr.And(linearityAssumes), assertCmd.Expr),
-            $"Gate of {first.ActionDecl.Name} not preserved by {second.ActionDecl.Name}"
+            $"Gate of {first.Name} not preserved by {second.Name}"
           )
         );
       }
@@ -287,11 +287,11 @@ namespace Microsoft.Boogie
         linearTypeChecker.DisjointnessExprForEachDomain(first.FirstImpl.InParams.Union(second.SecondImpl.OutParams)
           .Union(frame));
       AssertCmd gateFailureCheck = CmdHelper.AssertCmd(
-        first.ActionDecl.tok,
+        first.tok,
         Expr.Imp(Expr.And(linearityAssumes), firstNegatedGate),
-        $"Gate failure of {first.ActionDecl.Name} not preserved by {second.ActionDecl.Name}");
+        $"Gate failure of {first.Name} not preserved by {second.Name}");
 
-      string checkerName = $"FailurePreservationChecker_{first.ActionDecl.Name}_{second.ActionDecl.Name}";
+      string checkerName = $"FailurePreservationChecker_{first.Name}_{second.Name}";
 
       List<Variable> inputs = Enumerable.Union(first.FirstImpl.InParams, second.SecondImpl.InParams).ToList();
       List<Variable> outputs = Enumerable.Union(first.FirstImpl.OutParams, second.SecondImpl.OutParams).ToList();
@@ -311,7 +311,7 @@ namespace Microsoft.Boogie
         return;
       }
 
-      string checkerName = $"CooperationChecker_{action.ActionDecl.Name}";
+      string checkerName = $"CooperationChecker_{action.Name}";
 
       Implementation impl = action.Impl;
       HashSet<Variable> frame = new HashSet<Variable>();
@@ -327,9 +327,9 @@ namespace Microsoft.Boogie
       }
 
       AssertCmd cooperationCheck = CmdHelper.AssertCmd(
-        action.ActionDecl.tok,
+        action.tok,
         TransitionRelationComputation.Cooperation(civlTypeChecker, action, frame),
-        $"Cooperation check for {action.ActionDecl.Name} failed");
+        $"Cooperation check for {action.Name} failed");
 
       AddChecker(checkerName, new List<Variable>(impl.InParams), new List<Variable>(),
         new List<Variable>(), requires, new List<Cmd> { cooperationCheck });

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -9,17 +9,17 @@ namespace Microsoft.Boogie
     CivlTypeChecker civlTypeChecker;
     List<Declaration> decls;
 
-    HashSet<Tuple<AtomicAction, AtomicAction>> commutativityCheckerCache;
-    HashSet<Tuple<AtomicAction, AtomicAction>> gatePreservationCheckerCache;
-    HashSet<Tuple<AtomicAction, AtomicAction>> failurePreservationCheckerCache;
+    HashSet<Tuple<Action, Action>> commutativityCheckerCache;
+    HashSet<Tuple<Action, Action>> gatePreservationCheckerCache;
+    HashSet<Tuple<Action, Action>> failurePreservationCheckerCache;
 
     private MoverCheck(CivlTypeChecker civlTypeChecker, List<Declaration> decls)
     {
       this.civlTypeChecker = civlTypeChecker;
       this.decls = decls;
-      this.commutativityCheckerCache = new HashSet<Tuple<AtomicAction, AtomicAction>>();
-      this.gatePreservationCheckerCache = new HashSet<Tuple<AtomicAction, AtomicAction>>();
-      this.failurePreservationCheckerCache = new HashSet<Tuple<AtomicAction, AtomicAction>>();
+      this.commutativityCheckerCache = new HashSet<Tuple<Action, Action>>();
+      this.gatePreservationCheckerCache = new HashSet<Tuple<Action, Action>>();
+      this.failurePreservationCheckerCache = new HashSet<Tuple<Action, Action>>();
     }
 
     private ConcurrencyOptions Options => civlTypeChecker.Options;
@@ -109,25 +109,25 @@ namespace Microsoft.Boogie
       this.decls.Add(proc);
     }
 
-    private void CreateRightMoverCheckers(AtomicAction rightMover, AtomicAction action)
+    private void CreateRightMoverCheckers(Action rightMover, Action action)
     {
       CreateCommutativityChecker(rightMover, action);
       CreateGatePreservationChecker(action, rightMover);
     }
 
-    private void CreateLeftMoverCheckers(AtomicAction action, AtomicAction leftMover)
+    private void CreateLeftMoverCheckers(Action action, Action leftMover)
     {
       CreateCommutativityChecker(action, leftMover);
       CreateGatePreservationChecker(leftMover, action);
       CreateFailurePreservationChecker(action, leftMover);
     }
 
-    private CallCmd ActionCallCmd(AtomicAction action, DeclWithFormals paramProvider)
+    private CallCmd ActionCallCmd(Action action, DeclWithFormals paramProvider)
     {
       return CmdHelper.CallCmd(action.Impl.Proc, paramProvider.InParams, paramProvider.OutParams);
     }
 
-    private void CreateCommutativityChecker(AtomicAction first, AtomicAction second, Expr extraAssumption = null)
+    private void CreateCommutativityChecker(Action first, Action second, Expr extraAssumption = null)
     {
       if (first == second && first.FirstImpl.InParams.Count == 0 && first.FirstImpl.OutParams.Count == 0)
       {
@@ -194,7 +194,7 @@ namespace Microsoft.Boogie
       AddChecker(checkerName, inputs, outputs, new List<Variable>(), requires, cmds);
     }
 
-    private void CreateGatePreservationChecker(AtomicAction first, AtomicAction second, Expr extraAssumption = null)
+    private void CreateGatePreservationChecker(Action first, Action second, Expr extraAssumption = null)
     {
       if (!first.UsedGlobalVarsInGate.Intersect(second.ModifiedGlobalVars).Any())
       {
@@ -249,7 +249,7 @@ namespace Microsoft.Boogie
       AddChecker(checkerName, inputs, outputs, new List<Variable>(), requires, cmds);
     }
 
-    private void CreateFailurePreservationChecker(AtomicAction first, AtomicAction second, Expr extraAssumption = null)
+    private void CreateFailurePreservationChecker(Action first, Action second, Expr extraAssumption = null)
     {
       if (!first.UsedGlobalVarsInGate.Intersect(second.ModifiedGlobalVars).Any())
       {

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Boogie
 
     private CallCmd ActionCallCmd(AtomicAction action, DeclWithFormals paramProvider)
     {
-      return CmdHelper.CallCmd(action.ActionDecl, paramProvider.InParams, paramProvider.OutParams);
+      return CmdHelper.CallCmd(action.Impl.Proc, paramProvider.InParams, paramProvider.OutParams);
     }
 
     private void CreateCommutativityChecker(AtomicAction first, AtomicAction second, Expr extraAssumption = null)

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Boogie
     private IToken tok;
     private int layerNum;
 
-    private Dictionary<AtomicAction, Expr> transitionRelationCache;
+    private Dictionary<Action, Expr> transitionRelationCache;
 
     public ActionRefinementInstrumentation(
       CivlTypeChecker civlTypeChecker,
@@ -96,7 +96,7 @@ namespace Microsoft.Boogie
         newLocalVars.Add(eval);
       }
 
-      this.transitionRelationCache = new Dictionary<AtomicAction, Expr>();
+      this.transitionRelationCache = new Dictionary<Action, Expr>();
 
       oldOutputMap = new Dictionary<Variable, Variable>();
       foreach (Variable f in impl.OutParams)
@@ -115,7 +115,7 @@ namespace Microsoft.Boogie
       // The parameters of an atomic action come from the implementation that denotes the atomic action specification.
       // To use the transition relation computed below in the context of the yielding procedure of the refinement check,
       // we need to substitute the parameters.
-      AtomicAction atomicAction = civlTypeChecker.procToAtomicAction[yieldProcedureDecl.RefinedAction.ActionDecl];
+      var atomicAction = civlTypeChecker.procToAtomicAction[yieldProcedureDecl.RefinedAction.ActionDecl];
       Dictionary<Variable, Expr> alwaysMap = new Dictionary<Variable, Expr>();
       for (int i = 0, j = 0; i < impl.InParams.Count; i++)
       {
@@ -300,7 +300,7 @@ namespace Microsoft.Boogie
       return new List<Cmd>();
     }
 
-    private Expr GetTransitionRelation(AtomicAction atomicAction)
+    private Expr GetTransitionRelation(Action atomicAction)
     {
       if (!transitionRelationCache.ContainsKey(atomicAction))
       {

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -116,13 +116,12 @@ namespace Microsoft.Boogie
       // To use the transition relation computed below in the context of the yielding procedure of the refinement check,
       // we need to substitute the parameters.
       AtomicAction atomicAction = civlTypeChecker.procToAtomicAction[yieldProcedureDecl.RefinedAction.ActionDecl];
-      Implementation atomicActionImpl = atomicAction.Impl;
       Dictionary<Variable, Expr> alwaysMap = new Dictionary<Variable, Expr>();
       for (int i = 0, j = 0; i < impl.InParams.Count; i++)
       {
         if (yieldProcedureDecl.VisibleFormals.Contains(yieldProcedureDecl.InParams[i]))
         {
-          alwaysMap[atomicActionImpl.InParams[j]] = Expr.Ident(impl.InParams[i]);
+          alwaysMap[atomicAction.Impl.InParams[j]] = Expr.Ident(impl.InParams[i]);
           j++;
         }
       }
@@ -131,7 +130,7 @@ namespace Microsoft.Boogie
       {
         if (yieldProcedureDecl.VisibleFormals.Contains(yieldProcedureDecl.OutParams[i]))
         {
-          alwaysMap[atomicActionImpl.OutParams[j]] = Expr.Ident(impl.OutParams[i]);
+          alwaysMap[atomicAction.Impl.OutParams[j]] = Expr.Ident(impl.OutParams[i]);
           j++;
         }
       }

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Boogie
         civlTypeChecker,
         first.SecondImpl, second.FirstImpl,
         frame, triggers, false,
-        string.Format("Transition relation of {0} ∘ {1}", first.ActionDecl.Name, second.ActionDecl.Name));
+        string.Format("Transition relation of {0} ∘ {1}", first.Name, second.Name));
     }
 
     public static Expr Refinement(CivlTypeChecker civlTypeChecker, Action action, HashSet<Variable> frame)
@@ -96,7 +96,7 @@ namespace Microsoft.Boogie
         civlTypeChecker,
         action.Impl, null,
         frame, null, false,
-        string.Format("Transition relation of {0}", action.ActionDecl.Name));
+        string.Format("Transition relation of {0}", action.Name));
     }
 
     public static Expr Cooperation(CivlTypeChecker civlTypeChecker, Action action, HashSet<Variable> frame)
@@ -105,7 +105,7 @@ namespace Microsoft.Boogie
         civlTypeChecker,
         action.Impl, null,
         frame, null, true,
-        string.Format("Cooperation expression of {0}", action.ActionDecl.Name));
+        string.Format("Cooperation expression of {0}", action.Name));
     }
 
     private void EnumeratePaths()

--- a/Source/Concurrency/TransitionRelationComputation.cs
+++ b/Source/Concurrency/TransitionRelationComputation.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Boogie
 
     public static Expr Commutativity(
       CivlTypeChecker civlTypeChecker, 
-      AtomicAction first, AtomicAction second,
+      Action first, Action second,
       HashSet<Variable> frame)
     {
       var triggers = first.TriggerFunctions.Union(second.TriggerFunctions).ToDictionary(kv => kv.Key, kv => kv.Value);

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -252,6 +252,7 @@ namespace Microsoft.Boogie
         var linkAction = civlTypeChecker.procToAtomicAction[actionDecl];
         if (linkAction.LowerLayer == layerNum)
         {
+          newCall.Proc = linkAction.Impl.Proc;
           InjectGate(linkAction, newCall);
           newCmdSeq.Add(newCall);
         }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -551,7 +551,7 @@ namespace Microsoft.Boogie
 
     private void AddPendingAsync(CallCmd newCall, YieldProcedureDecl calleeProc)
     {
-      if (calleeProc.RefinedAction.ActionDecl == civlTypeChecker.SkipAtomicAction.ActionDecl)
+      if (calleeProc.RefinedAction.ActionDecl == civlTypeChecker.SkipActionDecl)
       {
         return;
       }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Boogie
     private YieldProcedureDecl enclosingYieldingProc;
     private bool IsRefinementLayer => layerNum == enclosingYieldingProc.Layer;
 
-    private AtomicAction RefinedAction =>
+    private Action RefinedAction =>
       civlTypeChecker.procToAtomicAction[enclosingYieldingProc.RefinedAction.ActionDecl];
 
     private List<Cmd> newCmdSeq;
@@ -481,7 +481,7 @@ namespace Microsoft.Boogie
       newCmdSeq.Add(new CommentCmd("injected gate >>>"));
     }
 
-    private void CollectReturnedPendingAsyncs(CallCmd newCall, AtomicAction calleeRefinedAction)
+    private void CollectReturnedPendingAsyncs(CallCmd newCall, Action calleeRefinedAction)
     {
       // Inject pending async collection
       newCall.Outs.AddRange(calleeRefinedAction.PendingAsyncs.Select(decl => Expr.Ident(ReturnedPAs(decl.PendingAsyncType))));

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Boogie
         else
         {
           newCmdSeq.Add(CmdHelper.AssertCmd(assertCmd.tok, expr,
-            $"this gate of {action.ActionDecl.Name} could not be proved"));
+            $"this gate of {action.Name} could not be proved"));
         }
       }
 

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -407,7 +407,7 @@ namespace Microsoft.Boogie
       var calleeRefinedAction = civlTypeChecker.procToAtomicAction[calleeActionProc.RefinedActionAtLayer(layerNum)];
 
       newCall.IsAsync = false;
-      newCall.Proc = calleeRefinedAction.ActionDecl;
+      newCall.Proc = calleeRefinedAction.Impl.Proc;
       newCall.callee = newCall.Proc.Name;
 
       // We drop the hidden parameters of the procedure from the call to the action.
@@ -452,7 +452,7 @@ namespace Microsoft.Boogie
       }
 
       Dictionary<Variable, Expr> map = new Dictionary<Variable, Expr>();
-      for (int i = 0; i < action.ActionDecl.InParams.Count; i++)
+      for (int i = 0; i < action.Impl.InParams.Count; i++)
       {
         // Parameters come from the implementation that defines the action
         map[action.Impl.InParams[i]] = callCmd.Ins[i];

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -756,7 +756,7 @@ namespace Microsoft.Boogie
         yield break;
       }
 
-      HashSet<AtomicAction> pendingAsyncsToCheck = new HashSet<AtomicAction>(
+      var pendingAsyncsToCheck = new HashSet<Action>(
         civlTypeChecker.MoverActions
           .Where(a => a.LayerRange.Contains(layerNum) && a.HasPendingAsyncs)
           .SelectMany(a => a.PendingAsyncs).Select(a => civlTypeChecker.procToAtomicAction[a]));

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -777,7 +777,7 @@ namespace Microsoft.Boogie
         cmds.AddRange(CreateCallToYieldProc());
         var blocks = new List<Block> { BlockHelper.Block("init", cmds) };
 
-        var name = civlTypeChecker.AddNamePrefix($"PendingAsyncNoninterferenceChecker_{action.ActionDecl.Name}_{layerNum}");
+        var name = civlTypeChecker.AddNamePrefix($"PendingAsyncNoninterferenceChecker_{action.Name}_{layerNum}");
         var proc = DeclHelper.Procedure(name, inputs, outputs, requires, modifies, ensures);
         var impl = DeclHelper.Implementation(proc, inputs, outputs, locals, blocks);
         yield return proc;

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -773,7 +773,7 @@ namespace Microsoft.Boogie
 
         cmds.AddRange(CreateUpdatesToOldGlobalVars());
         cmds.AddRange(CreateUpdatesToPermissionCollector(action.Impl));
-        cmds.Add(CmdHelper.CallCmd(action.ActionDecl, inputs, outputs));
+        cmds.Add(CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs));
         cmds.AddRange(CreateCallToYieldProc());
         var blocks = new List<Block> { BlockHelper.Block("init", cmds) };
 

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -746,6 +746,10 @@ namespace Microsoft.Boogie
 
   public class TypeCtorDecl : NamedDeclaration
   {
+    // If this declaration is a monomorphized instance, OriginalTypeCtorDecl
+    // points to the original from which this declaration was instantiated.
+    public TypeCtorDecl OriginalTypeCtorDecl;
+
     public readonly int Arity;
 
     public TypeCtorDecl(IToken /*!*/ tok, string /*!*/ name, int Arity)
@@ -1643,6 +1647,10 @@ namespace Microsoft.Boogie
 
   public abstract class DeclWithFormals : NamedDeclaration
   {
+    // If this declaration is a monomorphized instance, OriginalDeclWithFormals
+    // points to the original from which this declaration was instantiated.
+    public DeclWithFormals OriginalDeclWithFormals;
+
     public List<TypeVariable> /*!*/
       TypeParameters;
 

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -3536,6 +3536,10 @@ namespace Microsoft.Boogie
       {
         // ok
       }
+      else if (Proc.OriginalDeclWithFormals != null && CivlPrimitives.Async.Contains(Proc.OriginalDeclWithFormals.Name))
+      {
+        // ok
+      }
       else if (CivlPrimitives.Async.Contains(Proc.Name))
       {
         var type = TypeProxy.FollowProxy(TypeParameters[Proc.TypeParameters[0]].Expanded);

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -1247,8 +1247,8 @@ namespace Microsoft.Boogie
     private HashSet<Declaration> newInstantiatedDeclarations;
     private List<BinderExprMonomorphizer> binderExprMonomorphizers;
     private Dictionary<MapType, PolymorphicMapInfo> polymorphicMapInfos;
-    private Dictionary<DeclWithFormals, Tuple<DeclWithFormals, Dictionary<string, Type>>> declWithFormalsToTypeInstantiation;
-    private Dictionary<TypeCtorDecl, Tuple<TypeCtorDecl, List<Type>>> typeCtorDeclToTypeInstantiation;
+    private Dictionary<DeclWithFormals, Dictionary<string, Type>> declWithFormalsToTypeInstantiation;
+    private Dictionary<TypeCtorDecl, List<Type>> typeCtorDeclToTypeInstantiation;
     private HashSet<TypeCtorDecl> visitedTypeCtorDecls;
     private HashSet<Function> visitedFunctions;
     private Dictionary<Procedure, Implementation> procToImpl;
@@ -1281,8 +1281,8 @@ namespace Microsoft.Boogie
           nameToFunction.Add(function.Name, function);
           functionInstantiations.Add(function, new Dictionary<List<Type>, Function>(new ListComparer<Type>()));
         });
-      declWithFormalsToTypeInstantiation = new Dictionary<DeclWithFormals, Tuple<DeclWithFormals, Dictionary<string, Type>>>();
-      typeCtorDeclToTypeInstantiation = new Dictionary<TypeCtorDecl, Tuple<TypeCtorDecl, List<Type>>>();
+      declWithFormalsToTypeInstantiation = new Dictionary<DeclWithFormals, Dictionary<string, Type>>();
+      typeCtorDeclToTypeInstantiation = new Dictionary<TypeCtorDecl, List<Type>>();
       typeInstantiations = new Dictionary<TypeCtorDecl, Dictionary<List<Type>, TypeCtorDecl>>();
       newInstantiatedDeclarations = new HashSet<Declaration>();
       binderExprMonomorphizers = new List<BinderExprMonomorphizer>();
@@ -1481,8 +1481,7 @@ namespace Microsoft.Boogie
         newInstantiatedDeclarations.Add(instantiatedFunction);
         functionInstantiations[func][actualTypeParams] = instantiatedFunction;
         declWithFormalsToTypeInstantiation[instantiatedFunction] =
-          Tuple.Create<DeclWithFormals, Dictionary<string, Type>>(func,
-            LinqExtender.Map(func.TypeParameters.Select(x => x.Name), actualTypeParams));
+          LinqExtender.Map(func.TypeParameters.Select(x => x.Name), actualTypeParams);
         if (func.Body != null)
         {
           instantiatedFunction.Body = (Expr) InstantiateAbsy(func.Body, funcTypeParamInstantiation, variableMapping);
@@ -1533,11 +1532,11 @@ namespace Microsoft.Boogie
         var instantiatedProc = new Procedure(proc.tok, MkInstanceName(proc.Name, actualTypeParams),
           new List<TypeVariable>(), instantiatedInParams, instantiatedOutParams, proc.IsPure, requires, modifies, ensures,
           proc.Attributes == null ? null : VisitQKeyValue(proc.Attributes));
+        instantiatedProc.OriginalDeclWithFormals = proc;
         newInstantiatedDeclarations.Add(instantiatedProc);
         procInstantiations[proc][actualTypeParams] = instantiatedProc;
         declWithFormalsToTypeInstantiation[instantiatedProc] =
-          Tuple.Create<DeclWithFormals, Dictionary<string, Type>>(proc,
-            LinqExtender.Map(proc.TypeParameters.Select(x => x.Name), actualTypeParams));
+          LinqExtender.Map(proc.TypeParameters.Select(x => x.Name), actualTypeParams);
       }
       return procInstantiations[proc][actualTypeParams];
     }
@@ -1566,12 +1565,12 @@ namespace Microsoft.Boogie
         var instantiatedImpl = new Implementation(impl.tok, MkInstanceName(impl.Name, actualTypeParams),
           new List<TypeVariable>(), instantiatedInParams, instantiatedOutParams, instantiatedLocalVariables, blocks,
           impl.Attributes == null ? null : VisitQKeyValue(impl.Attributes));
+        instantiatedImpl.OriginalDeclWithFormals = impl;
         instantiatedImpl.Proc = InstantiateProcedure(impl.Proc, actualTypeParams);
         newInstantiatedDeclarations.Add(instantiatedImpl);
         implInstantiations[impl][actualTypeParams] = instantiatedImpl;
         declWithFormalsToTypeInstantiation[instantiatedImpl] =
-          Tuple.Create<DeclWithFormals, Dictionary<string, Type>>(impl,
-            LinqExtender.Map(impl.TypeParameters.Select(x => x.Name), actualTypeParams));
+          LinqExtender.Map(impl.TypeParameters.Select(x => x.Name), actualTypeParams);
       }
       return implInstantiations[impl][actualTypeParams];
     }
@@ -1616,6 +1615,7 @@ namespace Microsoft.Boogie
         instantiatedOutParams.First(),
         func.Comment,
         func.Attributes);
+      instantiatedFunction.OriginalDeclWithFormals = func;
       return instantiatedFunction;
     }
 
@@ -1629,10 +1629,11 @@ namespace Microsoft.Boogie
             new TypeCtorDecl(datatypeTypeCtorDecl.tok,
               MkInstanceName(datatypeTypeCtorDecl.Name, actualTypeParams), 0,
               datatypeTypeCtorDecl.Attributes));
+          newDatatypeTypeCtorDecl.OriginalTypeCtorDecl = datatypeTypeCtorDecl;
           newInstantiatedDeclarations.Add(newDatatypeTypeCtorDecl);
           typeInstantiations[datatypeTypeCtorDecl]
             .Add(actualTypeParams, newDatatypeTypeCtorDecl);
-          typeCtorDeclToTypeInstantiation[newDatatypeTypeCtorDecl] = Tuple.Create(typeCtorDecl, actualTypeParams);
+          typeCtorDeclToTypeInstantiation[newDatatypeTypeCtorDecl] = actualTypeParams;
           datatypeTypeCtorDecl.Constructors.Iter(constructor =>
           {
             var function = InstantiateFunctionSignature(constructor, actualTypeParams,
@@ -1645,9 +1646,10 @@ namespace Microsoft.Boogie
           var newTypeCtorDecl =
             new TypeCtorDecl(typeCtorDecl.tok, MkInstanceName(typeCtorDecl.Name, actualTypeParams), 0,
               typeCtorDecl.Attributes);
+          newTypeCtorDecl.OriginalTypeCtorDecl = typeCtorDecl;
           newInstantiatedDeclarations.Add(newTypeCtorDecl);
           typeInstantiations[typeCtorDecl].Add(actualTypeParams, newTypeCtorDecl);
-          typeCtorDeclToTypeInstantiation[newTypeCtorDecl] = Tuple.Create(typeCtorDecl, actualTypeParams);
+          typeCtorDeclToTypeInstantiation[newTypeCtorDecl] = actualTypeParams;
         }
       }
 
@@ -1730,12 +1732,12 @@ namespace Microsoft.Boogie
       return nameToTypeCtorDecl.TryGetValue(typeName, out typeCtorDecl);
     }
     
-    public bool GetTypeInstantiation(DeclWithFormals decl, out Tuple<DeclWithFormals, Dictionary<string, Type>> value)
+    public bool GetTypeInstantiation(DeclWithFormals decl, out Dictionary<string, Type> value)
     {
       return declWithFormalsToTypeInstantiation.TryGetValue(decl, out value);
     }
 
-    public bool GetTypeInstantiation(TypeCtorDecl decl, out Tuple<TypeCtorDecl, List<Type>> value)
+    public bool GetTypeInstantiation(TypeCtorDecl decl, out List<Type> value)
     {
       return typeCtorDeclToTypeInstantiation.TryGetValue(decl, out value);
     }
@@ -1864,38 +1866,30 @@ namespace Microsoft.Boogie
 
     public DeclWithFormals GetOriginalDecl(DeclWithFormals decl)
     {
-      if (!monomorphizationVisitor.GetTypeInstantiation(decl, out Tuple<DeclWithFormals, Dictionary<string, Type>> value))
-      {
-        return decl;
-      }
-      return value.Item1;
+      return decl.OriginalDeclWithFormals ?? decl;
     }
     
     public Dictionary<string, Type> GetTypeInstantiation(DeclWithFormals decl)
     {
-      if (!monomorphizationVisitor.GetTypeInstantiation(decl, out Tuple<DeclWithFormals, Dictionary<string, Type>> value))
+      if (!monomorphizationVisitor.GetTypeInstantiation(decl, out Dictionary<string, Type> value))
       {
         return null;
       }
-      return value.Item2;
+      return value;
     }
     
     public TypeCtorDecl GetOriginalDecl(TypeCtorDecl decl)
     {
-      if (!monomorphizationVisitor.GetTypeInstantiation(decl, out Tuple<TypeCtorDecl, List<Type>> value))
-      {
-        return decl;
-      }
-      return value.Item1;
+      return decl.OriginalTypeCtorDecl ?? decl;
     }
     
     public List<Type> GetTypeInstantiation(TypeCtorDecl decl)
     {
-      if (!monomorphizationVisitor.GetTypeInstantiation(decl, out Tuple<TypeCtorDecl, List<Type>> value))
+      if (!monomorphizationVisitor.GetTypeInstantiation(decl, out List<Type> value))
       {
         return null;
       }
-      return value.Item2;
+      return value;
     }
 
     private MonomorphizationVisitor monomorphizationVisitor;

--- a/Test/civl/GC.bpl
+++ b/Test/civl/GC.bpl
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //
 
-// RUN: %parallel-boogie /vcsSplitOnEveryAssert "%s" > "%t"
+// RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 type {:linear "tid"} X = int;

--- a/Test/civl/inductive-sequentialization/PingPong.bpl
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl
@@ -114,7 +114,7 @@ modifies channel;
 
   assert x > 0;
   assert p is Left;
-  assert (forall m:int :: left_channel[m] > 0 ==> m == x); // assertion to discharge
+  assert (forall {:pool "INV"} m:int :: {:add_to_pool "INV", m} left_channel[m] > 0 ==> m == x); // assertion to discharge
 
   assume left_channel[x] > 0;
   left_channel[x] := left_channel[x] - 1;
@@ -143,7 +143,7 @@ modifies channel;
 
   assert y > 0;
   assert p is Right;
-  assert (forall m:int :: right_channel[m] > 0 ==> m == y || m == 0); // assertion to discharge
+  assert (forall {:pool "INV"} m:int :: {:add_to_pool "INV", m} right_channel[m] > 0 ==> m == y || m == 0); // assertion to discharge
 
   if (*)
   {


### PR DESCRIPTION
- added OriginalDeclWithFormals field to DeclWithFormals and OriginalTypeCtorDecl to TypeCtorDecl to point to the polymorphic declaration from which this declaration was generated.
- Civl desugaring was busted because ActionDecl's were being generated in the output; problem fixed.
- Unified Action, AtomicAction, and InvariantAction into one type called Action; enabled lot of simplification in action creation and initialization.
- fixed flakiness in PingPong.bpl.