### PR TITLE
[Civl] Rewrite primitives in YieldProcedureDecl's 

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Boogie
         {
           if (cmd is CallCmd callCmd)
           {
-            var originalProc = (Procedure)civlTypeChecker.program.monomorphizer.GetOriginalDecl(callCmd.Proc);
+            var originalProc = (Procedure)Monomorphizer.GetOriginalDecl(callCmd.Proc);
             if (originalProc.Name == "create_async" || originalProc.Name == "create_asyncs" || originalProc.Name == "create_multi_asyncs")
             {
               var pendingAsyncType =
@@ -257,7 +257,7 @@ namespace Microsoft.Boogie
         {
           if (cmd is CallCmd callCmd)
           {
-            var originalProcName = civlTypeChecker.program.monomorphizer.GetOriginalDecl(callCmd.Proc).Name;
+            var originalProcName = Monomorphizer.GetOriginalDecl(callCmd.Proc).Name;
             if (originalProcName == "set_choice")
             {
               continue;
@@ -281,7 +281,7 @@ namespace Microsoft.Boogie
         {
           if (cmd is CallCmd callCmd)
           {
-            var originalProcName = civlTypeChecker.program.monomorphizer.GetOriginalDecl(callCmd.Proc).Name;
+            var originalProcName = Monomorphizer.GetOriginalDecl(callCmd.Proc).Name;
             if (originalProcName == "set_choice")
             {
               var pendingAsyncType = (CtorType)civlTypeChecker.program.monomorphizer.GetTypeInstantiation(callCmd.Proc)["T"];

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -7,19 +7,13 @@ public class LinearRewriter
 {
   private CivlTypeChecker civlTypeChecker;
 
-  private Procedure proc;
-  
   private Monomorphizer monomorphizer => civlTypeChecker.program.monomorphizer;
   
   private ConcurrencyOptions options => civlTypeChecker.Options;
 
-  private int? layerNum;
-
-  private LinearRewriter(CivlTypeChecker civlTypeChecker, Procedure proc)
+  public LinearRewriter(CivlTypeChecker civlTypeChecker)
   {
     this.civlTypeChecker = civlTypeChecker;
-    this.proc = proc;
-    this.layerNum = proc is YieldProcedureDecl decl ? decl.Layer : null;
   }
   
   public static bool IsPrimitive(DeclWithFormals decl)
@@ -29,7 +23,7 @@ public class LinearRewriter
 
   public static void Rewrite(CivlTypeChecker civlTypeChecker, Implementation impl)
   {
-    var linearRewriter = new LinearRewriter(civlTypeChecker, impl.Proc);
+    var linearRewriter = new LinearRewriter(civlTypeChecker);
     impl.Blocks.ForEach(block => block.Cmds = linearRewriter.RewriteCmdSeq(block.Cmds));
   }
 
@@ -50,7 +44,7 @@ public class LinearRewriter
     return newCmdSeq;
   }
 
-  private List<Cmd> RewriteCallCmd(CallCmd callCmd)
+  public List<Cmd> RewriteCallCmd(CallCmd callCmd)
   {
     switch (monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
     {
@@ -89,11 +83,6 @@ public class LinearRewriter
   private AssertCmd AssertCmd(IToken tok, Expr expr, string msg)
   {
     var assertCmd = CmdHelper.AssertCmd(tok, expr, msg);
-    if (layerNum.HasValue)
-    {
-      assertCmd.Attributes =
-        new QKeyValue(Token.NoToken, "layer", new List<object> { layerNum.Value }, assertCmd.Attributes);
-    }
     return assertCmd;
   }
   
@@ -484,7 +473,9 @@ public class LinearRewriter
       return;
     }
     var tc = new TypecheckingContext(null, options);
-    tc.Proc = proc;
+    var oldCheckModifies = tc.CheckModifies;
+    tc.CheckModifies = false;
     absys.ForEach(absy => absy.Typecheck(tc));
+    tc.CheckModifies = oldCheckModifies;
   }
 }

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -18,7 +18,7 @@ public class LinearRewriter
   
   public static bool IsPrimitive(DeclWithFormals decl)
   {
-    return CivlPrimitives.Linear.Contains(decl.Name);
+    return CivlPrimitives.Linear.Contains(Monomorphizer.GetOriginalDecl(decl).Name);
   }
 
   public static void Rewrite(CivlTypeChecker civlTypeChecker, Implementation impl)
@@ -32,7 +32,7 @@ public class LinearRewriter
     var newCmdSeq = new List<Cmd>();
     foreach (var cmd in cmdSeq)
     {
-      if (cmd is CallCmd callCmd && IsPrimitive(monomorphizer.GetOriginalDecl(callCmd.Proc)))
+      if (cmd is CallCmd callCmd && IsPrimitive(callCmd.Proc))
       {
         newCmdSeq.AddRange(RewriteCallCmd(callCmd));
       }
@@ -46,7 +46,7 @@ public class LinearRewriter
 
   public List<Cmd> RewriteCallCmd(CallCmd callCmd)
   {
-    switch (monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
+    switch (Monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
     {
       case "Ref_Alloc":
         return RewriteRefAlloc(callCmd);

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Boogie
       {
         return false;
       }
-      return LinearRewriter.IsPrimitive(program.monomorphizer.GetOriginalDecl(decl));
+      return LinearRewriter.IsPrimitive(decl);
     }
     
     private LinearDomain FindDomain(Variable v)
@@ -417,7 +417,7 @@ namespace Microsoft.Boogie
     
     private IdentifierExpr ModifiedArgument(CallCmd callCmd)
     {
-      switch (program.monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
+      switch (Monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
       {
         case "Ref_Alloc":
           return null;

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -491,22 +491,15 @@ namespace Microsoft.Boogie
         else if (lhsDomainName == null && rhsExpr is NAryExpr { Fun: FunctionCall { Func: DatatypeConstructor } } nAryExpr)
         {
           // pack
-          nAryExpr.Args.ForEach(arg =>
+          nAryExpr.Args.Where(arg => linearTypes.Contains(arg.Type)).ForEach(arg =>
           {
-            if (linearTypes.Contains(arg.Type))
+            if (arg is IdentifierExpr ie)
             {
-              if (arg is IdentifierExpr ie)
-              {
-                rhsVars.Add(ie.Decl);
-              }
-              else
-              {
-                Error(node, $"A source of pack of linear type must be a variable");
-              }
+              rhsVars.Add(ie.Decl);
             }
-            else if (arg is IdentifierExpr ie && LinearDomainCollector.FindDomainName(ie.Decl) != null)
+            else
             {
-              Error(node, $"A source of pack must not be a linear variable of name domain");
+              Error(node, $"A source of pack of linear type must be a variable");
             }
           });
         }

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -735,7 +735,10 @@ namespace Microsoft.Boogie
         var impls = program.TopLevelDeclarations.OfType<Implementation>().ToList();
         impls.ForEach(impl =>
         {
-          LinearRewriter.Rewrite(civlTypeChecker, impl);
+          if (impl.Proc is not YieldProcedureDecl)
+          {
+            LinearRewriter.Rewrite(civlTypeChecker, impl);
+          }
         }); 
       }
     }

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -318,7 +318,9 @@ namespace Microsoft.Boogie
 
       private string CallCmdLabel(CallCmd callCmd)
       {
-        if (callCmd.Proc is ActionDecl || callCmd.Proc.IsPure)
+        if (callCmd.Proc is ActionDecl ||
+            LinearRewriter.IsPrimitive(civlTypeChecker.program.monomorphizer.GetOriginalDecl(callCmd.Proc)) ||
+            callCmd.Proc.IsPure)
         {
           return P;
         }
@@ -387,7 +389,9 @@ namespace Microsoft.Boogie
 
       private string CallCmdLabelAsync(CallCmd callCmd)
       {
-        if (callCmd.Proc is ActionDecl || callCmd.Proc.IsPure)
+        if (callCmd.Proc is ActionDecl ||
+            LinearRewriter.IsPrimitive(civlTypeChecker.program.monomorphizer.GetOriginalDecl(callCmd.Proc)) ||
+            callCmd.Proc.IsPure)
         {
           return P;
         }

--- a/Source/Concurrency/YieldSufficiencyTypeChecker.cs
+++ b/Source/Concurrency/YieldSufficiencyTypeChecker.cs
@@ -318,9 +318,7 @@ namespace Microsoft.Boogie
 
       private string CallCmdLabel(CallCmd callCmd)
       {
-        if (callCmd.Proc is ActionDecl ||
-            LinearRewriter.IsPrimitive(civlTypeChecker.program.monomorphizer.GetOriginalDecl(callCmd.Proc)) ||
-            callCmd.Proc.IsPure)
+        if (callCmd.Proc is ActionDecl || LinearRewriter.IsPrimitive(callCmd.Proc) || callCmd.Proc.IsPure)
         {
           return P;
         }
@@ -389,9 +387,7 @@ namespace Microsoft.Boogie
 
       private string CallCmdLabelAsync(CallCmd callCmd)
       {
-        if (callCmd.Proc is ActionDecl ||
-            LinearRewriter.IsPrimitive(civlTypeChecker.program.monomorphizer.GetOriginalDecl(callCmd.Proc)) ||
-            callCmd.Proc.IsPure)
+        if (callCmd.Proc is ActionDecl || LinearRewriter.IsPrimitive(callCmd.Proc) || callCmd.Proc.IsPure)
         {
           return P;
         }

--- a/Source/Concurrency/YieldingProcChecker.cs
+++ b/Source/Concurrency/YieldingProcChecker.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Boogie
           }
         }
 
-        foreach (Implementation impl in program.Implementations.Where(impl => impl.Proc is YieldProcedureDecl))
+        // duplicator.VisitImplementation may invoke the monomorphizer which may cause more instantiations to be generated
+        // and added to program.TopLevelDeclarations; hence converting the enumeration to a new list.
+        foreach (Implementation impl in program.Implementations.Where(impl => impl.Proc is YieldProcedureDecl).ToList())
         {
           var yieldProcedureDecl = (YieldProcedureDecl)impl.Proc;
           if (yieldProcedureDecl.Layer >= layerNum)

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Boogie
     private Dictionary<CallCmd, CallCmd> refinementCallCmds; // rewritten -> original
     private Dictionary<CallCmd, Block> refinementBlocks; // rewritten -> block
 
+    private LinearRewriter linearRewriter;
+
     private ConcurrencyOptions Options => civlTypeChecker.Options;
 
     public YieldingProcDuplicator(CivlTypeChecker civlTypeChecker, int layerNum)
@@ -34,6 +36,7 @@ namespace Microsoft.Boogie
       this.absyMap = new AbsyMap();
       this.asyncCallPreconditionCheckers = new Dictionary<string, Procedure>();
       this.refinementBlocks = new Dictionary<CallCmd, Block>();
+      this.linearRewriter = new LinearRewriter(civlTypeChecker);
     }
 
     #region Procedure duplication
@@ -253,6 +256,17 @@ namespace Microsoft.Boogie
           newCall.Proc = linkAction.Impl.Proc;
           InjectGate(linkAction, newCall);
           newCmdSeq.Add(newCall);
+        }
+        return;
+      }
+
+      if (LinearRewriter.IsPrimitive(civlTypeChecker.program.monomorphizer.GetOriginalDecl(newCall.Proc)))
+      {
+        var callLayerRange = new LayerRange(newCall.Layers[0],
+          newCall.Layers.Count == 1 ? newCall.Layers[0] : newCall.Layers[1]);
+        if (callLayerRange.Contains(layerNum))
+        {
+          newCmdSeq.AddRange(linearRewriter.RewriteCallCmd(newCall));
         }
         return;
       }

--- a/Source/Concurrency/YieldingProcDuplicator.cs
+++ b/Source/Concurrency/YieldingProcDuplicator.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Boogie
         return;
       }
 
-      if (LinearRewriter.IsPrimitive(civlTypeChecker.program.monomorphizer.GetOriginalDecl(newCall.Proc)))
+      if (LinearRewriter.IsPrimitive(newCall.Proc))
       {
         var callLayerRange = new LayerRange(newCall.Layers[0],
           newCall.Layers.Count == 1 ? newCall.Layers[0] : newCall.Layers[1]);

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -2029,7 +2029,7 @@ namespace Microsoft.Boogie
       return monomorphizationVisitor.InstantiateTypeCtorDecl(typeCtorDeclName, actualTypeParams);
     }
 
-    public DeclWithFormals GetOriginalDecl(DeclWithFormals decl)
+    public static DeclWithFormals GetOriginalDecl(DeclWithFormals decl)
     {
       return decl.OriginalDeclWithFormals ?? decl;
     }

--- a/Source/Core/ResolutionContext.cs
+++ b/Source/Core/ResolutionContext.cs
@@ -750,11 +750,13 @@ namespace Microsoft.Boogie
     public LayerRange ExpectedLayerRange;
     public bool GlobalAccessOnlyInOld;
     public int InsideOld;
+    public bool CheckModifies;
 
     public TypecheckingContext(IErrorSink errorSink, CoreOptions options)
       : base(errorSink)
     {
       this.Options = options;
+      this.CheckModifies = !options?.DoModSetAnalysis ?? true;
     }
 
     public bool InFrame(Variable v)

--- a/Test/civl/regression-tests/linear_types_error.bpl
+++ b/Test/civl/regression-tests/linear_types_error.bpl
@@ -84,3 +84,6 @@ atomic action {:layer 1, 2} A14({:linear_in} a: Lval int) returns (b: Bar)
 {
     b := Bar(Lval(3), 3+4);
 }
+
+type {:linear "X"} X = int;
+yield procedure {:layer 1} A15({:linear_in "X"} a: Lval int);

--- a/Test/civl/regression-tests/linear_types_error.bpl.expect
+++ b/Test/civl/regression-tests/linear_types_error.bpl.expect
@@ -1,3 +1,4 @@
+linear_types_error.bpl(89,48): Error: Variable of linear type must not have a domain name
 linear_types_error.bpl(4,73): Error: Output variable l must be available at a return
 linear_types_error.bpl(8,0): Error: Input variable path must be available at a return
 linear_types_error.bpl(13,0): Error: Input variable path must be available at a return
@@ -14,4 +15,4 @@ linear_types_error.bpl(66,0): Error: Output variable b must be available at a re
 linear_types_error.bpl(72,14): Error: unavailable source for a linear read
 linear_types_error.bpl(78,9): Error: unavailable source for a linear read
 linear_types_error.bpl(85,6): Error: A source of pack of linear type must be a variable
-16 type checking errors detected in linear_types_error.bpl
+17 type checking errors detected in linear_types_error.bpl

--- a/Test/civl/regression-tests/yield-proc-rewrite.bpl
+++ b/Test/civl/regression-tests/yield-proc-rewrite.bpl
@@ -1,0 +1,23 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+yield procedure {:layer 1} Foo1({:linear_in} x: Lset int) returns (z: Lset int)
+{
+    var y: Lval int;
+    z := x;
+    call {:layer 1} Lval_Split(y, z);
+}
+
+atomic action {:layer 2} AtomicFoo2({:linear_in} x: Lset int) returns (z: Lset int)
+{
+    var y: Lval int;
+    z := x;
+    call Lval_Split(y, z);
+}
+yield procedure {:layer 1} Foo2({:linear_in} x: Lset int) returns (z: Lset int)
+refines AtomicFoo2;
+{
+    var y: Lval int;
+    z := x;
+    call {:layer 1} Lval_Split(y, z);
+}

--- a/Test/civl/regression-tests/yield-proc-rewrite.bpl.expect
+++ b/Test/civl/regression-tests/yield-proc-rewrite.bpl.expect
@@ -1,0 +1,5 @@
+yield-proc-rewrite.bpl(8,5): Error: Lval_Split failed
+Execution trace:
+    yield-proc-rewrite.bpl(7,7): anon0
+
+Boogie program verifier finished with 1 verified, 1 error


### PR DESCRIPTION
This diff allows linear primitives to be invoked in yield procedures (in addition to atomic actions).