### PR TITLE
Add options to detect brittleness across multiple runs and portfolio results.

### DIFF
--- a/Source/Core/CoreOptions.cs
+++ b/Source/Core/CoreOptions.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Boogie
     SubsumptionOption UseSubsumption { get; }
     int VcsCores { get; }
     int RandomizeVcIterations { get; }
+    bool PortfolioVcIterations { get; }
     List<string> ProverOptions { get; }
     bool Prune { get; }
     bool RunDiagnosticsOnTimeout { get; }

--- a/Source/Core/CoreOptions.cs
+++ b/Source/Core/CoreOptions.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Boogie
     int VcsCores { get; }
     int RandomizeVcIterations { get; }
     bool PortfolioVcIterations { get; }
+    int PortfolioVcBatchSize { get; }
     List<string> ProverOptions { get; }
     bool Prune { get; }
     bool RunDiagnosticsOnTimeout { get; }

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -165,6 +165,8 @@ namespace Microsoft.Boogie
 
     public int RandomizeVcIterations { get; set; } = 1;
 
+    public bool PortfolioVcIterations { get; set; } = false;
+
     public bool PrintWithUniqueASTIds {
       get => printWithUniqueAstIds;
       set => printWithUniqueAstIds = value;
@@ -1185,6 +1187,12 @@ namespace Microsoft.Boogie
           RandomSeed ??= 0; // Set to 0 if not already set
           return true;
 
+        case "portfolioVcIterations":
+          ps.GetIntArgument(x => RandomizeVcIterations = x, a => 1 <= a);
+          PortfolioVcIterations = true;
+          RandomSeed ??= 0; // Set to 0 if not already set
+          return true;
+
         case "vcsLoad":
           double load = 0.0;
           if (ps.GetDoubleArgument(x => load = x))
@@ -1884,7 +1892,8 @@ namespace Microsoft.Boogie
                 a linear number of splits. The default way (top-down) is more
                 aggressive and it may create an exponential number of splits.
   /randomSeed:<s>
-                Supply the random seed for /randomizeVcIterations option.
+                Supply the random seed for /randomizeVcIterations and 
+                /portfolioVcIterations options.
   /randomizeVcIterations:<n>
                 Turn on randomization of the input that Boogie passes to the
                 SMT solver and turn on randomization in the SMT solver itself.
@@ -1899,6 +1908,9 @@ namespace Microsoft.Boogie
                 This option is implemented by renaming variables and reordering
                 declarations in the input, and by setting solver options that have
                 similar effects.
+  /portfolioVcIterations:<n>
+                Enables /randomizeVcIterations and returns the first successful
+                proof result (if any) out of n randomized VCs.
   /trackVerificationCoverage
                 Track and report which program elements labeled with an
                 `{:id ...}` attribute were necessary to complete verification.

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -166,6 +166,7 @@ namespace Microsoft.Boogie
     public int RandomizeVcIterations { get; set; } = 1;
 
     public bool PortfolioVcIterations { get; set; } = false;
+    public int PortfolioVcBatchSize { get; set; } = 1;
 
     public bool PrintWithUniqueASTIds {
       get => printWithUniqueAstIds;
@@ -1193,6 +1194,10 @@ namespace Microsoft.Boogie
           RandomSeed ??= 0; // Set to 0 if not already set
           return true;
 
+        case "portfolioVcBatchSize":
+          ps.GetIntArgument(x => PortfolioVcBatchSize = x, a => 1 <= a);
+          return true;
+
         case "vcsLoad":
           double load = 0.0;
           if (ps.GetDoubleArgument(x => load = x))
@@ -1911,6 +1916,18 @@ namespace Microsoft.Boogie
   /portfolioVcIterations:<n>
                 Enables /randomizeVcIterations and returns the first successful
                 proof result (if any) out of n randomized VCs.
+  /portfolioVcBatchSize:<m>
+                Splits n in /portfolioVcIterations:<n> into n/m batches (or
+                n/m+1 batches if n is not divisible by m). 
+                Defaults to 1.
+
+                Iterations in a batch can be executed concurrently, but each
+                batch is executed sequentially to completion. A batch execution
+                is considered complete when all iterations in that batch
+                complete execution. If any of the iterations in a batch returns
+                a valid verification outcome, remaining batches are cancelled.
+                Since the iterations and batches are created deterministically,
+                this implies determinism when using /portfolioVcIterations.
   /trackVerificationCoverage
                 Track and report which program elements labeled with an
                 `{:id ...}` attribute were necessary to complete verification.

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1276,8 +1276,9 @@ namespace VC
 
         if (options.Trace && SplitIndex >= 0)
         {
-          run.OutputWriter.WriteLine("      --> split #{0} done,  [{1} s] {2}", SplitIndex + 1,
-            checker.ProverRunTime.TotalSeconds, outcome);
+          var iterationText =  options.RandomizeVcIterations > 1 ? $" (iteration {iteration}) " : " ";
+          run.OutputWriter.WriteLine("      --> split #{0}{3}done,  [{1} s] {2}", SplitIndex + 1,
+            checker.ProverRunTime.TotalSeconds, outcome, iterationText);
         }
         if (options.Trace && options.TrackVerificationCoverage) {
           run.OutputWriter.WriteLine("Proof dependencies:\n  {0}",

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1269,14 +1269,19 @@ namespace VC
         }
       }
 
-      public async Task<(ProverInterface.Outcome outcome, VCResult result, int resourceCount)> ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
+      public async Task<(ProverInterface.Outcome outcome, VCResult result, int resourceCount)>
+        ReadOutcome(int iteration, int batch, Checker checker, VerifierCallback callback)
       {
         Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
         ProverInterface.Outcome outcome = cce.NonNull(checker).ReadOutcome();
 
         if (options.Trace && SplitIndex >= 0)
         {
-          var iterationText =  options.RandomizeVcIterations > 1 ? $" (iteration {iteration}) " : " ";
+          var iterationText =  options.RandomizeVcIterations > 1 
+            ? batch >= 0 
+              ? $" (batch {batch} iteration {iteration}) " 
+              : $" (iteration {iteration}) " 
+            : " ";
           run.OutputWriter.WriteLine("      --> split #{0}{3}done,  [{1} s] {2}", SplitIndex + 1,
             checker.ProverRunTime.TotalSeconds, outcome, iterationText);
         }

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -195,7 +195,7 @@ namespace VC
         await StartCheck(iteration, split, checker, cancellationToken);
         await checker.ProverTask;
         var (newOutcome, result, newResourceCount) = await split.ReadOutcome(iteration, checker, callback);
-        var cex = split.ToCounterexample(checker.TheoremProver.Context);
+        var cex = IsProverFailed(newOutcome) ? split.ToCounterexample(checker.TheoremProver.Context) : null;
         TotalProverElapsedTime += checker.ProverRunTime;
         await checker.GoBackToIdle();
         await ProcessResult(split, newOutcome, result, newResourceCount, cex, cancellationToken);


### PR DESCRIPTION
(Detailed description to be added.)

Adds two main options:

```
/portfolioVcIterations:<n>
              Enables /randomizeVcIterations and returns the first successful
              proof result (if any) out of n randomized VCs.
/portfolioVcBatchSize:<m>
              Splits n in /portfolioVcIterations:<n> into n/m batches (or
              n/m+1 batches if n is not divisible by m). 
              Defaults to 1.

              Iterations in a batch can be executed concurrently, but each
              batch is executed sequentially to completion. A batch execution
              is considered complete when all iterations in that batch
              complete execution. If any of the iterations in a batch returns
              a valid verification outcome, remaining batches are cancelled.
              Since the iterations and batches are created deterministically,
              this implies determinism when using /portfolioVcIterations.
```

Also adds an analysis to detect brittleness among iterations in executed batches, and reports these as warnings.