### PR TITLE
Added doModSetAnalysis option into help message

### DIFF
--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -1716,6 +1716,8 @@ namespace Microsoft.Boogie
                 unroll loops, following up to n back edges (and then some)
   /soundLoopUnrolling
                 sound loop unrolling
+  /doModSetAnalysis
+                automatically infer modifies clauses
   /printModel:<n>
                 0 (default) - do not print Z3's error model
                 1 - print Z3's error model


### PR DESCRIPTION
Somehow this option was missing from the help message.
I just added it.