### PR TITLE
Allow absolute paths to prover plugins

### DIFF
--- a/Source/Provers/SMTLib/ProverUtil.cs
+++ b/Source/Provers/SMTLib/ProverUtil.cs
@@ -320,7 +320,7 @@ The generic options may or may not be used by the prover plugin.
       Contract.Ensures(cce.IsNew(Contract.Result<ProverFactory>()) && cce.Owner.New(Contract.Result<ProverFactory>()));
       string /*!*/
         path;
-      if (proverName.IndexOf("/") > 0 || proverName.IndexOf("\\") > 0)
+      if (proverName.IndexOf("/") >= 0 || proverName.IndexOf("\\") >= 0)
       {
         path = proverName;
       }


### PR DESCRIPTION
Previously, the `/proverDll` option allowed only relative paths, since it looked for `/` or `\` _within_ a name, but not at the beginning, to determine whether the given name was a filename or a portion of an internal DLL name. This changes it to also interpret a name as a filename when either of those characters is the first character.