### PR TITLE
Remove redundant assumptions in inlining

### DIFF
--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -677,38 +677,6 @@ namespace Microsoft.Boogie
         inCmds.Add(new HavocCmd(Token.NoToken, havocVars));
       }
 
-      // add where clauses of local vars as assume
-      for (int i = 0; i < locVars.Count; ++i)
-      {
-        Expr whereExpr = (cce.NonNull(locVars[i])).TypedIdent.WhereExpr;
-        if (whereExpr != null)
-        {
-          whereExpr = codeCopier.CopyExpr(whereExpr);
-          // FIXME we cannot overwrite it, can we?!
-          (cce.NonNull(locVars[i])).TypedIdent.WhereExpr = whereExpr;
-          AssumeCmd /*!*/
-            a = new AssumeCmd(Token.NoToken, whereExpr);
-          Contract.Assert(a != null);
-          inCmds.Add(a);
-        }
-      }
-
-      // add where clauses of output params as assume
-      for (int i = 0; i < impl.OutParams.Count; ++i)
-      {
-        Expr whereExpr = (cce.NonNull(impl.OutParams[i])).TypedIdent.WhereExpr;
-        if (whereExpr != null)
-        {
-          whereExpr = codeCopier.CopyExpr(whereExpr);
-          // FIXME likewise
-          (cce.NonNull(impl.OutParams[i])).TypedIdent.WhereExpr = whereExpr;
-          AssumeCmd /*!*/
-            a = new AssumeCmd(Token.NoToken, whereExpr);
-          Contract.Assert(a != null);
-          inCmds.Add(a);
-        }
-      }
-
       // assign modifies old values
       foreach (IdentifierExpr /*!*/ mie in proc.Modifies)
       {

--- a/Test/inline/testAssertWhere.bpl
+++ b/Test/inline/testAssertWhere.bpl
@@ -1,0 +1,10 @@
+// RUN: %parallel-boogie -inline:spec -print:- -env:0 -printInlined "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+procedure a() returns () {
+    call b();
+}
+
+procedure {:inline 1} b() returns () {
+    var v:int where v > 3;
+    assert v > 3;
+}

--- a/Test/inline/testAssertWhere.bpl.expect
+++ b/Test/inline/testAssertWhere.bpl.expect
@@ -22,7 +22,7 @@ implementation {:inline 1} b()
   var v: int where v > 3;
 
   anon0:
-    havoc v;
+    assert v > 3;
     return;
 }
 
@@ -43,7 +43,7 @@ implementation a()
     goto inline$b$0$anon0;
 
   inline$b$0$anon0:
-    havoc inline$b$0$v /* where inline$b$0$v > 3 */;
+    assert inline$b$0$v > 3;
     goto inline$b$0$Return;
 
   inline$b$0$Return:


### PR DESCRIPTION
This PR is a follow up on #753 and removes [redundant assumptions](https://github.com/boogie-org/boogie/blob/f292415255aeff4db8fb1309b92b877cefe07780/Source/Core/Inline.cs#L680-L710) emitted during inlining. The assumptions were meant to ensure the a variable abides by its associated type constraint even after a call to `havoc`. Such assumptions are not necessary, however, since `havoc` is desugared to respect the corresponding type constraint at a later point during VC Generation. [Here is the code](https://github.com/boogie-org/boogie/blob/f292415255aeff4db8fb1309b92b877cefe07780/Source/VCGeneration/ConditionGeneration.cs#L1448) that, if I am correct, is responsible for this desugaring. An additional empirical evidence that `havoc` is supposed to behave in this manner is that the following procedure verifies:
```Boogie
procedure p() {
    var a:int where a > 0;
    havoc a;
    assert a > 0;
}
```
The historical reason for why these assumptions are present in the code must be that the `where` clauses themselves were not correctly translated prior to #753, so, in particular, this PR adds a test case that would have failed prior to #753 if these redundant assumptions had been removed before fixing the translation of the where clauses.