### PR TITLE
Add a setter for ProcsToCheck option

### DIFF
--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -525,7 +525,7 @@ namespace Microsoft.Boogie
     // Note that procsToCheck stores all patterns <p> supplied with /proc:<p>
     // (and similarly procsToIgnore for /noProc:<p>). Thus, if procsToCheck
     // is empty it means that all procedures should be checked.
-    public List<string> ProcsToCheck { get; } = new();
+    public List<string> ProcsToCheck { get; set; } = new();
     public List<string /*!*/> ProcsToIgnore { get; set; } = new();
 
     [ContractInvariantMethod]


### PR DESCRIPTION
This PR adds a direct setter for the `ProcsToCheck` command line option. This allows copying the field from one instance of `CommandLineOptions` to another. Otherwise, even if one makes a shallow-copy of the options using reflection (like Dafny does [here](https://github.com/dafny-lang/dafny/blob/818d63bd870c7065fefd53e6531c77bcc2ca4094/Source/DafnyCore/DafnyOptions.cs#L399-L408), for example), there is no way of changing the value of `ProcsToCheck` in the copy without affecting the original or hardcoding the process of setting this specific field with reflection. 

The specific use case in which one would need to copy the options and change the `ProcsToCheck` field is test generation for Dafny but I think adding a setter makes sense in general, particularly because other reference fields like `ProverOptions` and `ProcsToIgnore` also have a setter.