### PR TITLE
Revert "Clean up threads from custom thread pool when disposing ExecutionEngine (#731)"

### DIFF
--- a/Source/Core/AsyncQueue.cs
+++ b/Source/Core/AsyncQueue.cs
@@ -57,7 +57,7 @@ public class AsyncQueue<T>
       }
 
       var source = new TaskCompletionSource<T>();
-      cancellationToken.Register(() => source.TrySetCanceled(cancellationToken));
+      cancellationToken.Register(() => source.SetCanceled(cancellationToken));
       customers.Enqueue(source);
       // Ensure that the TrySetResult call in Enqueue completes immediately.
       return source.Task.ContinueWith(t => t.Result, cancellationToken,

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.16.7</Version>
+    <Version>2.16.6</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>2.16.6</Version>
+    <Version>2.16.8</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Boogie
       checkerPool = new CheckerPool(options);
       verifyImplementationSemaphore = new SemaphoreSlim(Options.VcsCores);
       
-      largeThreadScheduler = CustomStackSizePoolTaskScheduler.Create(16 * 1024 * 1024, Options.VcsCores);
+      var largeThreadScheduler = CustomStackSizePoolTaskScheduler.Create(16 * 1024 * 1024, Options.VcsCores);
       largeThreadTaskFactory = new(CancellationToken.None, TaskCreationOptions.None, TaskContinuationOptions.None, largeThreadScheduler);
     }
 
@@ -87,8 +87,6 @@ namespace Microsoft.Boogie
 
     static readonly ConcurrentDictionary<string, CancellationTokenSource> RequestIdToCancellationTokenSource =
       new ConcurrentDictionary<string, CancellationTokenSource>();
-
-    private readonly CustomStackSizePoolTaskScheduler largeThreadScheduler;
 
     public async Task<bool> ProcessFiles(TextWriter output, IList<string> fileNames, bool lookForSnapshots = true,
       string programId = null) {
@@ -1378,7 +1376,6 @@ namespace Microsoft.Boogie
     public void Dispose()
     {
       checkerPool.Dispose();
-      largeThreadScheduler.Dispose();
     }
   }
 }

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -25,30 +24,6 @@ public class FakeDescription : ProofObligationDescription
 [TestFixture]
 public class ExecutionEngineTest {
 
-  [Test]
-  public async Task DisposeCleansUpThreads()
-  {
-    var options = new CommandLineOptions(TextWriter.Null, new ConsolePrinter());
-    options.VcsCores = 10;
-    int beforeCreation = Process.GetCurrentProcess().Threads.Count;
-    var engine = new ExecutionEngine(options, new VerificationResultCache());
-    engine.Dispose();
-    for (int i = 0; i < 50; i++)
-    {
-      await Task.Delay(10);
-      int afterDispose = Process.GetCurrentProcess().Threads.Count;
-      if (afterDispose + 2 <= beforeCreation + options.VcsCores)
-      {
-        // It's difficult to access the current managed threads and see if any of the ones we create with the ExecutionEngine are still there,
-        // More information on the difficulty: https://stackoverflow.com/questions/10315862/get-list-of-threads
-        // So we make this test less precise and only check that the number of OS threads has gone down by at least 2.
-        // We're expecting 10 threads to be removed, so even if some other code creates a few more threads we can still expect a drop of 2.
-        return;
-      }
-    }
-    Assert.Fail("Thread count didn't drop back down after waiting 500ms.");
-  }
-  
   [Test]
   public async Task GetImplementationTasksTest() {
     var programString = @"


### PR DESCRIPTION
This reverts commit fcf0dde0f9051e5271ed937908531119825a4b64.

The change was leading to stack overflows in Dafny. I'd like to be able to track down what's causing the stack overflows, even if it's best fixed on the Dafny side, before committing to this change.
