### PR TITLE
Add missing antecedents to function axioms

### DIFF
--- a/Source/VCExpr/TypeErasurePremisses.cs
+++ b/Source/VCExpr/TypeErasurePremisses.cs
@@ -575,19 +575,24 @@ namespace Microsoft.Boogie.TypeErasure
       List<VCExprLetBinding /*!*/> typeVarBindings =
         GenTypeParamBindings(implicitTypeParams, typedInputVars, bindings, true);
       Contract.Assert(cce.NonNullElements(typeVarBindings));
+      List<VCExpr> boundVarExprs = HelperFuns.ToVCExprList(boundVars);
 
       VCExpr /*!*/
-        funApp = Gen.Function(fun, HelperFuns.ToVCExprList(boundVars));
+        funApp = Gen.Function(fun, boundVarExprs);
       Contract.Assert(funApp != null);
       VCExpr /*!*/
         conclusion = Gen.Eq(TypeOf(funApp),
           Type2Term(originalResultType, bindings.TypeVariableBindings));
       Contract.Assert(conclusion != null);
+
+      // Create `(= (type var) ...)` premises for each U-type argument
+      var typePremisses =
+        boundVarExprs
+          .Where(e => e.Type.Equals(U))
+          .Select((e, i) => Gen.Eq(TypeOf(e), Type2Term(originalInTypes[i], bindings.TypeVariableBindings)))
+          .Aggregate(VCExpressionGenerator.True, (e1, e2) => Gen.AndSimp(e1, e2));
       VCExpr conclusionWithPremisses =
-        // leave out antecedents of function type axioms ... they don't appear necessary,
-        // because a function can always be extended to all U-values (right?)
-        //        AddTypePremisses(typeVarBindings, typePremisses, true, conclusion);
-        Gen.Let(typeVarBindings, conclusion);
+          AddTypePremisses(typeVarBindings, typePremisses, true, conclusion);
 
       if (boundVars.Count > 0)
       {

--- a/Test/test21/issue-735.bpl
+++ b/Test/test21/issue-735.bpl
@@ -1,4 +1,4 @@
-// RUN: %parallel-boogie /proverOpt:O:smt.mbqi=true /typeEncoding:p "%s" > "%t"
+// RUN: %parallel-boogie /proverOpt:O:smt.mbqi=true /timeLimit:5 /typeEncoding:p "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 // RUN: %parallel-boogie /proverOpt:O:smt.mbqi=true /typeEncoding:a "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"

--- a/Test/test21/issue-735.bpl
+++ b/Test/test21/issue-735.bpl
@@ -1,0 +1,18 @@
+// RUN: %parallel-boogie /proverOpt:O:smt.mbqi=true /typeEncoding:p "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+// RUN: %parallel-boogie /proverOpt:O:smt.mbqi=true /typeEncoding:a "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+// RUN: %parallel-boogie /proverOpt:O:smt.mbqi=true /typeEncoding:m "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type ref;
+type Field _;
+type Heap = [ref]<alpha>[Field alpha]alpha;
+function $IsGoodHeap(Heap) : bool;
+function $IsHeapAnchor(Heap) : bool;
+var $Heap: Heap where $IsGoodHeap($Heap) && $IsHeapAnchor($Heap);
+
+procedure P()
+{
+    assert false;
+}

--- a/Test/test21/issue-735.bpl.expect
+++ b/Test/test21/issue-735.bpl.expect
@@ -1,0 +1,5 @@
+issue-735.bpl(17,5): Error: this assertion could not be proved
+Execution trace:
+    issue-735.bpl(17,5): anon0
+
+Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
Add type-constraining antecedents for each argument of a function when generating the type axiom for that function.

These seem to have been intentionally but incorrectly left out in the original implementation.

This fixes the missing antecedent issue in #735 and dafny-lang/dafny#4053 but does not yet fix the missing type constructor parameters. I have yet to track down exactly why those are left out.

