### PR TITLE
Fix spec for allocation in Treiber stack

### DIFF
--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -64,8 +64,8 @@ public class LinearRewriter
         return RewriteLheapRead(callCmd);
       case "Lheap_Write":
         return RewriteLheapWrite(callCmd);
-      case "Lheap_Add":
-        return RewriteLheapAdd(callCmd);
+      case "Lheap_Alloc":
+        return RewriteLheapAlloc(callCmd);
       case "Lheap_Remove":
         return RewriteLheapRemove(callCmd);
       case "Lset_Empty":
@@ -290,7 +290,7 @@ public class LinearRewriter
     throw new cce.UnreachableException();
   }
 
-  private List<Cmd> RewriteLheapAdd(CallCmd callCmd)
+  private List<Cmd> RewriteLheapAlloc(CallCmd callCmd)
   {
     GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
       out Function lsetConstructor, out Function lvalConstructor);
@@ -303,13 +303,13 @@ public class LinearRewriter
     var k = callCmd.Outs[0];
 
     cmdSeq.Add(CmdHelper.HavocCmd(k));
-    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Neq(k, ExprHelper.FunctionCall(nilFunc))));
-    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Not(ExprHelper.FunctionCall(new MapSelect(callCmd.tok, 1), Dom(path), k))));
-    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Eq(ExprHelper.FunctionCall(new MapSelect(callCmd.tok, 1), Val(path), k), v)));
+    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Neq(Val(k), ExprHelper.FunctionCall(nilFunc))));
+    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Not(ExprHelper.FunctionCall(new MapSelect(callCmd.tok, 1), Dom(path), Val(k)))));
+    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Eq(ExprHelper.FunctionCall(new MapSelect(callCmd.tok, 1), Val(path), Val(k)), v)));
     cmdSeq.Add(CmdHelper.AssignCmd(
       CmdHelper.ExprToAssignLhs(path),
       ExprHelper.FunctionCall(lheapConstructor,
-        ExprHelper.FunctionCall(new MapStore(callCmd.tok, 1), Dom(path), k, Expr.True),
+        ExprHelper.FunctionCall(new MapStore(callCmd.tok, 1), Dom(path), Val(k), Expr.True),
         Val(path))));
     
     ResolveAndTypecheck(options, cmdSeq);
@@ -408,13 +408,13 @@ public class LinearRewriter
     var path = callCmd.Ins[1];
     
     var lsetContainsFunc = LsetContains(type);
-    cmdSeq.Add(AssertCmd(callCmd.tok, ExprHelper.FunctionCall(lsetContainsFunc, path, ExprHelper.FieldAccess(k, "val")), "Lval_Split failed"));
+    cmdSeq.Add(AssertCmd(callCmd.tok, ExprHelper.FunctionCall(lsetContainsFunc, path, Val(k)), "Lval_Split failed"));
 
     var mapOneFunc = MapOne(type);
     var mapDiffFunc = MapDiff(type);
     cmdSeq.Add(
       CmdHelper.AssignCmd(CmdHelper.FieldAssignLhs(path, "dom"),
-        ExprHelper.FunctionCall(mapDiffFunc, Dom(path), ExprHelper.FunctionCall(mapOneFunc, ExprHelper.FieldAccess(k, "val")))));
+        ExprHelper.FunctionCall(mapDiffFunc, Dom(path), ExprHelper.FunctionCall(mapOneFunc, Val(k)))));
     
     ResolveAndTypecheck(options, cmdSeq);
     return cmdSeq;

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -413,6 +413,8 @@ namespace Microsoft.Boogie
     {
       switch (program.monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
       {
+        case "Ref_Alloc":
+          return null;
         case "Lheap_Empty":
           return null;
         case "Lheap_Split":

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Boogie
           return null;
         case "Lheap_Write":
           return ExtractRootFromAccessPathExpr(callCmd.Ins[0]);
-        case "Lheap_Add":
+        case "Lheap_Alloc":
           return ExtractRootFromAccessPathExpr(callCmd.Ins[0]);
         case "Lheap_Remove":
           return ExtractRootFromAccessPathExpr(callCmd.Ins[0]);

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -180,6 +180,7 @@ namespace Microsoft.Boogie
   {
     public static HashSet<string> Linear = new()
     {
+      "Ref_Alloc",
       "Lheap_Empty", "Lheap_Split", "Lheap_Transfer", "Lheap_Read", "Lheap_Write", "Lheap_Alloc", "Lheap_Remove",
       "Lset_Empty", "Lset_Split", "Lset_Transfer",
       "Lval_Split", "Lval_Transfer"

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Boogie
   {
     public static HashSet<string> Linear = new()
     {
-      "Lheap_Empty", "Lheap_Split", "Lheap_Transfer", "Lheap_Read", "Lheap_Write", "Lheap_Add", "Lheap_Remove",
+      "Lheap_Empty", "Lheap_Split", "Lheap_Transfer", "Lheap_Read", "Lheap_Write", "Lheap_Alloc", "Lheap_Remove",
       "Lset_Empty", "Lset_Split", "Lset_Transfer",
       "Lval_Split", "Lval_Transfer"
     };

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -142,6 +142,8 @@ function {:builtin "seq.extract"} Seq_Extract<T>(a: Seq T, pos: int, length: int
 
 /// linear maps
 type Ref _;
+procedure Ref_Alloc<V>() returns (k: Lval (Ref V));
+
 datatype Lheap<V> { Lheap(dom: [Ref V]bool, val: [Ref V]V) }
 function Nil<V>(): Ref V;
 

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -149,7 +149,7 @@ function {:inline} Lheap_WellFormed<V>(l: Lheap V): bool {
     l->val == MapIte(l->dom, l->val, MapConst(Default()))
 }
 function {:inline} Lheap_Collector<V>(l: Lheap V): [Ref V]bool {
-    l->dom
+    MapConst(false)
 }
 function {:inline} Lheap_Contains<V>(l: Lheap V, k: Ref V): bool {
     l->dom[k]
@@ -162,7 +162,7 @@ procedure Lheap_Split<V>(k: [Ref V]bool, path: Lheap V) returns (l: Lheap V);
 procedure Lheap_Transfer<V>({:linear_in} path1: Lheap V, path2: Lheap V);
 procedure Lheap_Read<V>(path: V) returns (v: V);
 procedure Lheap_Write<V>(path: V, v: V);
-procedure Lheap_Add<V>(path: Lheap V, v: V) returns (k: Ref V);
+procedure Lheap_Alloc<V>(path: Lheap V, v: V) returns (k: Lval (Ref V));
 procedure Lheap_Remove<V>(path: Lheap V, k: Ref V) returns (v: V);
 
 /// linear sets

--- a/Test/civl/regression-tests/linear_types.bpl
+++ b/Test/civl/regression-tests/linear_types.bpl
@@ -15,10 +15,10 @@ atomic action {:layer 1, 2} A1({:linear_in} path: Lheap int, k: Ref int, v: int)
 }
 
 atomic action {:layer 1, 2} A2(v: int) returns (path': Lheap int, v': int) {
-    var k: Ref int;
+    var k: Lval (Ref int);
     call path' := Lheap_Empty();
-    call k := Lheap_Add(path', v);
-    call v' := Lheap_Remove(path', k);
+    call k := Lheap_Alloc(path', v);
+    call v' := Lheap_Remove(path', k->val);
 }
 
 atomic action {:layer 1, 2} A3({:linear_in} path: Lset int, {:linear_out} l: Lset int) returns (path': Lset int) {

--- a/Test/civl/treiber-stack.bpl
+++ b/Test/civl/treiber-stack.bpl
@@ -21,6 +21,20 @@ var {:layer 4, 5} Stack: [RefTreiber X]Vec X;
 var {:layer 0, 4} ts: Lheap (Treiber X);
 var {:layer 2, 4} unused: [RefTreiber X][RefNode X]bool;
 
+atomic action {:layer 5} AtomicAlloc() returns (ref_t: Lval (RefTreiber X))
+modifies Stack;
+{
+  call ref_t := Ref_Alloc();
+  Stack[ref_t->val] := Vec_Empty();
+}
+yield procedure {:layer 4} Alloc() returns (ref_t: Lval (RefTreiber X))
+refines AtomicAlloc;
+{
+  call ref_t := Alloc#0();
+  call AddStack(ref_t->val);
+  call {:layer 4} AbsDefinition(ts->val[ref_t->val]->top, ts->val[ref_t->val]->stack->val);
+}
+
 atomic action {:layer 5} AtomicPush(ref_t: RefTreiber X, x: X) returns (success: bool)
 modifies Stack;
 {
@@ -198,7 +212,7 @@ modifies ts;
 yield procedure {:layer 0} WriteTopOfStack(ref_t: RefTreiber X, old_ref_n: RefNode X, new_ref_n: RefNode X) returns (r: bool);
 refines AtomicWriteTopOfStack;
 
-atomic action {:layer 1, 4} AtomicAllocTreiber() returns (ref_t: Lval (RefTreiber X))
+atomic action {:layer 1, 4} AtomicAlloc#0() returns (ref_t: Lval (RefTreiber X))
 modifies ts;
 {
   var top: Ref (Node X);
@@ -209,8 +223,14 @@ modifies ts;
   treiber := Treiber(top, stack);
   call ref_t := Lheap_Alloc(ts, treiber);
 }
-yield procedure {:layer 0} AllocTreiber() returns (ref_t: Lval (RefTreiber X));
-refines AtomicAllocTreiber;
+yield procedure {:layer 0} Alloc#0() returns (ref_t: Lval (RefTreiber X));
+refines AtomicAlloc#0;
+
+action {:layer 4} AddStack(ref_t: RefTreiber X)
+modifies Stack;
+{
+  Stack[ref_t] := Vec_Empty();
+}
 
 action {:layer 4} PushStack(ref_t: RefTreiber X, x: X)
 modifies Stack;

--- a/Test/civl/treiber-stack.bpl.expect
+++ b/Test/civl/treiber-stack.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 40 verified, 0 errors
+Boogie program verifier finished with 44 verified, 0 errors

--- a/Test/datatypes/node-client.bpl
+++ b/Test/datatypes/node-client.bpl
@@ -34,8 +34,8 @@ modifies ts;
 procedure {:inline 1} AtomicPushIntermediate(ref_t: RefTreiber X, x: X)
 modifies ts;
 {
-  var ref_n: RefNode X;
+  var ref_n: Lval (RefNode X);
   assert ts->dom[ref_t];
-  call ref_n := Lheap_Add(ts->val[ref_t]->stack, Node(ts->val[ref_t]->top, x));
-  call Lheap_Write(ts->val[ref_t]->top, ref_n);
+  call ref_n := Lheap_Alloc(ts->val[ref_t]->stack, Node(ts->val[ref_t]->top, x));
+  call Lheap_Write(ts->val[ref_t]->top, ref_n->val);
 }


### PR DESCRIPTION
This PR makes the following changes:

1. Collector for Lheap instances now returns an empty set. This change implies that the domain of a linear heap of type T no longer contributes to the disjointness assumptions for the permission set Ref T. This change is needed to allow valid references to heap objects to be wrapped in an Lval. The new design appears to be reasonable because the disjointness of heap domains is important only for heap erasure and does not seem to be needed for property verification. On the other hand, it seems important to be able to conveniently encode unique pointers to heap addresses.

2. Lheap_Add is renamed to Lheap_Alloc and its output is wrapped inside Lval. This change allows us to express the specification that successive calls to allocations of Treiber stack return distinct references.

3.  A new primitive Ref_Alloc is introduces to allocate a Ref T by itself (i.e., without being associated with a Lheap instance). This is useful to write the specification for the operation that allocates a Treiber stack.