### PR TITLE
Clean up threads from custom thread pool when disposing ExecutionEngine

### DIFF
--- a/Source/Core/AsyncQueue.cs
+++ b/Source/Core/AsyncQueue.cs
@@ -57,7 +57,7 @@ public class AsyncQueue<T>
       }
 
       var source = new TaskCompletionSource<T>();
-      cancellationToken.Register(() => source.SetCanceled(cancellationToken));
+      cancellationToken.Register(() => source.TrySetCanceled(cancellationToken));
       customers.Enqueue(source);
       // Ensure that the TrySetResult call in Enqueue completes immediately.
       return source.Task.ContinueWith(t => t.Result, cancellationToken,

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.16.6</Version>
+    <Version>2.16.7</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
+++ b/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
@@ -60,7 +60,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
   
   private async void WorkLoop()
   {
-    while (true)
+    while (!disposeTokenSource.IsCancellationRequested)
     {
       try
       {

--- a/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
+++ b/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
@@ -13,7 +13,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
 {
   private readonly AsyncQueue<Task> queue = new();
   private readonly HashSet<Thread> threads;
-  private readonly CancellationTokenSource cancellationTokenSource = new();
+  private readonly CancellationTokenSource disposeTokenSource = new();
 
   public static CustomStackSizePoolTaskScheduler Create(int stackSize, int threadCount)
   {
@@ -64,7 +64,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
     {
       try
       {
-        var task = await queue.Dequeue(cancellationTokenSource.Token);
+        var task = await queue.Dequeue(disposeTokenSource.Token);
         TryExecuteTask(task);
       }
       catch (TaskCanceledException)
@@ -76,7 +76,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
 
   public void Dispose()
   {
-    cancellationTokenSource.Cancel();
+    disposeTokenSource.Cancel();
     foreach (var thread in threads)
     {
       thread.Join();

--- a/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
+++ b/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +13,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
 {
   private readonly AsyncQueue<Task> queue = new();
   private readonly HashSet<Thread> threads;
+  private readonly CancellationTokenSource cancellationTokenSource = new();
 
   public static CustomStackSizePoolTaskScheduler Create(int stackSize, int threadCount)
   {
@@ -27,7 +27,11 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
     threads = new HashSet<Thread>();
     for (int i = 0; i < maximumConcurrencyLevel; i++)
     {
-      var thread = new Thread(WorkLoop, stackSize) { IsBackground = true };
+      var thread = new Thread(WorkLoop, stackSize)
+      {
+        IsBackground = true,
+        Name = $"CustomStackSizePoolTaskScheduler thread #{i+1}/{maximumConcurrencyLevel}"
+      };
       threads.Add(thread);
       thread.Start();
     }
@@ -54,17 +58,25 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
     return queue.Items;
   }
   
-  private void WorkLoop()
+  private async void WorkLoop()
   {
     while (true)
     {
-      var task = queue.Dequeue(CancellationToken.None).Result;
-      TryExecuteTask(task);
+      try
+      {
+        var task = await queue.Dequeue(cancellationTokenSource.Token);
+        TryExecuteTask(task);
+      }
+      catch (TaskCanceledException)
+      {
+        break;
+      }
     }
   }
 
   public void Dispose()
   {
+    cancellationTokenSource.Cancel();
     foreach (var thread in threads)
     {
       thread.Join();

--- a/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
+++ b/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
@@ -79,7 +79,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
     disposeTokenSource.Cancel();
     foreach (var thread in threads)
     {
-      thread.Join();
+      thread.Join(TimeSpan.FromMilliseconds(100));
     }
   }
 }

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Boogie
       checkerPool = new CheckerPool(options);
       verifyImplementationSemaphore = new SemaphoreSlim(Options.VcsCores);
       
-      var largeThreadScheduler = CustomStackSizePoolTaskScheduler.Create(16 * 1024 * 1024, Options.VcsCores);
+      largeThreadScheduler = CustomStackSizePoolTaskScheduler.Create(16 * 1024 * 1024, Options.VcsCores);
       largeThreadTaskFactory = new(CancellationToken.None, TaskCreationOptions.None, TaskContinuationOptions.None, largeThreadScheduler);
     }
 
@@ -87,6 +87,8 @@ namespace Microsoft.Boogie
 
     static readonly ConcurrentDictionary<string, CancellationTokenSource> RequestIdToCancellationTokenSource =
       new ConcurrentDictionary<string, CancellationTokenSource>();
+
+    private readonly CustomStackSizePoolTaskScheduler largeThreadScheduler;
 
     public async Task<bool> ProcessFiles(TextWriter output, IList<string> fileNames, bool lookForSnapshots = true,
       string programId = null) {
@@ -1390,6 +1392,7 @@ namespace Microsoft.Boogie
     public void Dispose()
     {
       checkerPool.Dispose();
+      largeThreadScheduler.Dispose();
     }
   }
 }

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -30,15 +30,14 @@ public class ExecutionEngineTest {
   {
     var options = new CommandLineOptions(TextWriter.Null, new ConsolePrinter());
     options.VcsCores = 10;
+    int beforeCreation = Process.GetCurrentProcess().Threads.Count;
     var engine = new ExecutionEngine(options, new VerificationResultCache());
-    int afterAddition = Process.GetCurrentProcess().Threads.Count;
-
     engine.Dispose();
     for (int i = 0; i < 50; i++)
     {
       await Task.Delay(10);
       int afterDispose = Process.GetCurrentProcess().Threads.Count;
-      if (afterDispose + 2 <= afterAddition)
+      if (afterDispose + 2 <= beforeCreation + options.VcsCores)
       {
         // It's difficult to access the current managed threads and see if any of the ones we create with the ExecutionEngine are still there,
         // More information on the difficulty: https://stackoverflow.com/questions/10315862/get-list-of-threads


### PR DESCRIPTION
Clean up threads from custom thread pool when disposing ExecutionEngine to enable freeing up resources