### PR TITLE
Add sample for building mutex over a futex

### DIFF
--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -84,7 +84,11 @@ namespace Microsoft.Boogie
       })));
 
       var oldErrorCount = checkingContext.ErrorCount;
-      var impl = base.VisitImplementation(node);
+      // Visit relevant fields of node directly rather than calling VisitImplementation to
+      // avoid visiting node.Proc (which would cause Procedure's to be visited more than once)
+      VisitVariableSeq(node.LocVars);
+      VisitBlockList(node.Blocks);
+      var impl = (Implementation) this.VisitDeclWithFormals(node);
       if (oldErrorCount < checkingContext.ErrorCount)
       {
         return impl;

--- a/Source/Concurrency/YieldingProcChecker.cs
+++ b/Source/Concurrency/YieldingProcChecker.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Boogie
         {
           if (yieldProcedureDecl.Layer >= layerNum)
           {
-            duplicator.VisitProcedure(yieldProcedureDecl);
+            duplicator.VisitYieldProcedureDecl(yieldProcedureDecl);
           }
         }
 

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -38,12 +38,11 @@ namespace Microsoft.Boogie
 
     #region Procedure duplication
 
-    public override Procedure VisitProcedure(Procedure node)
+    public override Procedure VisitYieldProcedureDecl(YieldProcedureDecl node)
     {
       if (!procToDuplicate.ContainsKey(node))
       {
-        var yieldProcedureDecl = (YieldProcedureDecl)node;
-        Debug.Assert(layerNum <= yieldProcedureDecl.Layer);
+        Debug.Assert(layerNum <= node.Layer);
         var proc = new Procedure(
           node.tok,
           civlTypeChecker.AddNamePrefix($"{node.Name}_{layerNum}"),
@@ -52,8 +51,8 @@ namespace Microsoft.Boogie
           VisitVariableSeq(node.OutParams),
           false,
           VisitRequiresSeq(node.Requires),
-          (yieldProcedureDecl.HasMoverType && yieldProcedureDecl.Layer == layerNum
-            ? yieldProcedureDecl.ModifiedVars.Select(g => Expr.Ident(g))
+          (node.HasMoverType && node.Layer == layerNum
+            ? node.ModifiedVars.Select(g => Expr.Ident(g))
             : civlTypeChecker.GlobalVariables.Select(v => Expr.Ident(v))).ToList(),
           VisitEnsuresSeq(node.Ensures));
         procToDuplicate[node] = proc;

--- a/Source/Core/AST/Program.cs
+++ b/Source/Core/AST/Program.cs
@@ -61,7 +61,7 @@ public class Program : Absy
 
     ResolveTypes(rc);
       
-    var prunedTopLevelDeclarations = new List<Declaration /*!*/>();
+    var prunedTopLevelDeclarations = new List<Declaration>();
     foreach (var d in TopLevelDeclarations.Where(d => !QKeyValue.FindBoolAttribute(d.Attributes, "ignore")))
     {
       // resolve all the declarations that have not been resolved yet 
@@ -69,17 +69,14 @@ public class Program : Absy
       {
         int e = rc.ErrorCount;
         d.Resolve(rc);
-        if (d is Implementation impl)
+        if (rc.Options.OverlookBoogieTypeErrors && rc.ErrorCount != e && d is Implementation impl)
         {
-          if (rc.Options.OverlookBoogieTypeErrors && rc.ErrorCount != e)
-          {
-            // ignore this implementation
-            rc.Options.OutputWriter.WriteLine(
-              "Warning: Ignoring implementation {0} because of translation resolution errors",
-              impl.Name);
-            rc.ErrorCount = e;
-            continue;
-          }
+          // ignore this implementation
+          rc.Options.OutputWriter.WriteLine(
+            "Warning: Ignoring implementation {0} because of translation resolution errors",
+            impl.Name);
+          rc.ErrorCount = e;
+          continue;
         }
       }
       prunedTopLevelDeclarations.Add(d);

--- a/Source/Core/AST/Program.cs
+++ b/Source/Core/AST/Program.cs
@@ -65,13 +65,17 @@ public class Program : Absy
       {
         int e = rc.ErrorCount;
         d.Resolve(rc);
-        if (rc.Options.OverlookBoogieTypeErrors && rc.ErrorCount != e && d is Implementation)
+        if (d is Implementation impl)
         {
-          // ignore this implementation
-          rc.Options.OutputWriter.WriteLine("Warning: Ignoring implementation {0} because of translation resolution errors",
-            ((Implementation) d).Name);
-          rc.ErrorCount = e;
-          continue;
+          if (rc.Options.OverlookBoogieTypeErrors && rc.ErrorCount != e)
+          {
+            // ignore this implementation
+            rc.Options.OutputWriter.WriteLine(
+              "Warning: Ignoring implementation {0} because of translation resolution errors",
+              impl.Name);
+            rc.ErrorCount = e;
+            continue;
+          }
         }
       }
       prunedTopLevelDeclarations.Add(d);

--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -488,6 +488,11 @@ namespace Microsoft.Boogie
       return base.VisitActionDeclRef((ActionDeclRef)node.Clone());
     }
 
+    public override List<ElimDecl> VisitElimDeclSeq(List<ElimDecl> node)
+    {
+      return base.VisitElimDeclSeq(new List<ElimDecl>(node));
+    }
+
     public override Procedure VisitActionDecl(ActionDecl node)
     {
       Procedure newProcedure = null;
@@ -504,6 +509,11 @@ namespace Microsoft.Boogie
         }
       }
       return newProcedure;
+    }
+
+    public override HashSet<Variable> VisitVariableSet(HashSet<Variable> node)
+    {
+      return base.VisitVariableSet(new HashSet<Variable>(node));
     }
 
     public override YieldingLoop VisitYieldingLoop(YieldingLoop node)

--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -483,9 +483,9 @@ namespace Microsoft.Boogie
       return newProcedure;
     }
 
-    public override ActionDeclRef VisitActionDeclRef(ActionDeclRef node)
+    public override ElimDecl VisitElimDecl(ElimDecl node)
     {
-      return base.VisitActionDeclRef((ActionDeclRef)node.Clone());
+      return base.VisitElimDecl((ElimDecl)node.Clone());
     }
 
     public override List<ElimDecl> VisitElimDeclSeq(List<ElimDecl> node)
@@ -493,6 +493,9 @@ namespace Microsoft.Boogie
       return base.VisitElimDeclSeq(new List<ElimDecl>(node));
     }
 
+    // We duplicate ActionDecl's but we are not updating references to ActionDecl
+    // in ActionDeclRef instances. If ActionDeclRef instances need to be updated,
+    // override VisitActionDeclRef appropriately.
     public override Procedure VisitActionDecl(ActionDecl node)
     {
       Procedure newProcedure = null;

--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -189,6 +189,11 @@ namespace Microsoft.Boogie
       return base.VisitCmdSeq(new List<Cmd>(cmdSeq));
     }
 
+    public override List<CallCmd> VisitCallCmdSeq(List<CallCmd> callCmds)
+    {
+      return base.VisitCallCmdSeq(new List<CallCmd>(callCmds));
+    }
+
     public override Constant VisitConstant(Constant node)
     {
       //Contract.Requires(node != null);
@@ -379,6 +384,16 @@ namespace Microsoft.Boogie
         gotoCmd.labelNames = newLabelNames;
       }
 
+      if (impl.Proc is YieldProcedureDecl yieldProcedureDecl)
+      {
+        var newYieldingLoops = new Dictionary<Block, YieldingLoop>();
+        foreach (var kv in yieldProcedureDecl.YieldingLoops)
+        {
+          newYieldingLoops[blockDuplicationMapping[kv.Key]] = kv.Value;
+        }
+        yieldProcedureDecl.YieldingLoops = newYieldingLoops;
+      }
+
       return impl;
     }
 
@@ -489,6 +504,16 @@ namespace Microsoft.Boogie
         }
       }
       return newProcedure;
+    }
+
+    public override YieldingLoop VisitYieldingLoop(YieldingLoop node)
+    {
+      return base.VisitYieldingLoop(new YieldingLoop(node.Layer, node.YieldInvariants));
+    }
+
+    public override Dictionary<Block, YieldingLoop> VisitYieldingLoops(Dictionary<Block, YieldingLoop> node)
+    {
+      return base.VisitYieldingLoops(new Dictionary<Block, YieldingLoop>(node));
     }
 
     public override Procedure VisitYieldProcedureDecl(YieldProcedureDecl node)

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<Implementation>() != null);
       node.LocVars = this.VisitVariableSeq(node.LocVars);
       node.Blocks = this.VisitBlockList(node.Blocks);
-      node.Proc = this.VisitProcedure(cce.NonNull(node.Proc));
+      node.Proc = (Procedure)node.Proc.StdDispatch(this);
       node = (Implementation) this.VisitDeclWithFormals(node); // do this first or last?
       VisitAttributes(node);
       return node;
@@ -669,13 +669,15 @@ namespace Microsoft.Boogie
       {
         node.Creates[i] = VisitActionDeclRef(node.Creates[i]);
       }
-      node.RefinedAction = VisitActionDeclRef(node.RefinedAction);
-      node.InvariantAction = VisitActionDeclRef(node.InvariantAction);
-      node.Eliminates = VisitElimDeclSeq(node.Eliminates);
-      if (node.PendingAsyncCtorDecl != null)
+      if (node.RefinedAction != null)
       {
-        node.PendingAsyncCtorDecl = (DatatypeTypeCtorDecl)VisitTypeCtorDecl(node.PendingAsyncCtorDecl);
+        node.RefinedAction = VisitActionDeclRef(node.RefinedAction);
       }
+      if (node.InvariantAction != null)
+      {
+        node.InvariantAction = VisitActionDeclRef(node.InvariantAction);
+      }
+      node.Eliminates = VisitElimDeclSeq(node.Eliminates);
       return VisitProcedure(node);
     }
 
@@ -1416,7 +1418,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<Implementation>() == node);
       this.VisitVariableSeq(node.LocVars);
       this.VisitBlockList(node.Blocks);
-      this.VisitProcedure(cce.NonNull(node.Proc));
+      node.Proc = (Procedure)node.Proc.StdDispatch(this);
       return (Implementation) this.VisitDeclWithFormals(node); // do this first or last?
     }
 

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -658,12 +658,28 @@ namespace Microsoft.Boogie
       return VisitProcedure(node);
     }
 
+    public virtual YieldingLoop VisitYieldingLoop(YieldingLoop node)
+    {
+      node.YieldInvariants = VisitCallCmdSeq(node.YieldInvariants);
+      return node;
+    }
+
+    public virtual Dictionary<Block, YieldingLoop> VisitYieldingLoops(Dictionary<Block, YieldingLoop> node)
+    {
+      foreach (var block in node.Keys)
+      {
+        node[block] = VisitYieldingLoop(node[block]);
+      }
+      return node;
+    }
+
     public virtual Procedure VisitYieldProcedureDecl(YieldProcedureDecl node)
     {
-      node.YieldEnsures = this.VisitCallCmdSeq(node.YieldEnsures);
-      node.YieldPreserves = this.VisitCallCmdSeq(node.YieldPreserves);
-      node.YieldRequires = this.VisitCallCmdSeq(node.YieldRequires);
+      node.YieldEnsures = VisitCallCmdSeq(node.YieldEnsures);
+      node.YieldPreserves = VisitCallCmdSeq(node.YieldPreserves);
+      node.YieldRequires = VisitCallCmdSeq(node.YieldRequires);
       node.RefinedAction = VisitActionDeclRef(node.RefinedAction);
+      node.YieldingLoops = VisitYieldingLoops(node.YieldingLoops);
       return VisitProcedure(node);
     }
 

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -647,6 +647,22 @@ namespace Microsoft.Boogie
       return node;
     }
 
+    public virtual ElimDecl VisitElimDecl(ElimDecl node)
+    {
+      node.Abstraction = VisitActionDeclRef(node.Abstraction);
+      node.Target = VisitActionDeclRef(node.Target);
+      return node;
+    }
+
+    public virtual List<ElimDecl> VisitElimDeclSeq(List<ElimDecl> node)
+    {
+      for (int i = 0; i < node.Count; i++)
+      {
+        node[i] = VisitElimDecl(node[i]);
+      }
+      return node;
+    }
+
     public virtual Procedure VisitActionDecl(ActionDecl node)
     {
       for (int i = 0; i < node.Creates.Count; i++)
@@ -655,6 +671,11 @@ namespace Microsoft.Boogie
       }
       node.RefinedAction = VisitActionDeclRef(node.RefinedAction);
       node.InvariantAction = VisitActionDeclRef(node.InvariantAction);
+      node.Eliminates = VisitElimDeclSeq(node.Eliminates);
+      if (node.PendingAsyncCtorDecl != null)
+      {
+        node.PendingAsyncCtorDecl = (DatatypeTypeCtorDecl)VisitTypeCtorDecl(node.PendingAsyncCtorDecl);
+      }
       return VisitProcedure(node);
     }
 
@@ -673,12 +694,18 @@ namespace Microsoft.Boogie
       return node;
     }
 
+    public virtual HashSet<Variable> VisitVariableSet(HashSet<Variable> node)
+    {
+      return node;
+    }
+
     public virtual Procedure VisitYieldProcedureDecl(YieldProcedureDecl node)
     {
+      node.YieldRequires = VisitCallCmdSeq(node.YieldRequires);
       node.YieldEnsures = VisitCallCmdSeq(node.YieldEnsures);
       node.YieldPreserves = VisitCallCmdSeq(node.YieldPreserves);
-      node.YieldRequires = VisitCallCmdSeq(node.YieldRequires);
       node.RefinedAction = VisitActionDeclRef(node.RefinedAction);
+      node.VisibleFormals = VisitVariableSet(node.VisibleFormals);
       node.YieldingLoops = VisitYieldingLoops(node.YieldingLoops);
       return VisitProcedure(node);
     }

--- a/Test/civl/samples/MutexOverFutex.bpl
+++ b/Test/civl/samples/MutexOverFutex.bpl
@@ -1,0 +1,182 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Tid; // thread identifiers
+
+type Mutex = Option Tid;
+
+datatype Futex { Futex(word: int, waiters:[Tid]bool) }
+
+var {:layer 1, 2} mutex: Mutex;           // specification
+var {:layer 1, 1} inSlowPath: [Tid]bool;  // auxiliary helper
+var {:layer 0, 1} futex: Futex;           // implementation
+
+/// Implementation of Mutex
+
+atomic action {:layer 2} AtomicLock(tid: Lval Tid)
+modifies mutex;
+{
+  assume mutex == None();
+  mutex := Some(tid->val);
+}
+yield procedure {:layer 1} Lock(tid: Lval Tid)
+refines AtomicLock;
+preserves call YieldInv();
+preserves call YieldWait(tid);
+{
+  var oldValue, temp: int;
+  call oldValue := CmpXchg(0, 1);
+  if (oldValue != 0) {
+    call EnterSlowPath(tid);
+    while (true)
+    invariant {:yields} true;
+    invariant call YieldInv();
+    invariant call YieldWait(tid);
+    invariant call YieldSlowPath(tid);
+    {
+      if (oldValue != 2) {
+        call temp := CmpXchg(1, 2);
+      }
+      par YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
+      if (oldValue == 2 || temp != 0) {
+        call WaitEnter(tid->val, 2);
+        par YieldInv() | YieldSlowPath(tid);
+        call WaitExit(tid->val);
+      }
+      par YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
+      call oldValue := CmpXchg(0, 2);
+      if (oldValue == 0) {
+        call ExitSlowPath(tid);
+        break;
+      }
+    }
+  }
+  call SetMutex(Some(tid->val));
+}
+
+atomic action {:layer 2} AtomicUnlock(tid: Lval Tid)
+modifies mutex;
+{
+  assert mutex == Some(tid->val);
+  mutex := None();
+}
+yield procedure {:layer 1} Unlock(tid: Lval Tid)
+refines AtomicUnlock;
+preserves call YieldInv();
+preserves call YieldWait(tid);
+{
+  var oldValue: int;
+  call oldValue := FetchSub(1);
+  if (oldValue == 1) {
+    call SetMutex(None());
+  } else {
+    call EnterSlowPath(tid);
+    par YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
+    call Store(0);
+    call SetMutex(None());
+    par YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
+    call Wake();
+    call ExitSlowPath(tid);
+  }
+}
+
+/// Yield invariants
+
+function {:inline} IsValid(word: int): bool {
+  word == 0 || word == 1 || word == 2
+}
+
+yield invariant {:layer 1} YieldInv();
+invariant IsValid(futex->word);
+invariant (forall i: Tid :: futex->waiters[i] ==> inSlowPath[i]);
+invariant futex->word == 2 || futex->waiters == MapConst(false) || (exists i: Tid :: !futex->waiters[i] && inSlowPath[i]);
+invariant mutex == None() <==> futex->word == 0;
+
+yield invariant {:layer 1} YieldWait(tid: Lval Tid);
+invariant !futex->waiters[tid->val];
+
+yield invariant {:layer 1} YieldSlowPath(tid: Lval Tid);
+invariant inSlowPath[tid->val];
+
+/// Linking action for mutex
+
+action {:layer 1, 1} SetMutex(x: Mutex)
+modifies mutex;
+{
+  mutex := x;
+}
+
+/// Linking actions for inSlowPath
+
+action {:layer 1, 1} EnterSlowPath(tid: Lval Tid)
+modifies inSlowPath;
+{
+  inSlowPath[tid->val] := true;
+}
+
+action {:layer 1, 1} ExitSlowPath(tid: Lval Tid)
+modifies inSlowPath;
+{
+  inSlowPath[tid->val] := false;
+}
+
+/// Primitive atomic actions
+
+atomic action {:layer 1} AtomicCmpXchg(expected: int, newValue: int) returns (oldValue: int)
+modifies futex;
+{
+  oldValue := futex->word;
+  if (oldValue == expected) {
+    futex->word := newValue;
+  }
+}
+yield procedure {:layer 0} CmpXchg(expected: int, newValue: int) returns (oldValue: int);
+refines AtomicCmpXchg;
+
+atomic action {:layer 1} AtomicFetchSub(val: int) returns (oldValue: int)
+modifies futex;
+{
+  oldValue := futex->word;
+  futex->word := oldValue - 1;
+}
+yield procedure {:layer 0} FetchSub(val: int) returns (oldValue: int);
+refines AtomicFetchSub;
+
+atomic action {:layer 1} AtomicStore(val: int)
+modifies futex;
+{
+  futex->word := val;
+}
+yield procedure {:layer 0} Store(val: int);
+refines AtomicStore;
+
+atomic action {:layer 1} AtomicWaitEnter(tid: Tid, val: int)
+modifies futex;
+{
+  assert !futex->waiters[tid];
+  if (futex->word == val) {
+    futex->waiters[tid] := true;
+  }
+}
+yield procedure {:layer 0} WaitEnter(tid: Tid, val: int);
+refines AtomicWaitEnter;
+
+atomic action {:layer 1} AtomicWaitExit(tid: Tid)
+modifies futex;
+{
+  assume !futex->waiters[tid];
+}
+yield procedure {:layer 0} WaitExit(tid: Tid);
+refines AtomicWaitExit;
+
+atomic action {:layer 1} AtomicWake()
+modifies futex;
+{
+  var tid: Tid;
+  if (futex->waiters != MapConst(false)) {
+    assume futex->waiters[tid];
+    futex->waiters[tid] := false;
+  }
+}
+yield procedure {:layer 0} Wake();
+refines AtomicWake;

--- a/Test/civl/samples/MutexOverFutex.bpl.expect
+++ b/Test/civl/samples/MutexOverFutex.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 2 verified, 0 errors


### PR DESCRIPTION
This PR adds a sample to implement a mutex over a futex. In the processing of writing this sample, I discovered that the field YieldingLoops which is now part of the AST is not being duplicated properly. The discovery of this bug led to cleanup in the code for the new AST nodes in StandardVisitor and Duplicator.

YieldingLoops rightfully belongs to the class Implementation. At the moment, it is left in the class YieldProcedureDecl because Implementation already has a lot of clutter in it related to processing of VCs and DoomedVCs. It would be good to separate out this processing from the stuff that is related to the AST aspect of the Implementation class.