### PR TITLE
Renaming mover keywords

### DIFF
--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -747,10 +747,10 @@ SpecAction<.ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, 
   
 MoverQualifier<ref MoverType moverType>
 = (
-    "<-"  (. moverType = MoverType.Left; .)
-    | "->"  (. moverType = MoverType.Right; .)
-    | "<->" (. moverType = MoverType.Both; .)
-    | ">-<" (. moverType = MoverType.Atomic; .)
+      "left"   (. moverType = MoverType.Left; .)
+    | "right"  (. moverType = MoverType.Right; .)
+    | "both"   (. moverType = MoverType.Both; .)
+    | "atomic" (. moverType = MoverType.Atomic; .)
   )
   .
 
@@ -1783,10 +1783,17 @@ LetVar<.out Variable/*!*/ v.>
 /*------------------------------------------------------------------------*/
 Ident<out IToken/*!*/ x>
 =(.Contract.Ensures(Contract.ValueAtReturn(out x) != null);.)
-  ident            (.  x = t;
-                       if (x.val.StartsWith("\\"))
-                         x.val = x.val.Substring(1);
-                    .)
+  ( ident
+  | "atomic"   (. t.kind = _ident; .) // convert to ident
+  | "both"     (. t.kind = _ident; .) // convert to ident
+  | "left"     (. t.kind = _ident; .) // convert to ident
+  | "right"    (. t.kind = _ident; .) // convert to ident
+  )
+  (.
+    x = t;
+    if (x.val.StartsWith("\\"))
+      x.val = x.val.Substring(1);
+  .)
   .
 
 /*------------------------------------------------------------------------*/

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -36,7 +36,7 @@ public class Parser {
 	public const int _decimal = 5;
 	public const int _dec_float = 6;
 	public const int _float = 7;
-	public const int maxT = 118;
+	public const int maxT = 119;
 
 	const bool _T = true;
 	const bool _x = false;
@@ -315,7 +315,7 @@ private class BvBounds : Expr {
 					 Pgm.AddTopLevelDeclaration(im);
 					}
 					
-				} else SynErr(119);
+				} else SynErr(120);
 				break;
 			}
 			case 45: case 50: {
@@ -363,7 +363,7 @@ private class BvBounds : Expr {
 				axioms.Add(axiom); ds.Add(axiom); 
 			}
 			Expect(27);
-		} else SynErr(120);
+		} else SynErr(121);
 		foreach(TypedIdent/*!*/ x in xs){
 		 Contract.Assert(x != null);
 		 var constant = new Constant(y, x, u, kv, axioms);
@@ -417,7 +417,7 @@ private class BvBounds : Expr {
 			Get();
 			Type(out retTy);
 			retTyd = new TypedIdent(retTy.tok, TypedIdent.NoName, retTy); 
-		} else SynErr(121);
+		} else SynErr(122);
 		if (la.kind == 26) {
 			Get();
 			Expression(out tmp);
@@ -442,7 +442,7 @@ private class BvBounds : Expr {
 			Expect(27);
 		} else if (la.kind == 10) {
 			Get();
-		} else SynErr(122);
+		} else SynErr(123);
 		if (retTyd == null) {
 		 // construct a dummy type for the case of syntax error
 		 retTyd = new TypedIdent(t, TypedIdent.NoName, new BasicType(t, SimpleType.Int));
@@ -610,7 +610,7 @@ private class BvBounds : Expr {
 			impl = new Implementation(name, name.val, new List<TypeVariable>(), Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs),
 			                              locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
 			
-		} else SynErr(123);
+		} else SynErr(124);
 		if (isAsync) {
 		 if (moverType == MoverType.None)
 		 {
@@ -687,7 +687,7 @@ private class BvBounds : Expr {
 			impl = new Implementation(name, name.val, new List<TypeVariable>(), Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs),
 			                         locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
 			
-		} else SynErr(124);
+		} else SynErr(125);
 		ypDecl = new YieldProcedureDecl(name, name.val, moverType, ins, outs, pre, mods, post, yieldRequires, yieldEnsures, yieldPreserves, refinedAction, kv); 
 	}
 
@@ -723,7 +723,7 @@ private class BvBounds : Expr {
 			impl = new Implementation(x, x.val, typeParams.ConvertAll(tp => new TypeVariable(tp.tok, tp.Name)),
 			                         Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs), locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
 			
-		} else SynErr(125);
+		} else SynErr(126);
 		proc = new Procedure(x, x.val, typeParams, ins, outs, isPure, pre, mods, post, kv); 
 	}
 
@@ -774,7 +774,7 @@ private class BvBounds : Expr {
 		var context = allowWhereClauses ? "procedure formals" : "the 'implementation' copies of formals";
 		
 		Expect(11);
-		if (la.kind == 1 || la.kind == 26) {
+		if (StartOf(11)) {
 			AttrsIdsTypeWheres(allowWhereClauses, context, delegate(TypedIdent tyd, QKeyValue kv) { dsx.Add(new Formal(tyd.tok, tyd, incoming, kv)); });
 		}
 		Expect(12);
@@ -823,18 +823,18 @@ private class BvBounds : Expr {
 
 	void Type(out Bpl.Type/*!*/ ty) {
 		Contract.Ensures(Contract.ValueAtReturn(out ty) != null); IToken/*!*/ tok; ty = dummyType; 
-		if (StartOf(11)) {
+		if (StartOf(12)) {
 			TypeAtom(out ty);
-		} else if (la.kind == 1) {
+		} else if (StartOf(13)) {
 			Ident(out tok);
 			List<Bpl.Type>/*!*/ args = new List<Bpl.Type> (); 
-			if (StartOf(12)) {
+			if (StartOf(14)) {
 				TypeArgs(args);
 			}
 			ty = new UnresolvedTypeIdentifier (tok, tok.val, args); 
 		} else if (la.kind == 19 || la.kind == 21) {
 			MapType(out ty);
-		} else SynErr(126);
+		} else SynErr(127);
 	}
 
 	void AttributesIdsTypeWhere(bool allowWhereClauses, string context, System.Action<TypedIdent, QKeyValue> action ) {
@@ -870,7 +870,7 @@ private class BvBounds : Expr {
 	void Expression(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; 
 		ImpliesExpression(false, out e0);
-		while (la.kind == 67 || la.kind == 68) {
+		while (la.kind == 68 || la.kind == 69) {
 			EquivOp();
 			x = t; 
 			ImpliesExpression(false, out e1);
@@ -893,12 +893,26 @@ private class BvBounds : Expr {
 			Get();
 			Type(out ty);
 			Expect(12);
-		} else SynErr(127);
+		} else SynErr(128);
 	}
 
 	void Ident(out IToken/*!*/ x) {
 		Contract.Ensures(Contract.ValueAtReturn(out x) != null);
-		Expect(1);
+		if (la.kind == 1) {
+			Get();
+		} else if (la.kind == 44) {
+			Get();
+			t.kind = _ident; 
+		} else if (la.kind == 43) {
+			Get();
+			t.kind = _ident; 
+		} else if (la.kind == 41) {
+			Get();
+			t.kind = _ident; 
+		} else if (la.kind == 42) {
+			Get();
+			t.kind = _ident; 
+		} else SynErr(129);
 		x = t;
 		if (x.val.StartsWith("\\"))
 		 x.val = x.val.Substring(1);
@@ -907,23 +921,23 @@ private class BvBounds : Expr {
 
 	void TypeArgs(List<Bpl.Type>/*!*/ ts) {
 		Contract.Requires(ts != null); IToken/*!*/ tok; Bpl.Type/*!*/ ty; 
-		if (StartOf(11)) {
+		if (StartOf(12)) {
 			TypeAtom(out ty);
 			ts.Add(ty); 
-			if (StartOf(12)) {
+			if (StartOf(14)) {
 				TypeArgs(ts);
 			}
-		} else if (la.kind == 1) {
+		} else if (StartOf(13)) {
 			Ident(out tok);
 			List<Bpl.Type>/*!*/ args = new List<Bpl.Type> ();
 			ts.Add(new UnresolvedTypeIdentifier (tok, tok.val, args)); 
-			if (StartOf(12)) {
+			if (StartOf(14)) {
 				TypeArgs(ts);
 			}
 		} else if (la.kind == 19 || la.kind == 21) {
 			MapType(out ty);
 			ts.Add(ty); 
-		} else SynErr(128);
+		} else SynErr(130);
 	}
 
 	void MapType(out Bpl.Type/*!*/ ty) {
@@ -939,7 +953,7 @@ private class BvBounds : Expr {
 		}
 		Expect(19);
 		if (tok == null) tok = t;  
-		if (StartOf(12)) {
+		if (StartOf(14)) {
 			Types(arguments);
 		}
 		Expect(20);
@@ -1007,7 +1021,7 @@ private class BvBounds : Expr {
 		Contract.Ensures(Contract.ValueAtReturn(out decl) != null); IToken/*!*/ id; List<IToken>/*!*/ paramTokens = new List<IToken> ();
 		Bpl.Type/*!*/ body = dummyType; bool synonym = false; 
 		Ident(out id);
-		if (la.kind == 1) {
+		if (StartOf(13)) {
 			WhiteSpaceIdents(out paramTokens);
 		}
 		if (la.kind == 32) {
@@ -1031,7 +1045,7 @@ private class BvBounds : Expr {
 		Contract.Ensures(Contract.ValueAtReturn(out xs) != null); IToken/*!*/ id; xs = new List<IToken>(); 
 		Ident(out id);
 		xs.Add(id); 
-		while (la.kind == 1) {
+		while (StartOf(13)) {
 			Ident(out id);
 			xs.Add(id); 
 		}
@@ -1049,7 +1063,7 @@ private class BvBounds : Expr {
 		IToken name; List<TypedIdent> fields = new List<TypedIdent>(); 
 		Ident(out name);
 		Expect(11);
-		if (la.kind == 1) {
+		if (StartOf(13)) {
 			IdsTypeWheres(false, "datatype constructor", delegate(TypedIdent ti) { fields.Add(ti); });
 		}
 		Expect(12);
@@ -1084,7 +1098,7 @@ private class BvBounds : Expr {
 		} else if (la.kind == 44) {
 			Get();
 			moverType = MoverType.Atomic; 
-		} else SynErr(129);
+		} else SynErr(131);
 	}
 
 	void SpecAction(ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, List<IdentifierExpr> mods, List<ActionDeclRef> creates, List<ElimDecl> elims) {
@@ -1096,7 +1110,7 @@ private class BvBounds : Expr {
 			SpecCreates(creates);
 		} else if (la.kind == 39) {
 			SpecEliminates(elims);
-		} else SynErr(130);
+		} else SynErr(132);
 	}
 
 	void ImplBody(out List<Variable>/*!*/ locals, out StmtList/*!*/ stmtList) {
@@ -1158,7 +1172,7 @@ private class BvBounds : Expr {
 	void SpecModifies(List<IdentifierExpr> mods) {
 		List<IToken> ms; 
 		Expect(49);
-		if (la.kind == 1) {
+		if (StartOf(13)) {
 			Idents(out ms);
 			foreach(IToken m in ms) { mods.Add(new IdentifierExpr(m, m.val)); } 
 		}
@@ -1180,29 +1194,29 @@ private class BvBounds : Expr {
 		} else if (la.kind == 46) {
 			Get();
 			tok = t; 
-			if (StartOf(13)) {
+			if (StartOf(15)) {
 				while (la.kind == 26) {
 					Attribute(ref kv);
 				}
 				Proposition(out e);
 				pre.Add(new Requires(tok, false, e, null, kv)); 
-			} else if (la.kind == 35 || la.kind == 52 || la.kind == 64) {
+			} else if (la.kind == 35 || la.kind == 52 || la.kind == 65) {
 				CallCmd(out cmd);
 				yieldRequires.Add((CallCmd)cmd); 
-			} else SynErr(131);
+			} else SynErr(133);
 		} else if (la.kind == 47) {
 			Get();
 			tok = t; 
-			if (StartOf(13)) {
+			if (StartOf(15)) {
 				while (la.kind == 26) {
 					Attribute(ref kv);
 				}
 				Proposition(out e);
 				post.Add(new Ensures(tok, false, e, null, kv)); 
-			} else if (la.kind == 35 || la.kind == 52 || la.kind == 64) {
+			} else if (la.kind == 35 || la.kind == 52 || la.kind == 65) {
 				CallCmd(out cmd);
 				yieldEnsures.Add((CallCmd)cmd); 
-			} else SynErr(132);
+			} else SynErr(134);
 		} else if (la.kind == 48) {
 			Get();
 			tok = t; 
@@ -1211,11 +1225,11 @@ private class BvBounds : Expr {
 		} else if (la.kind == 49) {
 			Get();
 			List<IToken> ms; 
-			if (la.kind == 1) {
+			if (StartOf(13)) {
 				Idents(out ms);
 				foreach(IToken m in ms) { mods.Add(new IdentifierExpr(m, m.val)); } 
 			}
-		} else SynErr(133);
+		} else SynErr(135);
 		Expect(10);
 	}
 
@@ -1234,7 +1248,7 @@ private class BvBounds : Expr {
 			Get();
 			isFree = true; 
 		}
-		Expect(64);
+		Expect(65);
 		x = t; 
 		CallParams(isAsync, isFree, x, out c);
 		
@@ -1267,7 +1281,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			SpecPrePost(true, pre, post);
 		} else if (la.kind == 46 || la.kind == 47) {
 			SpecPrePost(false, pre, post);
-		} else SynErr(134);
+		} else SynErr(136);
 	}
 
 	void SpecPrePost(bool free, List<Requires>/*!*/ pre, List<Ensures>/*!*/ post) {
@@ -1290,7 +1304,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			Proposition(out e);
 			Expect(10);
 			post.Add(new Ensures(tok, free, e, null, kv)); 
-		} else SynErr(135);
+		} else SynErr(137);
 	}
 
 	void StmtList(out StmtList/*!*/ stmtList) {
@@ -1303,8 +1317,8 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		StructuredCmd ec = null;  StructuredCmd/*!*/ ecn;
 		TransferCmd tc = null;  TransferCmd/*!*/ tcn;
 		
-		while (StartOf(14)) {
-			if (StartOf(15)) {
+		while (StartOf(16)) {
+			if (StartOf(17)) {
 				LabelOrCmd(out c, out label);
 				Contract.Assert(c == null || label == null);
 				if (c != null) {
@@ -1370,7 +1384,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		QKeyValue kv = null;
 		
 		switch (la.kind) {
-		case 1: {
+		case 1: case 41: case 42: case 43: case 44: {
 			LabelOrAssign(out c, out label);
 			break;
 		}
@@ -1410,18 +1424,18 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			
 			break;
 		}
-		case 35: case 52: case 64: {
+		case 35: case 52: case 65: {
 			CallCmd(out cn);
 			Expect(10);
 			c = cn; 
 			break;
 		}
-		case 65: {
+		case 66: {
 			ParCallCmd(out cn);
 			c = cn; 
 			break;
 		}
-		default: SynErr(136); break;
+		default: SynErr(138); break;
 		}
 	}
 
@@ -1438,7 +1452,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		} else if (la.kind == 59) {
 			BreakCmd(out bcmd);
 			ec = bcmd; 
-		} else SynErr(137);
+		} else SynErr(139);
 	}
 
 	void TransferCmd(out TransferCmd/*!*/ tc) {
@@ -1458,7 +1472,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		} else if (la.kind == 54) {
 			Get();
 			tc = new ReturnCmd(t); 
-		} else SynErr(138);
+		} else SynErr(140);
 		Expect(10);
 	}
 
@@ -1483,7 +1497,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				Get();
 				StmtList(out els);
 				elseOption = els; 
-			} else SynErr(139);
+			} else SynErr(141);
 		}
 		ifcmd = new IfCmd(x, guard, thn, elseIfOption, elseOption); 
 	}
@@ -1510,7 +1524,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			while (la.kind == 26) {
 				Attribute(ref kv);
 			}
-			if (StartOf(16)) {
+			if (StartOf(18)) {
 				Expression(out e);
 				if (isFree) {
 				 invariants.Add(new AssumeCmd(z, e, kv));
@@ -1519,10 +1533,10 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				}
 				kv = null;
 				
-			} else if (la.kind == 35 || la.kind == 52 || la.kind == 64) {
+			} else if (la.kind == 35 || la.kind == 52 || la.kind == 65) {
 				CallCmd(out cmd);
 				yields.Add((CallCmd)cmd); 
-			} else SynErr(140);
+			} else SynErr(142);
 			Expect(10);
 		}
 		Expect(26);
@@ -1536,7 +1550,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		
 		Expect(59);
 		x = t; 
-		if (la.kind == 1) {
+		if (StartOf(13)) {
 			Ident(out y);
 			breakLabel = y.val; 
 		}
@@ -1550,10 +1564,10 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		if (la.kind == 58) {
 			Get();
 			e = null; 
-		} else if (StartOf(16)) {
+		} else if (StartOf(18)) {
 			Expression(out ee);
 			e = ee; 
-		} else SynErr(141);
+		} else SynErr(143);
 		Expect(12);
 	}
 
@@ -1588,10 +1602,10 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			Expect(10);
 			c = new UnpackCmd(x, lhsExpr, e0, kv);
 			
-		} else if (StartOf(17)) {
+		} else if (StartOf(19)) {
 			lhss = new List<AssignLhs/*!*/>(); 
 			lhs = new SimpleAssignLhs(id, new IdentifierExpr(id, id.val)); 
-			while (la.kind == 19 || la.kind == 42) {
+			while (la.kind == 19 || la.kind == 64) {
 				if (la.kind == 19) {
 					MapAssignIndex(out y, out indexes);
 					lhs = new MapAssignLhs(y, lhs, indexes); 
@@ -1605,7 +1619,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				Get();
 				Ident(out id);
 				lhs = new SimpleAssignLhs(id, new IdentifierExpr(id, id.val)); 
-				while (la.kind == 19 || la.kind == 42) {
+				while (la.kind == 19 || la.kind == 64) {
 					if (la.kind == 19) {
 						MapAssignIndex(out y, out indexes);
 						lhs = new MapAssignLhs(y, lhs, indexes); 
@@ -1631,7 +1645,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			}
 			Expect(10);
 			c = new AssignCmd(x, lhss, rhss, kv); 
-		} else SynErr(142);
+		} else SynErr(144);
 	}
 
 	void ParCallCmd(out Cmd d) {
@@ -1640,11 +1654,11 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		Cmd c = null;
 		List<CallCmd> callCmds = new List<CallCmd>();
 		
-		Expect(65);
+		Expect(66);
 		x = t; 
 		CallParams(false, false, x, out c);
 		callCmds.Add((CallCmd)c); 
-		while (la.kind == 66) {
+		while (la.kind == 67) {
 			Get();
 			CallParams(false, false, x, out c);
 			callCmds.Add((CallCmd)c); 
@@ -1659,7 +1673,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		
 		Expect(19);
 		x = t; 
-		if (StartOf(16)) {
+		if (StartOf(18)) {
 			Expression(out e);
 			indexes.Add(e); 
 			while (la.kind == 14) {
@@ -1673,7 +1687,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 
 	void FieldAccess(out IToken x, out FieldAccess fieldAccess) {
 		Contract.Ensures(Contract.ValueAtReturn(out fieldAccess) != null); IToken id; 
-		Expect(42);
+		Expect(64);
 		x = t; 
 		Ident(out id);
 		fieldAccess = new FieldAccess(id, id.val); 
@@ -1694,7 +1708,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		Ident(out first);
 		if (la.kind == 11) {
 			Get();
-			if (StartOf(16)) {
+			if (StartOf(18)) {
 				Expression(out en);
 				es.Add(en); 
 				while (la.kind == 14) {
@@ -1720,7 +1734,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			Expect(63);
 			Ident(out first);
 			Expect(11);
-			if (StartOf(16)) {
+			if (StartOf(18)) {
 				Expression(out en);
 				es.Add(en); 
 				while (la.kind == 14) {
@@ -1731,7 +1745,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			}
 			Expect(12);
 			c = new CallCmd(x, first.val, es, ids, kv); ((CallCmd) c).IsFree = isFree; ((CallCmd) c).IsAsync = isAsync; 
-		} else SynErr(143);
+		} else SynErr(145);
 	}
 
 	void Expressions(out List<Expr>/*!*/ es) {
@@ -1748,8 +1762,8 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	void ImpliesExpression(bool noExplies, out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; 
 		LogicalExpression(out e0);
-		if (StartOf(18)) {
-			if (la.kind == 69 || la.kind == 70) {
+		if (StartOf(20)) {
+			if (la.kind == 70 || la.kind == 71) {
 				ImpliesOp();
 				x = t; 
 				ImpliesExpression(true, out e1);
@@ -1761,7 +1775,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				x = t; 
 				LogicalExpression(out e1);
 				e0 = Expr.Binary(x, BinaryOperator.Opcode.Imp, e1, e0); 
-				while (la.kind == 71 || la.kind == 72) {
+				while (la.kind == 72 || la.kind == 73) {
 					ExpliesOp();
 					x = t; 
 					LogicalExpression(out e1);
@@ -1772,23 +1786,23 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	}
 
 	void EquivOp() {
-		if (la.kind == 67) {
+		if (la.kind == 68) {
 			Get();
-		} else if (la.kind == 68) {
+		} else if (la.kind == 69) {
 			Get();
-		} else SynErr(144);
+		} else SynErr(146);
 	}
 
 	void LogicalExpression(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; 
 		RelationalExpression(out e0);
-		if (StartOf(19)) {
-			if (la.kind == 73 || la.kind == 74) {
+		if (StartOf(21)) {
+			if (la.kind == 74 || la.kind == 75) {
 				AndOp();
 				x = t; 
 				RelationalExpression(out e1);
 				e0 = Expr.Binary(x, BinaryOperator.Opcode.And, e0, e1); 
-				while (la.kind == 73 || la.kind == 74) {
+				while (la.kind == 74 || la.kind == 75) {
 					AndOp();
 					x = t; 
 					RelationalExpression(out e1);
@@ -1799,7 +1813,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				x = t; 
 				RelationalExpression(out e1);
 				e0 = Expr.Binary(x, BinaryOperator.Opcode.Or, e0, e1); 
-				while (la.kind == 75 || la.kind == 76) {
+				while (la.kind == 76 || la.kind == 77) {
 					OrOp();
 					x = t; 
 					RelationalExpression(out e1);
@@ -1810,25 +1824,25 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	}
 
 	void ImpliesOp() {
-		if (la.kind == 69) {
+		if (la.kind == 70) {
 			Get();
-		} else if (la.kind == 70) {
+		} else if (la.kind == 71) {
 			Get();
-		} else SynErr(145);
+		} else SynErr(147);
 	}
 
 	void ExpliesOp() {
-		if (la.kind == 71) {
+		if (la.kind == 72) {
 			Get();
-		} else if (la.kind == 72) {
+		} else if (la.kind == 73) {
 			Get();
-		} else SynErr(146);
+		} else SynErr(148);
 	}
 
 	void RelationalExpression(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; BinaryOperator.Opcode op; 
 		BvTerm(out e0);
-		if (StartOf(20)) {
+		if (StartOf(22)) {
 			RelOp(out x, out op);
 			BvTerm(out e1);
 			e0 = Expr.Binary(x, op, e0, e1); 
@@ -1836,25 +1850,25 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	}
 
 	void AndOp() {
-		if (la.kind == 73) {
+		if (la.kind == 74) {
 			Get();
-		} else if (la.kind == 74) {
+		} else if (la.kind == 75) {
 			Get();
-		} else SynErr(147);
+		} else SynErr(149);
 	}
 
 	void OrOp() {
-		if (la.kind == 75) {
+		if (la.kind == 76) {
 			Get();
-		} else if (la.kind == 76) {
+		} else if (la.kind == 77) {
 			Get();
-		} else SynErr(148);
+		} else SynErr(150);
 	}
 
 	void BvTerm(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; 
 		Term(out e0);
-		while (la.kind == 84) {
+		while (la.kind == 85) {
 			Get();
 			x = t; 
 			Term(out e1);
@@ -1865,7 +1879,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	void RelOp(out IToken/*!*/ x, out BinaryOperator.Opcode op) {
 		Contract.Ensures(Contract.ValueAtReturn(out x) != null); x = Token.NoToken; op=BinaryOperator.Opcode.Add/*(dummy)*/; 
 		switch (la.kind) {
-		case 77: {
+		case 78: {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Eq; 
 			break;
@@ -1880,19 +1894,14 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			x = t; op=BinaryOperator.Opcode.Gt; 
 			break;
 		}
-		case 78: {
+		case 79: {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Le; 
 			break;
 		}
-		case 79: {
-			Get();
-			x = t; op=BinaryOperator.Opcode.Ge; 
-			break;
-		}
 		case 80: {
 			Get();
-			x = t; op=BinaryOperator.Opcode.Neq; 
+			x = t; op=BinaryOperator.Opcode.Ge; 
 			break;
 		}
 		case 81: {
@@ -1902,22 +1911,27 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		}
 		case 82: {
 			Get();
-			x = t; op=BinaryOperator.Opcode.Le; 
+			x = t; op=BinaryOperator.Opcode.Neq; 
 			break;
 		}
 		case 83: {
 			Get();
+			x = t; op=BinaryOperator.Opcode.Le; 
+			break;
+		}
+		case 84: {
+			Get();
 			x = t; op=BinaryOperator.Opcode.Ge; 
 			break;
 		}
-		default: SynErr(149); break;
+		default: SynErr(151); break;
 		}
 	}
 
 	void Term(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; BinaryOperator.Opcode op; 
 		Factor(out e0);
-		while (la.kind == 85 || la.kind == 86) {
+		while (la.kind == 86 || la.kind == 87) {
 			AddOp(out x, out op);
 			Factor(out e1);
 			e0 = Expr.Binary(x, op, e0, e1); 
@@ -1927,7 +1941,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	void Factor(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; BinaryOperator.Opcode op; 
 		Power(out e0);
-		while (StartOf(21)) {
+		while (StartOf(23)) {
 			MulOp(out x, out op);
 			Power(out e1);
 			e0 = Expr.Binary(x, op, e0, e1); 
@@ -1936,19 +1950,19 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 
 	void AddOp(out IToken/*!*/ x, out BinaryOperator.Opcode op) {
 		Contract.Ensures(Contract.ValueAtReturn(out x) != null); x = Token.NoToken; op=BinaryOperator.Opcode.Add/*(dummy)*/; 
-		if (la.kind == 85) {
+		if (la.kind == 86) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Add; 
-		} else if (la.kind == 86) {
+		} else if (la.kind == 87) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Sub; 
-		} else SynErr(150);
+		} else SynErr(152);
 	}
 
 	void Power(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x; Expr/*!*/ e1; 
 		IsConstructor(out e0);
-		if (la.kind == 90) {
+		if (la.kind == 91) {
 			Get();
 			x = t; 
 			Power(out e1);
@@ -1961,22 +1975,22 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		if (la.kind == 58) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Mul; 
-		} else if (la.kind == 87) {
-			Get();
-			x = t; op=BinaryOperator.Opcode.Div; 
 		} else if (la.kind == 88) {
 			Get();
-			x = t; op=BinaryOperator.Opcode.Mod; 
+			x = t; op=BinaryOperator.Opcode.Div; 
 		} else if (la.kind == 89) {
 			Get();
+			x = t; op=BinaryOperator.Opcode.Mod; 
+		} else if (la.kind == 90) {
+			Get();
 			x = t; op=BinaryOperator.Opcode.RealDiv; 
-		} else SynErr(151);
+		} else SynErr(153);
 	}
 
 	void IsConstructor(out Expr/*!*/ e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken/*!*/ x, id; 
 		UnaryExpression(out e0);
-		if (la.kind == 91) {
+		if (la.kind == 92) {
 			Get();
 			x = t; 
 			Ident(out id);
@@ -1990,27 +2004,27 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		Contract.Ensures(Contract.ValueAtReturn(out e) != null); IToken/*!*/ x;
 		e = dummyExpr;
 		
-		if (la.kind == 86) {
+		if (la.kind == 87) {
 			Get();
 			x = t; 
 			UnaryExpression(out e);
 			e = Expr.Unary(x, UnaryOperator.Opcode.Neg, e); 
-		} else if (la.kind == 92 || la.kind == 93) {
+		} else if (la.kind == 93 || la.kind == 94) {
 			NegOp();
 			x = t; 
 			UnaryExpression(out e);
 			e = Expr.Unary(x, UnaryOperator.Opcode.Not, e); 
-		} else if (StartOf(22)) {
+		} else if (StartOf(24)) {
 			CoercionExpression(out e);
-		} else SynErr(152);
+		} else SynErr(154);
 	}
 
 	void NegOp() {
-		if (la.kind == 92) {
+		if (la.kind == 93) {
 			Get();
-		} else if (la.kind == 93) {
+		} else if (la.kind == 94) {
 			Get();
-		} else SynErr(153);
+		} else SynErr(155);
 	}
 
 	void CoercionExpression(out Expr/*!*/ e) {
@@ -2022,7 +2036,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		while (la.kind == 13) {
 			Get();
 			x = t; 
-			if (StartOf(12)) {
+			if (StartOf(14)) {
 				Type(out coercedTo);
 				e = Expr.CoerceType(x, e, coercedTo); 
 			} else if (la.kind == 3) {
@@ -2034,7 +2048,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				 e = new BvBounds(x, bn, ((LiteralExpr)e).asBigNum);
 				}
 				
-			} else SynErr(154);
+			} else SynErr(156);
 		}
 	}
 
@@ -2046,14 +2060,14 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		List<Expr>/*!*/ allArgs = dummyExprSeq;
 		
 		AtomExpression(out e);
-		while (la.kind == 19 || la.kind == 42) {
+		while (la.kind == 19 || la.kind == 64) {
 			if (la.kind == 19) {
 				Get();
 				x = t; allArgs = new List<Expr> ();
 				allArgs.Add(e);
 				store = false; bvExtract = false; 
-				if (StartOf(23)) {
-					if (StartOf(16)) {
+				if (StartOf(25)) {
+					if (StartOf(18)) {
 						Expression(out index0);
 						if (index0 is BvBounds)
 						 bvExtract = true;
@@ -2095,7 +2109,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			} else {
 				Get();
 				x = t; 
-				if (la.kind == 1) {
+				if (StartOf(13)) {
 					Ident(out id);
 					e = new NAryExpr(x, new FieldAccess(id, id.val), new List<Expr> { e }); 
 				} else if (la.kind == 11) {
@@ -2106,7 +2120,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 					Expression(out e1);
 					Expect(12);
 					e = new NAryExpr(x, new FieldUpdate(id, id.val), new List<Expr> { e, e1 }); 
-				} else SynErr(155);
+				} else SynErr(157);
 			}
 		}
 	}
@@ -2133,18 +2147,18 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		List<Block/*!*/>/*!*/ blocks;
 		
 		switch (la.kind) {
-		case 94: {
+		case 95: {
 			Get();
 			e = new LiteralExpr(t, false); 
 			break;
 		}
-		case 95: {
+		case 96: {
 			Get();
 			e = new LiteralExpr(t, true); 
 			break;
 		}
-		case 96: case 97: {
-			if (la.kind == 96) {
+		case 97: case 98: {
+			if (la.kind == 97) {
 				Get();
 			} else {
 				Get();
@@ -2152,8 +2166,8 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, RoundingMode.RNE); 
 			break;
 		}
-		case 98: case 99: {
-			if (la.kind == 98) {
+		case 99: case 100: {
+			if (la.kind == 99) {
 				Get();
 			} else {
 				Get();
@@ -2161,8 +2175,8 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, RoundingMode.RNA); 
 			break;
 		}
-		case 100: case 101: {
-			if (la.kind == 100) {
+		case 101: case 102: {
+			if (la.kind == 101) {
 				Get();
 			} else {
 				Get();
@@ -2170,8 +2184,8 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, RoundingMode.RTP); 
 			break;
 		}
-		case 102: case 103: {
-			if (la.kind == 102) {
+		case 103: case 104: {
+			if (la.kind == 103) {
 				Get();
 			} else {
 				Get();
@@ -2179,8 +2193,8 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, RoundingMode.RTN); 
 			break;
 		}
-		case 104: case 105: {
-			if (la.kind == 104) {
+		case 105: case 106: {
+			if (la.kind == 105) {
 				Get();
 			} else {
 				Get();
@@ -2213,22 +2227,22 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, t.val.Trim('"')); 
 			break;
 		}
-		case 1: {
+		case 1: case 41: case 42: case 43: case 44: {
 			Ident(out x);
 			id = new IdentifierExpr(x, x.val);  e = id; 
 			if (la.kind == 11) {
 				Get();
-				if (StartOf(16)) {
+				if (StartOf(18)) {
 					Expressions(out es);
 					e = new NAryExpr(x, new FunctionCall(id), es); 
 				} else if (la.kind == 12) {
 					e = new NAryExpr(x, new FunctionCall(id), new List<Expr>()); 
-				} else SynErr(156);
+				} else SynErr(158);
 				Expect(12);
 			}
 			break;
 		}
-		case 106: {
+		case 107: {
 			Get();
 			x = t; 
 			Expect(11);
@@ -2257,23 +2271,23 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		}
 		case 11: {
 			Get();
-			if (StartOf(16)) {
+			if (StartOf(18)) {
 				Expression(out e);
 				if (e is BvBounds)
 				 this.SemErr("parentheses around bitvector bounds are not allowed"); 
-			} else if (la.kind == 110 || la.kind == 111) {
+			} else if (la.kind == 111 || la.kind == 112) {
 				Forall();
 				x = t; 
 				QuantifierBody(x, out typeParams, out ds, out kv, out trig, out e);
 				if (typeParams.Count + ds.Count > 0)
 				 e = new ForallExpr(x, typeParams, ds, kv, trig, e); 
-			} else if (la.kind == 112 || la.kind == 113) {
+			} else if (la.kind == 113 || la.kind == 114) {
 				Exists();
 				x = t; 
 				QuantifierBody(x, out typeParams, out ds, out kv, out trig, out e);
 				if (typeParams.Count + ds.Count > 0)
 				 e = new ExistsExpr(x, typeParams, ds, kv, trig, e); 
-			} else if (la.kind == 114 || la.kind == 115) {
+			} else if (la.kind == 115 || la.kind == 116) {
 				Lambda();
 				x = t; 
 				QuantifierBody(x, out typeParams, out ds, out kv, out trig, out e);
@@ -2283,7 +2297,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 				 e = new LambdaExpr(x, typeParams, ds, kv, e); 
 			} else if (la.kind == 9) {
 				LetExpr(out e);
-			} else SynErr(157);
+			} else SynErr(159);
 			Expect(12);
 			break;
 		}
@@ -2291,12 +2305,12 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 			IfThenElseExpression(out e);
 			break;
 		}
-		case 107: {
+		case 108: {
 			CodeExpression(out locals, out blocks);
 			e = new CodeExpr(locals, blocks); 
 			break;
 		}
-		default: SynErr(158); break;
+		default: SynErr(160); break;
 		}
 	}
 
@@ -2308,7 +2322,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		} else if (la.kind == 6) {
 			Get();
 			s = t.val; 
-		} else SynErr(159);
+		} else SynErr(161);
 		try {
 		 n = BigDec.FromString(s);
 		} catch (FormatException) {
@@ -2348,11 +2362,11 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	}
 
 	void Forall() {
-		if (la.kind == 110) {
+		if (la.kind == 111) {
 			Get();
-		} else if (la.kind == 111) {
+		} else if (la.kind == 112) {
 			Get();
-		} else SynErr(160);
+		} else SynErr(162);
 	}
 
 	void QuantifierBody(IToken/*!*/ q, out List<TypeVariable>/*!*/ typeParams, out List<Variable>/*!*/ ds,
@@ -2365,12 +2379,12 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		
 		if (la.kind == 21) {
 			TypeParams(out tok, out typeParams);
-			if (la.kind == 1 || la.kind == 26) {
+			if (StartOf(11)) {
 				BoundVars(out ds);
 			}
-		} else if (la.kind == 1 || la.kind == 26) {
+		} else if (StartOf(11)) {
 			BoundVars(out ds);
-		} else SynErr(161);
+		} else SynErr(163);
 		QSep();
 		while (la.kind == 26) {
 			AttributeOrTrigger(ref kv, ref trig);
@@ -2379,19 +2393,19 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 	}
 
 	void Exists() {
-		if (la.kind == 112) {
+		if (la.kind == 113) {
 			Get();
-		} else if (la.kind == 113) {
+		} else if (la.kind == 114) {
 			Get();
-		} else SynErr(162);
+		} else SynErr(164);
 	}
 
 	void Lambda() {
-		if (la.kind == 114) {
+		if (la.kind == 115) {
 			Get();
-		} else if (la.kind == 115) {
+		} else if (la.kind == 116) {
 			Get();
-		} else SynErr(163);
+		} else SynErr(165);
 	}
 
 	void LetExpr(out Expr/*!*/ letexpr) {
@@ -2436,7 +2450,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		Expect(55);
 		tok = t; 
 		Expression(out e0);
-		Expect(109);
+		Expect(110);
 		Expression(out e1);
 		Expect(56);
 		Expression(out e2);
@@ -2447,17 +2461,17 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		Contract.Ensures(Contract.ValueAtReturn(out locals) != null); Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out blocks))); locals = new List<Variable>(); Block/*!*/ b;
 		blocks = new List<Block/*!*/>();
 		
-		Expect(107);
+		Expect(108);
 		while (la.kind == 9) {
 			LocalVars(locals);
 		}
 		SpecBlock(out b);
 		blocks.Add(b); 
-		while (la.kind == 1) {
+		while (StartOf(13)) {
 			SpecBlock(out b);
 			blocks.Add(b); 
 		}
-		Expect(108);
+		Expect(109);
 	}
 
 	void SpecBlock(out Block/*!*/ b) {
@@ -2471,7 +2485,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		
 		Ident(out x);
 		Expect(13);
-		while (StartOf(15)) {
+		while (StartOf(17)) {
 			LabelOrCmd(out c, out label);
 			Contract.Assert(c == null || label == null);
 			if (c != null) {
@@ -2494,7 +2508,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			Get();
 			Expression(out e);
 			b = new Block(x,x.val,cs,new ReturnExprCmd(t,e)); 
-		} else SynErr(164);
+		} else SynErr(166);
 		Expect(10);
 	}
 
@@ -2509,7 +2523,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			Get();
 			Expect(1);
 			key = t.val;  parameters = new List<object/*!*/>(); 
-			if (StartOf(16)) {
+			if (StartOf(18)) {
 				AttributeParameter(out param);
 				parameters.Add(param); 
 				while (la.kind == 14) {
@@ -2537,7 +2551,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			 }
 			}
 			
-		} else if (StartOf(16)) {
+		} else if (StartOf(18)) {
 			Expression(out e);
 			es = new List<Expr> { e }; 
 			while (la.kind == 14) {
@@ -2551,7 +2565,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 			 trig.AddLast(new Trigger(tok, true, es, null));
 			}
 			
-		} else SynErr(165);
+		} else SynErr(167);
 		Expect(27);
 	}
 
@@ -2563,18 +2577,18 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		if (la.kind == 4) {
 			Get();
 			o = t.val.Substring(1, t.val.Length-2); 
-		} else if (StartOf(16)) {
+		} else if (StartOf(18)) {
 			Expression(out e);
 			o = e; 
-		} else SynErr(166);
+		} else SynErr(168);
 	}
 
 	void QSep() {
-		if (la.kind == 116) {
+		if (la.kind == 117) {
 			Get();
-		} else if (la.kind == 117) {
+		} else if (la.kind == 118) {
 			Get();
-		} else SynErr(167);
+		} else SynErr(169);
 	}
 
 	void LetVar(out Variable/*!*/ v) {
@@ -2603,30 +2617,32 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 	}
 
 	static readonly bool[,]/*!*/ set = {
-		{_T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_x,_T,_T, _x,_T,_x,_T, _T,_x,_x,_x, _x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_T,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_T,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_T, _T,_T,_T,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x}
+		{_T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_x,_T,_T, _x,_T,_x,_T, _T,_x,_x,_x, _x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_T,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_T,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_T, _T,_T,_T,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x}
 
 	};
 } // end Parser
@@ -2692,10 +2708,10 @@ public class Errors {
 			case 38: s = "\"using\" expected"; break;
 			case 39: s = "\"eliminates\" expected"; break;
 			case 40: s = "\"refines\" expected"; break;
-			case 41: s = "\"<-\" expected"; break;
-			case 42: s = "\"->\" expected"; break;
-			case 43: s = "\"<->\" expected"; break;
-			case 44: s = "\">-<\" expected"; break;
+			case 41: s = "\"left\" expected"; break;
+			case 42: s = "\"right\" expected"; break;
+			case 43: s = "\"both\" expected"; break;
+			case 44: s = "\"atomic\" expected"; break;
 			case 45: s = "\"procedure\" expected"; break;
 			case 46: s = "\"requires\" expected"; break;
 			case 47: s = "\"ensures\" expected"; break;
@@ -2715,110 +2731,112 @@ public class Errors {
 			case 61: s = "\"assume\" expected"; break;
 			case 62: s = "\"havoc\" expected"; break;
 			case 63: s = "\":=\" expected"; break;
-			case 64: s = "\"call\" expected"; break;
-			case 65: s = "\"par\" expected"; break;
-			case 66: s = "\"|\" expected"; break;
-			case 67: s = "\"<==>\" expected"; break;
-			case 68: s = "\"\\u21d4\" expected"; break;
-			case 69: s = "\"==>\" expected"; break;
-			case 70: s = "\"\\u21d2\" expected"; break;
-			case 71: s = "\"<==\" expected"; break;
-			case 72: s = "\"\\u21d0\" expected"; break;
-			case 73: s = "\"&&\" expected"; break;
-			case 74: s = "\"\\u2227\" expected"; break;
-			case 75: s = "\"||\" expected"; break;
-			case 76: s = "\"\\u2228\" expected"; break;
-			case 77: s = "\"==\" expected"; break;
-			case 78: s = "\"<=\" expected"; break;
-			case 79: s = "\">=\" expected"; break;
-			case 80: s = "\"!=\" expected"; break;
-			case 81: s = "\"\\u2260\" expected"; break;
-			case 82: s = "\"\\u2264\" expected"; break;
-			case 83: s = "\"\\u2265\" expected"; break;
-			case 84: s = "\"++\" expected"; break;
-			case 85: s = "\"+\" expected"; break;
-			case 86: s = "\"-\" expected"; break;
-			case 87: s = "\"div\" expected"; break;
-			case 88: s = "\"mod\" expected"; break;
-			case 89: s = "\"/\" expected"; break;
-			case 90: s = "\"**\" expected"; break;
-			case 91: s = "\"is\" expected"; break;
-			case 92: s = "\"!\" expected"; break;
-			case 93: s = "\"\\u00ac\" expected"; break;
-			case 94: s = "\"false\" expected"; break;
-			case 95: s = "\"true\" expected"; break;
-			case 96: s = "\"roundNearestTiesToEven\" expected"; break;
-			case 97: s = "\"RNE\" expected"; break;
-			case 98: s = "\"roundNearestTiesToAway\" expected"; break;
-			case 99: s = "\"RNA\" expected"; break;
-			case 100: s = "\"roundTowardPositive\" expected"; break;
-			case 101: s = "\"RTP\" expected"; break;
-			case 102: s = "\"roundTowardNegative\" expected"; break;
-			case 103: s = "\"RTN\" expected"; break;
-			case 104: s = "\"roundTowardZero\" expected"; break;
-			case 105: s = "\"RTZ\" expected"; break;
-			case 106: s = "\"old\" expected"; break;
-			case 107: s = "\"|{\" expected"; break;
-			case 108: s = "\"}|\" expected"; break;
-			case 109: s = "\"then\" expected"; break;
-			case 110: s = "\"forall\" expected"; break;
-			case 111: s = "\"\\u2200\" expected"; break;
-			case 112: s = "\"exists\" expected"; break;
-			case 113: s = "\"\\u2203\" expected"; break;
-			case 114: s = "\"lambda\" expected"; break;
-			case 115: s = "\"\\u03bb\" expected"; break;
-			case 116: s = "\"::\" expected"; break;
-			case 117: s = "\"\\u2022\" expected"; break;
-			case 118: s = "??? expected"; break;
-			case 119: s = "invalid BoogiePL"; break;
-			case 120: s = "invalid Consts"; break;
-			case 121: s = "invalid Function"; break;
+			case 64: s = "\"->\" expected"; break;
+			case 65: s = "\"call\" expected"; break;
+			case 66: s = "\"par\" expected"; break;
+			case 67: s = "\"|\" expected"; break;
+			case 68: s = "\"<==>\" expected"; break;
+			case 69: s = "\"\\u21d4\" expected"; break;
+			case 70: s = "\"==>\" expected"; break;
+			case 71: s = "\"\\u21d2\" expected"; break;
+			case 72: s = "\"<==\" expected"; break;
+			case 73: s = "\"\\u21d0\" expected"; break;
+			case 74: s = "\"&&\" expected"; break;
+			case 75: s = "\"\\u2227\" expected"; break;
+			case 76: s = "\"||\" expected"; break;
+			case 77: s = "\"\\u2228\" expected"; break;
+			case 78: s = "\"==\" expected"; break;
+			case 79: s = "\"<=\" expected"; break;
+			case 80: s = "\">=\" expected"; break;
+			case 81: s = "\"!=\" expected"; break;
+			case 82: s = "\"\\u2260\" expected"; break;
+			case 83: s = "\"\\u2264\" expected"; break;
+			case 84: s = "\"\\u2265\" expected"; break;
+			case 85: s = "\"++\" expected"; break;
+			case 86: s = "\"+\" expected"; break;
+			case 87: s = "\"-\" expected"; break;
+			case 88: s = "\"div\" expected"; break;
+			case 89: s = "\"mod\" expected"; break;
+			case 90: s = "\"/\" expected"; break;
+			case 91: s = "\"**\" expected"; break;
+			case 92: s = "\"is\" expected"; break;
+			case 93: s = "\"!\" expected"; break;
+			case 94: s = "\"\\u00ac\" expected"; break;
+			case 95: s = "\"false\" expected"; break;
+			case 96: s = "\"true\" expected"; break;
+			case 97: s = "\"roundNearestTiesToEven\" expected"; break;
+			case 98: s = "\"RNE\" expected"; break;
+			case 99: s = "\"roundNearestTiesToAway\" expected"; break;
+			case 100: s = "\"RNA\" expected"; break;
+			case 101: s = "\"roundTowardPositive\" expected"; break;
+			case 102: s = "\"RTP\" expected"; break;
+			case 103: s = "\"roundTowardNegative\" expected"; break;
+			case 104: s = "\"RTN\" expected"; break;
+			case 105: s = "\"roundTowardZero\" expected"; break;
+			case 106: s = "\"RTZ\" expected"; break;
+			case 107: s = "\"old\" expected"; break;
+			case 108: s = "\"|{\" expected"; break;
+			case 109: s = "\"}|\" expected"; break;
+			case 110: s = "\"then\" expected"; break;
+			case 111: s = "\"forall\" expected"; break;
+			case 112: s = "\"\\u2200\" expected"; break;
+			case 113: s = "\"exists\" expected"; break;
+			case 114: s = "\"\\u2203\" expected"; break;
+			case 115: s = "\"lambda\" expected"; break;
+			case 116: s = "\"\\u03bb\" expected"; break;
+			case 117: s = "\"::\" expected"; break;
+			case 118: s = "\"\\u2022\" expected"; break;
+			case 119: s = "??? expected"; break;
+			case 120: s = "invalid BoogiePL"; break;
+			case 121: s = "invalid Consts"; break;
 			case 122: s = "invalid Function"; break;
-			case 123: s = "invalid ActionDecl"; break;
-			case 124: s = "invalid YieldProcedureDecl"; break;
-			case 125: s = "invalid Procedure"; break;
-			case 126: s = "invalid Type"; break;
-			case 127: s = "invalid TypeAtom"; break;
-			case 128: s = "invalid TypeArgs"; break;
-			case 129: s = "invalid MoverQualifier"; break;
-			case 130: s = "invalid SpecAction"; break;
-			case 131: s = "invalid SpecYieldPrePost"; break;
-			case 132: s = "invalid SpecYieldPrePost"; break;
+			case 123: s = "invalid Function"; break;
+			case 124: s = "invalid ActionDecl"; break;
+			case 125: s = "invalid YieldProcedureDecl"; break;
+			case 126: s = "invalid Procedure"; break;
+			case 127: s = "invalid Type"; break;
+			case 128: s = "invalid TypeAtom"; break;
+			case 129: s = "invalid Ident"; break;
+			case 130: s = "invalid TypeArgs"; break;
+			case 131: s = "invalid MoverQualifier"; break;
+			case 132: s = "invalid SpecAction"; break;
 			case 133: s = "invalid SpecYieldPrePost"; break;
-			case 134: s = "invalid Spec"; break;
-			case 135: s = "invalid SpecPrePost"; break;
-			case 136: s = "invalid LabelOrCmd"; break;
-			case 137: s = "invalid StructuredCmd"; break;
-			case 138: s = "invalid TransferCmd"; break;
-			case 139: s = "invalid IfCmd"; break;
-			case 140: s = "invalid WhileCmd"; break;
-			case 141: s = "invalid Guard"; break;
-			case 142: s = "invalid LabelOrAssign"; break;
-			case 143: s = "invalid CallParams"; break;
-			case 144: s = "invalid EquivOp"; break;
-			case 145: s = "invalid ImpliesOp"; break;
-			case 146: s = "invalid ExpliesOp"; break;
-			case 147: s = "invalid AndOp"; break;
-			case 148: s = "invalid OrOp"; break;
-			case 149: s = "invalid RelOp"; break;
-			case 150: s = "invalid AddOp"; break;
-			case 151: s = "invalid MulOp"; break;
-			case 152: s = "invalid UnaryExpression"; break;
-			case 153: s = "invalid NegOp"; break;
-			case 154: s = "invalid CoercionExpression"; break;
-			case 155: s = "invalid ArrayExpression"; break;
-			case 156: s = "invalid AtomExpression"; break;
-			case 157: s = "invalid AtomExpression"; break;
+			case 134: s = "invalid SpecYieldPrePost"; break;
+			case 135: s = "invalid SpecYieldPrePost"; break;
+			case 136: s = "invalid Spec"; break;
+			case 137: s = "invalid SpecPrePost"; break;
+			case 138: s = "invalid LabelOrCmd"; break;
+			case 139: s = "invalid StructuredCmd"; break;
+			case 140: s = "invalid TransferCmd"; break;
+			case 141: s = "invalid IfCmd"; break;
+			case 142: s = "invalid WhileCmd"; break;
+			case 143: s = "invalid Guard"; break;
+			case 144: s = "invalid LabelOrAssign"; break;
+			case 145: s = "invalid CallParams"; break;
+			case 146: s = "invalid EquivOp"; break;
+			case 147: s = "invalid ImpliesOp"; break;
+			case 148: s = "invalid ExpliesOp"; break;
+			case 149: s = "invalid AndOp"; break;
+			case 150: s = "invalid OrOp"; break;
+			case 151: s = "invalid RelOp"; break;
+			case 152: s = "invalid AddOp"; break;
+			case 153: s = "invalid MulOp"; break;
+			case 154: s = "invalid UnaryExpression"; break;
+			case 155: s = "invalid NegOp"; break;
+			case 156: s = "invalid CoercionExpression"; break;
+			case 157: s = "invalid ArrayExpression"; break;
 			case 158: s = "invalid AtomExpression"; break;
-			case 159: s = "invalid Dec"; break;
-			case 160: s = "invalid Forall"; break;
-			case 161: s = "invalid QuantifierBody"; break;
-			case 162: s = "invalid Exists"; break;
-			case 163: s = "invalid Lambda"; break;
-			case 164: s = "invalid SpecBlock"; break;
-			case 165: s = "invalid AttributeOrTrigger"; break;
-			case 166: s = "invalid AttributeParameter"; break;
-			case 167: s = "invalid QSep"; break;
+			case 159: s = "invalid AtomExpression"; break;
+			case 160: s = "invalid AtomExpression"; break;
+			case 161: s = "invalid Dec"; break;
+			case 162: s = "invalid Forall"; break;
+			case 163: s = "invalid QuantifierBody"; break;
+			case 164: s = "invalid Exists"; break;
+			case 165: s = "invalid Lambda"; break;
+			case 166: s = "invalid SpecBlock"; break;
+			case 167: s = "invalid AttributeOrTrigger"; break;
+			case 168: s = "invalid AttributeParameter"; break;
+			case 169: s = "invalid QSep"; break;
 
 			default: s = "error " + n; break;
 		}

--- a/Source/Core/Scanner.cs
+++ b/Source/Core/Scanner.cs
@@ -220,8 +220,8 @@ public class UTF8Buffer: Buffer {
 public class Scanner {
 	const char EOL = '\n';
 	const int eofSym = 0; /* pdt */
-	const int maxT = 118;
-	const int noSym = 118;
+	const int maxT = 119;
+	const int noSym = 119;
 
 
 	[ContractInvariantMethod]
@@ -280,38 +280,38 @@ public class Scanner {
 		for (int i = 34; i <= 34; ++i) start[i] = 6;
 		start[92] = 1; 
 		start[48] = 52; 
-		start[45] = 99; 
+		start[45] = 96; 
 		start[59] = 61; 
 		start[40] = 62; 
 		start[41] = 63; 
-		start[58] = 100; 
+		start[58] = 97; 
 		start[44] = 64; 
 		start[91] = 65; 
 		start[93] = 66; 
-		start[60] = 101; 
-		start[62] = 102; 
+		start[60] = 98; 
+		start[62] = 99; 
 		start[123] = 67; 
-		start[125] = 103; 
-		start[61] = 104; 
-		start[42] = 105; 
-		start[124] = 106; 
-		start[8660] = 74; 
-		start[8658] = 76; 
-		start[8656] = 77; 
-		start[38] = 78; 
-		start[8743] = 80; 
-		start[8744] = 82; 
-		start[33] = 107; 
-		start[8800] = 85; 
-		start[8804] = 86; 
-		start[8805] = 87; 
-		start[43] = 108; 
-		start[47] = 89; 
-		start[172] = 91; 
-		start[8704] = 94; 
-		start[8707] = 95; 
-		start[955] = 96; 
-		start[8226] = 98; 
+		start[125] = 100; 
+		start[61] = 101; 
+		start[42] = 102; 
+		start[124] = 103; 
+		start[8660] = 71; 
+		start[8658] = 73; 
+		start[8656] = 74; 
+		start[38] = 75; 
+		start[8743] = 77; 
+		start[8744] = 79; 
+		start[33] = 104; 
+		start[8800] = 82; 
+		start[8804] = 83; 
+		start[8805] = 84; 
+		start[43] = 105; 
+		start[47] = 86; 
+		start[172] = 88; 
+		start[8704] = 91; 
+		start[8707] = 92; 
+		start[955] = 93; 
+		start[8226] = 95; 
 		start[Buffer.EOF] = -1;
 
 	}
@@ -534,6 +534,10 @@ public class Scanner {
 			case "using": t.kind = 38; break;
 			case "eliminates": t.kind = 39; break;
 			case "refines": t.kind = 40; break;
+			case "left": t.kind = 41; break;
+			case "right": t.kind = 42; break;
+			case "both": t.kind = 43; break;
+			case "atomic": t.kind = 44; break;
 			case "procedure": t.kind = 45; break;
 			case "requires": t.kind = 46; break;
 			case "ensures": t.kind = 47; break;
@@ -551,28 +555,28 @@ public class Scanner {
 			case "assert": t.kind = 60; break;
 			case "assume": t.kind = 61; break;
 			case "havoc": t.kind = 62; break;
-			case "call": t.kind = 64; break;
-			case "par": t.kind = 65; break;
-			case "div": t.kind = 87; break;
-			case "mod": t.kind = 88; break;
-			case "is": t.kind = 91; break;
-			case "false": t.kind = 94; break;
-			case "true": t.kind = 95; break;
-			case "roundNearestTiesToEven": t.kind = 96; break;
-			case "RNE": t.kind = 97; break;
-			case "roundNearestTiesToAway": t.kind = 98; break;
-			case "RNA": t.kind = 99; break;
-			case "roundTowardPositive": t.kind = 100; break;
-			case "RTP": t.kind = 101; break;
-			case "roundTowardNegative": t.kind = 102; break;
-			case "RTN": t.kind = 103; break;
-			case "roundTowardZero": t.kind = 104; break;
-			case "RTZ": t.kind = 105; break;
-			case "old": t.kind = 106; break;
-			case "then": t.kind = 109; break;
-			case "forall": t.kind = 110; break;
-			case "exists": t.kind = 112; break;
-			case "lambda": t.kind = 114; break;
+			case "call": t.kind = 65; break;
+			case "par": t.kind = 66; break;
+			case "div": t.kind = 88; break;
+			case "mod": t.kind = 89; break;
+			case "is": t.kind = 92; break;
+			case "false": t.kind = 95; break;
+			case "true": t.kind = 96; break;
+			case "roundNearestTiesToEven": t.kind = 97; break;
+			case "RNE": t.kind = 98; break;
+			case "roundNearestTiesToAway": t.kind = 99; break;
+			case "RNA": t.kind = 100; break;
+			case "roundTowardPositive": t.kind = 101; break;
+			case "RTP": t.kind = 102; break;
+			case "roundTowardNegative": t.kind = 103; break;
+			case "RTN": t.kind = 104; break;
+			case "roundTowardZero": t.kind = 105; break;
+			case "RTZ": t.kind = 106; break;
+			case "old": t.kind = 107; break;
+			case "then": t.kind = 110; break;
+			case "forall": t.kind = 111; break;
+			case "exists": t.kind = 113; break;
+			case "lambda": t.kind = 115; break;
 			default: break;
 		}
 	}
@@ -856,130 +860,117 @@ public class Scanner {
 			case 67:
 				{t.kind = 26; break;}
 			case 68:
-				{t.kind = 42; break;}
-			case 69:
-				{t.kind = 43; break;}
-			case 70:
-				if (ch == '<') {AddCh(); goto case 71;}
-				else {goto case 0;}
-			case 71:
-				{t.kind = 44; break;}
-			case 72:
 				{t.kind = 63; break;}
-			case 73:
-				{t.kind = 67; break;}
-			case 74:
+			case 69:
+				{t.kind = 64; break;}
+			case 70:
 				{t.kind = 68; break;}
-			case 75:
+			case 71:
 				{t.kind = 69; break;}
-			case 76:
+			case 72:
 				{t.kind = 70; break;}
-			case 77:
-				{t.kind = 72; break;}
-			case 78:
-				if (ch == '&') {AddCh(); goto case 79;}
-				else {goto case 0;}
-			case 79:
+			case 73:
+				{t.kind = 71; break;}
+			case 74:
 				{t.kind = 73; break;}
-			case 80:
+			case 75:
+				if (ch == '&') {AddCh(); goto case 76;}
+				else {goto case 0;}
+			case 76:
 				{t.kind = 74; break;}
-			case 81:
+			case 77:
 				{t.kind = 75; break;}
-			case 82:
+			case 78:
 				{t.kind = 76; break;}
-			case 83:
-				{t.kind = 79; break;}
-			case 84:
+			case 79:
+				{t.kind = 77; break;}
+			case 80:
 				{t.kind = 80; break;}
-			case 85:
+			case 81:
 				{t.kind = 81; break;}
-			case 86:
+			case 82:
 				{t.kind = 82; break;}
-			case 87:
+			case 83:
 				{t.kind = 83; break;}
-			case 88:
+			case 84:
 				{t.kind = 84; break;}
-			case 89:
-				{t.kind = 89; break;}
-			case 90:
+			case 85:
+				{t.kind = 85; break;}
+			case 86:
 				{t.kind = 90; break;}
-			case 91:
-				{t.kind = 93; break;}
-			case 92:
-				{t.kind = 107; break;}
-			case 93:
+			case 87:
+				{t.kind = 91; break;}
+			case 88:
+				{t.kind = 94; break;}
+			case 89:
 				{t.kind = 108; break;}
-			case 94:
-				{t.kind = 111; break;}
-			case 95:
-				{t.kind = 113; break;}
-			case 96:
-				{t.kind = 115; break;}
-			case 97:
+			case 90:
+				{t.kind = 109; break;}
+			case 91:
+				{t.kind = 112; break;}
+			case 92:
+				{t.kind = 114; break;}
+			case 93:
 				{t.kind = 116; break;}
-			case 98:
+			case 94:
 				{t.kind = 117; break;}
-			case 99:
-				recEnd = pos; recKind = 86;
+			case 95:
+				{t.kind = 118; break;}
+			case 96:
+				recEnd = pos; recKind = 87;
 				if (ch == '0') {AddCh(); goto case 16;}
-				else if (ch == '>') {AddCh(); goto case 68;}
-				else {t.kind = 86; break;}
-			case 100:
+				else if (ch == '>') {AddCh(); goto case 69;}
+				else {t.kind = 87; break;}
+			case 97:
 				recEnd = pos; recKind = 13;
-				if (ch == '=') {AddCh(); goto case 72;}
-				else if (ch == ':') {AddCh(); goto case 97;}
+				if (ch == '=') {AddCh(); goto case 68;}
+				else if (ch == ':') {AddCh(); goto case 94;}
 				else {t.kind = 13; break;}
-			case 101:
+			case 98:
 				recEnd = pos; recKind = 21;
-				if (ch == '-') {AddCh(); goto case 109;}
-				else if (ch == '=') {AddCh(); goto case 110;}
+				if (ch == '=') {AddCh(); goto case 106;}
 				else {t.kind = 21; break;}
-			case 102:
+			case 99:
 				recEnd = pos; recKind = 22;
-				if (ch == '-') {AddCh(); goto case 70;}
-				else if (ch == '=') {AddCh(); goto case 83;}
+				if (ch == '=') {AddCh(); goto case 80;}
 				else {t.kind = 22; break;}
-			case 103:
+			case 100:
 				recEnd = pos; recKind = 27;
-				if (ch == '|') {AddCh(); goto case 93;}
+				if (ch == '|') {AddCh(); goto case 90;}
 				else {t.kind = 27; break;}
-			case 104:
+			case 101:
 				recEnd = pos; recKind = 32;
-				if (ch == '=') {AddCh(); goto case 111;}
+				if (ch == '=') {AddCh(); goto case 107;}
 				else {t.kind = 32; break;}
-			case 105:
+			case 102:
 				recEnd = pos; recKind = 58;
-				if (ch == '*') {AddCh(); goto case 90;}
+				if (ch == '*') {AddCh(); goto case 87;}
 				else {t.kind = 58; break;}
+			case 103:
+				recEnd = pos; recKind = 67;
+				if (ch == '|') {AddCh(); goto case 78;}
+				else if (ch == '{') {AddCh(); goto case 89;}
+				else {t.kind = 67; break;}
+			case 104:
+				recEnd = pos; recKind = 93;
+				if (ch == '=') {AddCh(); goto case 81;}
+				else {t.kind = 93; break;}
+			case 105:
+				recEnd = pos; recKind = 86;
+				if (ch == '+') {AddCh(); goto case 85;}
+				else {t.kind = 86; break;}
 			case 106:
-				recEnd = pos; recKind = 66;
-				if (ch == '|') {AddCh(); goto case 81;}
-				else if (ch == '{') {AddCh(); goto case 92;}
-				else {t.kind = 66; break;}
+				recEnd = pos; recKind = 79;
+				if (ch == '=') {AddCh(); goto case 108;}
+				else {t.kind = 79; break;}
 			case 107:
-				recEnd = pos; recKind = 92;
-				if (ch == '=') {AddCh(); goto case 84;}
-				else {t.kind = 92; break;}
-			case 108:
-				recEnd = pos; recKind = 85;
-				if (ch == '+') {AddCh(); goto case 88;}
-				else {t.kind = 85; break;}
-			case 109:
-				recEnd = pos; recKind = 41;
-				if (ch == '>') {AddCh(); goto case 69;}
-				else {t.kind = 41; break;}
-			case 110:
 				recEnd = pos; recKind = 78;
-				if (ch == '=') {AddCh(); goto case 112;}
+				if (ch == '>') {AddCh(); goto case 72;}
 				else {t.kind = 78; break;}
-			case 111:
-				recEnd = pos; recKind = 77;
-				if (ch == '>') {AddCh(); goto case 75;}
-				else {t.kind = 77; break;}
-			case 112:
-				recEnd = pos; recKind = 71;
-				if (ch == '>') {AddCh(); goto case 73;}
-				else {t.kind = 71; break;}
+			case 108:
+				recEnd = pos; recKind = 72;
+				if (ch == '>') {AddCh(); goto case 70;}
+				else {t.kind = 72; break;}
 
 		}
 		t.val = new String(tval, 0, tlen);

--- a/Test/civl/DeviceCache.bpl
+++ b/Test/civl/DeviceCache.bpl
@@ -125,66 +125,66 @@ preserves call YieldToReadCache(tid, old(currsize));
     }
 }
 
->-< action {:layer 1} AtomicInit({:linear_in "tid"} xls:[X]bool)
+atomic action {:layer 1} AtomicInit({:linear_in "tid"} xls:[X]bool)
 modifies currsize, newsize, lock, ghostLock;
 { assert xls == MapConst(true); currsize := 0; newsize := 0; lock := nil; ghostLock := nil; }
 
 yield procedure {:layer 0} Init({:linear_in "tid"} xls:[X]bool);
 refines AtomicInit;
 
--> action {:layer 1} AtomicReadCurrsize({:linear "tid"} tid: X) returns (val: int)
+right action {:layer 1} AtomicReadCurrsize({:linear "tid"} tid: X) returns (val: int)
 { assert tid != nil; assert lock == tid || ghostLock == tid; val := currsize; }
 
 yield procedure {:layer 0} ReadCurrsize({:linear "tid"} tid: X) returns (val: int);
 refines AtomicReadCurrsize;
 
--> action {:layer 1} AtomicReadNewsize({:linear "tid"} tid: X) returns (val: int)
+right action {:layer 1} AtomicReadNewsize({:linear "tid"} tid: X) returns (val: int)
 { assert tid != nil; assert lock == tid || ghostLock == tid; val := newsize; }
 
 yield procedure {:layer 0} ReadNewsize({:linear "tid"} tid: X) returns (val: int);
 refines AtomicReadNewsize;
 
->-< action {:layer 1} AtomicWriteNewsize({:linear "tid"} tid: X, val: int)
+atomic action {:layer 1} AtomicWriteNewsize({:linear "tid"} tid: X, val: int)
 modifies newsize, ghostLock;
 { assert tid != nil; assert lock == tid && ghostLock == nil; newsize := val; ghostLock := tid; }
 
 yield procedure {:layer 0} WriteNewsize({:linear "tid"} tid: X, val: int);
 refines AtomicWriteNewsize;
 
->-< action {:layer 1} AtomicWriteCurrsize({:linear "tid"} tid: X, val: int)
+atomic action {:layer 1} AtomicWriteCurrsize({:linear "tid"} tid: X, val: int)
 modifies currsize, ghostLock;
 { assert tid != nil; assert lock == tid && ghostLock == tid; currsize := val; ghostLock := nil; }
 
 yield procedure {:layer 0} WriteCurrsize({:linear "tid"} tid: X, val: int);
 refines AtomicWriteCurrsize;
 
->-< action {:layer 1} AtomicReadCacheEntry({:linear "tid"} tid: X, index: int)
+atomic action {:layer 1} AtomicReadCacheEntry({:linear "tid"} tid: X, index: int)
 { assert 0 <= index && index < currsize; }
 
 yield procedure {:layer 0} ReadCacheEntry({:linear "tid"} tid: X, index: int);
 refines AtomicReadCacheEntry;
 
--> action {:layer 1} AtomicWriteCacheEntry({:linear "tid"} tid: X, index: int)
+right action {:layer 1} AtomicWriteCacheEntry({:linear "tid"} tid: X, index: int)
 { assert tid != nil; assert currsize <= index && ghostLock == tid; }
 
 yield procedure {:layer 0} WriteCacheEntry({:linear "tid"} tid: X, index: int);
 refines AtomicWriteCacheEntry;
 
--> action {:layer 1} atomic_acquire({:linear "tid"} tid: X)
+right action {:layer 1} atomic_acquire({:linear "tid"} tid: X)
 modifies lock;
 { assert tid != nil; assume lock == nil; lock := tid; }
 
 yield procedure {:layer 0} acquire({:linear "tid"} tid: X);
 refines atomic_acquire;
 
-<- action {:layer 1} atomic_release({:linear "tid"} tid: X)
+left action {:layer 1} atomic_release({:linear "tid"} tid: X)
 modifies lock;
 { assert tid != nil; assert lock == tid; lock := nil; }
 
 yield procedure {:layer 0} release({:linear "tid"} tid: X);
 refines atomic_release;
 
->-< action {:layer 1} AtomicAllocateLow() returns ({:linear "tid"} tid: X)
+atomic action {:layer 1} AtomicAllocateLow() returns ({:linear "tid"} tid: X)
 modifies unallocated;
 { assume tid != nil; assume unallocated[tid]; unallocated[tid] := false; }
 

--- a/Test/civl/FlanaganQadeer.bpl
+++ b/Test/civl/FlanaganQadeer.bpl
@@ -26,28 +26,28 @@ yield procedure {:layer 1} main()
     }
 }
 
->-< action {:layer 1} AtomicLock(tid: X)
+atomic action {:layer 1} AtomicLock(tid: X)
 modifies l;
 { assume l == nil; l := tid; }
 
 yield procedure {:layer 0} Lock(tid: X);
 refines AtomicLock;
 
->-< action {:layer 1} AtomicUnlock()
+atomic action {:layer 1} AtomicUnlock()
 modifies l;
 { l := nil; }
 
 yield procedure {:layer 0} Unlock();
 refines AtomicUnlock;
 
->-< action {:layer 1} AtomicSet(val: int)
+atomic action {:layer 1} AtomicSet(val: int)
 modifies x;
 { x := val; }
 
 yield procedure {:layer 0} Set(val: int);
 refines AtomicSet;
 
->-< action {:layer 1} AtomicAllocateLow() returns ({:linear "tid"} xl: X)
+atomic action {:layer 1} AtomicAllocateLow() returns ({:linear "tid"} xl: X)
 modifies unallocated;
 { assume xl != nil; assume unallocated[xl]; unallocated[xl] := false; }
 

--- a/Test/civl/GC.bpl
+++ b/Test/civl/GC.bpl
@@ -266,7 +266,7 @@ ensures call Yield_InitVars99(mutatorTids, MapConst(false) : [int]bool, numMutat
     async call GarbageCollect(tid);
 }
 
->-< action {:layer 101} AtomicAlloc({:linear "tid"} tid:Tid, y:idx)
+atomic action {:layer 101} AtomicAlloc({:linear "tid"} tid:Tid, y:idx)
 modifies allocSet, rootAbs, memAbs;
 {
     var o: obj;
@@ -295,7 +295,7 @@ requires call Yield_RootScanBarrierInv();
     call ptr, absPtr := AllocRaw(tid, y);
 }
 
->-< action {:layer 101} AtomicWriteField({:linear "tid"} tid:Tid, x: idx, f: fld, y: idx) // x.f = y
+atomic action {:layer 101} AtomicWriteField({:linear "tid"} tid:Tid, x: idx, f: fld, y: idx) // x.f = y
 modifies memAbs;
 { assert mutatorTidWhole(tid) && rootAddr(x) && tidOwns(tid, x) && fieldAddr(f) && rootAddr(y) && tidOwns(tid, y) && memAddrAbs(rootAbs[x]); memAbs[rootAbs[x]][f] := rootAbs[y]; }
 
@@ -310,7 +310,7 @@ preserves call Yield_Iso();
     call WriteFieldRaw(tid, x, f, y);
 }
 
->-< action {:layer 101} AtomicReadField({:linear "tid"} tid:Tid, x: idx, f: fld, y: idx) // y = x.f
+atomic action {:layer 101} AtomicReadField({:linear "tid"} tid:Tid, x: idx, f: fld, y: idx) // y = x.f
 modifies rootAbs;
 { assert mutatorTidWhole(tid) && rootAddr(x) && tidOwns(tid, x) && fieldAddr(f) && rootAddr(y) && tidOwns(tid, y) && memAddrAbs(rootAbs[x]); rootAbs[y] := memAbs[rootAbs[x]][f]; }
 
@@ -322,7 +322,7 @@ preserves call Yield_Iso();
     call ReadFieldRaw(tid, x, f, y);
 }
 
->-< action {:layer 101} AtomicEq({:linear "tid"} tid:Tid, x: idx, y:idx) returns (isEqual:bool)
+atomic action {:layer 101} AtomicEq({:linear "tid"} tid:Tid, x: idx, y:idx) returns (isEqual:bool)
 { assert mutatorTidWhole(tid) && rootAddr(x) && tidOwns(tid, x) && rootAddr(y) && tidOwns(tid, y); isEqual := rootAbs[x] == rootAbs[y]; }
 
 yield procedure {:layer 100}
@@ -547,7 +547,7 @@ requires call Yield_RootScanBarrierInv();
     }
 }
 
->-< action {:layer 100} AtomicCanMarkStop({:linear "tid"} tid:Tid) returns (canStop: bool)
+atomic action {:layer 100} AtomicCanMarkStop({:linear "tid"} tid:Tid) returns (canStop: bool)
 modifies Color;
 {
     assert tid == GcTid;
@@ -595,7 +595,7 @@ preserves call Yield_RootScanBarrierInv();
     call CollectorRootScanBarrierEnd(tid);
 }
 
->-< action {:layer 100} AtomicWriteFieldRaw({:linear "tid"} tid:Tid, x: idx, f: fld, y: idx)
+atomic action {:layer 100} AtomicWriteFieldRaw({:linear "tid"} tid:Tid, x: idx, f: fld, y: idx)
 modifies memAbs,  mem;
 {
     assert mutatorTidWhole(tid) && rootAddr(x) && tidOwns(tid, x) && fieldAddr(f) && rootAddr(y) && tidOwns(tid, y) && memAddr(root[x]) && toAbs[root[x]] != nil && memAddrAbs(rootAbs[x]);
@@ -616,7 +616,7 @@ requires {:layer 98} mutatorTidWhole(tid);
     call SetMemAbs1(x, f, y);
 }
 
->-< action {:layer 100} AtomicReadFieldRaw({:linear "tid"} tid:Tid, x: idx, f: fld, y: idx)
+atomic action {:layer 100} AtomicReadFieldRaw({:linear "tid"} tid:Tid, x: idx, f: fld, y: idx)
 modifies rootAbs, root;
 {
     assert mutatorTidWhole(tid) && rootAddr(x) && tidOwns(tid, x) && fieldAddr(f) && rootAddr(y) && tidOwns(tid, y) && memAddr(root[x]) && toAbs[root[x]] != nil && memAddrAbs(rootAbs[x]);
@@ -636,7 +636,7 @@ refines AtomicReadFieldRaw;
     call SetRootAbs1(x, f, y);
 }
 
->-< action {:layer 100} AtomicEqRaw({:linear "tid"} tid:Tid, x: idx, y:idx) returns (isEqual:bool)
+atomic action {:layer 100} AtomicEqRaw({:linear "tid"} tid:Tid, x: idx, y:idx) returns (isEqual:bool)
 { assert mutatorTidWhole(tid) && rootAddr(x) && tidOwns(tid, x) && rootAddr(y) && tidOwns(tid, y); isEqual := root[x] == root[y]; }
 
 yield procedure {:layer 99} EqRaw({:linear "tid"} tid:Tid, x: idx, y:idx) returns (isEqual:bool)
@@ -650,7 +650,7 @@ refines AtomicEqRaw;
     isEqual := vx == vy;
 }
 
->-< action {:layer 100} AtomicAllocRaw({:linear "tid"} tid:Tid, y:idx) returns (ptr: int, absPtr: obj)
+atomic action {:layer 100} AtomicAllocRaw({:linear "tid"} tid:Tid, y:idx) returns (ptr: int, absPtr: obj)
 modifies allocSet, rootAbs, root, toAbs, memAbs, Color, mem;
 {
     assert mutatorTidWhole(tid) && rootAddr(y) && tidOwns(tid, y);
@@ -676,7 +676,7 @@ refines AtomicAllocRaw;
     call SetRootAbs2(y, absPtr);
 }
 
->-< action {:layer 100} AtomicWriteBarrier({:linear "tid"} tid:Tid, y:idx)
+atomic action {:layer 100} AtomicWriteBarrier({:linear "tid"} tid:Tid, y:idx)
 modifies Color;
 {
     var val:int;
@@ -739,7 +739,7 @@ ensures call Yield_InitVars98(tid, mutatorTids, 0);
     call InitMarkStackPtr(tid, mutatorTids);
 }
 
->-< action {:layer 99} AtomicFindFreePtr({:linear "tid"} tid: Tid, absPtr: obj) returns (ptr: int)
+atomic action {:layer 99} AtomicFindFreePtr({:linear "tid"} tid: Tid, absPtr: obj) returns (ptr: int)
 modifies Color, toAbs, mem;
 {
     assert mutatorTidWhole(tid);
@@ -781,7 +781,7 @@ refines AtomicFindFreePtr;
     }
 }
 
->-< action {:layer 99} AtomicSET_InsertIntoSetIfWhiteByMutator({:linear "tid"} tid:Tid, memLocal:int)
+atomic action {:layer 99} AtomicSET_InsertIntoSetIfWhiteByMutator({:linear "tid"} tid:Tid, memLocal:int)
 modifies Color;
 {
     assert mutatorTidWhole(tid) && memAddr(memLocal) && MarkPhase(mutatorPhase[tid->i]);
@@ -809,7 +809,7 @@ preserves call Yield_MarkPhase(tid, memLocal);
     assert {:layer 98} MST(MarkStackPtr-1);
 }
 
-<- action {:layer 99} AtomicNoGrayInRootScanBarrier({:linear "tid"} tid:Tid) returns (noGray: bool)
+left action {:layer 99} AtomicNoGrayInRootScanBarrier({:linear "tid"} tid:Tid) returns (noGray: bool)
 {
     assert tid == GcTid && rootScanOn && mutatorsInRootScanBarrier == Mutators;
     noGray := (forall i: int :: memAddr(i) ==> !Gray(Color[i]));
@@ -825,7 +825,7 @@ preserves call Yield_CollectorPhase_98(tid, old(collectorPhase));
     assert {:layer 98} noGray || MST(0);
 }
 
-<- action {:layer 99} AtomicInsertIntoSetIfWhiteInRootScanBarrier({:linear "tid"} tid:Tid, memLocal:int)
+left action {:layer 99} AtomicInsertIntoSetIfWhiteInRootScanBarrier({:linear "tid"} tid:Tid, memLocal:int)
 modifies Color;
 {
     assert tid == GcTid && rootScanOn && mutatorsInRootScanBarrier == Mutators && memAddr(memLocal);
@@ -844,7 +844,7 @@ preserves call Yield_CollectorPhase_98(tid, old(collectorPhase));
     assert {:layer 98} MST(MarkStackPtr-1);
 }
 
-<- action {:layer 99,100} AtomicSET_InsertIntoSetIfWhite({:linear "tid"} tid:Tid, parent: int, child:int)
+left action {:layer 99,100} AtomicSET_InsertIntoSetIfWhite({:linear "tid"} tid:Tid, parent: int, child:int)
 modifies Color;
 {
     assert tid == GcTid;
@@ -865,7 +865,7 @@ preserves call Yield_CollectorPhase_98(tid, old(collectorPhase));
     assert {:layer 98} MST(MarkStackPtr-1);
 }
 
--> action {:layer 99,100} AtomicSET_Peek({:linear "tid"} tid:Tid) returns (isEmpty: bool, val:int)
+right action {:layer 99,100} AtomicSET_Peek({:linear "tid"} tid:Tid) returns (isEmpty: bool, val:int)
 {
     assert tid == GcTid;
     assert MarkPhase(collectorPhase) && PhaseConsistent(collectorPhase, mutatorPhase);
@@ -899,7 +899,7 @@ invariant tid == GcTid;
 invariant nextPhase == collectorPhase;
 invariant done ==> (forall j:int:: 1 <= j && j < i ==> nextPhase == mutatorPhase[j]);
 
->-< action {:layer 98,100} AtomicWaitForMutators({:linear "tid"} tid:Tid, nextPhase: int)
+atomic action {:layer 98,100} AtomicWaitForMutators({:linear "tid"} tid:Tid, nextPhase: int)
 {
     assert tid == GcTid;
     assume (forall j:int:: mutatorId(j) ==> nextPhase == mutatorPhase[j]);
@@ -941,7 +941,7 @@ requires call YieldWaitForMutators(tid, nextPhase, false, 0);
 // Layer 96
 //////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 97,100} AtomicInitVars100({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
+atomic action {:layer 97,100} AtomicInitVars100({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 modifies mutatorPhase, root, toAbs, Color, mem, collectorPhase, sweepPtr;
 {
     assert tid == GcTid;
@@ -1018,7 +1018,7 @@ refines AtomicInitVars100;
     call InitSweepPtr(tid, mutatorTids);
 }
 
->-< action {:layer 97,100} AtomicSET_RemoveFromSet({:linear "tid"} tid:Tid, scannedLocal:int)
+atomic action {:layer 97,100} AtomicSET_RemoveFromSet({:linear "tid"} tid:Tid, scannedLocal:int)
 modifies Color;
 {
     assert MarkPhase(collectorPhase) && PhaseConsistent(collectorPhase, mutatorPhase);
@@ -1035,7 +1035,7 @@ refines AtomicSET_RemoveFromSet;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,98} AtomicMsPushByCollector({:linear "tid"} tid: Tid, val: int)
+atomic action {:layer 97,98} AtomicMsPushByCollector({:linear "tid"} tid: Tid, val: int)
 modifies Color, MarkStack, MarkStackPtr;
 {
     assert memAddr(val) && tid == GcTid;
@@ -1065,7 +1065,7 @@ refines AtomicMsPushByCollector;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,98} AtomicMsPushByMutator({:linear "tid"} tid: Tid, val: int)
+atomic action {:layer 97,98} AtomicMsPushByMutator({:linear "tid"} tid: Tid, val: int)
 modifies Color, MarkStack, MarkStackPtr;
 {
     assert memAddr(val) && mutatorTidWhole(tid) && MarkPhase(mutatorPhase[tid->i]);
@@ -1095,7 +1095,7 @@ refines AtomicMsPushByMutator;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,98} AtomicMsPop({:linear "tid"} tid:Tid) returns (isEmpty: bool, val:int)
+atomic action {:layer 97,98} AtomicMsPop({:linear "tid"} tid:Tid) returns (isEmpty: bool, val:int)
 modifies MarkStackPtr;
 {
     assert tid == GcTid;
@@ -1131,7 +1131,7 @@ refines AtomicMsPop;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,98} AtomicMsIsEmpty({:linear "tid"} tid: Tid) returns (isEmpty: bool)
+atomic action {:layer 97,98} AtomicMsIsEmpty({:linear "tid"} tid: Tid) returns (isEmpty: bool)
 { assert tid == GcTid; isEmpty := MarkStackPtr == 0; }
 
 yield procedure {:layer 96} MsIsEmpty({:linear "tid"} tid: Tid) returns (isEmpty: bool)
@@ -1145,7 +1145,7 @@ refines AtomicMsIsEmpty;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,100} AtomicResetSweepPtr({:linear "tid"} tid:Tid)
+atomic action {:layer 97,100} AtomicResetSweepPtr({:linear "tid"} tid:Tid)
 modifies sweepPtr;
 { assert tid == GcTid; sweepPtr := memLo; }
 
@@ -1157,7 +1157,7 @@ refines AtomicResetSweepPtr;
     call LockRelease(tid);
 }
 
-<- action {:layer 97,100} AtomicSweepNext({:linear "tid"} tid:Tid)
+left action {:layer 97,100} AtomicSweepNext({:linear "tid"} tid:Tid)
 modifies Color, sweepPtr;
 {
     assert SweepPhase(collectorPhase) && PhaseConsistent(collectorPhase, mutatorPhase);
@@ -1184,7 +1184,7 @@ refines AtomicSweepNext;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,100} AtomicHandshakeCollector({:linear "tid"} tid:Tid) returns (nextPhase: int)
+atomic action {:layer 97,100} AtomicHandshakeCollector({:linear "tid"} tid:Tid) returns (nextPhase: int)
 modifies collectorPhase;
 {
     assert tid == GcTid;
@@ -1213,7 +1213,7 @@ refines AtomicHandshakeCollector;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,100} AtomicUpdateMutatorPhase({:linear "tid"} tid: Tid)
+atomic action {:layer 97,100} AtomicUpdateMutatorPhase({:linear "tid"} tid: Tid)
 modifies mutatorPhase;
 { assert mutatorTidWhole(tid); mutatorPhase[tid->i] := collectorPhase; }
 
@@ -1228,7 +1228,7 @@ refines AtomicUpdateMutatorPhase;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,99} AtomicCollectorRootScanBarrierStart({:linear "tid"} tid: Tid)
+atomic action {:layer 97,99} AtomicCollectorRootScanBarrierStart({:linear "tid"} tid: Tid)
 modifies rootScanOn;
 { assert tid == GcTid; rootScanOn := true; }
 
@@ -1240,7 +1240,7 @@ refines AtomicCollectorRootScanBarrierStart;
     call LockRelease(tid);
 }
 
-<- action {:layer 97,99} AtomicCollectorRootScanBarrierEnd({:linear "tid"} tid: Tid)
+left action {:layer 97,99} AtomicCollectorRootScanBarrierEnd({:linear "tid"} tid: Tid)
 modifies rootScanOn;
 { assert tid == GcTid; rootScanOn := false; }
 
@@ -1252,7 +1252,7 @@ refines AtomicCollectorRootScanBarrierEnd;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,99} AtomicCollectorRootScanBarrierWait({:linear "tid"} tid: Tid)
+atomic action {:layer 97,99} AtomicCollectorRootScanBarrierWait({:linear "tid"} tid: Tid)
 { assert tid == GcTid; assume rootScanBarrier == 0; }
 
 yield procedure {:layer 96} CollectorRootScanBarrierWait({:linear "tid"} tid: Tid)
@@ -1271,7 +1271,7 @@ refines AtomicCollectorRootScanBarrierWait;
     }
 }
 
->-< action {:layer 97,99} AtomicMutatorRootScanBarrierEnter({:linear_in "tid"} tid: Tid) returns({:linear "tid"} tid_left: Tid)
+atomic action {:layer 97,99} AtomicMutatorRootScanBarrierEnter({:linear_in "tid"} tid: Tid) returns({:linear "tid"} tid_left: Tid)
 modifies rootScanBarrier, mutatorsInRootScanBarrier;
 {
     assert mutatorTidWhole(tid);
@@ -1294,7 +1294,7 @@ ensures {:layer 95,96} tid_left->i == tid->i && tid_left->left;
     call LockRelease(tid_left);
 }
 
->-< action {:layer 97,99} AtomicMutatorRootScanBarrierWait({:linear_in "tid"} tid_left: Tid) returns({:linear "tid"} tid: Tid)
+atomic action {:layer 97,99} AtomicMutatorRootScanBarrierWait({:linear_in "tid"} tid_left: Tid) returns({:linear "tid"} tid: Tid)
 modifies rootScanBarrier, mutatorsInRootScanBarrier;
 {
     assert mutatorTidLeft(tid_left) && mutatorsInRootScanBarrier[tid_left->i];
@@ -1327,7 +1327,7 @@ ensures {:layer 95,96} tid->i == tid_left->i && tid->left && tid->right;
         goto loop;
 }
 
->-< action {:layer 97,98} AtomicAllocIfPtrFree({:linear "tid"} tid:Tid, ptr:int, absPtr:obj) returns (spaceFound:bool)
+atomic action {:layer 97,98} AtomicAllocIfPtrFree({:linear "tid"} tid:Tid, ptr:int, absPtr:obj) returns (spaceFound:bool)
 modifies Color, toAbs, mem;
 {
     assert mutatorTidWhole(tid) && memAddr(ptr) && (Unalloc(Color[ptr]) ==> toAbs[ptr] == nil);
@@ -1390,7 +1390,7 @@ refines AtomicAllocIfPtrFree;
     spaceFound := false;
 }
 
->-< action {:layer 97,100} AtomicIsWhiteByCollector({:linear "tid"} tid:Tid, i: int) returns (isWhite: bool)
+atomic action {:layer 97,100} AtomicIsWhiteByCollector({:linear "tid"} tid:Tid, i: int) returns (isWhite: bool)
 { assert tid == GcTid && memAddr(i); isWhite := White(Color[i]); }
 
 yield procedure {:layer 96} IsWhiteByCollector({:linear "tid"} tid:Tid, i: int) returns (isWhite: bool)
@@ -1404,7 +1404,7 @@ refines AtomicIsWhiteByCollector;
     call LockRelease(tid);
 }
 
->-< action {:layer 97,100} AtomicClearToAbsWhite({:linear "tid"} tid:Tid)
+atomic action {:layer 97,100} AtomicClearToAbsWhite({:linear "tid"} tid:Tid)
 modifies toAbs;
 { assert tid == GcTid; toAbs := (lambda x: int :: if memAddr(x) && White(Color[x]) then nil else toAbs[x]); }
 
@@ -1422,7 +1422,7 @@ yield invariant {:layer 96} Yield();
 // Layer 95
 //////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 96} AtomicLockedClearToAbsWhite({:linear "tid"} tid:Tid)
+atomic action {:layer 96} AtomicLockedClearToAbsWhite({:linear "tid"} tid:Tid)
 modifies toAbs;
 { assert tid == GcTid && tidHasLock(tid, lock); toAbs := (lambda x: int :: if memAddr(x) && White(Color[x]) then nil else toAbs[x]); }
 
@@ -1432,7 +1432,7 @@ refines AtomicLockedClearToAbsWhite;
     call SetToAbs1();
 }
 
-<-> action {:layer 96,99} AtomicInitField({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool, x: int, f: int)
+both action {:layer 96,99} AtomicInitField({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool, x: int, f: int)
 modifies mem;
 { assert gcAndMutatorTids(tid, mutatorTids) && memAddr(x) && fieldAddr(f); mem[x][f] := x; }
 
@@ -1442,7 +1442,7 @@ refines AtomicInitField;
     call PrimitiveWriteField(x, f, x);
 }
 
->-< action {:layer 96,100} AtomicReadFieldCollector({:linear "tid"} tid:Tid, x:int, f: fld) returns (y: int)
+atomic action {:layer 96,100} AtomicReadFieldCollector({:linear "tid"} tid:Tid, x:int, f: fld) returns (y: int)
 { assert tid == GcTid && memAddr(x) && fieldAddr(f) && toAbs[x] != nil; y := mem[x][f]; }
 
 yield procedure {:layer 95} ReadFieldCollector({:linear "tid"} tid:Tid, x:int, f: fld) returns (y: int)
@@ -1451,7 +1451,7 @@ refines AtomicReadFieldCollector;
     call y := PrimitiveReadField(x, f);
 }
 
->-< action {:layer 96,99} AtomicReadFieldGeneral({:linear "tid"} tid:Tid, x: int, f: fld) returns (y: int)
+atomic action {:layer 96,99} AtomicReadFieldGeneral({:linear "tid"} tid:Tid, x: int, f: fld) returns (y: int)
 { assert mutatorTidWhole(tid) && memAddr(x) && fieldAddr(f) && toAbs[x] != nil; y := mem[x][f]; }
 
 yield procedure {:layer 95} ReadFieldGeneral({:linear "tid"} tid:Tid, x: int, f: fld) returns (y: int)
@@ -1460,7 +1460,7 @@ refines AtomicReadFieldGeneral;
     call y := PrimitiveReadField(x, f);
 }
 
->-< action {:layer 96,99} AtomicWriteFieldGeneral({:linear "tid"} tid:Tid, x: int, f: fld, y: int)
+atomic action {:layer 96,99} AtomicWriteFieldGeneral({:linear "tid"} tid:Tid, x: int, f: fld, y: int)
 modifies mem;
 { assert mutatorTidWhole(tid) && memAddr(x) && fieldAddr(f) && toAbs[x] != nil; mem[x][f] := y; }
 
@@ -1470,7 +1470,7 @@ refines AtomicWriteFieldGeneral;
     call PrimitiveWriteField(x, f, y);
 }
 
--> action {:layer 96} AtomicInitializeFieldInAlloc({:linear "tid"} tid: Tid, ptr: int, fld: int)
+right action {:layer 96} AtomicInitializeFieldInAlloc({:linear "tid"} tid: Tid, ptr: int, fld: int)
 modifies mem;
 { assert mutatorTidWhole(tid) && tidHasLock(tid, lock) && memAddr(ptr) && fieldAddr(fld) && toAbs[ptr] == nil; mem[ptr][fld] := ptr; }
 
@@ -1480,7 +1480,7 @@ refines AtomicInitializeFieldInAlloc;
     call PrimitiveWriteField(ptr, fld, ptr);
 }
 
-<-> action {:layer 96} AtomicReadMarkStackPtr({:linear "tid"} tid:Tid) returns (val: int)
+both action {:layer 96} AtomicReadMarkStackPtr({:linear "tid"} tid:Tid) returns (val: int)
 { assert tidHasLock(tid, lock); val := MarkStackPtr; }
 
 yield procedure {:layer 95} ReadMarkStackPtr({:linear "tid"} tid:Tid) returns (val: int)
@@ -1489,7 +1489,7 @@ refines AtomicReadMarkStackPtr;
     call val := PrimitiveReadMarkStackPtr();
 }
 
->-< action {:layer 96,98} AtomicInitMarkStackPtr({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
+atomic action {:layer 96,98} AtomicInitMarkStackPtr({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 modifies MarkStackPtr;
 { assert gcAndMutatorTids(tid, mutatorTids); MarkStackPtr := 0; }
 
@@ -1499,7 +1499,7 @@ refines AtomicInitMarkStackPtr;
     call PrimitiveSetMarkStackPtr(0);
 }
 
-<-> action {:layer 96} AtomicSetMarkStackPtr({:linear "tid"} tid:Tid, val: int)
+both action {:layer 96} AtomicSetMarkStackPtr({:linear "tid"} tid:Tid, val: int)
 modifies MarkStackPtr;
 { assert tidHasLock(tid, lock); MarkStackPtr := val; }
 
@@ -1509,7 +1509,7 @@ refines AtomicSetMarkStackPtr;
     call PrimitiveSetMarkStackPtr(val);
 }
 
-<-> action {:layer 96} AtomicReadMarkStack({:linear "tid"} tid:Tid, ptr: int) returns(val: int)
+both action {:layer 96} AtomicReadMarkStack({:linear "tid"} tid:Tid, ptr: int) returns(val: int)
 { assert tidHasLock(tid, lock); val := MarkStack[ptr]; }
 
 yield procedure {:layer 95} ReadMarkStack({:linear "tid"} tid:Tid, ptr: int) returns(val: int)
@@ -1518,7 +1518,7 @@ refines AtomicReadMarkStack;
     call val := PrimitiveReadMarkStack(ptr);
 }
 
-<-> action {:layer 96} AtomicWriteMarkStack({:linear "tid"} tid:Tid, ptr: int, val: int)
+both action {:layer 96} AtomicWriteMarkStack({:linear "tid"} tid:Tid, ptr: int, val: int)
 modifies MarkStack;
 { assert tidHasLock(tid, lock); MarkStack[ptr] := val; }
 
@@ -1528,7 +1528,7 @@ refines AtomicWriteMarkStack;
     call PrimitiveWriteMarkStack(ptr, val);
 }
 
-<-> action {:layer 96,99} AtomicInitCollectorPhase({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
+both action {:layer 96,99} AtomicInitCollectorPhase({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 modifies collectorPhase;
 { assert gcAndMutatorTids(tid, mutatorTids); collectorPhase := IDLE(); }
 
@@ -1538,7 +1538,7 @@ refines AtomicInitCollectorPhase;
     call PrimitiveSetCollectorPhase(IDLE());
 }
 
->-< action {:layer 96} AtomicReadCollectorPhase({:linear "tid"} tid: Tid) returns (phase:int)
+atomic action {:layer 96} AtomicReadCollectorPhase({:linear "tid"} tid: Tid) returns (phase:int)
 { assert tid == GcTid; phase := collectorPhase; }
 
 yield procedure {:layer 95} ReadCollectorPhase({:linear "tid"} tid: Tid) returns (phase:int)
@@ -1547,7 +1547,7 @@ refines AtomicReadCollectorPhase;
     call phase := PrimitiveReadCollectorPhase();
 }
 
--> action {:layer 96} AtomicReadCollectorPhaseLocked({:linear "tid"} tid: Tid) returns (phase:int)
+right action {:layer 96} AtomicReadCollectorPhaseLocked({:linear "tid"} tid: Tid) returns (phase:int)
 { assert mutatorTidWhole(tid) && tidHasLock(tid, lock); phase := collectorPhase; }
 
 yield procedure {:layer 95} ReadCollectorPhaseLocked({:linear "tid"} tid: Tid) returns (phase:int)
@@ -1556,7 +1556,7 @@ refines AtomicReadCollectorPhaseLocked;
     call phase := PrimitiveReadCollectorPhase();
 }
 
-<-> action {:layer 96} AtomicSetCollectorPhase({:linear "tid"} tid: Tid, phase:int)
+both action {:layer 96} AtomicSetCollectorPhase({:linear "tid"} tid: Tid, phase:int)
 modifies collectorPhase;
 { assert tid == GcTid && tidHasLock(tid, lock); collectorPhase := phase; }
 
@@ -1566,7 +1566,7 @@ refines AtomicSetCollectorPhase;
     call PrimitiveSetCollectorPhase(phase);
 }
 
-<-> action {:layer 96,99} AtomicInitMutatorPhase({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool, id: int)
+both action {:layer 96,99} AtomicInitMutatorPhase({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool, id: int)
 modifies mutatorPhase;
 { assert gcAndMutatorTids(tid, mutatorTids); mutatorPhase[id] := IDLE(); }
 
@@ -1576,7 +1576,7 @@ refines AtomicInitMutatorPhase;
     call PrimitiveSetMutatorPhase(id, IDLE());
 }
 
->-< action {:layer 96,100} AtomicReadMutatorPhaseByCollector({:linear "tid"} tid: Tid, i: int) returns (phase:int)
+atomic action {:layer 96,100} AtomicReadMutatorPhaseByCollector({:linear "tid"} tid: Tid, i: int) returns (phase:int)
 { assert tid == GcTid; phase := mutatorPhase[i]; }
 
 yield procedure {:layer 95} ReadMutatorPhaseByCollector({:linear "tid"} tid: Tid, i: int) returns (phase:int)
@@ -1585,7 +1585,7 @@ refines AtomicReadMutatorPhaseByCollector;
     call phase := PrimitiveReadMutatorPhase(i);
 }
 
-<-> action {:layer 96,99} AtomicReadMutatorPhase({:linear "tid"} tid: Tid) returns (phase:int)
+both action {:layer 96,99} AtomicReadMutatorPhase({:linear "tid"} tid: Tid) returns (phase:int)
 { assert mutatorTidWhole(tid); phase := mutatorPhase[tid->i]; }
 
 yield procedure {:layer 95} ReadMutatorPhase({:linear "tid"} tid: Tid) returns (phase:int)
@@ -1594,7 +1594,7 @@ refines AtomicReadMutatorPhase;
     call phase := PrimitiveReadMutatorPhase(tid->i);
 }
 
->-< action {:layer 96} AtomicSetMutatorPhaseLocked({:linear "tid"} tid: Tid, phase: int)
+atomic action {:layer 96} AtomicSetMutatorPhaseLocked({:linear "tid"} tid: Tid, phase: int)
 modifies mutatorPhase;
 { assert mutatorTidWhole(tid) && tidHasLock(tid, lock) && phase == collectorPhase; mutatorPhase[tid->i] := phase; }
 
@@ -1604,7 +1604,7 @@ refines AtomicSetMutatorPhaseLocked;
     call PrimitiveSetMutatorPhase(tid->i, phase);
 }
 
-<-> action {:layer 96,99} AtomicInitSweepPtr({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
+both action {:layer 96,99} AtomicInitSweepPtr({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 modifies sweepPtr;
 { assert gcAndMutatorTids(tid, mutatorTids); sweepPtr := memHi; }
 
@@ -1614,7 +1614,7 @@ refines AtomicInitSweepPtr;
     call PrimitiveSetSweepPtr(memHi);
 }
 
-<-> action {:layer 96} AtomicReadSweepPtr({:linear "tid"} tid:Tid) returns(val:int)
+both action {:layer 96} AtomicReadSweepPtr({:linear "tid"} tid:Tid) returns(val:int)
 { assert tidHasLock(tid, lock); val := sweepPtr; }
 
 yield procedure {:layer 95} ReadSweepPtr({:linear "tid"} tid:Tid) returns(val:int)
@@ -1623,7 +1623,7 @@ refines AtomicReadSweepPtr;
     call val := PrimitiveReadSweepPtr();
 }
 
->-< action {:layer 96} AtomicSetSweepPtrLocked({:linear "tid"} tid:Tid, val: int)
+atomic action {:layer 96} AtomicSetSweepPtrLocked({:linear "tid"} tid:Tid, val: int)
 modifies sweepPtr;
 { assert tid == GcTid && tidHasLock(tid, lock); sweepPtr := val; }
 
@@ -1633,7 +1633,7 @@ refines AtomicSetSweepPtrLocked;
     call PrimitiveSetSweepPtr(val);
 }
 
->-< action {:layer 96} AtomicCollectorRootScanBarrierStartLocked({:linear "tid"} tid: Tid)
+atomic action {:layer 96} AtomicCollectorRootScanBarrierStartLocked({:linear "tid"} tid: Tid)
 modifies rootScanOn;
 { assert tid == GcTid && tidHasLock(tid, lock); rootScanOn := true; }
 
@@ -1643,7 +1643,7 @@ refines AtomicCollectorRootScanBarrierStartLocked;
     call PrimitiveSetRootScanOn(true);
 }
 
->-< action {:layer 96} AtomicCollectorRootScanBarrierEndLocked({:linear "tid"} tid: Tid)
+atomic action {:layer 96} AtomicCollectorRootScanBarrierEndLocked({:linear "tid"} tid: Tid)
 modifies rootScanOn;
 { assert tid == GcTid && tidHasLock(tid, lock); rootScanOn := false; }
 
@@ -1653,7 +1653,7 @@ refines AtomicCollectorRootScanBarrierEndLocked;
     call PrimitiveSetRootScanOn(false);
 }
 
--> action {:layer 96} AtomicMutatorReadBarrierOn({:linear "tid"} tid: Tid) returns (val:bool)
+right action {:layer 96} AtomicMutatorReadBarrierOn({:linear "tid"} tid: Tid) returns (val:bool)
 { assert tidHasLock(tid, lock); val := rootScanOn; }
 
 yield procedure {:layer 95} MutatorReadBarrierOn({:linear "tid"} tid: Tid) returns (val:bool)
@@ -1662,7 +1662,7 @@ refines AtomicMutatorReadBarrierOn;
     call val := PrimitiveReadRootScanOn();
 }
 
-<-> action {:layer 96,99} AtomicPollMutatorReadBarrierOn({:linear "tid"} tid: Tid) returns (val:bool)
+both action {:layer 96,99} AtomicPollMutatorReadBarrierOn({:linear "tid"} tid: Tid) returns (val:bool)
 { }
 
 yield procedure {:layer 95} PollMutatorReadBarrierOn({:linear "tid"} tid: Tid) returns (val:bool)
@@ -1671,7 +1671,7 @@ refines AtomicPollMutatorReadBarrierOn;
     call val := PrimitiveReadRootScanOn();
 }
 
->-< action {:layer 96,99} AtomicInitRootScanBarrier({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
+atomic action {:layer 96,99} AtomicInitRootScanBarrier({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 modifies rootScanBarrier;
 { assert gcAndMutatorTids(tid, mutatorTids); rootScanBarrier := numMutators; }
 
@@ -1681,7 +1681,7 @@ refines AtomicInitRootScanBarrier;
     call PrimitiveSetRootScanBarrier(numMutators);
 }
 
->-< action {:layer 96} AtomicCollectorRootScanBarrierRead({:linear "tid"} tid: Tid) returns (val:int)
+atomic action {:layer 96} AtomicCollectorRootScanBarrierRead({:linear "tid"} tid: Tid) returns (val:int)
 { assert tid == GcTid; val := rootScanBarrier; }
 
 yield procedure {:layer 95} CollectorRootScanBarrierRead({:linear "tid"} tid: Tid) returns (val:int)
@@ -1690,7 +1690,7 @@ refines AtomicCollectorRootScanBarrierRead;
     call val := PrimitiveReadRootScanBarrier();
 }
 
->-< action {:layer 96} AtomicAddRootScanBarrier({:linear "tid"} tid_left: Tid, val: int)
+atomic action {:layer 96} AtomicAddRootScanBarrier({:linear "tid"} tid_left: Tid, val: int)
 modifies rootScanBarrier;
 { assert mutatorTidLeft(tid_left) && tidHasLock(tid_left, lock); rootScanBarrier := rootScanBarrier + val; }
 
@@ -1700,7 +1700,7 @@ refines AtomicAddRootScanBarrier;
     call PrimitiveAddRootScanBarrier(val);
 }
 
--> action {:layer 96} AtomicMutatorsInRootScanBarrierAdd({:linear "tid"} tid_left: Tid, {:linear_in "tid"} tid_right: Tid)
+right action {:layer 96} AtomicMutatorsInRootScanBarrierAdd({:linear "tid"} tid_left: Tid, {:linear_in "tid"} tid_right: Tid)
 modifies mutatorsInRootScanBarrier;
 {
     assert tidHasLock(tid_left, lock) && mutatorTidRight(tid_right);
@@ -1713,7 +1713,7 @@ refines AtomicMutatorsInRootScanBarrierAdd;
     call PrimitiveMutatorsInRootScanBarrierAdd(tid_right);
 }
 
-<-> action {:layer 96} AtomicMutatorsInRootScanBarrierRemove({:linear "tid"} tid_left: Tid) returns({:linear "tid"} tid_right: Tid)
+both action {:layer 96} AtomicMutatorsInRootScanBarrierRemove({:linear "tid"} tid_left: Tid) returns({:linear "tid"} tid_right: Tid)
 modifies mutatorsInRootScanBarrier;
 {
     assert tidHasLock(tid_left, lock) && !rootScanOn && mutatorTidLeft(tid_left) && mutatorsInRootScanBarrier[tid_left->i];
@@ -1729,7 +1729,7 @@ ensures {:layer 95} tid_left->left && tid_right->right;
     call tid_right := PrimitiveMutatorsInRootScanBarrierRemove(tid_left);
 }
 
-<-> action {:layer 96,99} AtomicInitRoot({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool, x: int)
+both action {:layer 96,99} AtomicInitRoot({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool, x: int)
 modifies root;
 { assert gcAndMutatorTids(tid, mutatorTids) && rootAddr(x); root[x] := 0; }
 
@@ -1739,7 +1739,7 @@ refines AtomicInitRoot;
     call PrimitiveWriteRoot(x, 0);
 }
 
-<- action {:layer 96,99} AtomicReadRootInRootScanBarrier({:linear "tid"} tid:Tid, x: idx) returns (val: int)
+left action {:layer 96,99} AtomicReadRootInRootScanBarrier({:linear "tid"} tid:Tid, x: idx) returns (val: int)
 { assert tid == GcTid && rootAddr(x) && rootScanOn && mutatorsInRootScanBarrier == Mutators; val := root[x]; }
 
 yield procedure {:layer 95} ReadRootInRootScanBarrier({:linear "tid"} tid:Tid, x: idx) returns (val: int)
@@ -1748,7 +1748,7 @@ refines AtomicReadRootInRootScanBarrier;
     call val := PrimitiveReadRoot(x);
 }
 
-<-> action {:layer 96,99} AtomicWriteRoot({:linear "tid"} tid: Tid, i: idx, val: int)
+both action {:layer 96,99} AtomicWriteRoot({:linear "tid"} tid: Tid, i: idx, val: int)
 modifies root;
 { assert mutatorTidWhole(tid) && rootAddr(i) && tidOwns(tid, i); root[i] := val; }
 
@@ -1758,7 +1758,7 @@ refines AtomicWriteRoot;
     call PrimitiveWriteRoot(i, val);
 }
 
-<-> action {:layer 96,99} AtomicReadRoot({:linear "tid"} tid: Tid, i: idx) returns (val: int)
+both action {:layer 96,99} AtomicReadRoot({:linear "tid"} tid: Tid, i: idx) returns (val: int)
 { assert mutatorTidWhole(tid) && rootAddr(i) && tidOwns(tid, i); val := root[i]; }
 
 yield procedure {:layer 95} ReadRoot({:linear "tid"} tid: Tid, i: idx) returns (val: int)
@@ -1767,7 +1767,7 @@ refines AtomicReadRoot;
     call val := PrimitiveReadRoot(i);
 }
 
-<-> action {:layer 96,99} AtomicInitColor({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool, x: int)
+both action {:layer 96,99} AtomicInitColor({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool, x: int)
 modifies Color;
 { assert gcAndMutatorTids(tid, mutatorTids) && memAddr(x); Color[x] := UNALLOC(); }
 
@@ -1777,7 +1777,7 @@ refines AtomicInitColor;
     call PrimitiveSetColor(x, UNALLOC());
 }
 
-<-> action {:layer 96} AtomicReadColorByCollector({:linear "tid"} tid:Tid, i: int) returns (val: int)
+both action {:layer 96} AtomicReadColorByCollector({:linear "tid"} tid:Tid, i: int) returns (val: int)
 { assert tid == GcTid && tidHasLock(tid, lock) && memAddr(i); val := Color[i]; }
 
 yield procedure {:layer 95} ReadColorByCollector({:linear "tid"} tid:Tid, i: int) returns (val: int)
@@ -1786,7 +1786,7 @@ refines AtomicReadColorByCollector;
     call val := PrimitiveReadColor(i);
 }
 
->-< action {:layer 96} AtomicReadColorByMutator1({:linear "tid"} tid:Tid, i: int) returns (val: int)
+atomic action {:layer 96} AtomicReadColorByMutator1({:linear "tid"} tid:Tid, i: int) returns (val: int)
 { assert mutatorTidWhole(tid) && memAddr(i); }
 
 yield procedure {:layer 95} ReadColorByMutator1({:linear "tid"} tid:Tid, i: int) returns (val: int)
@@ -1795,7 +1795,7 @@ refines AtomicReadColorByMutator1;
     call val := PrimitiveReadColor(i);
 }
 
-<-> action {:layer 96} AtomicReadColorByMutator2({:linear "tid"} tid:Tid, i: int) returns (val: int)
+both action {:layer 96} AtomicReadColorByMutator2({:linear "tid"} tid:Tid, i: int) returns (val: int)
 { assert mutatorTidWhole(tid) && tidHasLock(tid, lock) && memAddr(i); val := Color[i]; }
 
 yield procedure {:layer 95} ReadColorByMutator2({:linear "tid"} tid:Tid, i: int) returns (val: int)
@@ -1804,7 +1804,7 @@ refines AtomicReadColorByMutator2;
     call val := PrimitiveReadColor(i);
 }
 
->-< action {:layer 96,98} AtomicReadColorByMutator3({:linear "tid"} tid:Tid, i: int) returns (val: int)
+atomic action {:layer 96,98} AtomicReadColorByMutator3({:linear "tid"} tid:Tid, i: int) returns (val: int)
 {
     assert mutatorTidWhole(tid) && memAddr(i) && MarkPhase(mutatorPhase[tid->i]);
     assume White(Color[i]) ==> White(val);
@@ -1816,7 +1816,7 @@ refines AtomicReadColorByMutator3;
     call val := PrimitiveReadColor(i);
 }
 
-<-> action {:layer 96} AtomicSetColor({:linear "tid"} tid:Tid, i: int, val: int)
+both action {:layer 96} AtomicSetColor({:linear "tid"} tid:Tid, i: int, val: int)
 modifies Color;
 { assert tidHasLock(tid, lock) && memAddr(i) && PhaseConsistent(collectorPhase, mutatorPhase) && !MarkPhase(collectorPhase); Color[i] := val; }
 
@@ -1826,7 +1826,7 @@ refines AtomicSetColor;
     call PrimitiveSetColor(i, val);
 }
 
-<- action {:layer 96} AtomicSetColor2({:linear "tid"} tid:Tid, i: int, val: int)
+left action {:layer 96} AtomicSetColor2({:linear "tid"} tid:Tid, i: int, val: int)
 modifies Color;
 {
     assert tidHasLock(tid, lock) && memAddr(i);
@@ -1840,7 +1840,7 @@ refines AtomicSetColor2;
     call PrimitiveSetColor(i, val);
 }
 
->-< action {:layer 96} AtomicSetColor3({:linear "tid"} tid:Tid, i: int, val: int, o: obj)
+atomic action {:layer 96} AtomicSetColor3({:linear "tid"} tid:Tid, i: int, val: int, o: obj)
 modifies Color, toAbs;
 {
     assert tidHasLock(tid, lock) && memAddr(i);
@@ -1856,7 +1856,7 @@ refines AtomicSetColor3;
     call SetToAbs2(i, o);
 }
 
-<-> action {:layer 96,99} AtomicInitToAbs({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
+both action {:layer 96,99} AtomicInitToAbs({:linear "tid"} tid:Tid, {:linear "tid"} mutatorTids:[int]bool)
 modifies toAbs;
 {
     assert gcAndMutatorTids(tid, mutatorTids);
@@ -1869,7 +1869,7 @@ refines AtomicInitToAbs;
     call SetToAbs3();
 }
 
--> action {:layer 96} AtomicLockAcquire({:linear "tid"} tid: Tid)
+right action {:layer 96} AtomicLockAcquire({:linear "tid"} tid: Tid)
 modifies lock;
 { assert tid->i != 0; assume lock == 0; lock := tid->i; }
 
@@ -1888,7 +1888,7 @@ refines AtomicLockAcquire;
     }
 }
 
-<- action {:layer 96} AtomicLockRelease({:linear "tid"} tid:Tid)
+left action {:layer 96} AtomicLockRelease({:linear "tid"} tid:Tid)
 modifies lock;
 { assert tidHasLock(tid, lock); lock := 0; }
 
@@ -1919,156 +1919,156 @@ action {:layer 100} GhostReadColor100() returns (snapColor: [int]int)
 //   (Note, though, that Boogie still verifies the mover types (atomic,left,right,both); these are not trusted.)
 //////////////////////////////////////////////////////////////////////////////
 
-<-> action {:layer 1,96} AtomicTidSplit({:linear_in "tid"} tid:Tid) returns({:linear "tid"} tid_left:Tid, {:linear "tid"} tid_right:Tid)
+both action {:layer 1,96} AtomicTidSplit({:linear_in "tid"} tid:Tid) returns({:linear "tid"} tid_left:Tid, {:linear "tid"} tid_right:Tid)
 { assert tid->left && tid->right; tid_left := Tid(tid->i, true, false); tid_right := Tid(tid->i, false, true); }
 yield procedure {:layer 0} TidSplit({:linear_in "tid"} tid:Tid) returns({:linear "tid"} tid_left:Tid, {:linear "tid"} tid_right:Tid);
 refines AtomicTidSplit;
 
-<-> action {:layer 1,96} AtomicTidCombine({:linear_in "tid"} tid_left:Tid, {:linear_in "tid"} tid_right:Tid) returns({:linear "tid"} tid:Tid)
+both action {:layer 1,96} AtomicTidCombine({:linear_in "tid"} tid_left:Tid, {:linear_in "tid"} tid_right:Tid) returns({:linear "tid"} tid:Tid)
 { assert tid_left->i == tid_right->i && tid_left->left && tid_right->right; tid := Tid(tid_left->i, true, true); }
 yield procedure {:layer 0} TidCombine({:linear_in "tid"} tid_left:Tid, {:linear_in "tid"} tid_right:Tid) returns({:linear "tid"} tid:Tid);
 refines AtomicTidCombine;
 
-<-> action {:layer 1,99} AtomicTidOutput({:linear_in "tid"} tid_in:Tid, {:linear_out "tid"} tid_out:Tid)
+both action {:layer 1,99} AtomicTidOutput({:linear_in "tid"} tid_in:Tid, {:linear_out "tid"} tid_out:Tid)
 { assert tid_in == tid_out; }
 yield procedure {:layer 0} TidOutput({:linear_in "tid"} tid_in:Tid, {:linear_out "tid"} tid_out:Tid);
 refines AtomicTidOutput;
 
->-< action {:layer 1,95} AtomicPrimitiveReadField(x: int, f: fld) returns (y: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadField(x: int, f: fld) returns (y: int)
 { assert memAddr(x) && fieldAddr(f); y := mem[x][f]; }
 yield procedure {:layer 0} PrimitiveReadField(x: int, f: fld) returns (y: int);
 refines AtomicPrimitiveReadField;
 
->-< action {:layer 1,95} AtomicPrimitiveWriteField(x: int, f: fld, y: int)
+atomic action {:layer 1,95} AtomicPrimitiveWriteField(x: int, f: fld, y: int)
 modifies mem;
 { assert memAddr(x) && fieldAddr(f); mem[x][f] := y; }
 yield procedure {:layer 0} PrimitiveWriteField(x: int, f: fld, y: int);
 refines AtomicPrimitiveWriteField;
 
--> action {:layer 1,99} AtomicPrimitiveFindFreePtrAbs() returns (o: obj)
+right action {:layer 1,99} AtomicPrimitiveFindFreePtrAbs() returns (o: obj)
 modifies allocSet;
 { assume (memAddrAbs(o) && !allocSet[o] && o != nil); allocSet[o] := true; }
 yield procedure {:layer 0} PrimitiveFindFreePtrAbs() returns (o: obj);
 refines AtomicPrimitiveFindFreePtrAbs;
 
->-< action {:layer 1,95} AtomicPrimitiveReadMarkStackPtr() returns (val: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadMarkStackPtr() returns (val: int)
 { val := MarkStackPtr; }
 yield procedure {:layer 0} PrimitiveReadMarkStackPtr() returns (val: int);
 refines AtomicPrimitiveReadMarkStackPtr;
 
->-< action {:layer 1,95} AtomicPrimitiveSetMarkStackPtr(val: int)
+atomic action {:layer 1,95} AtomicPrimitiveSetMarkStackPtr(val: int)
 modifies MarkStackPtr;
 { MarkStackPtr := val; }
 yield procedure {:layer 0} PrimitiveSetMarkStackPtr(val: int);
 refines AtomicPrimitiveSetMarkStackPtr;
 
->-< action {:layer 1,95} AtomicPrimitiveReadMarkStack(ptr: int) returns (val: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadMarkStack(ptr: int) returns (val: int)
 { val := MarkStack[ptr]; }
 yield procedure {:layer 0} PrimitiveReadMarkStack(ptr: int) returns (val: int);
 refines AtomicPrimitiveReadMarkStack;
 
->-< action {:layer 1,95} AtomicPrimitiveWriteMarkStack(ptr: int, val: int)
+atomic action {:layer 1,95} AtomicPrimitiveWriteMarkStack(ptr: int, val: int)
 modifies MarkStack;
 { MarkStack[ptr] := val; }
 yield procedure {:layer 0} PrimitiveWriteMarkStack(ptr: int, val: int);
 refines AtomicPrimitiveWriteMarkStack;
 
->-< action {:layer 1,95} AtomicPrimitiveReadCollectorPhase() returns (phase: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadCollectorPhase() returns (phase: int)
 { phase := collectorPhase; }
 yield procedure {:layer 0} PrimitiveReadCollectorPhase() returns (phase: int);
 refines AtomicPrimitiveReadCollectorPhase;
 
->-< action {:layer 1,95} AtomicPrimitiveSetCollectorPhase(phase:int)
+atomic action {:layer 1,95} AtomicPrimitiveSetCollectorPhase(phase:int)
 modifies collectorPhase;
 { collectorPhase := phase; }
 yield procedure {:layer 0} PrimitiveSetCollectorPhase(phase: int);
 refines AtomicPrimitiveSetCollectorPhase;
 
->-< action {:layer 1,95} AtomicPrimitiveReadMutatorPhase(i: int) returns (phase: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadMutatorPhase(i: int) returns (phase: int)
 { phase := mutatorPhase[i]; }
 yield procedure {:layer 0} PrimitiveReadMutatorPhase(i: int) returns (phase: int);
 refines AtomicPrimitiveReadMutatorPhase;
 
->-< action {:layer 1,95} AtomicPrimitiveSetMutatorPhase(i: int, phase: int)
+atomic action {:layer 1,95} AtomicPrimitiveSetMutatorPhase(i: int, phase: int)
 modifies mutatorPhase;
 { mutatorPhase[i] := phase; }
 yield procedure {:layer 0} PrimitiveSetMutatorPhase(i: int, phase: int);
 refines AtomicPrimitiveSetMutatorPhase;
 
->-< action {:layer 1,95} AtomicPrimitiveReadSweepPtr() returns(val: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadSweepPtr() returns(val: int)
 { val := sweepPtr; }
 yield procedure {:layer 0} PrimitiveReadSweepPtr() returns(val: int);
 refines AtomicPrimitiveReadSweepPtr;
 
->-< action {:layer 1,95} AtomicPrimitiveSetSweepPtr(val: int)
+atomic action {:layer 1,95} AtomicPrimitiveSetSweepPtr(val: int)
 modifies sweepPtr;
 { sweepPtr := val; }
 yield procedure {:layer 0} PrimitiveSetSweepPtr(val: int);
 refines AtomicPrimitiveSetSweepPtr;
 
->-< action {:layer 1,95} AtomicPrimitiveReadRootScanOn() returns(val: bool)
+atomic action {:layer 1,95} AtomicPrimitiveReadRootScanOn() returns(val: bool)
 { val := rootScanOn; }
 yield procedure {:layer 0} PrimitiveReadRootScanOn() returns(val: bool);
 refines AtomicPrimitiveReadRootScanOn;
 
->-< action {:layer 1,95} AtomicPrimitiveSetRootScanOn(val: bool)
+atomic action {:layer 1,95} AtomicPrimitiveSetRootScanOn(val: bool)
 modifies rootScanOn;
 { rootScanOn := val; }
 yield procedure {:layer 0} PrimitiveSetRootScanOn(val: bool);
 refines AtomicPrimitiveSetRootScanOn;
 
->-< action {:layer 1,95} AtomicPrimitiveReadRootScanBarrier() returns(val: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadRootScanBarrier() returns(val: int)
 { val := rootScanBarrier; }
 yield procedure {:layer 0} PrimitiveReadRootScanBarrier() returns(val: int);
 refines AtomicPrimitiveReadRootScanBarrier;
 
->-< action {:layer 1,95} AtomicPrimitiveSetRootScanBarrier(val: int)
+atomic action {:layer 1,95} AtomicPrimitiveSetRootScanBarrier(val: int)
 modifies rootScanBarrier;
 { rootScanBarrier := val; }
 yield procedure {:layer 0} PrimitiveSetRootScanBarrier(val: int);
 refines AtomicPrimitiveSetRootScanBarrier;
 
->-< action {:layer 1,95} AtomicPrimitiveAddRootScanBarrier(val: int)
+atomic action {:layer 1,95} AtomicPrimitiveAddRootScanBarrier(val: int)
 modifies rootScanBarrier;
 { rootScanBarrier := rootScanBarrier + val; }
 yield procedure {:layer 0} PrimitiveAddRootScanBarrier(val: int);
 refines AtomicPrimitiveAddRootScanBarrier;
 
->-< action {:layer 1,95} AtomicPrimitiveMutatorsInRootScanBarrierAdd({:linear_in "tid"} tid_right: Tid)
+atomic action {:layer 1,95} AtomicPrimitiveMutatorsInRootScanBarrierAdd({:linear_in "tid"} tid_right: Tid)
 modifies mutatorsInRootScanBarrier;
 { assert mutatorTidRight(tid_right); mutatorsInRootScanBarrier[tid_right->i] := true; }
 yield procedure {:layer 0} PrimitiveMutatorsInRootScanBarrierAdd({:linear_in "tid"} tid_right: Tid);
 refines AtomicPrimitiveMutatorsInRootScanBarrierAdd;
 
->-< action {:layer 1,95} AtomicPrimitiveMutatorsInRootScanBarrierRemove({:linear "tid"} tid_left: Tid) returns({:linear "tid"} tid_right: Tid)
+atomic action {:layer 1,95} AtomicPrimitiveMutatorsInRootScanBarrierRemove({:linear "tid"} tid_left: Tid) returns({:linear "tid"} tid_right: Tid)
 modifies mutatorsInRootScanBarrier;
 { assert mutatorTidLeft(tid_left) && mutatorsInRootScanBarrier[tid_left->i]; mutatorsInRootScanBarrier[tid_left->i] := false; tid_right := Tid(tid_left->i, false, true); }
 yield procedure {:layer 0} PrimitiveMutatorsInRootScanBarrierRemove({:linear "tid"} tid_left: Tid) returns({:linear "tid"} tid_right: Tid);
 refines AtomicPrimitiveMutatorsInRootScanBarrierRemove;
 
->-< action {:layer 1,95} AtomicPrimitiveWriteRoot(i: idx, val: int)
+atomic action {:layer 1,95} AtomicPrimitiveWriteRoot(i: idx, val: int)
 modifies root;
 { assert rootAddr(i); root[i] := val; }
 yield procedure {:layer 0} PrimitiveWriteRoot(i: idx, val: int);
 refines AtomicPrimitiveWriteRoot;
 
->-< action {:layer 1,95} AtomicPrimitiveReadRoot(i: idx) returns (val: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadRoot(i: idx) returns (val: int)
 { assert rootAddr(i); val := root[i]; }
 yield procedure {:layer 0} PrimitiveReadRoot(i: idx) returns (val: int);
 refines AtomicPrimitiveReadRoot;
 
->-< action {:layer 1,95} AtomicPrimitiveReadColor(i: int) returns (val: int)
+atomic action {:layer 1,95} AtomicPrimitiveReadColor(i: int) returns (val: int)
 { assert memAddr(i); val := Color[i]; }
 yield procedure {:layer 0} PrimitiveReadColor(i: int) returns (val: int);
 refines AtomicPrimitiveReadColor;
 
->-< action {:layer 1,95} AtomicPrimitiveSetColor(i: int, val: int)
+atomic action {:layer 1,95} AtomicPrimitiveSetColor(i: int, val: int)
 modifies Color;
 { assert memAddr(i); Color[i] := val; }
 yield procedure {:layer 0} PrimitiveSetColor(i: int, val: int);
 refines AtomicPrimitiveSetColor;
 
->-< action {:layer 1,95} AtomicPrimitiveLockCAS(next: int) returns (status: bool)
+atomic action {:layer 1,95} AtomicPrimitiveLockCAS(next: int) returns (status: bool)
 modifies lock;
 {
     assert next != 0;
@@ -2081,7 +2081,7 @@ modifies lock;
 yield procedure {:layer 0} PrimitiveLockCAS(next: int) returns (status: bool);
 refines AtomicPrimitiveLockCAS;
 
->-< action {:layer 1,95} AtomicPrimitiveLockZero()
+atomic action {:layer 1,95} AtomicPrimitiveLockZero()
 modifies lock;
 { lock := 0; }
 yield procedure {:layer 0} PrimitiveLockZero();

--- a/Test/civl/Program2.bpl
+++ b/Test/civl/Program2.bpl
@@ -21,7 +21,7 @@ yield procedure {:layer 1} q()
   call Incr(3);
 }
 
->-< action {:layer 1,1} AtomicIncr(val: int)
+atomic action {:layer 1,1} AtomicIncr(val: int)
 modifies x;
 {
   x := x + val;

--- a/Test/civl/Program3.bpl
+++ b/Test/civl/Program3.bpl
@@ -19,7 +19,7 @@ yield procedure {:layer 1} q()
   call Incr(3);
 }
 
-<-> action {:layer 1,1} AtomicIncr(val: int)
+both action {:layer 1,1} AtomicIncr(val: int)
 modifies x;
 {
   x := x + val;

--- a/Test/civl/Program4-fail.bpl
+++ b/Test/civl/Program4-fail.bpl
@@ -29,7 +29,7 @@ yield procedure {:layer 1} q()
   call Incr(3);
 }
 
-<-> action {:layer 1,1} AtomicIncr(val: int)
+both action {:layer 1,1} AtomicIncr(val: int)
 modifies x;
 {
   x := x + val;

--- a/Test/civl/Program4.bpl
+++ b/Test/civl/Program4.bpl
@@ -28,7 +28,7 @@ yield procedure {:layer 1} q()
   call Incr(3);
 }
 
-<-> action {:layer 1,1} AtomicIncr(val: int)
+both action {:layer 1,1} AtomicIncr(val: int)
 modifies x;
 {
   x := x + val;

--- a/Test/civl/Siddharth-queue.bpl
+++ b/Test/civl/Siddharth-queue.bpl
@@ -39,7 +39,7 @@ action {:layer 1} intro_writeLin(n: Invoc)
 
 // ---------- Specification program:
 
->-< action {:layer 2} pop_atomic(this: Invoc) returns (k: Key)
+atomic action {:layer 2} pop_atomic(this: Invoc) returns (k: Key)
   modifies lin, vis;
 {
   var my_vis: SetInvoc;

--- a/Test/civl/alloc-mem.bpl
+++ b/Test/civl/alloc-mem.bpl
@@ -62,7 +62,7 @@ requires {:layer 2} dom(local_in)[i];
   }
 }
 
--> action {:layer 2} atomic_Alloc() returns ({:linear "mem"} l:lmap, i:int)
+right action {:layer 2} atomic_Alloc() returns ({:linear "mem"} l:lmap, i:int)
 modifies pool;
 {
   var m:[int]int;
@@ -81,7 +81,7 @@ ensures call YieldMem(l, i);
   call l := AllocLinear(i);
 }
 
-<- action {:layer 2} atomic_Free({:linear_in "mem"} l:lmap, i:int)
+left action {:layer 2} atomic_Free({:linear_in "mem"} l:lmap, i:int)
 modifies pool;
 {
   assert dom(l)[i];
@@ -97,13 +97,13 @@ preserves call Yield();
   call ReturnAddr(i);
 }
 
-<-> action {:layer 2} atomic_Read ({:linear "mem"} l:lmap, i:int) returns (o:int)
+both action {:layer 2} atomic_Read ({:linear "mem"} l:lmap, i:int) returns (o:int)
 {
   assert dom(l)[i];
   o := map(l)[i];
 }
 
-<-> action {:layer 2} atomic_Write ({:linear_in "mem"} l:lmap, i:int, o:int) returns ({:linear "mem"} l':lmap)
+both action {:layer 2} atomic_Write ({:linear_in "mem"} l:lmap, i:int, o:int) returns ({:linear "mem"} l':lmap)
 {
   assert dom(l)[i];
   l' := cons(dom(l), map(l)[i := o]);
@@ -160,21 +160,21 @@ var {:layer 1, 2} {:linear "mem"} pool:lmap;
 var {:layer 0, 1} mem:[int]int;
 var {:layer 0, 1} unallocated:[int]bool;
 
->-< action {:layer 1} atomic_ReadLow (i:int) returns (o:int)
+atomic action {:layer 1} atomic_ReadLow (i:int) returns (o:int)
 { o := mem[i]; }
 
->-< action {:layer 1} atomic_WriteLow (i:int, o:int)
+atomic action {:layer 1} atomic_WriteLow (i:int, o:int)
 modifies mem;
 { mem[i] := o; }
 
->-< action {:layer 1} atomic_PickAddr () returns (i:int)
+atomic action {:layer 1} atomic_PickAddr () returns (i:int)
 modifies unallocated;
 {
   assume unallocated[i];
   unallocated[i] := false;
 }
 
->-< action {:layer 1} atomic_ReturnAddr (i:int)
+atomic action {:layer 1} atomic_ReturnAddr (i:int)
 modifies unallocated;
 { unallocated[i] := true; }
 

--- a/Test/civl/alloc-tid.bpl
+++ b/Test/civl/alloc-tid.bpl
@@ -41,7 +41,7 @@ ensures call Yield2(tid, old(a)[tid] + 1);
   call Write(tid, i, t + 1);
 }
 
->-< action {:layer 2,2} AtomicAllocate() returns ({:linear "tid"} tid: int, i: int)
+atomic action {:layer 2,2} AtomicAllocate() returns ({:linear "tid"} tid: int, i: int)
 modifies unallocated;
 {
   assume unallocated[tid];
@@ -58,7 +58,7 @@ preserves call Yield1();
   call tid := MakeLinear(i);
 }
 
->-< action {:layer 2,2} AtomicRead({:linear "tid"} tid: int, i: int) returns (val: int)
+atomic action {:layer 2,2} AtomicRead({:linear "tid"} tid: int, i: int) returns (val: int)
 {
   val := a[tid];
 }
@@ -72,7 +72,7 @@ preserves call Yield1();
   call val := ReadLow(i);
 }
 
->-< action {:layer 2,2} AtomicWrite({:linear "tid"} tid: int, i: int, val: int)
+atomic action {:layer 2,2} AtomicWrite({:linear "tid"} tid: int, i: int, val: int)
 modifies a;
 {
   a[tid] := val;
@@ -92,18 +92,18 @@ function {:inline} AllocInv(count: int, unallocated:[int]bool): (bool)
   (forall x: int :: unallocated[x] || x < count)
 }
 
->-< action {:layer 1,1} AtomicReadLow(i: int) returns (val: int)
+atomic action {:layer 1,1} AtomicReadLow(i: int) returns (val: int)
 {
   val := a[i];
 }
 
->-< action {:layer 1,1} AtomicWriteLow(i: int, val: int)
+atomic action {:layer 1,1} AtomicWriteLow(i: int, val: int)
 modifies a;
 {
   a[i] := val;
 }
 
->-< action {:layer 1,1} AtomicAllocateLow() returns (i: int)
+atomic action {:layer 1,1} AtomicAllocateLow() returns (i: int)
 modifies count;
 {
   i := count;

--- a/Test/civl/array-insert.bpl
+++ b/Test/civl/array-insert.bpl
@@ -13,7 +13,7 @@ var {:layer 0,2} lock:Tid;
 function {:inline} sorted (A:[int]int, count:int) : bool
 { (forall i:int, j:int :: 0 <= i && i <= j && j < count ==> A[i] <= A[j]) }
 
->-< action {:layer 2} INSERT ({:linear "tid"} tid:Tid, v:int)
+atomic action {:layer 2} INSERT ({:linear "tid"} tid:Tid, v:int)
 modifies A, count;
 {
   var idx:int; // index at which v is written
@@ -86,33 +86,33 @@ action {:layer 1} snapshot () returns (snapshot: [int]int)
 
 // =============================================================================
 
-<-> action {:layer 1} READ_A ({:linear "tid"} tid:Tid, i:int) returns (v:int)
+both action {:layer 1} READ_A ({:linear "tid"} tid:Tid, i:int) returns (v:int)
 {
   assert tid != nil && lock == tid;
   v := A[i];
 }
 
-<-> action {:layer 1} WRITE_A ({:linear "tid"} tid:Tid, i:int, v:int)
+both action {:layer 1} WRITE_A ({:linear "tid"} tid:Tid, i:int, v:int)
 modifies A;
 {
   assert tid != nil && lock == tid;
   A[i] := v;
 }
 
-<-> action {:layer 1} READ_COUNT ({:linear "tid"} tid:Tid) returns (c:int)
+both action {:layer 1} READ_COUNT ({:linear "tid"} tid:Tid) returns (c:int)
 {
   assert tid != nil && lock == tid;
   c := count;
 }
 
-<-> action {:layer 1} WRITE_COUNT ({:linear "tid"} tid:Tid, c:int)
+both action {:layer 1} WRITE_COUNT ({:linear "tid"} tid:Tid, c:int)
 modifies count;
 {
   assert tid != nil && lock == tid;
   count := c;
 }
 
--> action {:layer 1} ACQUIRE ({:linear "tid"} tid:Tid)
+right action {:layer 1} ACQUIRE ({:linear "tid"} tid:Tid)
 modifies lock;
 {
   assert tid != nil;
@@ -120,7 +120,7 @@ modifies lock;
   lock := tid;
 }
 
-<- action {:layer 1} RELEASE ({:linear "tid"} tid:Tid)
+left action {:layer 1} RELEASE ({:linear "tid"} tid:Tid)
 modifies lock;
 {
   assert tid != nil && lock == tid;

--- a/Test/civl/assert-not-first-1.bpl
+++ b/Test/civl/assert-not-first-1.bpl
@@ -7,11 +7,11 @@ requires {:layer 1} b ==> i >= 0;
     call o := bar(b, i);
 }
 
->-< action {:layer 1} BAR(b: bool, i: int) returns (o: int) {
+atomic action {:layer 1} BAR(b: bool, i: int) returns (o: int) {
     call o := FOO(b, i);
 }
 
->-< action {:layer 1} FOO(b: bool, i: int) returns (o: int) {
+atomic action {:layer 1} FOO(b: bool, i: int) returns (o: int) {
     if (b) {
         o := i + 1;
         assert o > 0;

--- a/Test/civl/assert-not-first-2.bpl
+++ b/Test/civl/assert-not-first-2.bpl
@@ -7,7 +7,7 @@ requires {:layer 1} (forall x: int :: arr[x] == 1);
     call foo(arr);
 }
 
->-< action {:layer 1} FOO(arr: [int]int) {
+atomic action {:layer 1} FOO(arr: [int]int) {
     var x: int;
     assert arr[x] == 1;
 }

--- a/Test/civl/assert-not-first-3.bpl
+++ b/Test/civl/assert-not-first-3.bpl
@@ -7,7 +7,7 @@ requires {:layer 1} (forall x: int :: arr[x] == 1);
     call foo(arr, i);
 }
 
->-< action {:layer 1} FOO(arr: [int]int, i: int) {
+atomic action {:layer 1} FOO(arr: [int]int, i: int) {
     var x: int;
     x := i;
     havoc x;

--- a/Test/civl/assert-not-first-4.bpl
+++ b/Test/civl/assert-not-first-4.bpl
@@ -8,7 +8,7 @@ requires {:layer 1} arr[i] == 1;
     call foo(arr, i);
 }
 
->-< action {:layer 1} FOO(arr: [int]int, i: int) {
+atomic action {:layer 1} FOO(arr: [int]int, i: int) {
     var x: int;
     x := i;
     havoc x;

--- a/Test/civl/async-yield-sufficiency.bpl
+++ b/Test/civl/async-yield-sufficiency.bpl
@@ -16,13 +16,13 @@ requires call Yield_Q(tid1);
   call assertion();
 }
 
-<- action {:layer 1} WRITE()
+left action {:layer 1} WRITE()
 modifies x;
 {
   x := 1;
 }
 
->-< action {:layer 1} ASSERTION()
+atomic action {:layer 1} ASSERTION()
 {
   assert x == 0;
 }

--- a/Test/civl/async/2agree.bpl
+++ b/Test/civl/async/2agree.bpl
@@ -15,7 +15,7 @@ function {:inline} perm (p : int) : bool
 // ###########################################################################
 // Main (process A sends initial proposal)
 
->-< action {:layer 3} atomic_agree ({:linear_in "lin"} p : int)
+atomic action {:layer 3} atomic_agree ({:linear_in "lin"} p : int)
 modifies val_a, val_b;
 {
   havoc val_a, val_b;
@@ -34,7 +34,7 @@ requires {:layer 2} perm(p);
 // ###########################################################################
 // Event handlers of process B
 
-yield <- procedure {:layer 2} propose_by_a (val : int, {:linear_in "lin"} p : int)
+yield left procedure {:layer 2} propose_by_a (val : int, {:linear_in "lin"} p : int)
 requires {:layer 2} perm(p);
 requires {:layer 2} val_a == val;
 ensures {:layer 2} val_a == val_b;
@@ -54,7 +54,7 @@ modifies val_a, val_b;
   }
 }
 
-yield <- procedure {:layer 2} ack_by_a({:linear_in "lin"} p : int)
+yield left procedure {:layer 2} ack_by_a({:linear_in "lin"} p : int)
 requires {:layer 2} perm(p);
 requires {:layer 2} val_a == val_b;
 ensures {:layer 2} val_a == val_b;
@@ -64,7 +64,7 @@ ensures {:layer 2} val_a == val_b;
 // ###########################################################################
 // Event handlers of process A
 
-yield <- procedure {:layer 2} propose_by_b (val : int, {:linear_in "lin"} p : int)
+yield left procedure {:layer 2} propose_by_b (val : int, {:linear_in "lin"} p : int)
 requires {:layer 2} perm(p);
 requires {:layer 2} val_b == val;
 ensures {:layer 2} val_a == val_b;
@@ -84,7 +84,7 @@ modifies val_a, val_b;
   }
 }
 
-yield <- procedure {:layer 2} ack_by_b({:linear_in "lin"} p : int)
+yield left procedure {:layer 2} ack_by_b({:linear_in "lin"} p : int)
 requires {:layer 2} perm(p);
 requires {:layer 2} val_a == val_b;
 ensures {:layer 2} val_a == val_b;
@@ -94,14 +94,14 @@ ensures {:layer 2} val_a == val_b;
 // ###########################################################################
 // Abstracted atomic actions with permissions
 
-<-> action {:layer 2} atomic_get_val_a_perm ({:linear "lin"} p : int) returns (ret : int)
+both action {:layer 2} atomic_get_val_a_perm ({:linear "lin"} p : int) returns (ret : int)
 { assert perm(p); ret := val_a; }
 
-<-> action {:layer 2} atomic_set_val_a_perm (val : int, {:linear "lin"} p : int)
+both action {:layer 2} atomic_set_val_a_perm (val : int, {:linear "lin"} p : int)
 modifies val_a;
 { assert perm(p); val_a := val; }
 
-<-> action {:layer 2} atomic_set_val_b_perm (val : int, {:linear "lin"} p : int)
+both action {:layer 2} atomic_set_val_b_perm (val : int, {:linear "lin"} p : int)
 modifies val_b;
 { assert perm(p); val_b := val; }
 
@@ -120,14 +120,14 @@ refines atomic_set_val_b_perm;
 // ###########################################################################
 // Primitive atomic actions
 
->-< action {:layer 1} atomic_get_val_a () returns (ret : int)
+atomic action {:layer 1} atomic_get_val_a () returns (ret : int)
 { ret := val_a; }
 
->-< action {:layer 1} atomic_set_val_a (val : int)
+atomic action {:layer 1} atomic_set_val_a (val : int)
 modifies val_a;
 { val_a := val; }
 
->-< action {:layer 1} atomic_set_val_b (val : int)
+atomic action {:layer 1} atomic_set_val_b (val : int)
 modifies val_b;
 { val_b := val; }
 

--- a/Test/civl/async/2pc.bpl
+++ b/Test/civl/async/2pc.bpl
@@ -190,7 +190,7 @@ action {:layer 10} GhostRead_10() returns (snapshot: GState)
    snapshot := state;
 }
 
->-< action {:layer 11} atomic_Coordinator_TransactionReq () returns (xid: Xid)
+atomic action {:layer 11} atomic_Coordinator_TransactionReq () returns (xid: Xid)
 modifies state;
 {
   var {:pool "A"} x: XState;
@@ -232,7 +232,7 @@ preserves call YieldConsistent_10();
 
 // ---------------------------------------------------------------------------
 
-<- action {:layer 10} atomic_Participant_VoteReq (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
+left action {:layer 10} atomic_Participant_VoteReq (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
 modifies state;
 {
   var {:pool "A"} x: XState;
@@ -262,7 +262,7 @@ requires call YieldInv_9(xid);
 
 // ---------------------------------------------------------------------------
 
-<- action {:layer 9} atomic_Coordinator_VoteYes (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
+left action {:layer 9} atomic_Coordinator_VoteYes (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
 modifies state, B;
 {
   var {:pool "A"} x: XState;
@@ -311,7 +311,7 @@ requires call YieldUndecidedOrCommitted_8(xid, mid, pair);
   assert {:layer 8} {:add_to_pool "A", state[xid]} true;
 }
 
-<- action {:layer 9} atomic_Coordinator_VoteNo (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
+left action {:layer 9} atomic_Coordinator_VoteNo (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair)
 modifies state;
 {
   var {:pool "A"} x: XState;
@@ -369,7 +369,7 @@ refines atomic_Participant_Commit;
 yield procedure {:layer 7} Participant_Abort (xid : Xid, mid : Mid);
 refines atomic_Participant_Abort;
 
->-< action {:layer 8,9} atomic_SetParticipantAborted (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
+atomic action {:layer 8,9} atomic_SetParticipantAborted (xid: Xid, mid: Mid, {:linear "pair"} pair: Pair)
 modifies state;
 {
   assert pair(xid, mid, pair);
@@ -377,7 +377,7 @@ modifies state;
   state[xid][mid] := ABORTED();
 }
 
->-< action {:layer 8} atomic_StateUpdateOnVoteYes (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair) returns (commit : bool)
+atomic action {:layer 8} atomic_StateUpdateOnVoteYes (xid: Xid, mid: Mid, {:linear_in "pair"} pair: Pair) returns (commit : bool)
 modifies votes, state, B;
 {
   assert !UnallocatedXids[xid];
@@ -392,7 +392,7 @@ modifies votes, state, B;
   }
 }
 
->-< action {:layer 8} atomic_StateUpdateOnVoteNo (xid: Xid, mid: Mid) returns (abort : bool)
+atomic action {:layer 8} atomic_StateUpdateOnVoteNo (xid: Xid, mid: Mid) returns (abort : bool)
 modifies votes, state;
 {
   assert !UnallocatedXids[xid];
@@ -404,7 +404,7 @@ modifies votes, state;
 
 // ---------------------------------------------------------------------------
 
-<- action {:layer 8} atomic_Participant_Commit (xid : Xid, mid : Mid)
+left action {:layer 8} atomic_Participant_Commit (xid : Xid, mid : Mid)
 modifies state;
 {
   assert participantMid(mid);
@@ -413,7 +413,7 @@ modifies state;
   state[xid][mid] := COMMITTED();
 }
 
-<- action {:layer 8} atomic_Participant_Abort (xid : Xid, mid : Mid)
+left action {:layer 8} atomic_Participant_Abort (xid : Xid, mid : Mid)
 modifies state;
 {
   assert participantMid(mid);
@@ -432,7 +432,7 @@ yield procedure {:layer 7} TransferPair (xid: Xid, mid: Mid, {:linear_in "pair"}
 returns ({:linear "pair"} pairs: [Pair]bool, {:linear "pair"} pair: Pair);
 refines atomic_TransferPair;
 
->-< action {:layer 8,10} atomic_AllocateXid () returns (xid: Xid, {:linear "pair"} pairs: [Pair]bool)
+atomic action {:layer 8,10} atomic_AllocateXid () returns (xid: Xid, {:linear "pair"} pairs: [Pair]bool)
 modifies UnallocatedXids;
 {
   assume UnallocatedXids[xid];
@@ -441,7 +441,7 @@ modifies UnallocatedXids;
   UnallocatedXids[xid] := false;
 }
 
-<-> action {:layer 8,10} atomic_TransferPair (xid: Xid, mid: Mid, {:linear_in "pair"} inPairs: [Pair]bool) returns ({:linear "pair"} pairs: [Pair]bool, {:linear "pair"} pair: Pair)
+both action {:layer 8,10} atomic_TransferPair (xid: Xid, mid: Mid, {:linear_in "pair"} inPairs: [Pair]bool) returns ({:linear "pair"} pairs: [Pair]bool, {:linear "pair"} pair: Pair)
 {
   assert inPairs[Pair(xid, mid)];
   pair := Pair(xid, mid);

--- a/Test/civl/async/async1.bpl
+++ b/Test/civl/async/async1.bpl
@@ -8,7 +8,7 @@ refines A_Inc;
   async call {:sync} Callback();
 }
 
-<-> action {:layer 1,2} A_Inc ()
+both action {:layer 1,2} A_Inc ()
 modifies x;
 { x := x + 1; }
 yield procedure {:layer 0} Callback ();

--- a/Test/civl/async/async2.bpl
+++ b/Test/civl/async/async2.bpl
@@ -2,11 +2,11 @@
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,2} x: int;
 
-<- action {:layer 1,2} AtomicIncr()
+left action {:layer 1,2} AtomicIncr()
 modifies x;
 { x := x + 1; }
 
-<- action {:layer 1,2} AtomicDecr()
+left action {:layer 1,2} AtomicDecr()
 modifies x;
 { x := x - 1; }
 

--- a/Test/civl/async/async3.bpl
+++ b/Test/civl/async/async3.bpl
@@ -9,7 +9,7 @@ refines A_Inc;
   call Service();
 }
 
->-< action {:layer 1} A_Service()
+atomic action {:layer 1} A_Service()
 refines A_Inc;
 creates A_Inc;
 {
@@ -21,7 +21,7 @@ refines A_Service;
   async call Callback();
 }
 
-async <-> action {:layer 1,3} A_Inc ()
+async both action {:layer 1,3} A_Inc ()
 modifies x;
 { x := x + 1; }
 yield procedure {:layer 0} Callback ();

--- a/Test/civl/async/async4.bpl
+++ b/Test/civl/async/async4.bpl
@@ -3,7 +3,7 @@
 
 var {:layer 0,2} x:int;
 
-<-> action {:layer 2} A_Add (n: int)
+both action {:layer 2} A_Add (n: int)
 modifies x;
 { assert 0 <= n; x := x + n; }
 
@@ -18,7 +18,7 @@ modifies x;
   call create_multi_asyncs(MapConst(0)[A_Inc() := n - i]);
 }
 
->-< action {:layer 1} Async_Add(n: int)
+atomic action {:layer 1} Async_Add(n: int)
 refines A_Add using INV;
 creates A_Inc;
 {
@@ -27,6 +27,6 @@ creates A_Inc;
   call create_multi_asyncs(MapConst(0)[A_Inc() := n]);
 }
 
-async <-> action {:layer 1,2} A_Inc ()
+async both action {:layer 1,2} A_Inc ()
 modifies x;
 { x := x + 1; }

--- a/Test/civl/async/inc-dec-2.bpl
+++ b/Test/civl/async/inc-dec-2.bpl
@@ -12,7 +12,7 @@ var {:layer 0,1} x : int;
 // ###########################################################################
 // Main
 
->-< action {:layer 2} skip () {}
+atomic action {:layer 2} skip () {}
 
 yield procedure {:layer 1} Main ()
 refines skip;
@@ -39,11 +39,11 @@ action {:layer 1} snapshot_x() returns (snapshot: int)
 // ###########################################################################
 // Low level atomic actions
 
-<- action {:layer 1} inc_atomic ()
+left action {:layer 1} inc_atomic ()
 modifies x;
 { x := x + 1; }
 
-<- action {:layer 1} dec_atomic ()
+left action {:layer 1} dec_atomic ()
 modifies x;
 { x := x - 1; }
 

--- a/Test/civl/async/inc-dec.bpl
+++ b/Test/civl/async/inc-dec.bpl
@@ -18,7 +18,7 @@ yield procedure {:layer 1} main ()
   async call {:sync} dec_by_N();
 }
 
-yield <- procedure {:layer 1} inc_by_N ()
+yield left procedure {:layer 1} inc_by_N ()
 modifies x;
 ensures {:layer 1} x == old(x) + N;
 {
@@ -33,7 +33,7 @@ ensures {:layer 1} x == old(x) + N;
   }
 }
 
-yield <- procedure {:layer 1} dec_by_N ()
+yield left procedure {:layer 1} dec_by_N ()
 modifies x;
 ensures {:layer 1} x == old(x) - N;
 {
@@ -51,11 +51,11 @@ ensures {:layer 1} x == old(x) - N;
 // ###########################################################################
 // Low level atomic actions
 
-<- action {:layer 1} inc_atomic ()
+left action {:layer 1} inc_atomic ()
 modifies x;
 { x := x + 1; }
 
-<- action {:layer 1} dec_atomic ()
+left action {:layer 1} dec_atomic ()
 modifies x;
 { x := x - 1; }
 

--- a/Test/civl/async/inc-server.bpl
+++ b/Test/civl/async/inc-server.bpl
@@ -27,7 +27,7 @@ requires call Yield_9(p);
 // ###########################################################################
 // Event Handlers
 
-<- action {:layer 10,11} inc_x_high_atomic ({:linear_in "lin"} p : int)
+left action {:layer 10,11} inc_x_high_atomic ({:linear_in "lin"} p : int)
 modifies x;
 { x := x + 1; }
 
@@ -52,11 +52,11 @@ invariant perm(p) && x == y;
 // ###########################################################################
 // Abstracted low-level atomic actions (i.e., enriched with permissions)
 
->-< action {:layer 9} inc_x_perm_atomic ({:linear "lin"} p : int)
+atomic action {:layer 9} inc_x_perm_atomic ({:linear "lin"} p : int)
 modifies x;
 { assert perm(p); x := x + 1; }
 
-<- action {:layer 9} Client_IncDone_atomic ({:linear_in "lin"} p : int)
+left action {:layer 9} Client_IncDone_atomic ({:linear_in "lin"} p : int)
 { assert perm(p) && x == y + 1; }
 
 yield procedure {:layer 8} inc_x_perm ({:linear "lin"} p : int)
@@ -74,11 +74,11 @@ refines Client_IncDone_atomic;
 // ###########################################################################
 // Low-level atomic actions
 
->-< action {:layer 8} inc_x_atomic ()
+atomic action {:layer 8} inc_x_atomic ()
 modifies x;
 { x := x + 1; }
 
->-< action {:layer 8} Assertion_atomic ()
+atomic action {:layer 8} Assertion_atomic ()
 { assert x == y + 1; }
 
 yield procedure {:layer 7} inc_x ();

--- a/Test/civl/async/inc-server_mover.bpl
+++ b/Test/civl/async/inc-server_mover.bpl
@@ -30,7 +30,7 @@ invariant perm(p) && x == y;
 // ###########################################################################
 // Event Handlers
 
-yield <- procedure {:layer 9} Server_Inc ({:linear_in "lin"} p : int)
+yield left procedure {:layer 9} Server_Inc ({:linear_in "lin"} p : int)
 requires {:layer 9} perm(p) && x == y;
 ensures  {:layer 9} x == old(x) + 1;
 modifies x;
@@ -40,7 +40,7 @@ modifies x;
   call Yield_8();
 }
 
-yield <- procedure {:layer 9} AsyncInc ({:linear_in "lin"} p : int)
+yield left procedure {:layer 9} AsyncInc ({:linear_in "lin"} p : int)
 requires {:layer 9} perm(p) && x == y;
 ensures  {:layer 9} x == old(x) + 1;
 modifies x;
@@ -56,11 +56,11 @@ yield invariant{:layer 8} Yield_8 ();
 // ###########################################################################
 // Abstracted low-level atomic actions (i.e., enriched with permissions)
 
-<- action {:layer 9} inc_x_perm_atomic ({:linear "lin"} p : int)
+left action {:layer 9} inc_x_perm_atomic ({:linear "lin"} p : int)
 modifies x;
 { assert perm(p); x := x + 1; }
 
-<- action {:layer 9} Client_IncDone_atomic ({:linear_in "lin"} p : int)
+left action {:layer 9} Client_IncDone_atomic ({:linear_in "lin"} p : int)
 { assert perm(p) && x == y + 1; }
 
 yield procedure {:layer 8} inc_x_perm ({:linear "lin"} p : int)
@@ -78,11 +78,11 @@ refines Client_IncDone_atomic;
 // ###########################################################################
 // Low-level atomic actions
 
->-< action {:layer 8} inc_x_atomic ()
+atomic action {:layer 8} inc_x_atomic ()
 modifies x;
 { x := x + 1; }
 
->-< action {:layer 8} Assertion_atomic ()
+atomic action {:layer 8} Assertion_atomic ()
 { assert x == y + 1; }
 
 yield procedure {:layer 7} inc_x ();

--- a/Test/civl/async/leader.bpl
+++ b/Test/civl/async/leader.bpl
@@ -51,7 +51,7 @@ function {:inline} all_decided' (r_bound:int, init_val:[int]int, dec_dom:[int]bo
 // ###########################################################################
 // Main
 
->-< action {:layer 2} main_atomic ({:linear_in "Perm"} perms:[Perm]bool)
+atomic action {:layer 2} main_atomic ({:linear_in "Perm"} perms:[Perm]bool)
 modifies col_dom, col_val, dec_dom, dec_val;
 {
   havoc dec_dom, dec_val;
@@ -83,7 +83,7 @@ ensures call YieldAllDecided();
   }
 }
 
-yield <- procedure {:layer 1} P (s:int, {:linear_in "Perm"} perms:[Perm]bool)
+yield left procedure {:layer 1} P (s:int, {:linear_in "Perm"} perms:[Perm]bool)
 requires {:layer 1} perms == s_perms_eq(s);
 requires {:layer 1} inv_val(s, init_val, col_dom, col_val);
 ensures  {:layer 1} inv_val(s+1, init_val, col_dom, col_val);
@@ -109,7 +109,7 @@ modifies col_dom, col_val, dec_dom, dec_val;
   }
 }
 
-<- action {:layer 1} Q_atomic (r:int, s:int, v:int, {:linear_in "Perm"} p:Perm)
+left action {:layer 1} Q_atomic (r:int, s:int, v:int, {:linear_in "Perm"} p:Perm)
 modifies col_dom, col_val, dec_dom, dec_val;
 {
   assert is_perm(s,r,p);
@@ -121,7 +121,7 @@ modifies col_dom, col_val, dec_dom, dec_val;
   }
 }
 
-<-> action {:layer 1} read_init_val_atomic (pid:Pid) returns (v:int)
+both action {:layer 1} read_init_val_atomic (pid:Pid) returns (v:int)
 {
   v := init_val[pid];
 }
@@ -140,12 +140,12 @@ function {:inline} s_perms_eq (s:Pid) : [Perm]bool { (lambda p:Perm :: p->s == s
 function {:inline} s_perms_geq (s:Pid) : [Perm]bool { (lambda p:Perm :: is_pid(p->s) && is_pid(p->r) && p->s >= s) }
 function {:inline} s_r_perms_geq (s:Pid, r:Pid) : [Perm]bool { (lambda p:Perm :: p->s == s && is_pid(p->r) && p->r >= r) }
 
-yield <-> procedure {:layer 1} split_perms_sender (s:Pid, {:linear_in "Perm"} perms_in:[Perm]bool) returns ({:linear "Perm"} perms_out_1:[Perm]bool, {:linear "Perm"} perms_out_2:[Perm]bool);
+yield both procedure {:layer 1} split_perms_sender (s:Pid, {:linear_in "Perm"} perms_in:[Perm]bool) returns ({:linear "Perm"} perms_out_1:[Perm]bool, {:linear "Perm"} perms_out_2:[Perm]bool);
 requires {:layer 1} perms_in == s_perms_geq(s);
 ensures {:layer 1} perms_out_1 == s_perms_geq(s+1);
 ensures {:layer 1} perms_out_2 == s_perms_eq(s);
 
-yield <-> procedure {:layer 1} split_perms_receiver (s:Pid, r:Pid, {:linear_in "Perm"} perms_in:[Perm]bool) returns ({:linear "Perm"} perms_out_1:[Perm]bool, {:linear "Perm"} perms_out_2:Perm);
+yield both procedure {:layer 1} split_perms_receiver (s:Pid, r:Pid, {:linear_in "Perm"} perms_in:[Perm]bool) returns ({:linear "Perm"} perms_out_1:[Perm]bool, {:linear "Perm"} perms_out_2:Perm);
 requires {:layer 1} perms_in ==  s_r_perms_geq(s,r);
 ensures {:layer 1} perms_out_1 == s_r_perms_geq(s,r+1);
 ensures {:layer 1} is_perm(s,r,perms_out_2);

--- a/Test/civl/async/lock-service.bpl
+++ b/Test/civl/async/lock-service.bpl
@@ -7,7 +7,7 @@ const nil:Tid;
 var {:layer 0,4} l:Tid;
 var {:layer 0,5} x:int;
 
->-< action {:layer 5} A_Client ()
+atomic action {:layer 5} A_Client ()
 modifies x;
 {
   x := x + 1;
@@ -19,14 +19,14 @@ requires {:layer 4} tid != nil;
   call GetLockAndCallback(tid);
 }
 
->-< action {:layer 4} A_GetLockAndCallback' ({:linear_in "tid"} tid:Tid)
+atomic action {:layer 4} A_GetLockAndCallback' ({:linear_in "tid"} tid:Tid)
 modifies x;
 {
   assert tid != nil;
   x := x + 1;
 }
 
-async <- action {:layer 3} A_Callback ({:linear_in "tid"} tid:Tid)
+async left action {:layer 3} A_Callback ({:linear_in "tid"} tid:Tid)
 modifies l, x;
 {
   assert tid != nil && l == tid;
@@ -42,25 +42,25 @@ refines A_Callback;
   async call {:sync} ReleaseLock(tid);
 }
 
-<-> action {:layer 2} A_read_x_lock ({:linear "tid"} tid:Tid) returns (v:int)
+both action {:layer 2} A_read_x_lock ({:linear "tid"} tid:Tid) returns (v:int)
 { assert tid != nil && l == tid; v := x; }
 yield procedure {:layer 1} read_x_lock ({:linear "tid"} tid:Tid) returns (v:int)
 refines A_read_x_lock;
 { call v := read_x(); }
 
-<-> action {:layer 2} A_write_x_lock (v:int, {:linear "tid"} tid:Tid)
+both action {:layer 2} A_write_x_lock (v:int, {:linear "tid"} tid:Tid)
 modifies x;
 { assert tid != nil && l == tid; x := v; }
 yield procedure {:layer 1} write_x_lock (v:int, {:linear "tid"} tid:Tid)
 refines A_write_x_lock;
 { call write_x(v); }
 
->-< action {:layer 1} A_read_x () returns (v:int)
+atomic action {:layer 1} A_read_x () returns (v:int)
 { v := x; }
 yield procedure {:layer 0} read_x () returns (v:int);
 refines A_read_x;
 
->-< action {:layer 1} A_write_x (v:int)
+atomic action {:layer 1} A_write_x (v:int)
 modifies x;
 { x := v; }
 yield procedure {:layer 0} write_x (v:int);
@@ -68,7 +68,7 @@ refines A_write_x;
 
 // -----------------------------------------------------------------------------
 
->-< action {:layer 3}
+atomic action {:layer 3}
 A_GetLockAndCallback ({:linear_in "tid"} tid:Tid)
 refines A_GetLockAndCallback';
 creates A_Callback;
@@ -86,7 +86,7 @@ refines A_GetLockAndCallback;
   async call Callback(tid);
 }
 
->-< action {:layer 2} A_GetLock ({:linear "tid"} tid:Tid)
+atomic action {:layer 2} A_GetLock ({:linear "tid"} tid:Tid)
 modifies l;
 {
   assert tid != nil;
@@ -107,7 +107,7 @@ refines A_GetLock;
   }
 }
 
-<- action {:layer 2} A_ReleaseLock ({:linear_in "tid"} tid:Tid)
+left action {:layer 2} A_ReleaseLock ({:linear_in "tid"} tid:Tid)
 modifies l;
 {
   assert tid != nil && l == tid;
@@ -119,7 +119,7 @@ refines A_ReleaseLock;
   call write_l(nil);
 }
 
->-< action {:layer 1} A_cas_l (oldval:Tid, newval:Tid) returns (success:bool)
+atomic action {:layer 1} A_cas_l (oldval:Tid, newval:Tid) returns (success:bool)
 modifies l;
 {
   if (l == oldval) {
@@ -132,7 +132,7 @@ modifies l;
 yield procedure {:layer 0} cas_l (oldval:Tid, newval:Tid) returns (success:bool);
 refines A_cas_l;
 
->-< action {:layer 1} A_write_l (v:Tid)
+atomic action {:layer 1} A_write_l (v:Tid)
 modifies l;
 { l := v; }
 yield procedure {:layer 0} write_l (v:Tid);

--- a/Test/civl/async/rec-inc.bpl
+++ b/Test/civl/async/rec-inc.bpl
@@ -14,7 +14,7 @@ requires {:layer 1} n >= 0;
   call inc(n);
 }
 
-yield <- procedure {:layer 1} inc (i : int)
+yield left procedure {:layer 1} inc (i : int)
 modifies x;
 requires {:layer 1} i >= 0;
 ensures {:layer 1} x == old(x) + i;
@@ -26,7 +26,7 @@ ensures {:layer 1} x == old(x) + i;
   }
 }
 
-<-> action {:layer 1,2} atomic_inc_x (n: int)
+both action {:layer 1,2} atomic_inc_x (n: int)
 modifies x;
 { x := x + n; }
 

--- a/Test/civl/async/simple-tds.bpl
+++ b/Test/civl/async/simple-tds.bpl
@@ -10,40 +10,40 @@ const unique r: int;
 
 yield procedure {:layer 0} P0({:linear "tid"} tid: int);
 refines AtomicP0;
-<- action {:layer 1} AtomicP0({:linear "tid"} tid: int)
+left action {:layer 1} AtomicP0({:linear "tid"} tid: int)
 modifies x;
 { assert tid == p; assert x == 0; x := 1; }
 
 yield procedure {:layer 0} Q0({:linear "tid"} tid: int);
 refines AtomicQ0;
->-< action {:layer 1} AtomicQ0({:linear "tid"} tid: int)
+atomic action {:layer 1} AtomicQ0({:linear "tid"} tid: int)
 modifies x;
 { assert tid == q; assume x == 1; x := 2; }
 
 yield procedure {:layer 0} R0({:linear "tid"} tid: int);
 refines AtomicR0;
->-< action {:layer 1,3} AtomicR0({:linear "tid"} tid: int)
+atomic action {:layer 1,3} AtomicR0({:linear "tid"} tid: int)
 modifies x;
 { assert tid == r; assume x == 2; x := 3; }
 
 yield procedure {:layer 1} P1({:linear_in "tid"} tid: int)
 refines AtomicP1;
 {  async call {:sync} P0(tid);  }
->-< action {:layer 2,3} AtomicP1({:linear_in "tid"} tid: int)
+atomic action {:layer 2,3} AtomicP1({:linear_in "tid"} tid: int)
 modifies x;
 { assert tid == p; assert x == 0; x := 1; }
 
 yield procedure {:layer 1} Q1({:linear "tid"} tid: int)
 refines AtomicQ1;
 {  call Q0(tid);  }
-<- action {:layer 2,3} AtomicQ1({:linear "tid"} tid: int)
+left action {:layer 2,3} AtomicQ1({:linear "tid"} tid: int)
 modifies x;
 { assert tid == q; assert x == 1; x := 2; }
 
 yield procedure {:layer 3} R3({:linear "tid"} tid: int)
 refines AtomicR3;
 {  call R0(tid);  }
-<- action {:layer 4} AtomicR3({:linear "tid"} tid: int)
+left action {:layer 4} AtomicR3({:linear "tid"} tid: int)
 modifies x;
 { assert tid == r; assert x == 2; x := 3; }
 
@@ -53,7 +53,7 @@ refines AtomicMain3;
     call P1(tidp);
     async call {:sync} Q1(tidq);
 }
->-< action {:layer 4} AtomicMain3({:linear_in "tid"} tidp: int, {:linear_in "tid"} tidq: int)
+atomic action {:layer 4} AtomicMain3({:linear_in "tid"} tidp: int, {:linear_in "tid"} tidq: int)
 modifies x;
 { assert tidp == p && tidq == q; assert x == 0; x := 2; }
 
@@ -63,6 +63,6 @@ refines AtomicMain4;
     call Main3(tidp, tidq);
     async call {:sync} R3(tidr);
 }
->-< action {:layer 5} AtomicMain4({:linear_in "tid"} tidp: int, {:linear_in "tid"} tidq: int, {:linear_in "tid"} tidr: int)
+atomic action {:layer 5} AtomicMain4({:linear_in "tid"} tidp: int, {:linear_in "tid"} tidq: int, {:linear_in "tid"} tidr: int)
 modifies x;
 { assert tidp == p && tidq == q && tidr == r; assert x == 0; x := 3; }

--- a/Test/civl/async/tds.bpl
+++ b/Test/civl/async/tds.bpl
@@ -10,7 +10,7 @@ const unique FINISHED: int;
 
 var status:[int]int;
 
->-< action {:layer 5} atomic_main({:linear "tid"} id: int, {:linear_in "tid"} tids: [int]bool)
+atomic action {:layer 5} atomic_main({:linear "tid"} id: int, {:linear_in "tid"} tids: [int]bool)
 modifies status;
 {
     assert id == c;
@@ -19,7 +19,7 @@ modifies status;
     status := (lambda j: int :: if (0 <= j && j < n) then FINISHED else status[j]);
 }
 
-<- action {:layer 4} atomic_server({:linear "tid"} id: int, {:linear_in "tid"} tids: [int]bool)
+left action {:layer 4} atomic_server({:linear "tid"} id: int, {:linear_in "tid"} tids: [int]bool)
 modifies status;
 {
     assert id == c;
@@ -28,7 +28,7 @@ modifies status;
     status := (lambda j: int :: if (0 <= j && j < n) then CREATED else status[j]);
 }
 
-<- action {:layer 4} atomic_client({:linear "tid"} id: int)
+left action {:layer 4} atomic_client({:linear "tid"} id: int)
 modifies status;
 {
     assert id == c;
@@ -36,7 +36,7 @@ modifies status;
     status := (lambda j: int :: if (0 <= j && j < n) then PROCESSED else status[j]);
 }
 
-<- action {:layer 4} atomic_master({:linear "tid"} id: int)
+left action {:layer 4} atomic_master({:linear "tid"} id: int)
 modifies status;
 {
     assert id == c;
@@ -68,7 +68,7 @@ action {:layer 3} StatusSnapshot() returns (snapshot: [int]int)
 
 yield procedure {:layer 2} Alloc(i: int, {:linear_in "tid"} tidq: [int]bool) returns ({:linear "tid"} id: int, {:linear "tid"} tidq':[int]bool);
 refines AtomicAlloc;
-<-> action {:layer 3} AtomicAlloc(i: int, {:linear_in "tid"} tidq: [int]bool) returns ({:linear "tid"} id: int, {:linear "tid"} tidq':[int]bool)
+both action {:layer 3} AtomicAlloc(i: int, {:linear_in "tid"} tidq: [int]bool) returns ({:linear "tid"} id: int, {:linear "tid"} tidq':[int]bool)
 { assert tidq[i]; id := i; tidq' := tidq[i := false]; }
 
 yield procedure {:layer 3} server3({:linear "tid"} id: int, {:linear_in "tid"} tids: [int]bool)
@@ -93,7 +93,7 @@ refines atomic_server;
     }
 }
 
-<- action {:layer 3} atomic_server2({:linear "tid"} i: int)
+left action {:layer 3} atomic_server2({:linear "tid"} i: int)
 modifies status;
 {
     assert status[i] == DEFAULT;
@@ -108,7 +108,7 @@ refines atomic_client;
     call client2();
 }
 
->-< action {:layer 3} atomic_client2()
+atomic action {:layer 3} atomic_client2()
 modifies status;
 {
     assume (forall i: int :: 0 <= i && i < n ==> status[i] == CREATED);
@@ -123,7 +123,7 @@ refines atomic_master;
     call master2();
 }
 
->-< action {:layer 3} atomic_master2()
+atomic action {:layer 3} atomic_master2()
 modifies status;
 {
     assert (forall i: int :: 0 <= i && i < n ==> status[i] == PROCESSED);

--- a/Test/civl/async/tds2.bpl
+++ b/Test/civl/async/tds2.bpl
@@ -13,7 +13,7 @@ var status:[int]int;
 const n: int;
 axiom 0 <= n;
 
-<- action {:layer 1} AtomicCreateTask({:linear "tid"} tid: int)
+left action {:layer 1} AtomicCreateTask({:linear "tid"} tid: int)
 modifies status;
 {
     assert status[tid] == DEFAULT;
@@ -22,7 +22,7 @@ modifies status;
 yield procedure {:layer 0} CreateTask({:linear "tid"} tid: int);
 refines AtomicCreateTask;
 
-<- action {:layer 1} AtomicProcessTask({:linear "tid"} tid: int)
+left action {:layer 1} AtomicProcessTask({:linear "tid"} tid: int)
 modifies status;
 {
     assert status[tid] == CREATED;
@@ -31,7 +31,7 @@ modifies status;
 yield procedure {:layer 0} ProcessTask({:linear "tid"} tid: int);
 refines AtomicProcessTask;
 
-<- action {:layer 1} AtomicFinishTask({:linear "tid"} tid: int)
+left action {:layer 1} AtomicFinishTask({:linear "tid"} tid: int)
 modifies status;
 {
     assert status[tid] == PROCESSED;
@@ -47,10 +47,10 @@ action {:layer 1} StatusSnapshot() returns (snapshot: [int]int)
 
 yield procedure {:layer 0} Alloc(i: int, {:linear_in "tid"} tidq: [int]bool) returns ({:linear "tid"} id: int, {:linear "tid"} tidq':[int]bool);
 refines AtomicAlloc;
-<-> action {:layer 1} AtomicAlloc(i: int, {:linear_in "tid"} tidq: [int]bool) returns ({:linear "tid"} id: int, {:linear "tid"} tidq':[int]bool)
+both action {:layer 1} AtomicAlloc(i: int, {:linear_in "tid"} tidq: [int]bool) returns ({:linear "tid"} id: int, {:linear "tid"} tidq':[int]bool)
 { assert tidq[i]; id := i; tidq' := tidq[i := false]; }
 
->-< action {:layer 2} AtomicMain({:linear_in "tid"} tids: [int]bool)
+atomic action {:layer 2} AtomicMain({:linear_in "tid"} tids: [int]bool)
 modifies status;
 {
     assert (forall i: int :: 0 <= i && i < n <==> tids[i]);
@@ -80,7 +80,7 @@ refines AtomicMain;
     }
 }
 
-yield <- procedure {:layer 1} StartClient({:linear_in "tid"} tid: int)
+yield left procedure {:layer 1} StartClient({:linear_in "tid"} tid: int)
 modifies status;
 requires {:layer 1} status[tid] == DEFAULT;
 ensures {:layer 1} status == old(status)[tid := FINISHED];
@@ -88,7 +88,7 @@ ensures {:layer 1} status == old(status)[tid := FINISHED];
     async call {:sync} GetTask(tid);
 }
 
-yield <- procedure {:layer 1} GetTask({:linear_in "tid"} tid: int)
+yield left procedure {:layer 1} GetTask({:linear_in "tid"} tid: int)
 modifies status;
 requires {:layer 1} status[tid] == DEFAULT;
 ensures {:layer 1} status == old(status)[tid := FINISHED];
@@ -97,7 +97,7 @@ ensures {:layer 1} status == old(status)[tid := FINISHED];
     async call {:sync} GetTaskCallback(tid);
 }
 
-yield <- procedure {:layer 1} GetTaskCallback({:linear_in "tid"} tid: int)
+yield left procedure {:layer 1} GetTaskCallback({:linear_in "tid"} tid: int)
 modifies status;
 requires {:layer 1} status[tid] == CREATED;
 ensures {:layer 1} status == old(status)[tid := FINISHED];
@@ -106,7 +106,7 @@ ensures {:layer 1} status == old(status)[tid := FINISHED];
     async call {:sync} CollectTask(tid);
 }
 
-yield <- procedure {:layer 1} CollectTask({:linear_in "tid"} tid: int)
+yield left procedure {:layer 1} CollectTask({:linear_in "tid"} tid: int)
 modifies status;
 requires {:layer 1} status[tid] == PROCESSED;
 ensures {:layer 1} status == old(status)[tid := FINISHED];

--- a/Test/civl/bluetooth.bpl
+++ b/Test/civl/bluetooth.bpl
@@ -56,7 +56,7 @@ requires {:layer 1, 2} l->val == Left(i) && r->val == Right(i);
     }
 }
 
->-< action {:layer 2} AtomicEnter#1(i: int, {:linear_in} l: Lval Perm, r: Lval Perm)
+atomic action {:layer 2} AtomicEnter#1(i: int, {:linear_in} l: Lval Perm, r: Lval Perm)
 modifies usersInDriver;
 {
     assume !stoppingFlag;
@@ -73,7 +73,7 @@ requires {:layer 1} l->val == Left(i) && r->val == Right(i);
     call AddToBarrier(i, l);
 }
 
-<- action {:layer 2} AtomicCheckAssert#1(i: int, r: Lval Perm)
+left action {:layer 2} AtomicCheckAssert#1(i: int, r: Lval Perm)
 {
     assert r->val == Right(i) && usersInDriver->dom[Left(i)];
     assert !stopped;
@@ -86,7 +86,7 @@ preserves call Inv1();
     call CheckAssert();
 }
 
-<- action {:layer 2} AtomicExit(i: int, {:linear_out} l: Lval Perm, r: Lval Perm)
+left action {:layer 2} AtomicExit(i: int, {:linear_out} l: Lval Perm, r: Lval Perm)
 modifies usersInDriver;
 {
     assert l->val == Left(i) && r->val == Right(i);
@@ -123,7 +123,7 @@ preserves call Inv1();
     call {:layer 1} SubsetSizeRelationLemma(MapConst(false), usersInDriver->dom);
 }
 
->-< action {:layer 2} AtomicWaitAndStop()
+atomic action {:layer 2} AtomicWaitAndStop()
 modifies stopped;
 {
     assume usersInDriver->dom == MapConst(false);
@@ -153,7 +153,7 @@ modifies usersInDriver;
 
 /// primitive actions
 
->-< action {:layer 1} AtomicEnter()
+atomic action {:layer 1} AtomicEnter()
 modifies pendingIo;
 {
     assume !stoppingFlag;
@@ -162,14 +162,14 @@ modifies pendingIo;
 yield procedure {:layer 0} Enter();
 refines AtomicEnter;
 
->-< action {:layer 1} AtomicCheckAssert()
+atomic action {:layer 1} AtomicCheckAssert()
 {
     assert !stopped;
 }
 yield procedure {:layer 0} CheckAssert();
 refines AtomicCheckAssert;
 
--> action {:layer 1,3} AtomicSetStoppingFlag(i: Lval int)
+right action {:layer 1,3} AtomicSetStoppingFlag(i: Lval int)
 modifies stoppingFlag;
 {
     // The first assertion ensures that there is at most one stopper.
@@ -181,7 +181,7 @@ modifies stoppingFlag;
 yield procedure {:layer 0} SetStoppingFlag(i: Lval int);
 refines AtomicSetStoppingFlag;
 
->-< action {:layer 1} AtomicDeleteReference()
+atomic action {:layer 1} AtomicDeleteReference()
 modifies pendingIo, stoppingEvent;
 {
     pendingIo := pendingIo - 1;
@@ -192,14 +192,14 @@ modifies pendingIo, stoppingEvent;
 yield procedure {:layer 0} DeleteReference();
 refines AtomicDeleteReference;
 
->-< action {:layer 1} AtomicWaitOnStoppingEvent()
+atomic action {:layer 1} AtomicWaitOnStoppingEvent()
 {
     assume stoppingEvent;
 }
 yield procedure {:layer 0} WaitOnStoppingEvent();
 refines AtomicWaitOnStoppingEvent;
 
-<- action {:layer 1} AtomicSetStopped()
+left action {:layer 1} AtomicSetStopped()
 modifies stopped;
 {
     stopped := true;

--- a/Test/civl/cav2020-1.bpl
+++ b/Test/civl/cav2020-1.bpl
@@ -38,7 +38,7 @@ requires call yield_y(0);
     assert {:layer 1} 0 <= x && 0 <= y;
 }
 
->-< action {:layer 1,1} atomic_incr_x()
+atomic action {:layer 1,1} atomic_incr_x()
 modifies x;
 {
     x := x + 1;
@@ -46,7 +46,7 @@ modifies x;
 yield procedure {:layer 0} _incr_x();
 refines atomic_incr_x;
 
->-< action {:layer 1,1} atomic_incr_y()
+atomic action {:layer 1,1} atomic_incr_y()
 modifies y;
 {
     y := y + 1;

--- a/Test/civl/cav2020-2.bpl
+++ b/Test/civl/cav2020-2.bpl
@@ -10,7 +10,7 @@ var {:layer 1, 2} l: Option Tid;
 yield invariant {:layer 1} LockInv();
 invariant b <==> (l != None());
 
->-< action {:layer 3,3} IncrSpec()
+atomic action {:layer 3,3} IncrSpec()
 modifies count;
 {
     count := count + 1;
@@ -27,7 +27,7 @@ preserves call LockInv();
     call Release(tid);
 }
 
--> action {:layer 2,2} AcquireSpec({:linear "tid"} tid: Tid)
+right action {:layer 2,2} AcquireSpec({:linear "tid"} tid: Tid)
 modifies l;
 {
     assume l == None();
@@ -47,7 +47,7 @@ preserves call LockInv();
     }
 }
 
-<- action {:layer 2,2} ReleaseSpec({:linear "tid"} tid: Tid)
+left action {:layer 2,2} ReleaseSpec({:linear "tid"} tid: Tid)
 modifies l;
 {
     assert l == Some(tid);
@@ -63,7 +63,7 @@ preserves call LockInv();
     call set_l(None());
 }
 
-<-> action {:layer 2,2} ReadSpec({:linear "tid"} tid: Tid) returns (v: int)
+both action {:layer 2,2} ReadSpec({:linear "tid"} tid: Tid) returns (v: int)
 {
     assert l == Some(tid);
     v := count;
@@ -74,7 +74,7 @@ refines ReadSpec;
     call v := READ();
 }
 
-<-> action {:layer 2,2} WriteSpec({:linear "tid"} tid: Tid, v: int)
+both action {:layer 2,2} WriteSpec({:linear "tid"} tid: Tid, v: int)
 modifies count;
 {
     assert l == Some(tid);
@@ -86,7 +86,7 @@ refines WriteSpec;
     call WRITE(v);
 }
 
->-< action {:layer 1,1} atomic_CAS(old_b: bool, new_b: bool) returns (success: bool)
+atomic action {:layer 1,1} atomic_CAS(old_b: bool, new_b: bool) returns (success: bool)
 modifies b;
 {
     success := b == old_b;
@@ -97,14 +97,14 @@ modifies b;
 yield procedure {:layer 0} CAS(old_b: bool, new_b: bool) returns (success: bool);
 refines atomic_CAS;
 
->-< action {:layer 1,1} atomic_READ() returns (v: int)
+atomic action {:layer 1,1} atomic_READ() returns (v: int)
 {
     v := count;
 }
 yield procedure {:layer 0} READ() returns (v: int);
 refines atomic_READ;
 
->-< action {:layer 1,1} atomic_WRITE(v: int)
+atomic action {:layer 1,1} atomic_WRITE(v: int)
 modifies count;
 {
     count := v;

--- a/Test/civl/cav2020-3.bpl
+++ b/Test/civl/cav2020-3.bpl
@@ -49,14 +49,14 @@ var {:layer 0,1} barrierOn: bool;
 var {:layer 0,1} barrierCounter: int;
 var {:layer 0,1} {:linear "perm"} mutatorsInBarrier: [int]bool;
 
->-< action {:layer 1} AtomicIsBarrierOn() returns (b: bool)
+atomic action {:layer 1} AtomicIsBarrierOn() returns (b: bool)
 {
     b := barrierOn;
 }
 yield procedure {:layer 0} IsBarrierOn() returns (b: bool);
 refines AtomicIsBarrierOn;
 
->-< action {:layer 1} AtomicEnterBarrier({:linear_in "perm"} i: int) returns ({:linear "perm"} p: Perm)
+atomic action {:layer 1} AtomicEnterBarrier({:linear_in "perm"} i: int) returns ({:linear "perm"} p: Perm)
 modifies barrierCounter, mutatorsInBarrier;
 {
     assert IsMutator(i);
@@ -67,7 +67,7 @@ modifies barrierCounter, mutatorsInBarrier;
 yield procedure {:layer 0} EnterBarrier({:linear_in "perm"} i: int) returns ({:linear "perm"} p: Perm);
 refines AtomicEnterBarrier;
 
->-< action {:layer 1} AtomicWaitForBarrierRelease({:linear_in "perm"} p: Perm, {:linear_out "perm"} i: int)
+atomic action {:layer 1} AtomicWaitForBarrierRelease({:linear_in "perm"} p: Perm, {:linear_out "perm"} i: int)
 modifies barrierCounter, mutatorsInBarrier;
 {
     assert p == Right(i) && mutatorsInBarrier[i];
@@ -78,7 +78,7 @@ modifies barrierCounter, mutatorsInBarrier;
 yield procedure {:layer 0} WaitForBarrierRelease({:linear_in "perm"} p: Perm, {:linear_out "perm"} i: int);
 refines AtomicWaitForBarrierRelease;
 
->-< action {:layer 1} AtomicSetBarrier(b: bool)
+atomic action {:layer 1} AtomicSetBarrier(b: bool)
 modifies barrierOn;
 {
     barrierOn := b;
@@ -86,7 +86,7 @@ modifies barrierOn;
 yield procedure {:layer 0} SetBarrier(b: bool);
 refines AtomicSetBarrier;
 
->-< action {:layer 1} AtomicWaitBarrier()
+atomic action {:layer 1} AtomicWaitBarrier()
 {
     assume barrierCounter == 0;
 }

--- a/Test/civl/cav2020-talk.bpl
+++ b/Test/civl/cav2020-talk.bpl
@@ -37,7 +37,7 @@ requires call yield_y(0);
     assert {:layer 1} x >= 2 && y >= 2;
 }
 
->-< action {:layer 1,1} atomic_inc_x()
+atomic action {:layer 1,1} atomic_inc_x()
 modifies x;
 {
     x := x + 1;
@@ -45,7 +45,7 @@ modifies x;
 yield procedure {:layer 0} inc_x();
 refines atomic_inc_x;
 
->-< action {:layer 1,1} atomic_inc_y()
+atomic action {:layer 1,1} atomic_inc_y()
 modifies y;
 {
     y := y + 1;

--- a/Test/civl/chris.bpl
+++ b/Test/civl/chris.bpl
@@ -6,7 +6,7 @@ yield procedure {:layer 2} Havoc()
 {
 }
 
->-< action {:layer 2,3} AtomicRecover()
+atomic action {:layer 2,3} AtomicRecover()
 { assert x == 5; }
 
 yield procedure {:layer 1} Recover()

--- a/Test/civl/chris2.bpl
+++ b/Test/civl/chris2.bpl
@@ -2,14 +2,14 @@
 // RUN: %diff "%s.expect" "%t"
 var{:layer 20,40} x:int;
 
-<-> action {:layer 21,25} atomic_p_gt1_lower()
+both action {:layer 21,25} atomic_p_gt1_lower()
 modifies x;
 { x := x + 1; }
 
 yield procedure {:layer 20} p_gt1_lower();
 refines atomic_p_gt1_lower;
 
-<-> action {:layer 26,40} atomic_p_gt1()
+both action {:layer 26,40} atomic_p_gt1()
 modifies x;
 { x := x + 1; }
 
@@ -19,7 +19,7 @@ refines atomic_p_gt1;
   call p_gt1_lower();
 }
 
-<-> action {:layer 21,40} atomic_p_gt2()
+both action {:layer 21,40} atomic_p_gt2()
 { assert x == 0; }
 
 yield procedure {:layer 20} p_gt2();

--- a/Test/civl/chris2.bpl.expect
+++ b/Test/civl/chris2.bpl.expect
@@ -1,22 +1,22 @@
 chris2.bpl(23,3): Error: Gate of atomic_p_gt2 not preserved by atomic_p_gt1_lower
 Execution trace:
-    chris2.bpl(5,27): inline$atomic_p_gt1_lower$0$Entry
+    chris2.bpl(5,28): inline$atomic_p_gt1_lower$0$Entry
     chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
-    chris2.bpl(5,27): inline$atomic_p_gt1_lower$0$Return
+    chris2.bpl(5,28): inline$atomic_p_gt1_lower$0$Return
 chris2.bpl(23,3): Error: Gate of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
-    chris2.bpl(12,27): inline$atomic_p_gt1$0$Entry
+    chris2.bpl(12,28): inline$atomic_p_gt1$0$Entry
     chris2.bpl(14,5): inline$atomic_p_gt1$0$anon0
-    chris2.bpl(12,27): inline$atomic_p_gt1$0$Return
-chris2.bpl(22,27): Error: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
+    chris2.bpl(12,28): inline$atomic_p_gt1$0$Return
+chris2.bpl(22,28): Error: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1_lower
 Execution trace:
-    chris2.bpl(5,27): inline$atomic_p_gt1_lower$0$Entry
+    chris2.bpl(5,28): inline$atomic_p_gt1_lower$0$Entry
     chris2.bpl(7,5): inline$atomic_p_gt1_lower$0$anon0
-    chris2.bpl(5,27): inline$atomic_p_gt1_lower$0$Return
-chris2.bpl(22,27): Error: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1
+    chris2.bpl(5,28): inline$atomic_p_gt1_lower$0$Return
+chris2.bpl(22,28): Error: Gate failure of atomic_p_gt2 not preserved by atomic_p_gt1
 Execution trace:
-    chris2.bpl(12,27): inline$atomic_p_gt1$0$Entry
+    chris2.bpl(12,28): inline$atomic_p_gt1$0$Entry
     chris2.bpl(14,5): inline$atomic_p_gt1$0$anon0
-    chris2.bpl(12,27): inline$atomic_p_gt1$0$Return
+    chris2.bpl(12,28): inline$atomic_p_gt1$0$Return
 
 Boogie program verifier finished with 1 verified, 4 errors

--- a/Test/civl/chris3.bpl
+++ b/Test/civl/chris3.bpl
@@ -1,7 +1,7 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
->-< action {:layer 95} skip() { }
+atomic action {:layer 95} skip() { }
 
 yield procedure {:layer 94} H()
 refines skip;

--- a/Test/civl/chris6.bpl
+++ b/Test/civl/chris6.bpl
@@ -1,6 +1,6 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
->-< action {:layer 2} atomic_P1() { }
+atomic action {:layer 2} atomic_P1() { }
 
 yield procedure {:layer 1} P1()
 refines atomic_P1;

--- a/Test/civl/civl-paper.bpl
+++ b/Test/civl/civl-paper.bpl
@@ -43,7 +43,7 @@ preserves call InvMem();
     call ReleaseProtected(tid);
 }
 
-<-> action {:layer 3} AtomicTransferToGlobalProtected({:linear "tid"} tid: X, {:linear_in "mem"} l: lmap)
+both action {:layer 3} AtomicTransferToGlobalProtected({:linear "tid"} tid: X, {:linear_in "mem"} l: lmap)
 modifies g;
 { assert tid != nil && lock == tid; g := l; }
 
@@ -55,7 +55,7 @@ preserves call InvLock();
   call TransferToGlobal(tid, l);
 }
 
-<-> action {:layer 3} AtomicTransferFromGlobalProtected({:linear "tid"} tid: X) returns ({:linear "mem"} l: lmap)
+both action {:layer 3} AtomicTransferFromGlobalProtected({:linear "tid"} tid: X) returns ({:linear "mem"} l: lmap)
 modifies g;
 { assert tid != nil && lock == tid; l := g; g := emptyDom(g); }
 
@@ -67,7 +67,7 @@ preserves call InvLock();
   call l := TransferFromGlobal(tid);
 }
 
--> action {:layer 3} AtomicAcquireProtected({:linear "tid"} tid: X)
+right action {:layer 3} AtomicAcquireProtected({:linear "tid"} tid: X)
 modifies lock;
 { assert tid != nil; assume lock == nil; lock := tid; }
 
@@ -79,7 +79,7 @@ preserves call InvLock();
   call Acquire(tid);
 }
 
-<- action {:layer 3} AtomicReleaseProtected({:linear "tid"} tid: X)
+left action {:layer 3} AtomicReleaseProtected({:linear "tid"} tid: X)
 modifies lock;
 { assert tid != nil && lock == tid; lock := nil; }
 
@@ -90,7 +90,7 @@ preserves call InvLock();
   call Release(tid);
 }
 
->-< action {:layer 2} AtomicAcquire({:linear "tid"} tid: X)
+atomic action {:layer 2} AtomicAcquire({:linear "tid"} tid: X)
 modifies lock;
 { assume lock == nil; lock := tid; }
 
@@ -113,7 +113,7 @@ preserves call InvLock();
     }
 }
 
->-< action {:layer 2} AtomicRelease({:linear "tid"} tid: X)
+atomic action {:layer 2} AtomicRelease({:linear "tid"} tid: X)
 modifies lock;
 { lock := nil; }
 
@@ -124,33 +124,33 @@ preserves call InvLock();
     call CLEAR(tid, false);
 }
 
->-< action {:layer 1,2} AtomicTransferToGlobal({:linear "tid"} tid: X, {:linear_in "mem"} l: lmap)
+atomic action {:layer 1,2} AtomicTransferToGlobal({:linear "tid"} tid: X, {:linear_in "mem"} l: lmap)
 modifies g;
 { g := l; }
 
 yield procedure {:layer 0} TransferToGlobal({:linear "tid"} tid: X, {:linear_in "mem"} l: lmap);
 refines AtomicTransferToGlobal;
 
->-< action {:layer 1,2} AtomicTransferFromGlobal({:linear "tid"} tid: X) returns ({:linear "mem"} l: lmap)
+atomic action {:layer 1,2} AtomicTransferFromGlobal({:linear "tid"} tid: X) returns ({:linear "mem"} l: lmap)
 modifies g;
 { l := g; g := emptyDom(g); }
 
 yield procedure {:layer 0} TransferFromGlobal({:linear "tid"} tid: X) returns ({:linear "mem"} l: lmap);
 refines AtomicTransferFromGlobal;
 
-<-> action {:layer 1,3} AtomicLoad({:linear "mem"} l: lmap, a: int) returns (v: int)
+both action {:layer 1,3} AtomicLoad({:linear "mem"} l: lmap, a: int) returns (v: int)
 { v := map(l)[a]; }
 
 yield procedure {:layer 0} Load({:linear "mem"} l: lmap, a: int) returns (v: int);
 refines AtomicLoad;
 
-<-> action {:layer 1,3} AtomicStore({:linear_in "mem"} l_in: lmap, a: int, v: int) returns ({:linear "mem"} l_out: lmap)
+both action {:layer 1,3} AtomicStore({:linear_in "mem"} l_in: lmap, a: int, v: int) returns ({:linear "mem"} l_out: lmap)
 { l_out := cons(dom(l_in), map(l_in)[a := v]); }
 
 yield procedure {:layer 0} Store({:linear_in "mem"} l_in: lmap, a: int, v: int) returns ({:linear "mem"} l_out: lmap);
 refines AtomicStore;
 
->-< action {:layer 1} AtomicCAS(tid: X, prev: bool, next: bool) returns (status: bool)
+atomic action {:layer 1} AtomicCAS(tid: X, prev: bool, next: bool) returns (status: bool)
 modifies b, lock;
 {
   if (*) {
@@ -163,7 +163,7 @@ modifies b, lock;
 yield procedure {:layer 0} CAS(tid: X, prev: bool, next: bool) returns (status: bool);
 refines AtomicCAS;
 
->-< action {:layer 1} AtomicCLEAR(tid: X, next: bool)
+atomic action {:layer 1} AtomicCLEAR(tid: X, next: bool)
 modifies b, lock;
 { b := next; lock := nil; }
 

--- a/Test/civl/cyclic-concur.bpl
+++ b/Test/civl/cyclic-concur.bpl
@@ -2,7 +2,7 @@
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,2} x : int;
 
->-< action {:layer 2} MAIN ()
+atomic action {:layer 2} MAIN ()
 modifies x;
 {
   havoc x;
@@ -16,7 +16,7 @@ refines MAIN;
   async call {:sync} a();
 }
 
-yield <- procedure {:layer 1} a ()
+yield left procedure {:layer 1} a ()
 modifies x;
 ensures {:layer 1} x > old(x) && (x - old(x)) mod 6 == 0;
 {
@@ -24,7 +24,7 @@ ensures {:layer 1} x > old(x) && (x - old(x)) mod 6 == 0;
   async call {:sync} b();
 }
 
-yield <- procedure {:layer 1} b ()
+yield left procedure {:layer 1} b ()
 modifies x;
 ensures {:layer 1} x > old(x) && (x - old(x)) mod 6 == 5;
 {
@@ -32,7 +32,7 @@ ensures {:layer 1} x > old(x) && (x - old(x)) mod 6 == 5;
   async call {:sync} c();
 }
 
-yield <- procedure {:layer 1} c ()
+yield left procedure {:layer 1} c ()
 modifies x;
 ensures {:layer 1} x > old(x) && (x - old(x)) mod 6 == 3;
 {
@@ -45,7 +45,7 @@ ensures {:layer 1} x > old(x) && (x - old(x)) mod 6 == 3;
 // ###########################################################################
 // Low level atomic actions
 
-<- action {:layer 1} ADD (n:int)
+left action {:layer 1} ADD (n:int)
 modifies x;
 { x := x + n; }
 

--- a/Test/civl/freund.bpl
+++ b/Test/civl/freund.bpl
@@ -3,7 +3,7 @@
 
 var {:layer 0, 2} count: int;
 
->-< action {:layer 2} AtomicInc()
+atomic action {:layer 2} AtomicInc()
 modifies count;
 {
     count := count + 1;
@@ -26,7 +26,7 @@ refines AtomicInc;
     }
 }
 
->-< action {:layer 1} AtomicCAS(prev: int, next: int) returns (status: bool)
+atomic action {:layer 1} AtomicCAS(prev: int, next: int) returns (status: bool)
 modifies count;
 {
     if (count == prev) {
@@ -39,7 +39,7 @@ modifies count;
 yield procedure {:layer 0} CAS(prev: int, next: int) returns (status: bool);
 refines AtomicCAS;
 
->-< action {:layer 1} AtomicRead() returns (val: int)
+atomic action {:layer 1} AtomicRead() returns (val: int)
 {
     val := count;
 }

--- a/Test/civl/funky.bpl
+++ b/Test/civl/funky.bpl
@@ -8,75 +8,75 @@ var {:layer 0,3} B: X;
 var {:layer 0,3} counter: int;
 var {:layer 0,3}{:linear "tid"} unallocated:[X]bool;
 
--> action {:layer 1,3} AtomicLockA({:linear "tid"} tid: X)
+right action {:layer 1,3} AtomicLockA({:linear "tid"} tid: X)
 modifies A;
 { assert tid != nil; assume A == nil; A := tid; }
 
 yield procedure {:layer 0} LockA({:linear "tid"} tid: X);
 refines AtomicLockA;
 
--> action {:layer 1} AtomicIncrA({:linear "tid"} tid: X)
+right action {:layer 1} AtomicIncrA({:linear "tid"} tid: X)
 modifies counter;
 { assert tid != nil && A == tid; counter := counter + 1; }
 
 yield procedure {:layer 0} IncrA({:linear "tid"} tid: X);
 refines AtomicIncrA;
 
--> action {:layer 1} AtomicDecrA({:linear "tid"} tid: X)
+right action {:layer 1} AtomicDecrA({:linear "tid"} tid: X)
 modifies counter;
 { assert tid != nil && A == tid; counter := counter - 1; }
 
 yield procedure {:layer 0} DecrA({:linear "tid"} tid: X);
 refines AtomicDecrA;
 
-<- action {:layer 1,3} AtomicUnlockA({:linear "tid"} tid: X)
+left action {:layer 1,3} AtomicUnlockA({:linear "tid"} tid: X)
 modifies A;
 { assert tid != nil && A == tid; A := nil; }
 
 yield procedure {:layer 0} UnlockA({:linear "tid"} tid: X);
 refines AtomicUnlockA;
 
--> action {:layer 1,3} AtomicLockB({:linear "tid"} tid: X)
+right action {:layer 1,3} AtomicLockB({:linear "tid"} tid: X)
 modifies B;
 { assert tid != nil; assume B == nil; B := tid; }
 
 yield procedure {:layer 0} LockB({:linear "tid"} tid: X);
 refines AtomicLockB;
 
->-< action {:layer 1,2} AtomicIncrB({:linear "tid"} tid: X)
+atomic action {:layer 1,2} AtomicIncrB({:linear "tid"} tid: X)
 modifies counter;
 { assert tid != nil && B == tid; counter := counter + 1; }
 
 yield procedure {:layer 0} IncrB({:linear "tid"} tid: X);
 refines AtomicIncrB;
 
->-< action {:layer 1} AtomicDecrB({:linear "tid"} tid: X)
+atomic action {:layer 1} AtomicDecrB({:linear "tid"} tid: X)
 modifies counter;
 { assert tid != nil && B == tid; counter := counter - 1; }
 
 yield procedure {:layer 0} DecrB({:linear "tid"} tid: X);
 refines AtomicDecrB;
 
-<- action {:layer 1,3} AtomicUnlockB({:linear "tid"} tid: X)
+left action {:layer 1,3} AtomicUnlockB({:linear "tid"} tid: X)
 modifies B;
 { assert tid != nil && B == tid; B := nil; }
 
 yield procedure {:layer 0} UnlockB({:linear "tid"} tid: X);
 refines AtomicUnlockB;
 
->-< action {:layer 1,3} AtomicAssertA({:linear "tid"} tid: X)
+atomic action {:layer 1,3} AtomicAssertA({:linear "tid"} tid: X)
 { assert tid != nil && A == tid; assert counter >= -1; }
 
 yield procedure {:layer 0} AssertA({:linear "tid"} tid: X);
 refines AtomicAssertA;
 
->-< action {:layer 1,3} AtomicAssertB({:linear "tid"} tid: X)
+atomic action {:layer 1,3} AtomicAssertB({:linear "tid"} tid: X)
 { assert tid != nil && A == tid && B == tid; assert counter == 0; }
 
 yield procedure {:layer 0} AssertB({:linear "tid"} tid: X);
 refines AtomicAssertB;
 
--> action {:layer 1,3} AtomicAllocTid() returns ({:linear "tid"} tid: X)
+right action {:layer 1,3} AtomicAllocTid() returns ({:linear "tid"} tid: X)
 modifies unallocated;
 {
   assume tid != nil;
@@ -87,7 +87,7 @@ modifies unallocated;
 yield procedure {:layer 0} AllocTid() returns ({:linear "tid"} tid: X);
 refines AtomicAllocTid;
 
--> action {:layer 2} AtomicAbsDecrB({:linear "tid"} tid: X)
+right action {:layer 2} AtomicAbsDecrB({:linear "tid"} tid: X)
 modifies counter;
 { assert tid != nil && B == tid && counter == 0; counter := counter - 1; }
 
@@ -97,7 +97,7 @@ refines AtomicAbsDecrB;
     call DecrB(tid);
 }
 
-<-> action {:layer 3} AtomicAbsAssertA({:linear "tid"} tid: X)
+both action {:layer 3} AtomicAbsAssertA({:linear "tid"} tid: X)
 { assert tid != nil && A == tid; assert counter >= -1; }
 
 yield procedure {:layer 2} AbsAssertA({:linear "tid"} tid: X)
@@ -106,7 +106,7 @@ refines AtomicAbsAssertA;
     call AssertA(tid);
 }
 
-<-> action {:layer 3} AtomicAbsAssertB({:linear "tid"} tid: X)
+both action {:layer 3} AtomicAbsAssertB({:linear "tid"} tid: X)
 { assert tid != nil && A == tid && B == tid; assert counter == 0; }
 
 yield procedure {:layer 2} AbsAssertB({:linear "tid"} tid: X)
@@ -124,7 +124,7 @@ requires {:layer 1} tid != nil;
     call UnlockA(tid);
 }
 
-<-> action {:layer 3} AtomicTB({:linear "tid"} tid: X)
+both action {:layer 3} AtomicTB({:linear "tid"} tid: X)
 { assert tid != nil && counter == 0; }
 
 yield procedure {:layer 2} TB({:linear "tid"} tid: X)

--- a/Test/civl/ghost.bpl
+++ b/Test/civl/ghost.bpl
@@ -2,7 +2,7 @@
 // RUN: %diff "%s.expect" "%t"
 var {:layer 0,2} x: int;
 
--> action {:layer 1} AtomicIncr()
+right action {:layer 1} AtomicIncr()
 modifies x;
 { x := x + 1; }
 
@@ -14,7 +14,7 @@ action {:layer 1} ghost(y: int) returns (z: int)
   z := y + 1;
 }
 
--> action {:layer 2} AtomicIncr2()
+right action {:layer 2} AtomicIncr2()
 modifies x;
 { x := x + 2; }
 

--- a/Test/civl/hide-params-pa-2.bpl
+++ b/Test/civl/hide-params-pa-2.bpl
@@ -1,7 +1,7 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
->-< action {:layer 1,2} SPEC ()
+atomic action {:layer 1,2} SPEC ()
 creates A;
 {
   call create_async(A(1));
@@ -19,7 +19,7 @@ refines SPEC;
   async call a(true, 1, 2.3); // This call is still to procedure a when it is turned into a pending async.
 }
 
-async >-< action {:layer 1,2} A (i:int) { }
+async atomic action {:layer 1,2} A (i:int) { }
 
 yield procedure {:layer 0} a ({:hide} b:bool, i:int, {:hide} r:real);
 refines A;

--- a/Test/civl/hide-params-pa.bpl
+++ b/Test/civl/hide-params-pa.bpl
@@ -1,7 +1,7 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-async >-< action {:layer 2} SKIP () returns () { }
+async atomic action {:layer 2} SKIP () returns () { }
 
 yield procedure {:layer 1} b ()
 refines SKIP;
@@ -19,7 +19,7 @@ refines SKIP;
   // call i', returnedPAs := A(i);
 }
 
->-< action {:layer 1} A (i:int) returns (i':int)
+atomic action {:layer 1} A (i:int) returns (i':int)
 {
   assert i > 0;
   assume i' > i;

--- a/Test/civl/hide-params.bpl
+++ b/Test/civl/hide-params.bpl
@@ -6,7 +6,7 @@ yield procedure {:layer 1} b ()
   call a(1);
 }
 
->-< action {:layer 1} A () { }
+atomic action {:layer 1} A () { }
 
 yield procedure {:layer 0} a ({:hide} i:int);
 refines A;

--- a/Test/civl/inc-dec.bpl
+++ b/Test/civl/inc-dec.bpl
@@ -16,7 +16,7 @@ requires {:layer 1} N >= 0;
   async call {:sync} dec_by_N(N);
 }
 
-yield <- procedure {:layer 1} inc_by_N (N: int)
+yield left procedure {:layer 1} inc_by_N (N: int)
 modifies x;
 requires {:layer 1} N >= 0;
 ensures {:layer 1} x == old(x) + N;
@@ -32,7 +32,7 @@ ensures {:layer 1} x == old(x) + N;
   }
 }
 
-yield <- procedure {:layer 1} dec_by_N (N: int)
+yield left procedure {:layer 1} dec_by_N (N: int)
 modifies x;
 requires {:layer 1} N >= 0;
 ensures {:layer 1} x == old(x) - N;
@@ -51,11 +51,11 @@ ensures {:layer 1} x == old(x) - N;
 // ###########################################################################
 // Low level atomic actions
 
-<-> action {:layer 1} atomic_inc ()
+both action {:layer 1} atomic_inc ()
 modifies x;
 { x := x + 1; }
 
-<-> action {:layer 1} atomic_dec ()
+both action {:layer 1} atomic_dec ()
 modifies x;
 { x := x - 1; }
 

--- a/Test/civl/inductive-sequentialization/Gauss.bpl
+++ b/Test/civl/inductive-sequentialization/Gauss.bpl
@@ -5,7 +5,7 @@ var {:layer 0,2} x:int;
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 1} SUM (n: int)
+atomic action {:layer 1} SUM (n: int)
 refines MAIN' using INV;
 creates ADD;
 modifies x;
@@ -16,7 +16,7 @@ modifies x;
   call create_asyncs((lambda pa: ADD :: 1 <= pa->i && pa->i <= n));
 }
 
->-< action {:layer 2} MAIN' (n: int)
+atomic action {:layer 2} MAIN' (n: int)
 modifies x;
 {
   assert n >= 0;
@@ -42,7 +42,7 @@ modifies x;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-async <- action {:layer 1} ADD (i: int)
+async left action {:layer 1} ADD (i: int)
 modifies x;
 {
   x := x + i;

--- a/Test/civl/inductive-sequentialization/NoChoice.bpl
+++ b/Test/civl/inductive-sequentialization/NoChoice.bpl
@@ -5,7 +5,7 @@ var {:layer 0,2} x:int;
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 1} MAIN ()
+atomic action {:layer 1} MAIN ()
 refines MAIN';
 creates INC, DEC;
 {
@@ -13,19 +13,19 @@ creates INC, DEC;
   call create_async(DEC());
 }
 
->-< action {:layer 2} MAIN' ()
+atomic action {:layer 2} MAIN' ()
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-async <- action {:layer 1} INC ()
+async left action {:layer 1} INC ()
 modifies x;
 {
   x := x + 1;
 }
 
-async <- action {:layer 1} DEC ()
+async left action {:layer 1} DEC ()
 modifies x;
 {
   x := x - 1;

--- a/Test/civl/inductive-sequentialization/PingPong.bpl
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl
@@ -32,7 +32,7 @@ function {:inline} EmptyChannel () : [int]int
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 3}
+atomic action {:layer 3}
 MAIN' ({:linear_in "cid"} cid: ChannelId)
 {
   assert channel[cid] == ChannelPair(EmptyChannel(), EmptyChannel());
@@ -89,7 +89,7 @@ modifies channel;
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 2}
+atomic action {:layer 2}
 MAIN ({:linear_in "cid"} cid: ChannelId)
 refines MAIN' using INV;
 creates PING, PONG;
@@ -102,7 +102,7 @@ modifies channel;
   call create_async(PONG(1, Right(cid)));
 }
 
-async >-< action {:layer 2} PING (x: int, {:linear_in "cid"} p: ChannelHandle)
+async atomic action {:layer 2} PING (x: int, {:linear_in "cid"} p: ChannelHandle)
 creates PING;
 modifies channel;
 {
@@ -131,7 +131,7 @@ modifies channel;
   channel[p->cid] := ChannelPair(left_channel, right_channel);
 }
 
-async >-< action {:layer 2} PONG (y: int, {:linear_in "cid"} p: ChannelHandle)
+async atomic action {:layer 2} PONG (y: int, {:linear_in "cid"} p: ChannelHandle)
 creates PONG;
 modifies channel;
 {
@@ -212,7 +212,7 @@ refines PONG;
 ////////////////////////////////////////////////////////////////////////////////
 // Bidirectional channels
 
--> action {:layer 1} RECEIVE (p: ChannelHandle) returns (m: int)
+right action {:layer 1} RECEIVE (p: ChannelHandle) returns (m: int)
 modifies channel;
 {
   var left_channel: [int]int;
@@ -230,7 +230,7 @@ modifies channel;
   channel[p->cid] := ChannelPair(left_channel, right_channel);
 }
 
-<- action {:layer 1} SEND (p: ChannelHandle, m: int)
+left action {:layer 1} SEND (p: ChannelHandle, m: int)
 modifies channel;
 {
   var left_channel: [int]int;
@@ -246,7 +246,7 @@ modifies channel;
   channel[p->cid] := ChannelPair(left_channel, right_channel);
 }
 
-<-> action {:layer 1} SPLIT({:linear_in "cid"} cid: ChannelId)
+both action {:layer 1} SPLIT({:linear_in "cid"} cid: ChannelId)
   returns ({:linear "cid"} left: ChannelHandle, {:linear "cid"} right: ChannelHandle)
 {
   left := Left(cid);

--- a/Test/civl/inductive-sequentialization/ProducerConsumer.bpl
+++ b/Test/civl/inductive-sequentialization/ProducerConsumer.bpl
@@ -19,7 +19,7 @@ var {:layer 0,3} channels: [ChannelId]Channel;
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 2} MAIN ({:linear_in "cid"} cid: ChannelId)
+atomic action {:layer 2} MAIN ({:linear_in "cid"} cid: ChannelId)
 refines MAIN' using INV;
 creates PRODUCER, CONSUMER;
 eliminates CONSUMER using CONSUMER';
@@ -29,7 +29,7 @@ eliminates CONSUMER using CONSUMER';
   call create_async(CONSUMER(1, Receive(cid)));
 }
 
->-< action {:layer 3} MAIN' ({:linear_in "cid"} cid: ChannelId)
+atomic action {:layer 3} MAIN' ({:linear_in "cid"} cid: ChannelId)
 modifies channels;
 {
   var channel: Channel;
@@ -77,7 +77,7 @@ modifies channels;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-async <- action {:layer 2} PRODUCER (x: int, {:linear_in "cid"} send_handle: ChannelHandle)
+async left action {:layer 2} PRODUCER (x: int, {:linear_in "cid"} send_handle: ChannelHandle)
 creates PRODUCER;
 modifies channels;
 {
@@ -105,7 +105,7 @@ modifies channels;
   assume {:add_to_pool "INV2", channels[send_handle->cid]} true;
 }
 
-async >-< action {:layer 2} CONSUMER (x: int, {:linear_in "cid"} receive_handle: ChannelHandle)
+async atomic action {:layer 2} CONSUMER (x: int, {:linear_in "cid"} receive_handle: ChannelHandle)
 creates CONSUMER;
 modifies channels;
 {
@@ -192,7 +192,7 @@ refines CONSUMER;
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 1} SEND (m: int, {:linear "cid"} send_handle: ChannelHandle)
+atomic action {:layer 1} SEND (m: int, {:linear "cid"} send_handle: ChannelHandle)
 modifies channels;
 {
   var channel: Channel;
@@ -209,7 +209,7 @@ modifies channels;
   channels[send_handle->cid] := Channel(C, head, tail);
 }
 
->-< action {:layer 1} RECEIVE ({:linear "cid"} receive_handle: ChannelHandle) returns (m:int)
+atomic action {:layer 1} RECEIVE ({:linear "cid"} receive_handle: ChannelHandle) returns (m:int)
 modifies channels;
 {
   var channel: Channel;
@@ -227,7 +227,7 @@ modifies channels;
   channels[receive_handle->cid] := Channel(C, head, tail);
 }
 
-<-> action {:layer 1} SPLIT({:linear_in "cid"} cid: ChannelId)
+both action {:layer 1} SPLIT({:linear_in "cid"} cid: ChannelId)
   returns ({:linear "cid"} send_handle: ChannelHandle, {:linear "cid"} receive_handle: ChannelHandle)
 {
   send_handle := Send(cid);

--- a/Test/civl/inductive-sequentialization/paxos/PaxosActions.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosActions.bpl
@@ -1,4 +1,4 @@
-async >-< action {:layer 2} A_StartRound(r: Round, {:linear_in "perm"} r_lin: Round)
+async atomic action {:layer 2} A_StartRound(r: Round, {:linear_in "perm"} r_lin: Round)
 creates A_Join, A_Propose;
 {
   assert r == r_lin;
@@ -14,7 +14,7 @@ creates A_Join, A_Propose;
   call create_async(A_Propose(r, ProposePermissions(r)));
 }
 
-async >-< action {:layer 2} A_Propose(r: Round, {:linear_in "perm"} ps: [Permission]bool)
+async atomic action {:layer 2} A_Propose(r: Round, {:linear_in "perm"} ps: [Permission]bool)
 creates A_Vote, A_Conclude;
 modifies voteInfo;
 {
@@ -46,7 +46,7 @@ modifies voteInfo;
   }
 }
 
-async >-< action {:layer 2} A_Conclude(r: Round, v: Value, {:linear_in "perm"} p: Permission)
+async atomic action {:layer 2} A_Conclude(r: Round, v: Value, {:linear_in "perm"} p: Permission)
 modifies decision;
 {
   var {:pool "NodeSet"} q: NodeSet;
@@ -64,7 +64,7 @@ modifies decision;
   }
 }
 
-async >-< action {:layer 2} A_Join(r: Round, n: Node, {:linear_in "perm"} p: Permission)
+async atomic action {:layer 2} A_Join(r: Round, n: Node, {:linear_in "perm"} p: Permission)
 modifies joinedNodes;
 {
   assert Round(r);
@@ -81,7 +81,7 @@ modifies joinedNodes;
   }
 }
 
-async >-< action {:layer 2} A_Vote(r: Round, n: Node, v: Value, {:linear_in "perm"} p: Permission)
+async atomic action {:layer 2} A_Vote(r: Round, n: Node, v: Value, {:linear_in "perm"} p: Permission)
 modifies joinedNodes, voteInfo;
 {
   assert Round(r);

--- a/Test/civl/inductive-sequentialization/paxos/PaxosImpl.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosImpl.bpl
@@ -117,7 +117,7 @@ requires call YieldInvChannels();
   async call Propose(r, ps');
 }
 
-yield -> procedure {:layer 1} ProposeHelper(r: Round) returns (maxRound: Round, maxValue: Value, {:layer 1} ns: NodeSet)
+yield right procedure {:layer 1} ProposeHelper(r: Round) returns (maxRound: Round, maxValue: Value, {:layer 1} ns: NodeSet)
 modifies permJoinChannel, joinChannel;
 requires {:layer 1} Round(r);
 requires {:layer 1} Inv(joinedNodes, voteInfo, acceptorState, permJoinChannel, permVoteChannel);
@@ -303,13 +303,13 @@ ensures MaxRound(r, MapOr(ns1, ns2), voteInfo) ==
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 1} A_SetDecision(round: Round, value: Value)
+atomic action {:layer 1} A_SetDecision(round: Round, value: Value)
 modifies decision;
 {
   decision[round] := Some(value);
 }
 
->-< action {:layer 1} A_JoinUpdate(r: Round, n: Node)
+atomic action {:layer 1} A_JoinUpdate(r: Round, n: Node)
 returns (join:bool, lastVoteRound: Round, lastVoteValue: Value)
 modifies acceptorState;
 {
@@ -325,7 +325,7 @@ modifies acceptorState;
   }
 }
 
->-< action {:layer 1} A_VoteUpdate(r: Round, n: Node, v: Value)
+atomic action {:layer 1} A_VoteUpdate(r: Round, n: Node, v: Value)
 returns (vote:bool)
 modifies acceptorState;
 {
@@ -350,13 +350,13 @@ refines A_VoteUpdate;
 
 //// Channel send/receive actions
 
-<- action {:layer 1} A_SendJoinResponse(round: Round, from: Node, lastVoteRound: Round, lastVoteValue: Value)
+left action {:layer 1} A_SendJoinResponse(round: Round, from: Node, lastVoteRound: Round, lastVoteValue: Value)
 modifies joinChannel;
 {
   joinChannel[round][JoinResponse(from, lastVoteRound, lastVoteValue)] := joinChannel[round][JoinResponse(from, lastVoteRound, lastVoteValue)] + 1;
 }
 
--> action {:layer 1} A_ReceiveJoinResponse(round: Round)
+right action {:layer 1} A_ReceiveJoinResponse(round: Round)
 returns (joinResponse: JoinResponse)
 modifies joinChannel;
 {
@@ -364,13 +364,13 @@ modifies joinChannel;
   joinChannel[round][joinResponse] := joinChannel[round][joinResponse] - 1;
 }
 
-<- action {:layer 1} A_SendVoteResponse(round: Round, from: Node)
+left action {:layer 1} A_SendVoteResponse(round: Round, from: Node)
 modifies voteChannel;
 {
   voteChannel[round][VoteResponse(from)] := voteChannel[round][VoteResponse(from)] + 1;
 }
 
--> action {:layer 1} A_ReceiveVoteResponse(round: Round)
+right action {:layer 1} A_ReceiveVoteResponse(round: Round)
 returns (voteResponse: VoteResponse)
 modifies voteChannel;
 {

--- a/Test/civl/inductive-sequentialization/paxos/PaxosSeq.bpl
+++ b/Test/civl/inductive-sequentialization/paxos/PaxosSeq.bpl
@@ -1,4 +1,4 @@
->-< action {:layer 2} A_Paxos({:linear_in "perm"} rs: [Round]bool)
+atomic action {:layer 2} A_Paxos({:linear_in "perm"} rs: [Round]bool)
 refines A_Paxos' using INV;
 creates A_StartRound;
 {
@@ -12,7 +12,7 @@ creates A_StartRound;
   call create_asyncs((lambda pa: A_StartRound :: pa->r == pa->r_lin && Round(pa->r) && pa->r <= numRounds));
 }
 
->-< action {:layer 3} A_Paxos'({:linear_in "perm"} rs: [Round]bool)
+atomic action {:layer 3} A_Paxos'({:linear_in "perm"} rs: [Round]bool)
 modifies joinedNodes, voteInfo, decision;
 {
   assert Init(rs, joinedNodes, voteInfo, decision);

--- a/Test/civl/intro-inline-check.bpl
+++ b/Test/civl/intro-inline-check.bpl
@@ -3,7 +3,7 @@
 
 var {:layer 1} g: int;
 
->-< action {:layer 1} A()
+atomic action {:layer 1} A()
 modifies g;
 {
     call I();

--- a/Test/civl/intro.bpl
+++ b/Test/civl/intro.bpl
@@ -4,10 +4,10 @@
 var {:layer 1,2} y:int;
 var {:layer 0,1} x:int;
 
->-< action {:layer 2,2} atomic_read_y () returns (v:int)
+atomic action {:layer 2,2} atomic_read_y () returns (v:int)
 { v := y; }
 
->-< action {:layer 2,2} atomic_write_y (y':int)
+atomic action {:layer 2,2} atomic_write_y (y':int)
 modifies y;
 { y := y'; }
 
@@ -32,10 +32,10 @@ modifies y;
   y := x;
 }
 
->-< action {:layer 1,1} atomic_read_x () returns (v:int)
+atomic action {:layer 1,1} atomic_read_x () returns (v:int)
 { v := x; }
 
->-< action {:layer 1,1} atomic_write_x (x':int)
+atomic action {:layer 1,1} atomic_write_x (x':int)
 modifies x;
 { x := x'; }
 

--- a/Test/civl/lamport.bpl
+++ b/Test/civl/lamport.bpl
@@ -60,13 +60,13 @@ modifies done;
 
 // Low-level atomic actions
 
->-< action {:layer 1} atomic_update_x(i: int)
+atomic action {:layer 1} atomic_update_x(i: int)
 modifies x;
 {
   x[i] := 1;
 }
 
->-< action {:layer 1} atomic_update_y(i: int)
+atomic action {:layer 1} atomic_update_y(i: int)
 modifies y;
 {
   y[i] := x[(i-1) mod N];

--- a/Test/civl/lease.bpl
+++ b/Test/civl/lease.bpl
@@ -35,7 +35,7 @@ function nextNode(me:int):int;
 
 ////// primitive actions //////
 
-<-> action {:layer 2} AtomicGetNode({:linear "me"} me:int) returns(n:node)
+both action {:layer 2} AtomicGetNode({:linear "me"} me:int) returns(n:node)
 {
         n := nodes[me];
 }
@@ -43,7 +43,7 @@ function nextNode(me:int):int;
 yield procedure {:layer 1} GetNode({:linear "me"} me:int) returns(n:node);
 refines AtomicGetNode;
 
-<-> action {:layer 2} AtomicSetNode({:linear "me"} me:int, n:node)
+both action {:layer 2} AtomicSetNode({:linear "me"} me:int, n:node)
 modifies nodes;
 {
         nodes := nodes[me := n];
@@ -52,7 +52,7 @@ modifies nodes;
 yield procedure {:layer 1} SetNode({:linear "me"} me:int, n:node);
 refines AtomicSetNode;
 
--> action {:layer 2} AtomicRecv({:linear "me"} me:int) returns(m:msg)
+right action {:layer 2} AtomicRecv({:linear "me"} me:int) returns(m:msg)
 {
         assume network[m] && m->dst == me;
 }
@@ -60,7 +60,7 @@ refines AtomicSetNode;
 yield procedure {:layer 1} Recv({:linear "me"} me:int) returns(m:msg);
 refines AtomicRecv;
 
-<- action {:layer 2} AtomicSendInternal({:linear "me"} me:int, dst:int, payload:lockMsg)
+left action {:layer 2} AtomicSendInternal({:linear "me"} me:int, dst:int, payload:lockMsg)
 modifies network;
 {
         network := network[msg(me, dst, payload) := true];
@@ -69,7 +69,7 @@ modifies network;
 yield procedure {:layer 1} SendInternal({:linear "me"} me:int, dst:int, payload:lockMsg);
 refines AtomicSendInternal;
 
-<- action {:layer 2} AtomicSendExternal({:linear "me"} me:int, dst:int, payload:lockMsg)
+left action {:layer 2} AtomicSendExternal({:linear "me"} me:int, dst:int, payload:lockMsg)
 modifies network, external;
 {
         network  := network [msg(me, dst, payload) := true];
@@ -79,7 +79,7 @@ modifies network, external;
 yield procedure {:layer 1} SendExternal({:linear "me"} me:int, dst:int, payload:lockMsg);
 refines AtomicSendExternal;
 
->-< action {:layer 2} AtomicAddHistory(l:int)
+atomic action {:layer 2} AtomicAddHistory(l:int)
 modifies history;
 {
         history  := addHistory(history, l);
@@ -122,7 +122,7 @@ function Inv(network:[msg]bool, nodes:[int]node, history:history):bool
 && (forall m:msg :: network[m] ==> InvMsg(network, nodes, history, m))
 }
 
->-< action {:layer 3} AtomicGrant({:linear "me"} me:int) returns(dst:int, epoch:int)
+atomic action {:layer 3} AtomicGrant({:linear "me"} me:int) returns(dst:int, epoch:int)
 modifies history;
 {
         history := addHistory(history, dst);
@@ -144,7 +144,7 @@ preserves call YieldInv();
   call SendInternal(me, dst, transfer(epoch + 1));
 }
 
->-< action {:layer 3} AtomicAccept({:linear "me"} me:int, dst:int) returns(epoch:int)
+atomic action {:layer 3} AtomicAccept({:linear "me"} me:int, dst:int) returns(epoch:int)
 modifies external;
 {
         // specify that the message source (me) must appear at right epoch in history:

--- a/Test/civl/left-mover.bpl
+++ b/Test/civl/left-mover.bpl
@@ -3,25 +3,25 @@
 
 var {:layer 0,2} x : int;
 
-<- action {:layer 1} inc ()
+left action {:layer 1} inc ()
 modifies x;
 { x := x + 1; }
 
 // Error: Gate failure of ass_eq_1 not preserved by inc
->-< action {:layer 1} ass_eq_1 ()
+atomic action {:layer 1} ass_eq_1 ()
 { assert x == 1; }
 
 // Correct
->-< action {:layer 1} ass_leq_1 ()
+atomic action {:layer 1} ass_leq_1 ()
 { assert x <= 1; }
 
 // Error: init and inc do not commute
->-< action {:layer 1} init ()
+atomic action {:layer 1} init ()
 modifies x;
 { x := 0; }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 // Error block is blocking
-<- action {:layer 2} block ()
+left action {:layer 2} block ()
 { assume x >= 0; }

--- a/Test/civl/left-mover.bpl.expect
+++ b/Test/civl/left-mover.bpl.expect
@@ -1,14 +1,14 @@
-left-mover.bpl(11,23): Error: Gate failure of ass_eq_1 not preserved by inc
+left-mover.bpl(11,26): Error: Gate failure of ass_eq_1 not preserved by inc
 Execution trace:
-    left-mover.bpl(6,22): inline$inc$0$Entry
+    left-mover.bpl(6,24): inline$inc$0$Entry
     left-mover.bpl(8,5): inline$inc$0$anon0
-    left-mover.bpl(6,22): inline$inc$0$Return
-left-mover.bpl(19,23): Error: Commutativity check between init and inc failed
+    left-mover.bpl(6,24): inline$inc$0$Return
+left-mover.bpl(19,26): Error: Commutativity check between init and inc failed
 Execution trace:
-    left-mover.bpl(19,23): inline$init$0$Entry
+    left-mover.bpl(19,26): inline$init$0$Entry
     left-mover.bpl(8,5): inline$inc$0$anon0
-    left-mover.bpl(6,22): inline$inc$0$Return
-left-mover.bpl(26,22): Error: Cooperation check for block failed
+    left-mover.bpl(6,24): inline$inc$0$Return
+left-mover.bpl(26,24): Error: Cooperation check for block failed
 Execution trace:
     (0,0): init
 

--- a/Test/civl/linear_out_bug.bpl
+++ b/Test/civl/linear_out_bug.bpl
@@ -7,14 +7,14 @@ var {:layer 0,2} {:linear "addr"} Addrs:[int]bool;
 // linear_out parameter of RemoveAddr was still part of the disjointness
 // expression in the post-state.
 
->-< action {:layer 1,2} AddAddr({:linear_in "addr"} i: int)
+atomic action {:layer 1,2} AddAddr({:linear_in "addr"} i: int)
 modifies Addrs;
 {
     Addrs[i] := true;
 }
 
 // Gate not preserved by itself
-<- action {:layer 1} RemoveAddr_1({:linear_out "addr"} i: int)
+left action {:layer 1} RemoveAddr_1({:linear_out "addr"} i: int)
 modifies Addrs;
 {
     assert Addrs[i];
@@ -22,7 +22,7 @@ modifies Addrs;
 }
 
 // Without the gate, RemoveAddr does not commute with AddAddr
-<- action {:layer 2} RemoveAddr_2({:linear_out "addr"} i: int)
+left action {:layer 2} RemoveAddr_2({:linear_out "addr"} i: int)
 modifies Addrs;
 {
     Addrs[i] := false;

--- a/Test/civl/linear_out_bug.bpl.expect
+++ b/Test/civl/linear_out_bug.bpl.expect
@@ -1,18 +1,18 @@
-linear_out_bug.bpl(10,25): Error: Commutativity check between AddAddr and RemoveAddr_2 failed
+linear_out_bug.bpl(10,28): Error: Commutativity check between AddAddr and RemoveAddr_2 failed
 Execution trace:
-    linear_out_bug.bpl(10,25): inline$AddAddr$0$Entry
+    linear_out_bug.bpl(10,28): inline$AddAddr$0$Entry
     linear_out_bug.bpl(13,14): inline$AddAddr$0$anon0
     linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0
-    linear_out_bug.bpl(25,22): inline$RemoveAddr_2$0$Return
+    linear_out_bug.bpl(25,24): inline$RemoveAddr_2$0$Return
 linear_out_bug.bpl(20,5): Error: Gate of RemoveAddr_1 not preserved by RemoveAddr_1
 Execution trace:
-    linear_out_bug.bpl(17,22): inline$RemoveAddr_1$0$Entry
+    linear_out_bug.bpl(17,24): inline$RemoveAddr_1$0$Entry
     linear_out_bug.bpl(20,5): inline$RemoveAddr_1$0$anon0
-    linear_out_bug.bpl(17,22): inline$RemoveAddr_1$0$Return
-linear_out_bug.bpl(25,22): Error: Potential linearity violation in outputs for domain addr.
+    linear_out_bug.bpl(17,24): inline$RemoveAddr_1$0$Return
+linear_out_bug.bpl(25,24): Error: Potential linearity violation in outputs for domain addr.
 Execution trace:
-    linear_out_bug.bpl(25,22): inline$RemoveAddr_2$0$Entry
+    linear_out_bug.bpl(25,24): inline$RemoveAddr_2$0$Entry
     linear_out_bug.bpl(28,14): inline$RemoveAddr_2$0$anon0
-    linear_out_bug.bpl(25,22): inline$RemoveAddr_2$0$Return
+    linear_out_bug.bpl(25,24): inline$RemoveAddr_2$0$Return
 
 Boogie program verifier finished with 7 verified, 3 errors

--- a/Test/civl/linear_types.bpl
+++ b/Test/civl/linear_types.bpl
@@ -1,46 +1,46 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
->-< action {:layer 1, 2} A0({:linear_in} path: Lheap int, k: [Ref int]bool) returns (path': Lheap int, l: Lheap int) {
+atomic action {:layer 1, 2} A0({:linear_in} path: Lheap int, k: [Ref int]bool) returns (path': Lheap int, l: Lheap int) {
     call path' := Lheap_Empty();
     call Lheap_Transfer(path, path');
     call l := Lheap_Split(k, path');
 }
 
->-< action {:layer 1, 2} A1({:linear_in} path: Lheap int, k: Ref int, v: int) returns (path': Lheap int, v': int) {
+atomic action {:layer 1, 2} A1({:linear_in} path: Lheap int, k: Ref int, v: int) returns (path': Lheap int, v': int) {
     call path' := Lheap_Empty();
     call Lheap_Transfer(path, path');
     call Lheap_Write(path'->val[k], v);
     call v' := Lheap_Read(path'->val[k]);
 }
 
->-< action {:layer 1, 2} A2(v: int) returns (path': Lheap int, v': int) {
+atomic action {:layer 1, 2} A2(v: int) returns (path': Lheap int, v': int) {
     var k: Ref int;
     call path' := Lheap_Empty();
     call k := Lheap_Add(path', v);
     call v' := Lheap_Remove(path', k);
 }
 
->-< action {:layer 1, 2} A3({:linear_in} path: Lset int, {:linear_out} l: Lset int) returns (path': Lset int) {
+atomic action {:layer 1, 2} A3({:linear_in} path: Lset int, {:linear_out} l: Lset int) returns (path': Lset int) {
     call path' := Lset_Empty();
     call Lset_Transfer(path, path');
     call Lset_Split(l, path');
 }
 
->-< action {:layer 1, 2} A4({:linear_in} path: Lset int, l: Lval int) returns (path': Lset int) {
+atomic action {:layer 1, 2} A4({:linear_in} path: Lset int, l: Lval int) returns (path': Lset int) {
     call path' := Lset_Empty();
     call Lset_Transfer(path, path');
     call Lval_Transfer(l, path');
     call Lval_Split(l, path');
 }
 
->-< action {:layer 1, 2} A5({:linear_in} path: Lheap int) returns (path': Lheap int) {
+atomic action {:layer 1, 2} A5({:linear_in} path: Lheap int) returns (path': Lheap int) {
     path' := path;
 }
 
 var {:layer 0, 2} g: Lheap int;
 
->-< action {:layer 1, 2} A6({:linear_in} path: Lheap int) returns (path': Lheap int)
+atomic action {:layer 1, 2} A6({:linear_in} path: Lheap int) returns (path': Lheap int)
 modifies g;
 {
     path' := path;
@@ -50,26 +50,26 @@ modifies g;
 
 datatype Foo { Foo(f: Lheap int) }
 
->-< action {:layer 1, 2} A7({:linear_in} path: Lheap Foo, x: Ref Foo, y: Ref int) returns (path': Lheap Foo)
+atomic action {:layer 1, 2} A7({:linear_in} path: Lheap Foo, x: Ref Foo, y: Ref int) returns (path': Lheap Foo)
 {
     var l: Lheap int;
     path' := path;
     call l := Lheap_Split(MapOne(y), path'->val[x]->f);
 }
 
->-< action {:layer 1, 2} A8({:linear_out} l: Lval int, {:linear_in} path: Lset int) returns (path': Lset int)
+atomic action {:layer 1, 2} A8({:linear_out} l: Lval int, {:linear_in} path: Lset int) returns (path': Lset int)
 {
     path' := path;
     call Lval_Split(l, path');
 }
 
->-< action {:layer 1, 2} A9({:linear_in} path1: Lheap int, x: Ref Foo) returns (path2: Lheap Foo)
+atomic action {:layer 1, 2} A9({:linear_in} path1: Lheap int, x: Ref Foo) returns (path2: Lheap Foo)
 {
     call path2 := Lheap_Empty();
     call Lheap_Transfer(path1, path2->val[x]->f);
 }
 
->-< action {:layer 1, 2} A10({:linear_in} a: Foo) returns (b: Foo)
+atomic action {:layer 1, 2} A10({:linear_in} a: Foo) returns (b: Foo)
 {
     var x: Lheap int;
     Foo(x) := a;

--- a/Test/civl/linear_types_error.bpl
+++ b/Test/civl/linear_types_error.bpl
@@ -1,20 +1,20 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
->-< action {:layer 1, 2} A0(path: Lheap int) returns (l: Lheap int) { }
+atomic action {:layer 1, 2} A0(path: Lheap int) returns (l: Lheap int) { }
 
->-< action {:layer 1, 2} A1(path: Lheap int) returns (path': Lheap int) {
+atomic action {:layer 1, 2} A1(path: Lheap int) returns (path': Lheap int) {
     path' := path;
 }
 
->-< action {:layer 1, 2} A2(path: Lheap int) returns (path': Lheap int) {
+atomic action {:layer 1, 2} A2(path: Lheap int) returns (path': Lheap int) {
     call path' := Lheap_Empty();
     call Lheap_Transfer(path, path');
 }
 
 var {:layer 0, 2} g: Lheap int;
 
->-< action {:layer 1, 2} A3({:linear_in} path: Lheap int) returns (path': Lheap int)
+atomic action {:layer 1, 2} A3({:linear_in} path: Lheap int) returns (path': Lheap int)
 {
     path' := path;
     call Lheap_Transfer(g, path');
@@ -23,56 +23,56 @@ var {:layer 0, 2} g: Lheap int;
 datatype Foo { Foo(f: Lheap int) }
 
 
->-< action {:layer 1, 2} A4({:linear_in} path: Lheap Foo, x: Ref Foo, {:linear_in} l: Lheap int) returns (path': Lheap Foo, l': Lheap int)
+atomic action {:layer 1, 2} A4({:linear_in} path: Lheap Foo, x: Ref Foo, {:linear_in} l: Lheap int) returns (path': Lheap Foo, l': Lheap int)
 {
     path' := path;
     l' := l;
     call Lheap_Transfer(path'->val[x]->f, l');
 }
 
->-< action {:layer 1, 2} A5({:linear_out} path: Lheap int) { }
+atomic action {:layer 1, 2} A5({:linear_out} path: Lheap int) { }
 
->-< action {:layer 1, 2} A6({:linear_in} path: Lheap int) returns (path': Lheap int)
+atomic action {:layer 1, 2} A6({:linear_in} path: Lheap int) returns (path': Lheap int)
 {
     path' := path;
     call Lheap_Transfer(path', path');
 }
 
->-< action {:layer 1, 2} A7(path1: Lheap int, {:linear_in} path2: Lheap int) returns (path': Lheap int)
+atomic action {:layer 1, 2} A7(path1: Lheap int, {:linear_in} path2: Lheap int) returns (path': Lheap int)
 {
     path' := path2;
     call Lheap_Transfer(path1, path');
 }
 
->-< action {:layer 1, 2} A8({:linear_in} path1: Lheap int, x: Ref Foo) returns (path2: Lheap Foo)
+atomic action {:layer 1, 2} A8({:linear_in} path1: Lheap int, x: Ref Foo) returns (path2: Lheap Foo)
 {
     call Lheap_Transfer(path1, path2->val[x]->f);
 }
 
->-< action {:layer 1, 2} A9({:linear_in} l: Lheap int)
+atomic action {:layer 1, 2} A9({:linear_in} l: Lheap int)
 {
     call Lheap_Transfer(l, g);
 }
 
->-< action {:layer 1, 2} A10({:linear_in} l: Lheap int, l': Lheap int)
+atomic action {:layer 1, 2} A10({:linear_in} l: Lheap int, l': Lheap int)
 {
     call Lheap_Transfer(l, l');
 }
 
->-< action {:layer 1, 2} A11({:linear_in} a: Foo) returns (b: Foo)
+atomic action {:layer 1, 2} A11({:linear_in} a: Foo) returns (b: Foo)
 {
     var x: Lheap int;
     Foo(x) := a;
 }
 
->-< action {:layer 1, 2} A12({:linear_in} a: Foo) returns (b: Foo)
+atomic action {:layer 1, 2} A12({:linear_in} a: Foo) returns (b: Foo)
 {
     var x: Lheap int;
     b := a;
     Foo(x) := a;
 }
 
->-< action {:layer 1, 2} A13({:linear_in} a: Foo) returns (b: Foo)
+atomic action {:layer 1, 2} A13({:linear_in} a: Foo) returns (b: Foo)
 {
     var x: Lheap int;
     b := Foo(x);

--- a/Test/civl/linear_types_error.bpl.expect
+++ b/Test/civl/linear_types_error.bpl.expect
@@ -1,9 +1,9 @@
-linear_types_error.bpl(4,70): Error: Output variable l must be available at a return
+linear_types_error.bpl(4,73): Error: Output variable l must be available at a return
 linear_types_error.bpl(8,0): Error: Input variable path must be available at a return
 linear_types_error.bpl(13,0): Error: Input variable path must be available at a return
 linear_types_error.bpl(21,0): Error: Global variable g must be available at a return
 linear_types_error.bpl(30,4): Error: Only variable can be passed to linear parameter: path'->val[x]->f
-linear_types_error.bpl(33,61): Error: Input variable path must be available at a return
+linear_types_error.bpl(33,64): Error: Input variable path must be available at a return
 linear_types_error.bpl(38,4): Error: Linear variable path' can occur only once as an input parameter
 linear_types_error.bpl(45,0): Error: Input variable path1 must be available at a return
 linear_types_error.bpl(49,31): Error: unavailable source path2 for linear parameter at position 1

--- a/Test/civl/linearity-bug-1.bpl
+++ b/Test/civl/linearity-bug-1.bpl
@@ -10,14 +10,14 @@ var {:linear "tid"} {:layer 0,1} S : TidSet;
 // commutativity checker procedure contained t and thus made the whole
 // postcondition 'vacuously' (because t is added to A) true.
 
->-< action {:layer 1} atomic_inc_n ({:linear_in "tid"} t : Tid)
+atomic action {:layer 1} atomic_inc_n ({:linear_in "tid"} t : Tid)
 modifies S, n;
 { assert !S[t]; S[t] := true; n := n + 1; }
 
 yield procedure {:layer 0} inc_n ({:linear_in "tid"} t : Tid);
 refines atomic_inc_n;
 
--> action {:layer 1} atomic_read_n () returns (ret : int)
+right action {:layer 1} atomic_read_n () returns (ret : int)
 { ret := n; }
 
 yield procedure {:layer 0} read_n () returns (ret : int);

--- a/Test/civl/linearity-bug-1.bpl.expect
+++ b/Test/civl/linearity-bug-1.bpl.expect
@@ -1,7 +1,7 @@
-linearity-bug-1.bpl(20,22): Error: Commutativity check between atomic_read_n and atomic_inc_n failed
+linearity-bug-1.bpl(20,25): Error: Commutativity check between atomic_read_n and atomic_inc_n failed
 Execution trace:
-    linearity-bug-1.bpl(20,22): inline$atomic_read_n$0$Entry
+    linearity-bug-1.bpl(20,25): inline$atomic_read_n$0$Entry
     linearity-bug-1.bpl(15,3): inline$atomic_inc_n$0$anon0
-    linearity-bug-1.bpl(13,23): inline$atomic_inc_n$0$Return
+    linearity-bug-1.bpl(13,26): inline$atomic_inc_n$0$Return
 
 Boogie program verifier finished with 1 verified, 1 error

--- a/Test/civl/linearity-bug-2.bpl
+++ b/Test/civl/linearity-bug-2.bpl
@@ -3,7 +3,7 @@
 
 var {:linear "lin"} {:layer 1,2} set : [int]bool;
 
->-< action {:layer 2} atomic_foo ({:linear "lin"} i : int)
+atomic action {:layer 2} atomic_foo ({:linear "lin"} i : int)
 modifies set;
 { set[i] := true; }
 

--- a/Test/civl/linearity-bug-2.bpl.expect
+++ b/Test/civl/linearity-bug-2.bpl.expect
@@ -1,7 +1,7 @@
-linearity-bug-2.bpl(6,23): Error: Potential linearity violation in outputs for domain lin.
+linearity-bug-2.bpl(6,26): Error: Potential linearity violation in outputs for domain lin.
 Execution trace:
-    linearity-bug-2.bpl(6,23): inline$atomic_foo$0$Entry
+    linearity-bug-2.bpl(6,26): inline$atomic_foo$0$Entry
     linearity-bug-2.bpl(8,10): inline$atomic_foo$0$anon0
-    linearity-bug-2.bpl(6,23): inline$atomic_foo$0$Return
+    linearity-bug-2.bpl(6,26): inline$atomic_foo$0$Return
 
 Boogie program verifier finished with 0 verified, 1 error

--- a/Test/civl/lipton.bpl
+++ b/Test/civl/lipton.bpl
@@ -13,11 +13,11 @@ yield procedure {:layer 1} Thread ()
   call v();
 }
 
--> action {:layer 1} P ()
+right action {:layer 1} P ()
 modifies c;
 { assume c > 0; c := c - 1; }
 
-<- action {:layer 1} V ()
+left action {:layer 1} V ()
 modifies c;
 { c := c + 1; }
 

--- a/Test/civl/lock-introduced.bpl
+++ b/Test/civl/lock-introduced.bpl
@@ -25,7 +25,7 @@ function {:inline} InvLock(lock: X, b: bool) : bool
 yield invariant {:layer 2} Yield({:linear "tid"} tid: X);
 invariant tid != nil && InvLock(lock, b);
 
--> action {:layer 3} AtomicEnter({:linear "tid"} tid: X)
+right action {:layer 3} AtomicEnter({:linear "tid"} tid: X)
 modifies lock;
 { assume lock == nil && tid != nil; lock := tid; }
 
@@ -36,7 +36,7 @@ preserves call Yield(tid);
   call LowerEnter(tid);
 }
 
-<- action {:layer 3} AtomicLeave({:linear "tid"} tid:X)
+left action {:layer 3} AtomicLeave({:linear "tid"} tid:X)
 modifies lock;
 { assert lock == tid && tid != nil; lock := nil; }
 
@@ -47,7 +47,7 @@ preserves call Yield(tid);
   call LowerLeave();
 }
 
->-< action {:layer 2} AtomicLowerEnter({:linear "tid"} tid: X)
+atomic action {:layer 2} AtomicLowerEnter({:linear "tid"} tid: X)
 modifies b, lock;
 { assume !b; b := true; lock := tid; }
 
@@ -67,7 +67,7 @@ refines AtomicLowerEnter;
   }
 }
 
->-< action {:layer 2} AtomicLowerLeave()
+atomic action {:layer 2} AtomicLowerLeave()
 modifies b, lock;
 { b := false; lock := nil; }
 
@@ -82,7 +82,7 @@ action{:layer 1} SetLock(v: X)
 modifies lock;
 { lock := v; }
 
->-< action {:layer 1} AtomicCAS(prev: bool, next: bool) returns (status: bool)
+atomic action {:layer 1} AtomicCAS(prev: bool, next: bool) returns (status: bool)
 modifies b;
 {
   if (b == prev) {
@@ -93,7 +93,7 @@ modifies b;
   }
 }
 
->-< action {:layer 1} AtomicSET(next: bool)
+atomic action {:layer 1} AtomicSET(next: bool)
 modifies b;
 { b := next; }
 

--- a/Test/civl/lock.bpl
+++ b/Test/civl/lock.bpl
@@ -21,7 +21,7 @@ yield procedure {:layer 2} Customer()
     }
 }
 
->-< action {:layer 2} AtomicEnter()
+atomic action {:layer 2} AtomicEnter()
 modifies b;
 { assume !b; b := true; }
 
@@ -40,7 +40,7 @@ refines AtomicEnter;
     }
 }
 
->-< action {:layer 1,2} AtomicCAS(prev: bool, next: bool) returns (status: bool)
+atomic action {:layer 1,2} AtomicCAS(prev: bool, next: bool) returns (status: bool)
 modifies b;
 {
   if (b == prev) {
@@ -54,7 +54,7 @@ modifies b;
 yield procedure {:layer 0} CAS(prev: bool, next: bool) returns (status: bool);
 refines AtomicCAS;
 
->-< action {:layer 1,2} AtomicLeave()
+atomic action {:layer 1,2} AtomicLeave()
 modifies b;
 { b := false; }
 

--- a/Test/civl/lock2.bpl
+++ b/Test/civl/lock2.bpl
@@ -21,7 +21,7 @@ yield procedure {:layer 2} Customer()
     }
 }
 
->-< action {:layer 2} AtomicEnter()
+atomic action {:layer 2} AtomicEnter()
 modifies b;
 { assume b == 0; b := 1; }
 
@@ -48,13 +48,13 @@ refines AtomicEnter;
     }
 }
 
->-< action {:layer 1,2} AtomicRead() returns (val: int)
+atomic action {:layer 1,2} AtomicRead() returns (val: int)
 { val := b; }
 
 yield procedure {:layer 0} Read() returns (val: int);
 refines AtomicRead;
 
->-< action {:layer 1,2} AtomicCAS(prev: int, next: int) returns (_old: int)
+atomic action {:layer 1,2} AtomicCAS(prev: int, next: int) returns (_old: int)
 modifies b;
 {
   _old := b;
@@ -66,7 +66,7 @@ modifies b;
 yield procedure {:layer 0} CAS(prev: int, next: int) returns (_old: int);
 refines AtomicCAS;
 
->-< action {:layer 1,2} AtomicLeave()
+atomic action {:layer 1,2} AtomicLeave()
 modifies b;
 { b := 0; }
 

--- a/Test/civl/multiset.bpl
+++ b/Test/civl/multiset.bpl
@@ -14,54 +14,54 @@ const max : int;
 
 axiom (max > 0);
 
--> action {:layer 1,2} atomic_acquire(i : int, {:linear "tid"} tid: X)
+right action {:layer 1,2} atomic_acquire(i : int, {:linear "tid"} tid: X)
 modifies lock;
 { assert 0 <= i && i < max; assert tid != nil && tid != done; assume lock[i] == nil; lock[i] := tid; }
 
 yield procedure {:layer 0} acquire(i : int, {:linear "tid"} tid: X);
 refines atomic_acquire;
 
-<- action {:layer 1,2} atomic_release(i : int, {:linear "tid"} tid: X)
+left action {:layer 1,2} atomic_release(i : int, {:linear "tid"} tid: X)
 modifies lock;
 { assert 0 <= i && i < max; assert lock[i] == tid; assert tid != nil && tid != done; lock[i] := nil; }
 
 yield procedure {:layer 0} release(i : int, {:linear "tid"} tid: X);
 refines atomic_release;
 
-<-> action {:layer 1} atomic_getElt(j : int, {:linear "tid"} tid: X) returns (elt_j:int)
+both action {:layer 1} atomic_getElt(j : int, {:linear "tid"} tid: X) returns (elt_j:int)
 { assert 0 <= j && j < max; assert tid != nil && tid != done; assert lock[j] == tid; elt_j := elt[j]; }
 
 yield procedure {:layer 0} getElt(j : int, {:linear "tid"} tid: X) returns (elt_j:int);
 refines atomic_getElt;
 
-<-> action {:layer 1} atomic_setElt(j : int, x : int, {:linear "tid"} tid: X)
+both action {:layer 1} atomic_setElt(j : int, x : int, {:linear "tid"} tid: X)
 modifies elt, owner;
 { assert x != null && owner[j] == nil; assert 0 <= j && j < max; assert lock[j] == tid; assert tid != nil && tid != done; elt[j] := x; owner[j] := tid; }
 
 yield procedure {:layer 0} setElt(j : int, x : int, {:linear "tid"} tid: X);
 refines atomic_setElt;
 
-<- action {:layer 1,2} atomic_setEltToNull(j : int, {:linear "tid"} tid: X)
+left action {:layer 1,2} atomic_setEltToNull(j : int, {:linear "tid"} tid: X)
 modifies elt, owner;
 { assert owner[j] == tid && lock[j] == tid; assert 0 <= j && j < max; assert !valid[j]; assert tid != nil  && tid != done; elt[j] := null; owner[j] := nil; }
 
 yield procedure {:layer 0} setEltToNull(j : int, {:linear "tid"} tid: X);
 refines atomic_setEltToNull;
 
-<-> action {:layer 1,2} atomic_setValid(j : int, {:linear "tid"} tid: X)
+both action {:layer 1,2} atomic_setValid(j : int, {:linear "tid"} tid: X)
 modifies valid, owner;
 { assert 0 <= j && j < max; assert lock[j] == tid; assert tid != nil && tid != done; assert owner[j] == tid; valid[j] := true; owner[j] := done; }
 
 yield procedure {:layer 0} setValid(j : int, {:linear "tid"} tid: X);
 refines atomic_setValid;
 
-<-> action {:layer 1,2} atomic_isEltThereAndValid(j : int, x : int, {:linear "tid"} tid: X) returns (fnd:bool)
+both action {:layer 1,2} atomic_isEltThereAndValid(j : int, x : int, {:linear "tid"} tid: X) returns (fnd:bool)
 { assert 0 <= j && j < max; assert lock[j] == tid; assert tid != nil && tid != done; fnd := (elt[j] == x) && valid[j]; }
 
 yield procedure {:layer 0} isEltThereAndValid(j : int, x : int, {:linear "tid"} tid: X) returns (fnd:bool);
 refines atomic_isEltThereAndValid;
 
--> action {:layer 2} AtomicFindSlot(x : int, {:linear "tid"} tid: X) returns (r : int)
+right action {:layer 2} AtomicFindSlot(x : int, {:linear "tid"} tid: X) returns (r : int)
 modifies elt, owner;
 {
   assert tid != nil && tid != done;
@@ -118,7 +118,7 @@ preserves call Yield1();
   return;
 }
 
->-< action {:layer 3} AtomicInsert(x : int, {:linear "tid"} tid: X) returns (result : bool)
+atomic action {:layer 3} AtomicInsert(x : int, {:linear "tid"} tid: X) returns (result : bool)
 modifies elt, valid, owner;
 {
   var r:int;
@@ -166,7 +166,7 @@ preserves call Yield2();
   return;
 }
 
->-< action {:layer 3} AtomicInsertPair(x : int, y : int, {:linear "tid"} tid: X) returns (result : bool)
+atomic action {:layer 3} AtomicInsertPair(x : int, y : int, {:linear "tid"} tid: X) returns (result : bool)
 modifies elt, valid, owner;
 {
   var rx:int;
@@ -240,7 +240,7 @@ preserves call Yield2();
   return;
 }
 
->-< action {:layer 3} AtomicLookUp(x : int, {:linear "tid"} tid: X, old_valid:[int]bool, old_elt:[int]int) returns (found : bool)
+atomic action {:layer 3} AtomicLookUp(x : int, {:linear "tid"} tid: X, old_valid:[int]bool, old_elt:[int]int) returns (found : bool)
 {
   assert tid != nil && tid != done;
   assert x != null;

--- a/Test/civl/non-interference-1.bpl
+++ b/Test/civl/non-interference-1.bpl
@@ -7,14 +7,14 @@ yield procedure {:layer 1} PB()
   call Incr();
 }
 
->-< action {:layer 1} AtomicIncr()
+atomic action {:layer 1} AtomicIncr()
 modifies g;
 { g := g + 1; }
 
 yield procedure {:layer 0} Incr();
 refines AtomicIncr;
 
->-< action {:layer 1} AtomicSet(v: int)
+atomic action {:layer 1} AtomicSet(v: int)
 modifies g;
 { g := v; }
 

--- a/Test/civl/non-interference-2.bpl
+++ b/Test/civl/non-interference-2.bpl
@@ -7,14 +7,14 @@ yield procedure {:layer 1} PB()
   call Incr();
 }
 
->-< action {:layer 1} AtomicIncr()
+atomic action {:layer 1} AtomicIncr()
 modifies g;
 { g := g + 1; }
 
 yield procedure {:layer 0} Incr();
 refines AtomicIncr;
 
->-< action {:layer 1} AtomicSet(v: int)
+atomic action {:layer 1} AtomicSet(v: int)
 modifies g;
 { g := v; }
 

--- a/Test/civl/ogcounter.bpl
+++ b/Test/civl/ogcounter.bpl
@@ -9,7 +9,7 @@ var {:layer 0,2} x: int;
 yield procedure {:layer 0} Incr();
 refines AtomicIncr;
 
-<- action {:layer 1} AtomicIncr()
+left action {:layer 1} AtomicIncr()
 modifies x;
 { x := x + 1; }
 
@@ -19,7 +19,7 @@ refines AtomicIncrBy2;
   par Incr() | Incr();
 }
 
-<- action {:layer 2} AtomicIncrBy2()
+left action {:layer 2} AtomicIncrBy2()
 modifies x;
 { x := x + 2; }
 

--- a/Test/civl/ogcounter2.bpl
+++ b/Test/civl/ogcounter2.bpl
@@ -10,41 +10,41 @@ var {:layer 2,3} lock: X;
 
 var {:layer 1,4}{:linear "tid"} unallocated:[X]bool;
 
--> action {:layer 2,4} AtomicAllocTid() returns ({:linear "tid"} tid: X)
+right action {:layer 2,4} AtomicAllocTid() returns ({:linear "tid"} tid: X)
 modifies unallocated;
 { assume tid != Nil && unallocated[tid]; unallocated[tid] := false; }
 
 yield procedure {:layer 1} AllocTid() returns ({:linear "tid"} tid: X);
 refines AtomicAllocTid;
 
--> action {:layer 3} atomic_acq({:linear "tid"} tid: X)
+right action {:layer 3} atomic_acq({:linear "tid"} tid: X)
 modifies lock;
 { assert tid != Nil; assume lock == Nil; lock := tid; }
 
 yield procedure {:layer 2} acq({:linear "tid"} tid: X);
 refines atomic_acq;
 
-<- action {:layer 3} atomic_rel({:linear "tid"} tid: X)
+left action {:layer 3} atomic_rel({:linear "tid"} tid: X)
 modifies lock;
 { assert tid != Nil && lock == tid; lock := Nil; }
 
 yield procedure {:layer 2} rel({:linear "tid"} tid: X);
 refines atomic_rel;
 
-<-> action {:layer 3} atomic_read({:linear "tid"} tid: X) returns (v: int)
+both action {:layer 3} atomic_read({:linear "tid"} tid: X) returns (v: int)
 { assert tid != Nil && lock == tid; v := x; }
 
 yield procedure {:layer 2} read({:linear "tid"} tid: X) returns (v: int);
 refines atomic_read;
 
-<-> action {:layer 3} atomic_write({:linear "tid"} tid: X, v: int)
+both action {:layer 3} atomic_write({:linear "tid"} tid: X, v: int)
 modifies x;
 { assert tid != Nil && lock == tid; x := v; }
 
 yield procedure {:layer 2} write({:linear "tid"} tid: X, v: int);
 refines atomic_write;
 
-<- action {:layer 4} AtomicIncr({:linear "tid"} tid: X)
+left action {:layer 4} AtomicIncr({:linear "tid"} tid: X)
 modifies x;
 { x := x + 1; }
 
@@ -60,7 +60,7 @@ requires {:layer 3} tid != Nil;
   call rel(tid);
 }
 
-<- action {:layer 5} AtomicIncrBy2()
+left action {:layer 5} AtomicIncrBy2()
 modifies x;
 { x := x + 2; }
 

--- a/Test/civl/par-incr.bpl
+++ b/Test/civl/par-incr.bpl
@@ -3,14 +3,14 @@
 
 var {:layer 0,3} x: int;
 
--> action {:layer 1} AtomicIncr()
+right action {:layer 1} AtomicIncr()
 modifies x;
 { x := x + 1; }
 
 yield procedure {:layer 0} Incr();
 refines AtomicIncr;
 
--> action {:layer 2} AtomicIncr2()
+right action {:layer 2} AtomicIncr2()
 modifies x;
 { x := x + 2; }
 
@@ -22,7 +22,7 @@ refines AtomicIncr2;
 
 yield invariant {:layer 1} Yield();
 
->-< action {:layer 3} AtomicIncr4()
+atomic action {:layer 3} AtomicIncr4()
 modifies x;
 { x := x + 4; }
 

--- a/Test/civl/parallel-patterns.bpl
+++ b/Test/civl/parallel-patterns.bpl
@@ -24,19 +24,19 @@ yield procedure {:layer 1} baz2()
     par A() | R();
 }
 
->-< action {:layer 1,1} atomic_A()
+atomic action {:layer 1,1} atomic_A()
 {
 }
 yield procedure {:layer 0} A();
 refines atomic_A;
 
-<- action {:layer 1,1} atomic_L()
+left action {:layer 1,1} atomic_L()
 {
 }
 yield procedure {:layer 0} L();
 refines atomic_L;
 
--> action {:layer 1,1} atomic_R()
+right action {:layer 1,1} atomic_R()
 {
 }
 yield procedure {:layer 0} R();

--- a/Test/civl/parallel0.bpl
+++ b/Test/civl/parallel0.bpl
@@ -7,13 +7,13 @@ yield procedure {:layer 1} P()
   par x := A(y) | y := B(x);
 }
 
-<- action {:layer 1} AtomicA(a: int) returns (b: int)
+left action {:layer 1} AtomicA(a: int) returns (b: int)
 { }
 
 yield procedure {:layer 0} A(a: int) returns (b: int);
 refines AtomicA;
 
-<- action {:layer 1} AtomicB(v: int) returns (w: int)
+left action {:layer 1} AtomicB(v: int) returns (w: int)
 { }
 
 yield procedure {:layer 0} B(v: int) returns (w: int);

--- a/Test/civl/parallel1.bpl
+++ b/Test/civl/parallel1.bpl
@@ -7,14 +7,14 @@ yield procedure {:layer 1} PB()
   call Incr();
 }
 
->-< action {:layer 1} AtomicIncr()
+atomic action {:layer 1} AtomicIncr()
 modifies g;
 { g := g + 1; }
 
 yield procedure {:layer 0} Incr();
 refines AtomicIncr;
 
->-< action {:layer 1} AtomicSet(v: int)
+atomic action {:layer 1} AtomicSet(v: int)
 modifies g;
 { g := v; }
 

--- a/Test/civl/parallel2.bpl
+++ b/Test/civl/parallel2.bpl
@@ -5,7 +5,7 @@ var {:layer 0,1} a:[int]int;
 
 yield procedure {:layer 1} Allocate() returns ({:linear "tid"} tid: int);
 
->-< action {:layer 1} AtomicWrite(idx: int, val: int)
+atomic action {:layer 1} AtomicWrite(idx: int, val: int)
 modifies a;
 { a[idx] := val; }
 

--- a/Test/civl/parallel4.bpl
+++ b/Test/civl/parallel4.bpl
@@ -27,7 +27,7 @@ yield procedure {:layer 1} t({:linear_in "tid"} i': int) returns ({:linear "tid"
   call Incr();
 }
 
->-< action {:layer 1} AtomicIncr()
+atomic action {:layer 1} AtomicIncr()
 modifies a;
 { a := a + 1; }
 

--- a/Test/civl/parallel5.bpl
+++ b/Test/civl/parallel5.bpl
@@ -7,7 +7,7 @@ var {:layer 0,1} a:[int]int;
 
 yield procedure {:layer 1} Allocate() returns ({:linear "tid"} tid: int);
 
->-< action {:layer 1} AtomicWrite(idx: int, val: int)
+atomic action {:layer 1} AtomicWrite(idx: int, val: int)
 modifies a;
 { a[idx] := val; }
 

--- a/Test/civl/parallel6.bpl
+++ b/Test/civl/parallel6.bpl
@@ -18,13 +18,13 @@ refines atomic_incr_by_two;
     par incr() | decr() | Yield() | incr();
     call incr();
 }
-<-> action {:layer 1,2} atomic_incr_by_two()
+both action {:layer 1,2} atomic_incr_by_two()
 modifies x;
 {
     x := x + 2;
 }
 
-<-> action {:layer 1,1} atomic_incr()
+both action {:layer 1,1} atomic_incr()
 modifies x;
 {
     x := x + 1;
@@ -32,7 +32,7 @@ modifies x;
 yield procedure {:layer 0} incr();
 refines atomic_incr;
 
-<-> action {:layer 1,1} atomic_decr()
+both action {:layer 1,1} atomic_decr()
 modifies x;
 {
     x := x - 1;

--- a/Test/civl/pending-async-1.bpl
+++ b/Test/civl/pending-async-1.bpl
@@ -3,15 +3,15 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-async >-< action {:layer 1,2} A () {}
+async atomic action {:layer 1,2} A () {}
 
-<- action {:layer 1} B ()
+left action {:layer 1} B ()
 creates A;
 {
   call create_async(A());
 }
 
-<- action {:layer 1} C (flag:bool)
+left action {:layer 1} C (flag:bool)
 creates A;
 {
   if (flag) {
@@ -36,7 +36,7 @@ refines TEST1;
   call b();
 }
 
->-< action {:layer 2} TEST1 ()
+atomic action {:layer 2} TEST1 ()
 creates A;
 {
   call create_multi_asyncs(MapConst(0)[A() := 2]);
@@ -52,7 +52,7 @@ refines TEST2;
   call b();
 }
 
->-< action {:layer 2} TEST2 ()
+atomic action {:layer 2} TEST2 ()
 creates A;
 {
   call create_async(A());
@@ -67,7 +67,7 @@ refines TEST3;
   call c(true);
 }
 
->-< action {:layer 2} TEST3 () returns () {}
+atomic action {:layer 2} TEST3 () returns () {}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -78,7 +78,7 @@ refines TEST4;
   call c(false);
 }
 
->-< action {:layer 2} TEST4 () returns () {}
+atomic action {:layer 2} TEST4 () returns () {}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -99,7 +99,7 @@ refines TEST5;
   }
 }
 
->-< action {:layer 2} TEST5 ()
+atomic action {:layer 2} TEST5 ()
 creates A;
 {
   call create_multi_asyncs(MapConst(0)[A() := 10]);

--- a/Test/civl/pending-async-2.bpl
+++ b/Test/civl/pending-async-2.bpl
@@ -6,10 +6,10 @@ axiom n > 0;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-async >-< action {:layer 1} A () {}
-async >-< action {:layer 1} B () {}
+async atomic action {:layer 1} A () {}
+async atomic action {:layer 1} B () {}
 
-<- action {:layer 1} C ()
+left action {:layer 1} C ()
 creates A;
 {
   call create_async(A());
@@ -17,7 +17,7 @@ creates A;
   call create_async(B());
 }
 
-<- action {:layer 1} D ()
+left action {:layer 1} D ()
 creates A, B;
 {
   // do nothing

--- a/Test/civl/pending-async-linearity.bpl
+++ b/Test/civl/pending-async-linearity.bpl
@@ -3,52 +3,52 @@
 
 type {:linear "pid"} Pid = int;
 
-async >-< action {:layer 1} A ({:linear_in "pid"} pid:int)
+async atomic action {:layer 1} A ({:linear_in "pid"} pid:int)
 {}
 
-async >-< action {:layer 1} B ({:linear_in "pid"} pid:int)
+async atomic action {:layer 1} B ({:linear_in "pid"} pid:int)
 {}
 
->-< action {:layer 1} M0 (pid:int)
+atomic action {:layer 1} M0 (pid:int)
 creates A;
 {
   call create_async(A(/* out of thin air */ pid));
 }
 
->-< action {:layer 1} M1 ({:linear_in "pid"} pid:int)
+atomic action {:layer 1} M1 ({:linear_in "pid"} pid:int)
 creates A;
 {
   call create_async(A(pid));
 }
 
->-< action {:layer 1} M2 ({:linear "pid"} pid:int)
+atomic action {:layer 1} M2 ({:linear "pid"} pid:int)
 creates A;
 {
   call create_async(A(/* duplication */ pid));
 }
 
->-< action {:layer 1} M3 ({:linear_in "pid"} pid1:int, {:linear_in "pid"} pid2:int)
+atomic action {:layer 1} M3 ({:linear_in "pid"} pid1:int, {:linear_in "pid"} pid2:int)
 creates A, B;
 {
   call create_async(A(pid1));
   call create_async(B(pid2));
 }
 
->-< action {:layer 1} M4 ({:linear_in "pid"} pid1:int, {:linear_in "pid"} pid2:int)
+atomic action {:layer 1} M4 ({:linear_in "pid"} pid1:int, {:linear_in "pid"} pid2:int)
 creates A, B;
 {
   call create_async(A(pid1));
   call create_async(B(/* duplication */ pid1));
 }
 
->-< action {:layer 1} M5 ({:linear_in "pid"} pid:int) returns ({:linear "pid"} pid_out:int)
+atomic action {:layer 1} M5 ({:linear_in "pid"} pid:int) returns ({:linear "pid"} pid_out:int)
 creates A;
 {
   pid_out := pid;
   call create_async(A(/* duplication */ pid));
 }
 
->-< action {:layer 1} M6 ({:linear_in "pid"} pid1:int, {:linear_in "pid"} pid2:int, {:linear_in "pid"} pid3:int)
+atomic action {:layer 1} M6 ({:linear_in "pid"} pid1:int, {:linear_in "pid"} pid2:int, {:linear_in "pid"} pid3:int)
 returns ({:linear "pid"} pid_out:int)
 creates A, B;
 {
@@ -57,14 +57,14 @@ creates A, B;
   call create_async(B(pid2));
 }
 
->-< action {:layer 1} M7 ({:linear_in "pid"} pid:[int]bool)
+atomic action {:layer 1} M7 ({:linear_in "pid"} pid:[int]bool)
 creates A;
 {
   assert pid == (lambda i:int :: 1 <= i && i <= 10);
   call create_async(A(5));
 }
 
->-< action {:layer 1} M8 ({:linear_in "pid"} pid:[int]bool)
+atomic action {:layer 1} M8 ({:linear_in "pid"} pid:[int]bool)
 creates A;
 {
   assert pid == (lambda i:int :: 1 <= i && i <= 10);

--- a/Test/civl/pending-async-linearity.bpl.expect
+++ b/Test/civl/pending-async-linearity.bpl.expect
@@ -1,26 +1,26 @@
-pending-async-linearity.bpl(12,23): Error: Potential linearity violation in outputs and pending async of A for domain pid.
+pending-async-linearity.bpl(12,26): Error: Potential linearity violation in outputs and pending async of A for domain pid.
 Execution trace:
-    pending-async-linearity.bpl(12,23): inline$M0$0$Entry
+    pending-async-linearity.bpl(12,26): inline$M0$0$Entry
     pending-async-linearity.bpl(15,3): inline$M0$0$anon0
     (0,0): pid_single_A
-pending-async-linearity.bpl(24,23): Error: Potential linearity violation in outputs and pending async of A for domain pid.
+pending-async-linearity.bpl(24,26): Error: Potential linearity violation in outputs and pending async of A for domain pid.
 Execution trace:
-    pending-async-linearity.bpl(24,23): inline$M2$0$Entry
+    pending-async-linearity.bpl(24,26): inline$M2$0$Entry
     pending-async-linearity.bpl(27,3): inline$M2$0$anon0
     (0,0): pid_single_A
-pending-async-linearity.bpl(37,23): Error: Potential lnearity violation in pending asyncs of A and B for domain pid.
+pending-async-linearity.bpl(37,26): Error: Potential lnearity violation in pending asyncs of A and B for domain pid.
 Execution trace:
-    pending-async-linearity.bpl(37,23): inline$M4$0$Entry
+    pending-async-linearity.bpl(37,26): inline$M4$0$Entry
     pending-async-linearity.bpl(40,3): inline$M4$0$anon0
     (0,0): pid_distinct_A_B
-pending-async-linearity.bpl(44,23): Error: Potential linearity violation in outputs and pending async of A for domain pid.
+pending-async-linearity.bpl(44,26): Error: Potential linearity violation in outputs and pending async of A for domain pid.
 Execution trace:
-    pending-async-linearity.bpl(44,23): inline$M5$0$Entry
+    pending-async-linearity.bpl(44,26): inline$M5$0$Entry
     pending-async-linearity.bpl(47,11): inline$M5$0$anon0
     (0,0): pid_single_A
-pending-async-linearity.bpl(67,23): Error: Potential linearity violation in outputs and pending async of A for domain pid.
+pending-async-linearity.bpl(67,26): Error: Potential linearity violation in outputs and pending async of A for domain pid.
 Execution trace:
-    pending-async-linearity.bpl(67,23): inline$M8$0$Entry
+    pending-async-linearity.bpl(67,26): inline$M8$0$Entry
     pending-async-linearity.bpl(70,3): inline$M8$0$anon0
     (0,0): pid_single_A
 

--- a/Test/civl/pending-async-noninterference-fail.bpl
+++ b/Test/civl/pending-async-noninterference-fail.bpl
@@ -6,13 +6,13 @@ var {:layer 0,1} x:int;
 yield invariant {:layer 1} yield_x(n: int);
 invariant x >= n;
 
-async >-< action {:layer 1} A ()
+async atomic action {:layer 1} A ()
 modifies x;
 {
   x := x - 1;
 }
 
-<- action {:layer 1} ASYNC_A ()
+left action {:layer 1} ASYNC_A ()
 creates A;
 {
   call create_async(A());

--- a/Test/civl/pending-async-noninterference-fail.bpl.expect
+++ b/Test/civl/pending-async-noninterference-fail.bpl.expect
@@ -1,7 +1,7 @@
 pending-async-noninterference-fail.bpl(7,1): Error: Non-interference check failed
 Execution trace:
-    pending-async-noninterference-fail.bpl(9,29): inline$A$0$Entry
+    pending-async-noninterference-fail.bpl(9,32): inline$A$0$Entry
     pending-async-noninterference-fail.bpl(12,5): inline$A$0$anon0
-    pending-async-noninterference-fail.bpl(9,29): inline$A$0$Return
+    pending-async-noninterference-fail.bpl(9,32): inline$A$0$Return
 
 Boogie program verifier finished with 1 verified, 1 error

--- a/Test/civl/pending-async-noninterference-linear.bpl
+++ b/Test/civl/pending-async-noninterference-linear.bpl
@@ -6,13 +6,13 @@ var {:layer 0,1} x:[int]int;
 yield invariant {:layer 1} yield_x({:linear "tid"} tid:int);
 invariant x[tid] == 0;
 
-async >-< action {:layer 1} A ({:linear "tid"} tid:int)
+async atomic action {:layer 1} A ({:linear "tid"} tid:int)
 modifies x;
 {
   x[tid] := 1;
 }
 
-<- action {:layer 1} ASYNC_A ({:linear_in "tid"} tid:int)
+left action {:layer 1} ASYNC_A ({:linear_in "tid"} tid:int)
  creates A;
 {
   call create_async(A(tid));

--- a/Test/civl/pending-async-noninterference-ok.bpl
+++ b/Test/civl/pending-async-noninterference-ok.bpl
@@ -6,13 +6,13 @@ var {:layer 0,1} x:int;
 yield invariant {:layer 1} yield_x(n: int);
 invariant x >= n;
 
-async >-< action {:layer 1} A ()
+async atomic action {:layer 1} A ()
 modifies x;
 {
   x := x + 1;
 }
 
-<- action {:layer 1} ASYNC_A ()
+left action {:layer 1} ASYNC_A ()
 creates A;
 {
   call create_async(A());

--- a/Test/civl/perm.bpl
+++ b/Test/civl/perm.bpl
@@ -24,7 +24,7 @@ requires call Yield(permVar_in, 0);
   call Yield(permVar_out, 1);
 }
 
->-< action {:layer 1} AtomicIncr()
+atomic action {:layer 1} AtomicIncr()
 modifies x;
 { x := x + 1; }
 

--- a/Test/civl/perm2.bpl
+++ b/Test/civl/perm2.bpl
@@ -7,14 +7,14 @@ var {:layer 0,1} g: int;
 var {:layer 0,1} h: int;
 var {:layer 0,1}{:linear "tid"} unallocated:[int]bool;
 
->-< action {:layer 1} AtomicSetG(val:int)
+atomic action {:layer 1} AtomicSetG(val:int)
 modifies g;
 {g := val; }
 
 yield procedure {:layer 0} SetG(val:int);
 refines AtomicSetG;
 
->-< action {:layer 1} AtomicSetH(val:int)
+atomic action {:layer 1} AtomicSetH(val:int)
 modifies h;
 { h := val; }
 
@@ -27,7 +27,7 @@ ensures {:layer 1} xl != 0;
     call xl := AllocateLow();
 }
 
->-< action {:layer 1} AtomicAllocateLow() returns ({:linear "tid"} xls: int)
+atomic action {:layer 1} AtomicAllocateLow() returns ({:linear "tid"} xls: int)
 modifies unallocated;
 { assume xls != 0; assume unallocated[xls]; unallocated[xls] := false; }
 

--- a/Test/civl/perm3.bpl
+++ b/Test/civl/perm3.bpl
@@ -19,14 +19,14 @@ requires {:layer 1} Permissions == MapConst(true);
   async call PB(Permissions);
 }
 
->-< action {:layer 1} AtomicSetG(val:int)
+atomic action {:layer 1} AtomicSetG(val:int)
 modifies g;
 { g := val; }
 
 yield procedure {:layer 0} SetG(val:int);
 refines AtomicSetG;
 
->-< action {:layer 1} AtomicIncrG()
+atomic action {:layer 1} AtomicIncrG()
 modifies g;
 { g := g + 1; }
 

--- a/Test/civl/perm4.bpl
+++ b/Test/civl/perm4.bpl
@@ -7,14 +7,14 @@ var {:layer 0,1} h: int;
 
 var {:layer 0,1}{:linear "tid"} unallocated:[int]bool;
 
->-< action {:layer 1} AtomicSetG(val:int)
+atomic action {:layer 1} AtomicSetG(val:int)
 modifies g;
 { g := val; }
 
 yield procedure {:layer 0} SetG(val:int);
 refines AtomicSetG;
 
->-< action {:layer 1} AtomicSetH(val:int)
+atomic action {:layer 1} AtomicSetH(val:int)
 modifies h;
 { h := val; }
 
@@ -30,7 +30,7 @@ ensures {:layer 1} xl != 0;
     call xl := AllocateLow();
 }
 
->-< action {:layer 1} AtomicAllocateLow() returns ({:linear "tid"} xls: int)
+atomic action {:layer 1} AtomicAllocateLow() returns ({:linear "tid"} xls: int)
 modifies unallocated;
 { assume xls != 0 && unallocated[xls]; unallocated[xls] := false; }
 

--- a/Test/civl/podelski/t-s.bpl
+++ b/Test/civl/podelski/t-s.bpl
@@ -25,14 +25,14 @@ preserves call Inv();
   call inc_s();
 }
 
--> action {:layer 1} INC_T ()
+right action {:layer 1} INC_T ()
 modifies t;
 {
   assert s <= t;
   t := t + 1;
 }
 
->-< action {:layer 1} INC_S ()
+atomic action {:layer 1} INC_S ()
 modifies s;
 {
   assert s < t;

--- a/Test/civl/podelski/x.bpl
+++ b/Test/civl/podelski/x.bpl
@@ -24,14 +24,14 @@ preserves call Inv();
   call geq0_dec();
 }
 
--> action {:layer 1} GEQ0_INC ()
+right action {:layer 1} GEQ0_INC ()
 modifies x;
 {
   assert x >= 0;
   x := x + 1;
 }
 
->-< action {:layer 1} GEQ0_DEC ()
+atomic action {:layer 1} GEQ0_DEC ()
 modifies x;
 {
   assert x >= 0;

--- a/Test/civl/podelski/x_perm.bpl
+++ b/Test/civl/podelski/x_perm.bpl
@@ -86,7 +86,7 @@ requires call Inv();
   }
 }
 
-<-> action {:layer 1} TRANSFER_AB (x:int, {:linear_in "perm"} abs:[AB]bool) returns ({:linear "perm"} ab:AB, {:linear "perm"} abs':[AB]bool)
+both action {:layer 1} TRANSFER_AB (x:int, {:linear_in "perm"} abs:[AB]bool) returns ({:linear "perm"} ab:AB, {:linear "perm"} abs':[AB]bool)
 {
   assert !abs[AB(-x)];
   assert abs[AB(x)];
@@ -94,7 +94,7 @@ requires call Inv();
   ab := AB(x);
 }
 
-<-> action {:layer 1} SPLIT_AB ({:linear_in "perm"} ab:AB) returns ({:linear "perm"} a:A, {:linear "perm"} b:B)
+both action {:layer 1} SPLIT_AB ({:linear_in "perm"} ab:AB) returns ({:linear "perm"} a:A, {:linear "perm"} b:B)
 {
   assert ab->x != 0;
   a := A(ab->x);
@@ -117,7 +117,7 @@ preserves call Inv();
   call geq0_dec(b);
 }
 
->-< action {:layer 1} GEQ0_INC ({:linear_in "perm"} a:A, {:linear "perm"} b:B)
+atomic action {:layer 1} GEQ0_INC ({:linear_in "perm"} a:A, {:linear "perm"} b:B)
 modifies x, As;
 {
   assert x >= 0;
@@ -126,7 +126,7 @@ modifies x, As;
   As[a] := true;
 }
 
->-< action {:layer 1} GEQ0_DEC ({:linear_in "perm"} b:B)
+atomic action {:layer 1} GEQ0_DEC ({:linear_in "perm"} b:B)
 modifies x, Bs;
 {
   assert x >= 0;

--- a/Test/civl/purity-issta.bpl
+++ b/Test/civl/purity-issta.bpl
@@ -9,7 +9,7 @@ axiom 0 <= max;
 var {:layer 0,1} l: [int]X;
 var {:layer 0,2} status: [int]bool;
 
->-< action {:layer 2} atomic_Alloc({:linear "tid"} tid: X) returns (r: int)
+atomic action {:layer 2} atomic_Alloc({:linear "tid"} tid: X) returns (r: int)
 modifies status;
 {
   assert tid != nil;
@@ -21,7 +21,7 @@ modifies status;
   }
 }
 
->-< action {:layer 2} atomic_Free({:linear "tid"} tid: X, i: int)
+atomic action {:layer 2} atomic_Free({:linear "tid"} tid: X, i: int)
 modifies status;
 { assert tid != nil; status[i] := true; }
 
@@ -58,18 +58,18 @@ refines atomic_Free;
   call release(tid, i);
 }
 
--> action {:layer 1} atomic_acquire({:linear "tid"} tid: X, i: int)
+right action {:layer 1} atomic_acquire({:linear "tid"} tid: X, i: int)
 modifies l;
 { assert tid != nil; assume l[i] == nil; l[i] := tid; }
 
-<- action {:layer 1} atomic_release({:linear "tid"} tid: X, i: int)
+left action {:layer 1} atomic_release({:linear "tid"} tid: X, i: int)
 modifies l;
 { assert tid != nil; assert l[i] == tid; l[i] := nil; }
 
-<-> action {:layer 1} atomic_Read({:linear "tid"} tid: X, i: int) returns (val: bool)
+both action {:layer 1} atomic_Read({:linear "tid"} tid: X, i: int) returns (val: bool)
 { assert tid != nil; assert l[i] == tid; val := status[i]; }
 
-<-> action {:layer 1} atomic_Write({:linear "tid"} tid: X, i: int, val: bool)
+both action {:layer 1} atomic_Write({:linear "tid"} tid: X, i: int, val: bool)
 modifies status;
 { assert tid != nil; assert l[i] == tid; status[i] := val; }
 

--- a/Test/civl/refinement.bpl
+++ b/Test/civl/refinement.bpl
@@ -52,13 +52,13 @@ refines INCR;
   }
 }
 
-<-> action {:layer 1,2} INCR ()
+both action {:layer 1,2} INCR ()
 modifies x;
 {
   x := x + 1;
 }
 
-<-> action {:layer 1,2} DECR ()
+both action {:layer 1,2} DECR ()
 modifies x;
 {
   x := x - 1;

--- a/Test/civl/refinement2.bpl
+++ b/Test/civl/refinement2.bpl
@@ -16,7 +16,7 @@ refines atomic_incr;
     par incr() | {:mark} nop() | nop();
 }
 
->-< action {:layer 1,2} atomic_incr()
+atomic action {:layer 1,2} atomic_incr()
 modifies x;
 {
     x := x + 1;
@@ -24,7 +24,7 @@ modifies x;
 yield procedure {:layer 1} incr();
 refines atomic_incr;
 
->-< action {:layer 1,2} atomic_nop()
+atomic action {:layer 1,2} atomic_nop()
 {
 }
 yield procedure {:layer 1} nop();

--- a/Test/civl/refinement2.bpl.expect
+++ b/Test/civl/refinement2.bpl.expect
@@ -2,14 +2,14 @@ refinement2.bpl(13,28): Error: On some path no yield-to-yield fragment matched t
 Execution trace:
     refinement2.bpl(16,5): anon0
     (0,0): Civl_call_refinement_4
-    refinement2.bpl(27,25): inline$atomic_nop$0$Return
+    refinement2.bpl(27,28): inline$atomic_nop$0$Return
     (0,0): Civl_ReturnChecker
 refinement2.bpl(13,28): Error: A yield-to-yield fragment illegally modifies layer-2 globals
 Execution trace:
     refinement2.bpl(16,5): anon0
     (0,0): Civl_call_refinement_3
     refinement2.bpl(22,7): inline$atomic_incr$0$anon0
-    refinement2.bpl(19,25): inline$atomic_incr$0$Return
+    refinement2.bpl(19,28): inline$atomic_incr$0$Return
     (0,0): Civl_UnchangedChecker
 
 Boogie program verifier finished with 1 verified, 2 errors

--- a/Test/civl/reserve.bpl
+++ b/Test/civl/reserve.bpl
@@ -60,7 +60,7 @@ ensures Size(Y) == Size(X) + Size(MapDiff(Y, X));
 yield procedure {:layer 0} DecrementFreeSpace({:linear "tid"} tid: Tid);
 refines atomic_DecrementFreeSpace;
 
->-< action {:layer 1} atomic_DecrementFreeSpace({:linear "tid"} tid: Tid)
+atomic action {:layer 1} atomic_DecrementFreeSpace({:linear "tid"} tid: Tid)
 modifies freeSpace, allocMap;
 {
     var ptr: int;
@@ -72,7 +72,7 @@ modifies freeSpace, allocMap;
     call allocMap := Reserve(allocMap, tid, ptr);
 }
 
->-< action Reserve(allocMap: Bijection, tid: Tid, ptr: int) returns (allocMap': Bijection) {
+atomic action Reserve(allocMap: Bijection, tid: Tid, ptr: int) returns (allocMap': Bijection) {
     assert !allocMap->domain[tid];
     assert !allocMap->range[ptr];
     assert memAddr(ptr);
@@ -86,7 +86,7 @@ modifies freeSpace, allocMap;
 yield procedure {:layer 0} AllocIfPtrFree({:linear "tid"} tid: Tid, ptr: int) returns (spaceFound:bool);
 refines atomic_AllocIfPtrFree;
 
->-< action {:layer 1} atomic_AllocIfPtrFree({:linear "tid"} tid: Tid, ptr: int) returns (spaceFound:bool)
+atomic action {:layer 1} atomic_AllocIfPtrFree({:linear "tid"} tid: Tid, ptr: int) returns (spaceFound:bool)
 modifies isFree, allocMap;
 {
     var tid': Tid;
@@ -102,7 +102,7 @@ modifies isFree, allocMap;
     }
 }
 
->-< action Alloc(allocMap: Bijection, tid: Tid, ptr: int) returns (allocMap': Bijection) {
+atomic action Alloc(allocMap: Bijection, tid: Tid, ptr: int) returns (allocMap': Bijection) {
     var tid': Tid;
     var ptr': int;
     assert allocMap->domain[tid];
@@ -131,7 +131,7 @@ modifies isFree, allocMap;
 yield procedure {:layer 0} Reclaim() returns (ptr: int);
 refines atomic_Reclaim;
 
->-< action {:layer 1} atomic_Reclaim() returns (ptr: int)
+atomic action {:layer 1} atomic_Reclaim() returns (ptr: int)
 modifies freeSpace, isFree;
 {
     assume memAddr(ptr) && !isFree[ptr];

--- a/Test/civl/rwlock.bpl
+++ b/Test/civl/rwlock.bpl
@@ -27,7 +27,7 @@ var {:layer 0, 1} rwlock: RwLock;
 
 // Acquiring a read lock is possible if there is no writer, and has the effect
 // of adding us to `readers`.
--> action {:layer 1, 1} atomic_acquire_read({:linear "tid"} tid: Tid)
+right action {:layer 1, 1} atomic_acquire_read({:linear "tid"} tid: Tid)
 modifies rwlock;
 {
     assume rwlock->writer == None();
@@ -36,7 +36,7 @@ modifies rwlock;
 
 // Acquiring a write lock is possbile if there is no other writer and no reader,
 // and has the effect of storing us as the `writer`.
--> action {:layer 1, 1} atomic_acquire_write({:linear "tid"} tid: Tid)
+right action {:layer 1, 1} atomic_acquire_write({:linear "tid"} tid: Tid)
 modifies rwlock;
 {
     assume rwlock->writer == None();
@@ -61,7 +61,7 @@ function {:inline} holds_write_lock(tid: Tid, rwlock: RwLock): bool
 }
 
 // Releasing a read lock takes us out of `readers`.
-<- action {:layer 1, 1} atomic_release_read({:linear "tid"} tid: Tid)
+left action {:layer 1, 1} atomic_release_read({:linear "tid"} tid: Tid)
 modifies rwlock;
 {
     assert holds_read_lock(tid, rwlock);
@@ -69,7 +69,7 @@ modifies rwlock;
 }
 
 // Releasing a write lock takes us out of `writer`.
-<- action {:layer 1, 1} atomic_release_write({:linear "tid"} tid: Tid)
+left action {:layer 1, 1} atomic_release_write({:linear "tid"} tid: Tid)
 modifies rwlock;
 {
     assert holds_write_lock(tid, rwlock);
@@ -100,13 +100,13 @@ type Val;
 
 var {:layer 0, 2} memory: [Addr]Val;
 
-<-> action {:layer 1,1} atomic_read({:linear "tid"} tid: Tid, a: Addr) returns (v: Val)
+both action {:layer 1,1} atomic_read({:linear "tid"} tid: Tid, a: Addr) returns (v: Val)
 {
     assert holds_read_lock(tid, rwlock);
     v := memory[a];
 }
 
-<-> action {:layer 1,1} atomic_write({:linear "tid"} tid: Tid, a: Addr, v: Val)
+both action {:layer 1,1} atomic_write({:linear "tid"} tid: Tid, a: Addr, v: Val)
 modifies memory;
 {
     assert holds_write_lock(tid, rwlock);
@@ -151,13 +151,13 @@ refines atomic_write2;
 // We can prove that the above procedures perform their operations on two memory
 // locations atomically.
 
->-< action {:layer 2} atomic_read2(a1: Addr, a2: Addr) returns (v1: Val, v2: Val)
+atomic action {:layer 2} atomic_read2(a1: Addr, a2: Addr) returns (v1: Val, v2: Val)
 {
     v1 := memory[a1];
     v2 := memory[a2];
 }
 
->-< action {:layer 2} atomic_write2(a1: Addr, a2:Addr, v1: Val, v2: Val)
+atomic action {:layer 2} atomic_write2(a1: Addr, a2:Addr, v1: Val, v2: Val)
 modifies memory;
 {
     memory[a1] := v1;

--- a/Test/civl/signature-mismatch.bpl
+++ b/Test/civl/signature-mismatch.bpl
@@ -10,7 +10,7 @@ yield procedure {:layer 1} main ()
   call write_x_1(true);
 }
 
->-< action {:layer 1,1} atomic_write_x_1 (x':bool)
+atomic action {:layer 1,1} atomic_write_x_1 (x':bool)
 modifies y;
 { y := x'; }
 
@@ -19,7 +19,7 @@ refines atomic_write_x_1;
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 1,1} atomic_write_x_2 (x':int, foo:int)
+atomic action {:layer 1,1} atomic_write_x_2 (x':int, foo:int)
 modifies x;
 { x := x'; }
 
@@ -29,7 +29,7 @@ refines atomic_write_x_2;
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 1,1} atomic_write_x_3 ({:linear "lin"} x':int)
+atomic action {:layer 1,1} atomic_write_x_3 ({:linear "lin"} x':int)
 modifies x;
 { x := x'; }
 
@@ -38,7 +38,7 @@ refines atomic_write_x_3;
 
 ////////////////////////////////////////////////////////////////////////////////
 
->-< action {:layer 1,1} atomic_write_x_4 (x':int)
+atomic action {:layer 1,1} atomic_write_x_4 (x':int)
 modifies x;
 { x := x'; }
 

--- a/Test/civl/ticket.bpl
+++ b/Test/civl/ticket.bpl
@@ -100,7 +100,7 @@ requires {:layer 2} tid != nil;
 
 // Note how GetTicketAbstract becomes a right mover
 
->-< action {:layer 2} AtomicInitAbstract ({:linear "tid"} xls:[X]bool)
+atomic action {:layer 2} AtomicInitAbstract ({:linear "tid"} xls:[X]bool)
 modifies cs, s, T;
 { assert xls == MapConst(true); cs := nil; s := 0; T := RightOpen(0); }
 
@@ -111,7 +111,7 @@ ensures call Yield1();
   call Init(xls);
 }
 
--> action {:layer 2} AtomicGetTicketAbstract ({:linear "tid"} tid: X) returns (m: int)
+right action {:layer 2} AtomicGetTicketAbstract ({:linear "tid"} tid: X) returns (m: int)
 modifies T;
 { assume !T[m]; T[m] := true; }
 
@@ -125,35 +125,35 @@ preserves call Yield1();
 // ###########################################################################
 // Primitive atomic actions
 
->-< action {:layer 1} AtomicInit ({:linear "tid"} xls:[X]bool)
+atomic action {:layer 1} AtomicInit ({:linear "tid"} xls:[X]bool)
 modifies cs, t, s, T;
 { assert xls == MapConst(true); cs := nil; t := 0; s := 0; T := RightOpen(0); }
 
 yield procedure {:layer 0} Init ({:linear "tid"} xls:[X]bool);
 refines AtomicInit;
 
->-< action {:layer 1} AtomicGetTicket ({:linear "tid"} tid: X) returns (m: int)
+atomic action {:layer 1} AtomicGetTicket ({:linear "tid"} tid: X) returns (m: int)
 modifies t, T;
 { m := t; t := t + 1; T[m] := true; }
 
 yield procedure {:layer 0} GetTicket ({:linear "tid"} tid: X) returns (m: int);
 refines AtomicGetTicket;
 
->-< action {:layer 1,2} AtomicWaitAndEnter ({:linear "tid"} tid: X, m:int)
+atomic action {:layer 1,2} AtomicWaitAndEnter ({:linear "tid"} tid: X, m:int)
 modifies cs;
 { assume m == s; cs := tid; }
 
 yield procedure {:layer 0} WaitAndEnter ({:linear "tid"} tid: X, m:int);
 refines AtomicWaitAndEnter;
 
->-< action {:layer 1,2} AtomicLeave ({:linear "tid"} tid: X)
+atomic action {:layer 1,2} AtomicLeave ({:linear "tid"} tid: X)
 modifies cs, s;
 { assert cs == tid; s := s + 1; cs := nil; }
 
 yield procedure {:layer 0} Leave ({:linear "tid"} tid: X);
 refines AtomicLeave;
 
->-< action {:layer 1,2} AtomicAllocateLow ({:linear_in "tid"} xls':[X]bool) returns ({:linear "tid"} xls: [X]bool, {:linear "tid"} xl: X)
+atomic action {:layer 1,2} AtomicAllocateLow ({:linear_in "tid"} xls':[X]bool) returns ({:linear "tid"} xls: [X]bool, {:linear "tid"} xl: X)
 { assume xl != nil && xls'[xl]; xls := xls'[xl := false]; }
 
 yield procedure {:layer 0} AllocateLow ({:linear_in "tid"} xls':[X]bool) returns ({:linear "tid"} xls: [X]bool, {:linear "tid"} xl: X);

--- a/Test/civl/treiber-stack.bpl
+++ b/Test/civl/treiber-stack.bpl
@@ -22,7 +22,7 @@ type X; // module type parameter
 var {:layer 0, 4} ts: Lheap (Treiber X);
 var {:layer 2, 4} unused: [RefTreiber X][RefNode X]bool;
 
->-< action {:layer 4} AtomicPopIntermediate(ref_t: RefTreiber X) returns (success: bool, x: X)
+atomic action {:layer 4} AtomicPopIntermediate(ref_t: RefTreiber X) returns (success: bool, x: X)
 modifies ts;
 {
   var new_ref_n: RefNode X;
@@ -52,7 +52,7 @@ preserves call YieldInv#3(ref_t);
   call success := WriteTopOfStack#Pop(ref_t, ref_n, new_ref_n);
 }
 
->-< action {:layer 3} AtomicPushIntermediate(ref_t: RefTreiber X, x: X) returns (success: bool)
+atomic action {:layer 3} AtomicPushIntermediate(ref_t: RefTreiber X, x: X) returns (success: bool)
 modifies ts, unused;
 {
   var {:pool "A"} ref_n: RefNode X;
@@ -80,7 +80,7 @@ refines AtomicPushIntermediate;
   call AddToUnusedNodes(success, ref_t, new_ref_n);
 }
 
--> action {:layer 3}
+right action {:layer 3}
 AtomicReadTopOfStack#Pop(ref_t: RefTreiber X) returns (ref_n: RefNode X)
 {
   assert ts->dom[ref_t];
@@ -94,7 +94,7 @@ preserves call YieldInv#2(ref_t);
   call ref_n := ReadTopOfStack(ref_t);
 }
 
--> action {:layer 2}
+right action {:layer 2}
 AtomicReadTopOfStack#Push(ref_t: RefTreiber X) returns (ref_n: RefNode X)
 {
   assert ts->dom[ref_t];
@@ -106,7 +106,7 @@ refines AtomicReadTopOfStack#Push;
   call ref_n := ReadTopOfStack(ref_t);
 }
 
->-< action {:layer 1, 2}
+atomic action {:layer 1, 2}
 AtomicReadTopOfStack(ref_t: RefTreiber X) returns (ref_n: RefNode X)
 {
   assert ts->dom[ref_t];
@@ -116,7 +116,7 @@ yield procedure {:layer 0}
 ReadTopOfStack(ref_t: RefTreiber X) returns (ref_n: RefNode X);
 refines AtomicReadTopOfStack;
 
--> action {:layer 1, 3}
+right action {:layer 1, 3}
 AtomicLoadNode(ref_t: RefTreiber X, ref_n: RefNode X) returns (node: Node X)
 {
   assert ts->dom[ref_t];
@@ -127,7 +127,7 @@ yield procedure {:layer 0}
 LoadNode(ref_t: RefTreiber X, ref_n: RefNode X) returns (node: Node X);
 refines AtomicLoadNode;
 
--> action {:layer 1, 2}
+right action {:layer 1, 2}
 AtomicAllocInStack(ref_t: RefTreiber X, node: Node X) returns (ref_n: RefNode X)
 modifies ts;
 {
@@ -138,7 +138,7 @@ yield procedure {:layer 0}
 AllocInStack(ref_t: RefTreiber X, node: Node X) returns (ref_n: RefNode X);
 refines AtomicAllocInStack;
 
->-< action {:layer 3}
+atomic action {:layer 3}
 AtomicWriteTopOfStack#Pop(ref_t: RefTreiber X, old_ref_n: RefNode X, new_ref_n: RefNode X) returns (r: bool)
 modifies ts;
 {
@@ -153,7 +153,7 @@ preserves call YieldInv#2(ref_t);
   call r := WriteTopOfStack(ref_t, old_ref_n, new_ref_n);
 }
 
->-< action {:layer 1, 3}
+atomic action {:layer 1, 3}
 AtomicWriteTopOfStack(ref_t: RefTreiber X, old_ref_n: RefNode X, new_ref_n: RefNode X) returns (r: bool)
 modifies ts;
 {
@@ -170,7 +170,7 @@ yield procedure {:layer 0}
 WriteTopOfStack(ref_t: RefTreiber X, old_ref_n: RefNode X, new_ref_n: RefNode X) returns (r: bool);
 refines AtomicWriteTopOfStack;
 
->-< action {:layer 1, 4}
+atomic action {:layer 1, 4}
 AtomicAllocTreiber() returns (ref_t: RefTreiber X)
 modifies ts;
 {

--- a/Test/civl/unprotected-read.bpl
+++ b/Test/civl/unprotected-read.bpl
@@ -12,20 +12,20 @@ var {:layer 0,1} x:int;
 
 ////////////////////////////////////////////////////////////////////////////////
 
--> action {:layer 1} Acquire({:linear "tid"} tid:Tid)
+right action {:layer 1} Acquire({:linear "tid"} tid:Tid)
 modifies lock;
 { assert tid != nil; assume lock == nil; lock := tid; }
 
-<- action {:layer 1} Release({:linear "tid"} tid:Tid)
+left action {:layer 1} Release({:linear "tid"} tid:Tid)
 modifies lock;
 { assert tid != nil && lock == tid; lock := nil; }
 
->-< action {:layer 1} Write({:linear "tid"} tid:Tid, val:int)
+atomic action {:layer 1} Write({:linear "tid"} tid:Tid, val:int)
 modifies x;
 { assert tid != nil && lock == tid; x := val; }
 
-<-> action {:layer 1} ReadLock({:linear "tid"} tid:Tid) returns (val:int)
+both action {:layer 1} ReadLock({:linear "tid"} tid:Tid) returns (val:int)
 { assert tid != nil && lock == tid; val := x; }
 
->-< action {:layer 1} ReadNoLock() returns (val:int)
+atomic action {:layer 1} ReadNoLock() returns (val:int)
 { val := x; }

--- a/Test/civl/verified-ft.bpl
+++ b/Test/civl/verified-ft.bpl
@@ -192,13 +192,13 @@ function {:inline} FTPreserved({:linear "tid" } tid:Tid,
 // VarState Lock
 yield procedure {:layer 0} AcquireVarLock({:linear "tid"} tid: Tid, x : Var);
 refines AtomicAcquireVarLock;
--> action {:layer 1,20} AtomicAcquireVarLock({:linear "tid"} tid: Tid, x : Var)
+right action {:layer 1,20} AtomicAcquireVarLock({:linear "tid"} tid: Tid, x : Var)
 modifies shadow.Lock;
 { assert ValidTid(tid); assume shadow.Lock[ShadowableVar(x)] == nil; shadow.Lock[ShadowableVar(x)] := tid; }
 
 yield procedure {:layer 0} ReleaseVarLock({:linear "tid"} tid: Tid, x : Var);
 refines AtomicReleaseVarLock;
-<- action {:layer 1,20} AtomicReleaseVarLock({:linear "tid"} tid: Tid, x : Var)
+left action {:layer 1,20} AtomicReleaseVarLock({:linear "tid"} tid: Tid, x : Var)
 modifies shadow.Lock;
 { assert ValidTid(tid); assert shadow.Lock[ShadowableVar(x)] == tid; shadow.Lock[ShadowableVar(x)] := nil; }
 
@@ -206,46 +206,46 @@ modifies shadow.Lock;
 // ThreadState
 yield procedure {:layer 0} ThreadStateGetE({:linear "tid"} tid: Tid) returns (e:Epoch);
 refines AtomicThreadStateGetE;
-<-> action {:layer 1,20} AtomicThreadStateGetE({:linear "tid"} tid: Tid) returns (e:Epoch)
+both action {:layer 1,20} AtomicThreadStateGetE({:linear "tid"} tid: Tid) returns (e:Epoch)
 { assert ValidTid(tid); assert shadow.Lock[ShadowableTid(tid)] == tid; e := shadow.VC[ShadowableTid(tid)][tid]; }
 
 
 // VarState
 yield procedure {:layer 0} VarStateSetW({:linear "tid"} tid:Tid, x : Var, e:Epoch);
 refines AtomicVarStateSetW;
->-< action {:layer 1,20} AtomicVarStateSetW({:linear "tid"} tid:Tid, x : Var, e:Epoch)
+atomic action {:layer 1,20} AtomicVarStateSetW({:linear "tid"} tid:Tid, x : Var, e:Epoch)
 modifies sx.W;
 { assert ValidTid(tid); assert shadow.Lock[ShadowableVar(x)] == tid; sx.W[x] := e; }
 
 yield procedure {:layer 0} VarStateGetW({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch);
 refines AtomicVarStateGetW;
-<-> action {:layer 1,20} AtomicVarStateGetW({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
+both action {:layer 1,20} AtomicVarStateGetW({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
 { assert ValidTid(tid); assert shadow.Lock[ShadowableVar(x)] == tid; e := sx.W[x]; }
 
 yield procedure {:layer 0} VarStateGetWNoLock({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch);
 refines AtomicVarStateGetWNoLock;
->-< action {:layer 1,20} AtomicVarStateGetWNoLock({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
+atomic action {:layer 1,20} AtomicVarStateGetWNoLock({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
 { assert ValidTid(tid); e := sx.W[x]; }
 
 yield procedure {:layer 0} VarStateSetR({:linear "tid"} tid:Tid, x : Var, e:Epoch);
 refines AtomicVarStateSetR;
->-< action {:layer 1,20} AtomicVarStateSetR({:linear "tid"} tid:Tid, x : Var, e:Epoch)
+atomic action {:layer 1,20} AtomicVarStateSetR({:linear "tid"} tid:Tid, x : Var, e:Epoch)
 modifies sx.R;
 { assert ValidTid(tid); assert shadow.Lock[ShadowableVar(x)] == tid; assert sx.R[x] != SHARED; sx.R[x] := e; }
 
 yield procedure {:layer 0} VarStateGetRNoLock({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch);
 refines AtomicVarStateGetRNoLock;
->-< action {:layer 1,20} AtomicVarStateGetRNoLock({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
+atomic action {:layer 1,20} AtomicVarStateGetRNoLock({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
 { assert ValidTid(tid); e := sx.R[x]; }
 
 yield procedure {:layer 0} VarStateGetR({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch);
 refines AtomicVarStateGetR;
-<-> action {:layer 1,20} AtomicVarStateGetR({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
+both action {:layer 1,20} AtomicVarStateGetR({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
 { assert ValidTid(tid); assert shadow.Lock[ShadowableVar(x)] == tid; e := sx.R[x]; }
 
 yield procedure {:layer 0} VarStateGetRShared({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch);
 refines AtomicVarStateGetRShared;
--> action {:layer 1,20} AtomicVarStateGetRShared({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
+right action {:layer 1,20} AtomicVarStateGetRShared({:linear "tid"} tid:Tid, x : Var) returns (e:Epoch)
 { assert ValidTid(tid); assume sx.R[x] == SHARED; e := SHARED; }
 
 
@@ -253,7 +253,7 @@ refines AtomicVarStateGetRShared;
 
 yield procedure {:layer 0} VCGetSize({:linear "tid" } tid: Tid, r: Shadowable) returns (i: int);
 refines AtomicVCGetSize;
-<-> action {:layer 1,10} AtomicVCGetSize({:linear "tid" } tid: Tid, r: Shadowable) returns (i: int)
+both action {:layer 1,10} AtomicVCGetSize({:linear "tid" } tid: Tid, r: Shadowable) returns (i: int)
 {
    assert ValidTid(tid);
    assert (shadow.Lock[r] == tid);
@@ -262,7 +262,7 @@ refines AtomicVCGetSize;
 
 yield procedure {:layer 0} VCGetElem({:linear "tid" } tid: Tid, r: Shadowable, i: int) returns (e: Epoch);
 refines AtomicVCGetElem;
-<-> action {:layer 1,20} AtomicVCGetElem({:linear "tid" } tid: Tid, r: Shadowable, i: int) returns (e: Epoch)
+both action {:layer 1,20} AtomicVCGetElem({:linear "tid" } tid: Tid, r: Shadowable, i: int) returns (e: Epoch)
 {
    assert ValidTid(tid);
    assert (shadow.Lock[r] == tid);
@@ -271,7 +271,7 @@ refines AtomicVCGetElem;
 
 yield procedure {:layer 0} VCGetElemShared({:linear "tid" } tid: Tid, x : Var) returns (e: Epoch);
 refines AtomicVCGetElemShared;
->-< action {:layer 1,20} AtomicVCGetElemShared({:linear "tid" } tid: Tid, x : Var) returns (e: Epoch)
+atomic action {:layer 1,20} AtomicVCGetElemShared({:linear "tid" } tid: Tid, x : Var) returns (e: Epoch)
 {
    assert sx.R[x] == SHARED;
    assert ValidTid(tid);
@@ -280,7 +280,7 @@ refines AtomicVCGetElemShared;
 
 yield procedure {:layer 0} VCSetElemShared({:linear "tid" } tid: Tid, x : Var, e: Epoch);
 refines AtomicVCSetElemShared;
-<-> action {:layer 1,20} AtomicVCSetElemShared({:linear "tid" } tid: Tid, x : Var, e: Epoch)
+both action {:layer 1,20} AtomicVCSetElemShared({:linear "tid" } tid: Tid, x : Var, e: Epoch)
 modifies shadow.VC;
 {
    assert sx.R[x] == SHARED;
@@ -292,7 +292,7 @@ modifies shadow.VC;
 
 yield procedure {:layer 0} VCSetElem({:linear "tid" } tid: Tid, r: Shadowable, i: int, e: Epoch);
 refines AtomicVCSetElem;
-<-> action {:layer 1,20} AtomicVCSetElem({:linear "tid" } tid: Tid, r: Shadowable, i: int, e: Epoch)
+both action {:layer 1,20} AtomicVCSetElem({:linear "tid" } tid: Tid, r: Shadowable, i: int, e: Epoch)
 modifies shadow.VC;
 {
    assert r is ShadowableVar ==> sx.R[r->x] != SHARED;
@@ -304,7 +304,7 @@ modifies shadow.VC;
 
 yield procedure {:layer 0} VCInit({:linear "tid" } tid: Tid, r: Shadowable);
 refines AtomicVCInit;
-<-> action {:layer 1,20} AtomicVCInit({:linear "tid" } tid: Tid, r: Shadowable)
+both action {:layer 1,20} AtomicVCInit({:linear "tid" } tid: Tid, r: Shadowable)
 modifies shadow.VC;
 {
    assert ValidTid(tid);
@@ -331,7 +331,7 @@ invariant ValidTid(tid);
 invariant LocksPreserved(tid, old.shadow.Lock, shadow.Lock);
 invariant (forall s: Shadowable :: s != v1 && s != v2 && old.shadow.Lock[s] == tid ==> old.shadow.VC[s] == shadow.VC[s]);
 
-<-> action {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
+both action {:layer 11,20} AtomicVC.Leq({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable) returns (res: bool)
 {
    assert ValidTid(tid);
    assert shadow.Lock[v1] == tid;
@@ -377,7 +377,7 @@ preserves call Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(s
   return;
 }
 
-<-> action {:layer 11,20} AtomicVC.Copy({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
+both action {:layer 11,20} AtomicVC.Copy({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
 modifies shadow.VC;
 {
     var {:pool "A"} vc: VC;
@@ -438,7 +438,7 @@ ensures call Yield_VCPreserved_10(tid, v1, v1, old(shadow.Lock), old(shadow.VC))
 }
 
 
--> action {:layer 11,20} AtomicVC.Join({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
+right action {:layer 11,20} AtomicVC.Join({:linear "tid"} tid: Tid, v1: Shadowable, v2: Shadowable)
 modifies shadow.VC;
 {
     var {:pool "A"} vc: VC;
@@ -501,7 +501,7 @@ action{:layer 10} GhostRead() returns (lock : [Shadowable]Tid, data : [Shadowabl
   data := shadow.VC;
 }
 
-<-> action {:layer 11,20} AtomicVC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
+both action {:layer 11,20} AtomicVC.Inc({:linear "tid" } tid: Tid, v: Shadowable, i: int)
 modifies shadow.VC;
 {
    assert ValidTid(tid);
@@ -547,7 +547,7 @@ yield invariant {:layer 20} Yield_FTPreserved_20({:linear "tid"} tid:Tid, old.sh
 invariant ValidTid(tid);
 invariant FTPreserved(tid, old.shadow.Lock, old.shadow.VC, old.sx.W, old.sx.R, shadow.Lock, shadow.VC, sx.W, sx.R);
 
->-< action {:layer 21,30} AtomicFork({:linear "tid"} tid:Tid, uid : Tid)
+atomic action {:layer 21,30} AtomicFork({:linear "tid"} tid:Tid, uid : Tid)
 modifies shadow.VC;
 {
     var v1,v2: Shadowable;
@@ -589,7 +589,7 @@ ensures call Yield_VCPreserved_20(tid, ShadowableTid(tid), ShadowableTid(uid), o
   assume {:add_to_pool "A", shadow.VC[ShadowableTid(uid)], shadow.VC[ShadowableTid(tid)]} true;
 }
 
->-< action {:layer 21,30} AtomicJoin({:linear "tid"} tid:Tid, uid : Tid)
+atomic action {:layer 21,30} AtomicJoin({:linear "tid"} tid:Tid, uid : Tid)
 modifies shadow.VC;
 {
     var v1, v2: Shadowable;
@@ -626,7 +626,7 @@ ensures call Yield_VCPreserved_20(tid, ShadowableTid(tid), ShadowableTid(tid), o
 }
 
 
->-< action {:layer 21,30} AtomicAcquire({:linear "tid"} tid: Tid, l: Lock)
+atomic action {:layer 21,30} AtomicAcquire({:linear "tid"} tid: Tid, l: Lock)
 modifies shadow.VC;
 {
     var v1, v2: Shadowable;
@@ -658,7 +658,7 @@ ensures call Yield_VCPreserved_20(tid, ShadowableTid(tid), ShadowableTid(tid), o
   call VC.Join(tid, ShadowableTid(tid), ShadowableLock(l));
 }
 
->-< action {:layer 21,30} AtomicRelease({:linear "tid"} tid: Tid, l: Lock)
+atomic action {:layer 21,30} AtomicRelease({:linear "tid"} tid: Tid, l: Lock)
 modifies shadow.VC;
 {
     var v1,v2: Shadowable;
@@ -707,7 +707,7 @@ ensures call Yield_VCPreserved_20(tid, ShadowableTid(tid), ShadowableLock(l), ol
 }
 
 
->-< action {:layer 21,30} AtomicWrite({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
+atomic action {:layer 21,30} AtomicWrite({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 modifies sx.W;
 {
              var st : Shadowable;
@@ -812,7 +812,7 @@ preserves call Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(s
 }
 
 
->-< action {:layer 21,30} AtomicRead({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
+atomic action {:layer 21,30} AtomicRead({:linear "tid"} tid:Tid, x : Var) returns (ok : bool)
 modifies sx.R, shadow.VC;
 {
              var st : Shadowable;
@@ -1019,7 +1019,7 @@ requires call Yield_ThreadState_30(tid);
 
 yield procedure {:layer 0} ReleaseJoinLock({:linear "tid"} tid:Tid, uid: Tid);
 refines AtomicReleaseJoinLock;
->-< action {:layer 1,30} AtomicReleaseJoinLock({:linear "tid"} tid:Tid, uid: Tid)
+atomic action {:layer 1,30} AtomicReleaseJoinLock({:linear "tid"} tid:Tid, uid: Tid)
 modifies shadow.Lock;
 {
     assert ValidTid(tid);
@@ -1031,7 +1031,7 @@ modifies shadow.Lock;
 
 yield procedure {:layer 0} ChooseThreadToJoin({:linear "tid"} tid:Tid) returns (uid: Tid);
 refines AtomicChooseThreadToJoin;
->-< action {:layer 1,30} AtomicChooseThreadToJoin({:linear "tid"} tid:Tid) returns (uid: Tid)
+atomic action {:layer 1,30} AtomicChooseThreadToJoin({:linear "tid"} tid:Tid) returns (uid: Tid)
 modifies shadow.Lock, thread.HasJoined;
 {
     assert thread.State[tid] == RUNNING() && ValidTid(tid);
@@ -1044,7 +1044,7 @@ modifies shadow.Lock, thread.HasJoined;
 
 yield procedure {:layer 0} AllocTid({:linear "tid"} tid:Tid) returns (uid: Tid);
 refines AtomicAllocTid;
->-< action {:layer 1,30} AtomicAllocTid({:linear "tid"} tid:Tid) returns (uid: Tid)
+atomic action {:layer 1,30} AtomicAllocTid({:linear "tid"} tid:Tid) returns (uid: Tid)
 modifies thread.State, thread.ForkedBy, shadow.Lock;
 {
     assert thread.State[tid] == RUNNING() && ValidTid(tid);
@@ -1059,7 +1059,7 @@ modifies thread.State, thread.ForkedBy, shadow.Lock;
 
 yield procedure {:layer 0} StartThread({:linear "tid"} tid:Tid, uid: Tid);
 refines AtomicStartThread;
->-< action {:layer 1,30} AtomicStartThread({:linear "tid"} tid:Tid, uid: Tid)
+atomic action {:layer 1,30} AtomicStartThread({:linear "tid"} tid:Tid, uid: Tid)
 modifies thread.State, shadow.Lock;
 {
     assert ValidTid(tid);
@@ -1073,7 +1073,7 @@ modifies thread.State, shadow.Lock;
 
 yield procedure {:layer 0} ChooseLockToAcquire({:linear "tid"} tid:Tid) returns (l: Lock);
 refines AtomicChooseLockToAcquire;
->-< action {:layer 1,30} AtomicChooseLockToAcquire({:linear "tid"} tid:Tid) returns (l: Lock)
+atomic action {:layer 1,30} AtomicChooseLockToAcquire({:linear "tid"} tid:Tid) returns (l: Lock)
 modifies shadow.Lock;
 {
     assert ValidTid(tid);
@@ -1083,7 +1083,7 @@ modifies shadow.Lock;
 
 yield procedure {:layer 0} ChooseLockToRelease({:linear "tid"} tid:Tid) returns (l: Lock);
 refines AtomicChooseLockToRelease;
->-< action {:layer 1,30} AtomicChooseLockToRelease({:linear "tid"} tid:Tid) returns (l: Lock)
+atomic action {:layer 1,30} AtomicChooseLockToRelease({:linear "tid"} tid:Tid) returns (l: Lock)
 {
     assert ValidTid(tid);
     assume shadow.Lock[ShadowableLock(l)] == tid;
@@ -1091,7 +1091,7 @@ refines AtomicChooseLockToRelease;
 
 yield procedure {:layer 0} ReleaseChosenLock({:linear "tid"} tid:Tid, l: Lock);
 refines AtomicReleaseChosenLock;
->-< action {:layer 1,30} AtomicReleaseChosenLock({:linear "tid"} tid:Tid, l: Lock)
+atomic action {:layer 1,30} AtomicReleaseChosenLock({:linear "tid"} tid:Tid, l: Lock)
 modifies shadow.Lock;
 {
     assert ValidTid(tid);

--- a/Test/civl/wilcox.bpl
+++ b/Test/civl/wilcox.bpl
@@ -11,7 +11,7 @@ var {:layer 0,2} x: int;
 yield procedure {:layer 0} IncX();
 refines AtomicIncX;
 
-<-> action {:layer 1} AtomicIncX()
+both action {:layer 1} AtomicIncX()
 modifies x;
 { x := x + 1; }
 
@@ -35,6 +35,6 @@ requires {:layer 1} n >= 0;
     assert {:layer 1} i == n;
 }
 
-<-> action {:layer 2} AtomicSlowAdd(n: int)
+both action {:layer 2} AtomicSlowAdd(n: int)
 modifies x;
 { x := x + n; }

--- a/Test/civl/write-barrier.bpl
+++ b/Test/civl/write-barrier.bpl
@@ -41,7 +41,7 @@ refines AtomicWriteBarrier;
   call ReleaseLock(tid);
 }
 
->-< action {:layer 2,3} AtomicWriteBarrier({:linear "tid"} tid:Tid)
+atomic action {:layer 2,3} AtomicWriteBarrier({:linear "tid"} tid:Tid)
 modifies Color;
 {
   assert tid != nil;
@@ -50,7 +50,7 @@ modifies Color;
   }
 }
 
--> action {:layer 1,1} AtomicAcquireLock({:linear "tid"} tid: Tid)
+right action {:layer 1,1} AtomicAcquireLock({:linear "tid"} tid: Tid)
 modifies lock;
 {
   assert tid != nil;
@@ -58,7 +58,7 @@ modifies lock;
   lock := tid;
 }
 
-<- action {:layer 1,1} AtomicReleaseLock({:linear "tid"} tid: Tid)
+left action {:layer 1,1} AtomicReleaseLock({:linear "tid"} tid: Tid)
 modifies lock;
 {
   assert tid != nil;
@@ -66,7 +66,7 @@ modifies lock;
   lock := nil;
 }
 
->-< action {:layer 1,1} AtomicSetColorLocked({:linear "tid"} tid:Tid, newCol:int)
+atomic action {:layer 1,1} AtomicSetColorLocked({:linear "tid"} tid:Tid, newCol:int)
 modifies Color;
 {
   assert tid != nil;
@@ -74,14 +74,14 @@ modifies Color;
   Color := newCol;
 }
 
-<-> action {:layer 1,1} AtomicGetColorLocked({:linear "tid"} tid:Tid) returns (col:int)
+both action {:layer 1,1} AtomicGetColorLocked({:linear "tid"} tid:Tid) returns (col:int)
 {
   assert tid != nil;
   assert lock == tid;
   col := Color;
 }
 
->-< action {:layer 1,2} AtomicGetColorNoLock() returns (col:int)
+atomic action {:layer 1,2} AtomicGetColorNoLock() returns (col:int)
 {
   col := Color;
 }

--- a/Test/civl/yield-invariant-fails.bpl
+++ b/Test/civl/yield-invariant-fails.bpl
@@ -13,7 +13,7 @@ yield procedure {:layer 1} foo()
 
 yield procedure {:layer 0} A();
 refines atomic_A;
->-< action {:layer 1,1} atomic_A()
+atomic action {:layer 1,1} atomic_A()
 modifies g;
 {
     g := g - 1;

--- a/Test/civl/zeldovich.bpl
+++ b/Test/civl/zeldovich.bpl
@@ -9,12 +9,12 @@ var {:layer 0,1} lock_y: Tid;
 var {:layer 0,2} x: int;
 var {:layer 0,2} y: int;
 
->-< action {:layer 2} GET_X (tid: Lval Tid) returns (v: int)
+atomic action {:layer 2} GET_X (tid: Lval Tid) returns (v: int)
 {
   v := x;
 }
 
->-< action {:layer 2} SET_BOTH (tid: Lval Tid, v: int, w: int)
+atomic action {:layer 2} SET_BOTH (tid: Lval Tid, v: int, w: int)
 modifies x, y;
 {
   x := v;
@@ -42,7 +42,7 @@ requires {:layer 1} tid->val != nil;
   call release_y(tid);
 }
 
--> action {:layer 1} ACQUIRE_X (tid: Lval Tid)
+right action {:layer 1} ACQUIRE_X (tid: Lval Tid)
 modifies lock_x;
 {
   assert tid->val != nil;
@@ -50,14 +50,14 @@ modifies lock_x;
   lock_x := tid->val;
 }
 
-<- action {:layer 1} RELEASE_X (tid: Lval Tid)
+left action {:layer 1} RELEASE_X (tid: Lval Tid)
 modifies lock_x;
 {
   assert tid->val != nil && lock_x == tid->val;
   lock_x := nil;
 }
 
--> action {:layer 1} ACQUIRE_Y (tid: Lval Tid)
+right action {:layer 1} ACQUIRE_Y (tid: Lval Tid)
 modifies lock_y;
 {
   assert tid->val != nil;
@@ -65,28 +65,28 @@ modifies lock_y;
   lock_y := tid->val;
 }
 
-<- action {:layer 1} RELEASE_Y (tid: Lval Tid)
+left action {:layer 1} RELEASE_Y (tid: Lval Tid)
 modifies lock_y;
 {
   assert tid->val != nil && lock_y == tid->val;
   lock_y := nil;
 }
 
-<-> action {:layer 1} WRITE_X (tid: Lval Tid, v: int)
+both action {:layer 1} WRITE_X (tid: Lval Tid, v: int)
 modifies x;
 {
   assert tid->val != nil && lock_x == tid->val;
   x := v;
 }
 
-<-> action {:layer 1} WRITE_Y (tid: Lval Tid, v: int)
+both action {:layer 1} WRITE_Y (tid: Lval Tid, v: int)
 modifies y;
 {
   assert tid->val != nil && lock_y == tid->val;
   y := v;
 }
 
-<-> action {:layer 1} READ_X (tid: Lval Tid) returns (r: int)
+both action {:layer 1} READ_X (tid: Lval Tid) returns (r: int)
 {
   assert tid->val != nil && lock_x == tid->val;
   r := x;

--- a/Test/roundingmodes/InvalidFuncName.bpl.expect
+++ b/Test/roundingmodes/InvalidFuncName.bpl.expect
@@ -1,2 +1,2 @@
-InvalidFuncName.bpl(4,34): error: ident expected
+InvalidFuncName.bpl(4,34): error: invalid Ident
 1 parse errors detected in InvalidFuncName.bpl


### PR DESCRIPTION
Based on a suggestion by the reviewers, this PR uses contextual keywords for mover types.