### PR TITLE
Support verification coverage in batch mode

### DIFF
--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -143,6 +143,9 @@ namespace Microsoft.Boogie.SMTLib
         requests.Add($"(get-info :{Z3.RlimitOption})");
       }
       requests.Add("(get-model)");
+      if (options.LibOptions.ProduceUnsatCores) {
+        requests.Add($"(get-unsat-core)");
+      }
 
       if (Process == null || HadErrors) {
         return Outcome.Undetermined;
@@ -175,6 +178,11 @@ namespace Microsoft.Boogie.SMTLib
 
         var modelSExp = responseStack.Pop();
         errorModel = ParseErrorModel(modelSExp);
+
+        if (options.LibOptions.ProduceUnsatCores) {
+          var unsatCoreSExp = responseStack.Pop();
+          ReportCoveredElements(unsatCoreSExp);
+        }
 
         if (result == Outcome.Invalid) {
           var labels = CalculatePath(currentErrorHandler.StartingProcId(), errorModel);

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1484,6 +1484,18 @@ namespace Microsoft.Boogie.SMTLib
       return dict.Count > 0 ? dict : null;
     }
 
+    protected void ReportCoveredElements(SExpr unsatCoreSExp) {
+      if (libOptions.TrackVerificationCoverage && unsatCoreSExp.Name != "") {
+        currentErrorHandler.AddCoveredElement(TrackedNodeComponent.ParseSolverString(unsatCoreSExp.Name.Substring("aux$$assume$$".Length)));
+      }
+
+      foreach (var arg in unsatCoreSExp.Arguments) {
+        if (libOptions.TrackVerificationCoverage) {
+          currentErrorHandler.AddCoveredElement(TrackedNodeComponent.ParseSolverString(arg.Name.Substring("aux$$assume$$".Length)));
+        }
+      }
+    }
+
     protected List<string> ParseUnsatCore(string resp)
     {
       if (resp == "" || resp == "()")

--- a/Test/coverage/verificationCoverage.bpl
+++ b/Test/coverage/verificationCoverage.bpl
@@ -99,7 +99,6 @@
 // RUN: %diff "%s.expect" "%t.coverage-d"
 // RUN: %boogie -trackVerificationCoverage -normalizeNames:1 -prune "%s" > "%t.coverage-n"
 // RUN: %diff "%s.expect" "%t.coverage-n"
-// UNSUPPORTED: batch_mode
 
 procedure testRequiresAssign(n: int)
   requires {:id "r0"} n > 0; // covered


### PR DESCRIPTION
Previously, the batch mode prover interface (selected with `-proverOpt:BATCH_MODE=true`) didn't support extracting unsat cores and therefore didn't support tracking verification coverage. This PR fixes that issue.