### PR TITLE
Consistent augmented execution trace after multiple verification runs

### DIFF
--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -3510,6 +3510,7 @@ namespace Microsoft.Boogie
     // Both are used only when /inline is set.
     public List<Block> OriginalBlocks;
     public List<Variable> OriginalLocVars;
+    public Dictionary<Cmd, List<object>> debugInfos = new();
 
     public readonly ISet<byte[]> AssertionChecksums = new HashSet<byte[]>(ChecksumComparer.Default);
 

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -3510,6 +3510,8 @@ namespace Microsoft.Boogie
     // Both are used only when /inline is set.
     public List<Block> OriginalBlocks;
     public List<Variable> OriginalLocVars;
+    
+    // Map filled in during passification to allow augmented error trace reporting
     public Dictionary<Cmd, List<object>> debugInfos = new();
 
     public readonly ISet<byte[]> AssertionChecksums = new HashSet<byte[]>(ChecksumComparer.Default);

--- a/Source/Houdini/HoudiniSession.cs
+++ b/Source/Houdini/HoudiniSession.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Boogie.Houdini
         new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "", Type.Bool), false));
       proverInterface.DefineMacro(macro, conjecture);
       conjecture = exprGen.Function(macro);
-      handler = new VCGen.ErrorReporter(this.houdini.Options, gotoCmdOrigins, absyIds, impl.Blocks, vcgen.debugInfos, collector,
+      handler = new VCGen.ErrorReporter(this.houdini.Options, gotoCmdOrigins, absyIds, impl.Blocks, impl.debugInfos, collector,
         mvInfo, proverInterface.Context, program, this);
     }
 

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Boogie.VCExprAST
     }
   }
 
-  public delegate VCExpr CodeExprConverter(CodeExpr codeExpr, List<VCExprLetBinding> bindings, bool isPositiveContext);
+  public delegate VCExpr CodeExprConverter(CodeExpr codeExpr, List<VCExprLetBinding> bindings, bool isPositiveContext, Dictionary<Cmd, List<object>> debugInfos);
 
   public class Boogie2VCExprTranslator : ReadOnlyVisitor, ICloneable
   {
@@ -876,7 +876,7 @@ namespace Microsoft.Boogie.VCExprAST
       Contract.Assume(codeExprConverter != null);
       
       List<VCExprLetBinding> bindings = new List<VCExprLetBinding>();
-      VCExpr e = codeExprConverter(codeExpr, bindings, isPositiveContext);
+      VCExpr e = codeExprConverter(codeExpr, bindings, isPositiveContext, new());
       Push(e);
       return codeExpr;
     }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1343,7 +1343,7 @@ namespace VC
             exprGen.ControlFlowFunctionApplication(exprGen.Integer(BigNum.ZERO), exprGen.Integer(BigNum.ZERO));
           VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(Implementation.Blocks[0]))));
           vc = exprGen.Implies(eqExpr, vc);
-          reporter = new VCGen.ErrorReporter(options, gotoCmdOrigins, absyIds, Implementation.Blocks, parent.debugInfos, callback,
+          reporter = new VCGen.ErrorReporter(options, gotoCmdOrigins, absyIds, Implementation.Blocks, Implementation.debugInfos, callback,
             mvInfo, checker.TheoremProver.Context, parent.program, this);
         }
 

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -84,7 +84,7 @@ namespace VC
         this.ctx = ctx;
       }
 
-      public VCExpr CodeExprToVerificationCondition(CodeExpr codeExpr, List<VCExprLetBinding> bindings, bool isPositiveContext)
+      public VCExpr CodeExprToVerificationCondition(CodeExpr codeExpr, List<VCExprLetBinding> bindings, bool isPositiveContext, Dictionary<Cmd, List<object>> debugInfos)
       {
         VCGen vcgen = new VCGen(new Program(), new CheckerPool(options));
         vcgen.variable2SequenceNumber = new Dictionary<Variable, int>();
@@ -94,7 +94,7 @@ namespace VC
         ResetPredecessors(codeExpr.Blocks);
         vcgen.AddBlocksBetween(codeExpr.Blocks);
         Dictionary<Variable, Expr> gotoCmdOrigins = vcgen.ConvertBlocks2PassiveCmd(traceWriter, codeExpr.Blocks,
-          new List<IdentifierExpr>(), new ModelViewInfo(codeExpr));
+          new List<IdentifierExpr>(), new ModelViewInfo(codeExpr), debugInfos);
         VCExpr startCorrect = vcgen.LetVC(codeExpr.Blocks, null, absyIds, ctx, out var ac, isPositiveContext);
         VCExpr vce = ctx.ExprGen.Let(bindings, startCorrect);
         if (vcgen.CurrentLocalVariables.Count != 0)


### PR DESCRIPTION
This PR makes Boogie produce a consistent enhanced error trace when verifying the same implementation several times, and it also adds a corresponding test case.

In more detail: To produce the enhanced error trace triggered by the `/enhancedErrorMessages` command line option, Boogie relies on the `debugInfos` map that is [filled in during passification](https://github.com/boogie-org/boogie/blob/24047c7b2d339e91cb39ebf8f8bf8d6ac5e6184e/Source/VCGeneration/ConditionGeneration.cs#L1055-L1095). This information is lost once the corresponding `ConditionGeneration` object is disposed, but an implementation is only ever passified once (see [here](https://github.com/boogie-org/boogie/blob/24047c7b2d339e91cb39ebf8f8bf8d6ac5e6184e/Source/VCGeneration/VCGen.cs#L383-L389)), so the augmented error trace is not produced on successive calls to `VerifyImplementation`. This PR attaches the `debugInfos` field to the `Implementation` object itself, meaning that this information is preserved across verification attempts.

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/boogie-org/boogie/blob/master/LICENSE.txt).