### PR TITLE
Update version, and remove race condition

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>3.0.6</Version>
+    <Version>3.0.7</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -270,16 +270,10 @@ public abstract class ProverInterface
   {
   }
 
-  // Sets a local SMT option (cleared with ClearLocalSMTOptions)
-  public virtual void SetLocalSMTOption(string name, string value)
+  public virtual void SetAdditionalSmtOptions(IEnumerable<OptionValue> entries)
   {
   }
-
-  // Clear options set with SetLocalSMTOption
-  public virtual void ClearLocalSMTOptions()
-  {
-  }
-
+  
   public virtual Task<int> GetRCount()
   {
     throw new NotImplementedException();

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Boogie.SMTLib
           SendCommon("(set-option :produce-models true)");
         }
 
-        SendSolverOptions();
+        SendSmtOptions();
 
         if (!string.IsNullOrEmpty(options.Logic))
         {
@@ -391,7 +391,7 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    private void SendSolverOptions()
+    private void SendSmtOptions()
     {
       foreach (var opt in options.SmtOptions.Concat(additionalSmtOptions))
       {
@@ -447,7 +447,7 @@ namespace Microsoft.Boogie.SMTLib
       }
 
 
-      SendSolverOptions();
+      SendSmtOptions();
     }
 
     protected void SendVCId(string descriptiveName)

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,7 +7,6 @@ using System.Diagnostics.Contracts;
 using Microsoft.Boogie.VCExprAST;
 using Microsoft.Boogie.TypeErasure;
 using System.Text;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Boogie.SMTLib
 {
@@ -47,7 +45,7 @@ namespace Microsoft.Boogie.SMTLib
     }
 
     [NotDelayed]
-    protected SMTLibProcessTheoremProver(SMTLibOptions libOptions, SMTLibSolverOptions options, VCExpressionGenerator gen,
+    public SMTLibProcessTheoremProver(SMTLibOptions libOptions, SMTLibSolverOptions options, VCExpressionGenerator gen,
       SMTLibProverContext ctx)
     {
       Contract.Requires(options != null);
@@ -347,7 +345,10 @@ namespace Microsoft.Boogie.SMTLib
           SendCommon("(set-option :produce-models true)");
         }
 
-        SendSmtOptions();
+        foreach (var opt in SmtOptions())
+        {
+          SendCommon("(set-option :" + opt.Option + " " + opt.Value + ")");
+        }
 
         if (!string.IsNullOrEmpty(options.Logic))
         {
@@ -391,12 +392,9 @@ namespace Microsoft.Boogie.SMTLib
       }
     }
 
-    private void SendSmtOptions()
+    private IEnumerable<OptionValue> SmtOptions()
     {
-      foreach (var opt in options.SmtOptions.Concat(additionalSmtOptions))
-      {
-        SendCommon("(set-option :" + opt.Option + " " + opt.Value + ")");
-      }
+      return options.SmtOptions.Concat(additionalSmtOptions);
     }
 
     private void SetupAxioms()
@@ -446,8 +444,10 @@ namespace Microsoft.Boogie.SMTLib
         }
       }
 
-
-      SendSmtOptions();
+      foreach (var opt in SmtOptions())
+      {
+        SendThisVC("(set-option :" + opt.Option + " " + opt.Value + ")");
+      }
     }
 
     protected void SendVCId(string descriptiveName)

--- a/Source/Provers/SMTLib/SMTLibSolverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibSolverOptions.cs
@@ -38,13 +38,13 @@ namespace Microsoft.Boogie.SMTLib
     public bool UseWeights = true;
     public bool UseTickleBool => Solver == SolverKind.Z3;
     public SolverKind Solver = SolverKind.Z3;
-    public List<OptionValue> SmtOptions = new List<OptionValue>();
-    public List<string> SolverArguments = new List<string>();
+    public List<OptionValue> SmtOptions = new();
+    public List<string> SolverArguments = new();
     public string Logic = null;
 
     // Z3 specific (at the moment; some of them make sense also for other provers)
     public string Inspector = null;
-
+    
     public SMTLibSolverOptions(SMTLibOptions libOptions) : base(libOptions)
     {
     }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1353,9 +1353,7 @@ namespace VC
           Print();
         }
 
-        foreach (var entry in Implementation.GetExtraSMTOptions()) {
-          checker.TheoremProver.SetLocalSMTOption(entry.Key, entry.Value);
-        }
+        checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions().Select(kv => new OptionValue(kv.Key, kv.Value)));
         await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
       }
 

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -193,8 +193,6 @@ namespace VC
         batchCompletions.OnNext((split, result));
         await checker.GoBackToIdle();
       }
-
-      checker.TheoremProver.ClearLocalSMTOptions();
     }
 
     private static bool IsProverFailed(ProverInterface.Outcome outcome)

--- a/Test/.lit_test_times.txt
+++ b/Test/.lit_test_times.txt
@@ -1,0 +1,1 @@
+6.946981e-01 prover/smt-options.bpl

--- a/Test/.lit_test_times.txt
+++ b/Test/.lit_test_times.txt
@@ -1,1 +1,0 @@
-6.946981e-01 prover/smt-options.bpl


### PR DESCRIPTION
`ClearLocalSMTOptions()` was called _after_ the checker was released, which leads to a race condition because a new thread may already be using the checker's options while they're still being cleared. Here's an example: https://github.com/dafny-lang/dafny/actions/runs/6930078076/job/18849083894?pr=4773

This PR reduces statefulness of the code, since it no longer clears and reparses `SMTLibProcessTheoremProver.options`. Instead it has a field `IEnumerable<OptionValue> additionalSmtOptions` that can be used to tweak SmtOptions between runs.