### PR TITLE
[Civl] Combine linear heaps and maps into a single abstraction

### DIFF
--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -297,6 +297,15 @@ namespace Microsoft.Boogie
     
     private void InlineAtomicActions(HashSet<ActionDecl> actionDecls)
     {
+      var primitiveImpls = program.TopLevelDeclarations.OfType<Implementation>().Where(impl =>
+      {
+        var originalDecl = impl.Proc.OriginalDeclWithFormals;
+        return originalDecl != null && CivlPrimitives.LinearPrimitives.Contains(originalDecl.Name);
+      });
+      primitiveImpls.ForEach(impl => {
+        impl.OriginalBlocks = impl.Blocks;
+        impl.OriginalLocVars = impl.LocVars;
+      });
       CivlUtil.AddInlineAttribute(SkipActionDecl);
       actionDecls.ForEach(proc =>
       {
@@ -316,6 +325,10 @@ namespace Microsoft.Boogie
       actionDecls.ForEach(proc =>
       {
         var impl = proc.Impl;
+        impl.OriginalBlocks = null;
+        impl.OriginalLocVars = null;
+      });
+      primitiveImpls.ForEach(impl => {
         impl.OriginalBlocks = null;
         impl.OriginalLocVars = null;
       });

--- a/Source/Concurrency/LinearDomainCollector.cs
+++ b/Source/Concurrency/LinearDomainCollector.cs
@@ -176,11 +176,7 @@ namespace Microsoft.Boogie
       var typeCtorDecl = type.AsCtor.Decl;
       var originalTypeCtorDecl = Monomorphizer.GetOriginalDecl(typeCtorDecl);
       var actualTypeParams = program.monomorphizer.GetTypeInstantiation(typeCtorDecl);
-      return 
-        originalTypeCtorDecl.Name == "Lheap"
-          ? new CtorType(Token.NoToken, program.monomorphizer.InstantiateTypeCtorDecl("Ref", actualTypeParams),
-            new List<Type>())
-          : actualTypeParams[0];
+      return actualTypeParams[0];
     }
     
     private Dictionary<Type, LinearDomain> MakeLinearDomains()
@@ -208,8 +204,6 @@ namespace Microsoft.Boogie
           {
             var typeParamInstantiationMap = new Dictionary<string, Type> { { "V", actualTypeParams[0] } };
             var collector =
-                originalTypeCtorDecl.Name == "Lheap"
-                  ? program.monomorphizer.InstantiateFunction("Lheap_Collector", typeParamInstantiationMap) :
                 originalTypeCtorDecl.Name == "Lset"
                   ? program.monomorphizer.InstantiateFunction("Lset_Collector", typeParamInstantiationMap) :
                   program.monomorphizer.InstantiateFunction("Lval_Collector", typeParamInstantiationMap);

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -383,8 +383,8 @@ public class LinearRewriter
         Monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lmap")
     {
       var cmdSeq = CreateAccessAsserts(mapAssignLhs.Map, tok, msg);
-      var lheapContainsFunc = LmapContains(mapAssignLhs.Indexes[0].Type, mapAssignLhs.Map.Type);
-      cmdSeq.Add(AssertCmd(tok, ExprHelper.FunctionCall(lheapContainsFunc, fieldAssignLhs1.Datatype.AsExpr, mapAssignLhs.Indexes[0]), msg));
+      var lmapContainsFunc = LmapContains(mapAssignLhs.Indexes[0].Type, mapAssignLhs.Map.Type);
+      cmdSeq.Add(AssertCmd(tok, ExprHelper.FunctionCall(lmapContainsFunc, fieldAssignLhs1.Datatype.AsExpr, mapAssignLhs.Indexes[0]), msg));
       return cmdSeq;
     }
     return new List<Cmd>();

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -24,6 +24,9 @@ public class LinearRewriter
 
   public static void Rewrite(CivlTypeChecker civlTypeChecker, Implementation impl)
   {
+    if (IsPrimitive(impl)) {
+      return;
+    }
     var linearRewriter = new LinearRewriter(civlTypeChecker);
     impl.Blocks.ForEach(block => block.Cmds = linearRewriter.RewriteCmdSeq(block.Cmds));
   }
@@ -69,28 +72,18 @@ public class LinearRewriter
   {
     switch (Monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
     {
-      case "Ref_Alloc":
-        return RewriteRefAlloc(callCmd);
-      case "Lheap_Empty":
-        return RewriteLheapEmpty(callCmd);
-      case "Lheap_Alloc":
-        return RewriteLheapAlloc(callCmd);
-      case "Lheap_Free":
-        return RewriteLheapFree(callCmd);
-      case "Lheap_Get":
-        return RewriteLheapGet(callCmd);
-      case "Lheap_Put":
-        return RewriteLheapPut(callCmd);
+      case "Loc_New":
+        return new List<Cmd>{callCmd};
       case "Lmap_Empty":
-        return RewriteLmapEmpty(callCmd);
+        return new List<Cmd>{callCmd};
       case "Lmap_Alloc":
-        return RewriteLmapAlloc(callCmd);
+        return new List<Cmd>{callCmd};
+      case "Lmap_Create":
+        return new List<Cmd>{callCmd};
       case "Lmap_Free":
-        return RewriteLmapFree(callCmd);
-      case "Lmap_Get":
-        return RewriteLmapGet(callCmd);
-      case "Lmap_Put":
-        return RewriteLmapPut(callCmd);
+        return new List<Cmd>{callCmd};
+      case "Lmap_Move":
+        return new List<Cmd>{callCmd};
       case "Lset_Empty":
         return RewriteLsetEmpty(callCmd);
       case "Lset_Split":
@@ -148,14 +141,9 @@ public class LinearRewriter
     return monomorphizer.InstantiateFunction("MapIte",new Dictionary<string, Type>() { { "T", domain }, { "U", range } });
   }
 
-  private Function LheapContains(Type type)
+  private Function LmapContains(Type keyType, Type valueType)
   {
-    return monomorphizer.InstantiateFunction("Lheap_Contains",new Dictionary<string, Type>() { { "V", type } });
-  }
-
-  private Function LheapDeref(Type type)
-  {
-    return monomorphizer.InstantiateFunction("Lheap_Deref",new Dictionary<string, Type>() { { "V", type } });
+    return monomorphizer.InstantiateFunction("Lmap_Contains",new Dictionary<string, Type>() { {"K", keyType}, { "V", valueType } });
   }
 
   private Function LsetContains(Type type)
@@ -179,252 +167,9 @@ public class LinearRewriter
     return ExprHelper.FunctionCall(defaultFunc);
   }
 
-  private List<Cmd> RewriteRefAlloc(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
-      out Function lsetConstructor, out Function lvalConstructor);
-    var instantiation = monomorphizer.GetTypeInstantiation(callCmd.Proc);
-    var nilFunc = monomorphizer.InstantiateFunction("Nil", instantiation);
-
-    var cmdSeq = new List<Cmd>();
-    var k = callCmd.Outs[0];
-
-    cmdSeq.Add(CmdHelper.HavocCmd(k));
-    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Neq(Val(k), ExprHelper.FunctionCall(nilFunc))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLheapEmpty(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
-      out Function lsetConstructor, out Function lvalConstructor);
-
-    var cmdSeq = new List<Cmd>();
-    var l = callCmd.Outs[0].Decl;
-
-    var mapConstFunc1 = MapConst(refType, Type.Bool);
-    var mapConstFunc2 = MapConst(refType, type);
-
-    cmdSeq.Add(CmdHelper.AssignCmd(l,
-      ExprHelper.FunctionCall(lheapConstructor, ExprHelper.FunctionCall(mapConstFunc1, Expr.False),
-        ExprHelper.FunctionCall(mapConstFunc2, Default(type)))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLheapAlloc(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
-      out Function lsetConstructor, out Function lvalConstructor);
-    var instantiation = monomorphizer.GetTypeInstantiation(callCmd.Proc);
-    var nilFunc = monomorphizer.InstantiateFunction("Nil", instantiation);
-
-    var cmdSeq = new List<Cmd>();
-    var path = callCmd.Ins[0];
-    var v = callCmd.Ins[1];
-    var l = callCmd.Outs[0];
-
-    cmdSeq.Add(CmdHelper.HavocCmd(l));
-    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Neq(Val(l), ExprHelper.FunctionCall(nilFunc))));
-    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Not(ExprHelper.FunctionCall(new MapSelect(callCmd.tok, 1), Dom(path), Val(l)))));
-    cmdSeq.Add(CmdHelper.AssumeCmd(Expr.Eq(ExprHelper.FunctionCall(new MapSelect(callCmd.tok, 1), Val(path), Val(l)), v)));
-    cmdSeq.Add(CmdHelper.AssignCmd(
-      CmdHelper.ExprToAssignLhs(path),
-      ExprHelper.FunctionCall(lheapConstructor,
-        ExprHelper.FunctionCall(new MapStore(callCmd.tok, 1), Dom(path), Val(l), Expr.True),
-        Val(path))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLheapFree(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
-      out Function lsetConstructor, out Function lvalConstructor);
-
-    var cmdSeq = new List<Cmd>();
-    var path = callCmd.Ins[0];
-    var k = callCmd.Ins[1];
-
-    var lheapContainsFunc = LheapContains(type);
-    cmdSeq.Add(AssertCmd(callCmd.tok, ExprHelper.FunctionCall(lheapContainsFunc, path, k), "Lheap_Free failed"));
-
-    cmdSeq.Add(
-      CmdHelper.AssignCmd(CmdHelper.ExprToAssignLhs(path),
-      ExprHelper.FunctionCall(lheapConstructor,
-        ExprHelper.FunctionCall(new MapStore(callCmd.tok, 1), Dom(path), k, Expr.False),
-        ExprHelper.FunctionCall(new MapStore(callCmd.tok, 1), Val(path), k, Default(type)))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLheapGet(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
-      out Function lsetConstructor, out Function lvalConstructor);
-
-    var cmdSeq = new List<Cmd>();
-    var path = callCmd.Ins[0];
-    var k = callCmd.Ins[1];
-    var l = callCmd.Outs[0].Decl;
-
-    var mapImpFunc = MapImp(refType);
-    var mapIteFunc = MapIte(refType, type);
-    var mapConstFunc1 = MapConst(refType, Type.Bool);
-    var mapConstFunc2 = MapConst(refType, type);
-    var mapDiffFunc = MapDiff(refType);
-
-    cmdSeq.Add(AssertCmd(callCmd.tok,
-      Expr.Eq(ExprHelper.FunctionCall(mapImpFunc, k, Dom(path)), ExprHelper.FunctionCall(mapConstFunc1, Expr.True)),
-      "Lheap_Get failed"));
-
-    cmdSeq.Add(CmdHelper.AssignCmd(l,
-      ExprHelper.FunctionCall(lheapConstructor, k,
-        ExprHelper.FunctionCall(mapIteFunc, k, Val(path), ExprHelper.FunctionCall(mapConstFunc2, Default(type))))));
-
-    cmdSeq.Add(CmdHelper.AssignCmd(CmdHelper.ExprToAssignLhs(path),
-      ExprHelper.FunctionCall(lheapConstructor, ExprHelper.FunctionCall(mapDiffFunc, Dom(path), k),
-        ExprHelper.FunctionCall(mapIteFunc, ExprHelper.FunctionCall(mapDiffFunc, Dom(path), k), Val(path),
-          ExprHelper.FunctionCall(mapConstFunc2, Default(type))))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLheapPut(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
-      out Function lsetConstructor, out Function lvalConstructor);
-
-    var cmdSeq = new List<Cmd>();
-    var path = callCmd.Ins[0];
-    var l = callCmd.Ins[1];
-
-    var mapOrFunc = MapOr(refType);
-    var mapIteFunc = MapIte(refType, type);
-    cmdSeq.Add(CmdHelper.AssignCmd(
-      CmdHelper.ExprToAssignLhs(path),
-      ExprHelper.FunctionCall(lheapConstructor,
-        ExprHelper.FunctionCall(mapOrFunc, Dom(path), Dom(l)),
-        ExprHelper.FunctionCall(mapIteFunc, Dom(path), Val(path), Val(l)))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLmapEmpty(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type keyType, out Type valType, out Function lmapConstructor);
-
-    var cmdSeq = new List<Cmd>();
-    var l = callCmd.Outs[0].Decl;
-
-    var mapConstFunc1 = MapConst(keyType, Type.Bool);
-    var mapConstFunc2 = MapConst(keyType, valType);
-
-    cmdSeq.Add(CmdHelper.AssignCmd(l,
-      ExprHelper.FunctionCall(lmapConstructor, ExprHelper.FunctionCall(mapConstFunc1, Expr.False),
-        ExprHelper.FunctionCall(mapConstFunc2, Default(valType)))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLmapAlloc(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type keyType, out Type valType, out Function lmapConstructor);
-
-    var cmdSeq = new List<Cmd>();
-    var k = callCmd.Ins[0];
-    var val = callCmd.Ins[1];
-    var l = callCmd.Outs[0].Decl;
-
-    var mapIteFunc = MapIte(keyType, valType);
-    var mapConstFunc = MapConst(keyType, valType);
-    cmdSeq.Add(CmdHelper.AssignCmd(l,
-      ExprHelper.FunctionCall(lmapConstructor, Dom(k),
-        ExprHelper.FunctionCall(mapIteFunc, Dom(k), val, ExprHelper.FunctionCall(mapConstFunc, Default(valType))))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLmapFree(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type keyType, out Type valType, out Function lmapConstructor);
-    var lsetTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lset", new List<Type>() { keyType });
-    var lsetConstructor = lsetTypeCtorDecl.Constructors[0];
-
-    var cmdSeq = new List<Cmd>();
-    var l = callCmd.Ins[0];
-    var k = callCmd.Outs[0].Decl;
-
-    cmdSeq.Add(CmdHelper.AssignCmd(k, ExprHelper.FunctionCall(lsetConstructor, Dom(l))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLmapGet(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type keyType, out Type valType, out Function lmapConstructor);
-
-    var cmdSeq = new List<Cmd>();
-    var path = callCmd.Ins[0];
-    var k = callCmd.Ins[1];
-    var l = callCmd.Outs[0].Decl;
-
-    var mapImpFunc = MapImp(keyType);
-    var mapIteFunc = MapIte(keyType, valType);
-    var mapConstFunc1 = MapConst(keyType, Type.Bool);
-    var mapConstFunc2 = MapConst(keyType, valType);
-    var mapDiffFunc = MapDiff(keyType);
-
-    cmdSeq.Add(AssertCmd(callCmd.tok,
-      Expr.Eq(ExprHelper.FunctionCall(mapImpFunc, k, Dom(path)), ExprHelper.FunctionCall(mapConstFunc1, Expr.True)),
-      "Lmap_Get failed"));
-
-    cmdSeq.Add(CmdHelper.AssignCmd(l,
-      ExprHelper.FunctionCall(lmapConstructor, k,
-        ExprHelper.FunctionCall(mapIteFunc, k, Val(path), ExprHelper.FunctionCall(mapConstFunc2, Default(valType))))));
-
-    cmdSeq.Add(CmdHelper.AssignCmd(CmdHelper.ExprToAssignLhs(path),
-      ExprHelper.FunctionCall(lmapConstructor, ExprHelper.FunctionCall(mapDiffFunc, Dom(path), k),
-        ExprHelper.FunctionCall(mapIteFunc, ExprHelper.FunctionCall(mapDiffFunc, Dom(path), k), Val(path),
-          ExprHelper.FunctionCall(mapConstFunc2, Default(valType))))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
-  private List<Cmd> RewriteLmapPut(CallCmd callCmd)
-  {
-    GetRelevantInfo(callCmd, out Type keyType, out Type valType, out Function lmapConstructor);
-
-    var cmdSeq = new List<Cmd>();
-    var path = callCmd.Ins[0];
-    var l = callCmd.Ins[1];
-
-    var mapOrFunc = MapOr(keyType);
-    var mapIteFunc = MapIte(keyType, valType);
-    cmdSeq.Add(CmdHelper.AssignCmd(
-      CmdHelper.ExprToAssignLhs(path),
-      ExprHelper.FunctionCall(lmapConstructor,
-        ExprHelper.FunctionCall(mapOrFunc, Dom(path), Dom(l)),
-        ExprHelper.FunctionCall(mapIteFunc, Dom(path), Val(path), Val(l)))));
-
-    ResolveAndTypecheck(options, cmdSeq);
-    return cmdSeq;
-  }
-
   private List<Cmd> RewriteLsetEmpty(CallCmd callCmd)
   {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
+    GetRelevantInfo(callCmd, out Type type, out Type refType,
       out Function lsetConstructor, out Function lvalConstructor);
 
     var cmdSeq = new List<Cmd>();
@@ -439,7 +184,7 @@ public class LinearRewriter
 
   private List<Cmd> RewriteLsetSplit(CallCmd callCmd)
   {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
+    GetRelevantInfo(callCmd, out Type type, out Type refType,
       out Function lsetConstructor, out Function lvalConstructor);
 
     var cmdSeq = new List<Cmd>();
@@ -462,7 +207,7 @@ public class LinearRewriter
 
   private List<Cmd> RewriteLsetGet(CallCmd callCmd)
   {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
+    GetRelevantInfo(callCmd, out Type type, out Type refType,
       out Function lsetConstructor, out Function lvalConstructor);
 
     var cmdSeq = new List<Cmd>();
@@ -488,7 +233,7 @@ public class LinearRewriter
 
   private List<Cmd> RewriteLsetPut(CallCmd callCmd)
   {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
+    GetRelevantInfo(callCmd, out Type type, out Type refType,
       out Function lsetConstructor, out Function lvalConstructor);
 
     var cmdSeq = new List<Cmd>();
@@ -506,7 +251,7 @@ public class LinearRewriter
 
   private List<Cmd> RewriteLvalSplit(CallCmd callCmd)
   {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
+    GetRelevantInfo(callCmd, out Type type, out Type refType,
       out Function lsetConstructor, out Function lvalConstructor);
 
     var cmdSeq = new List<Cmd>();
@@ -528,7 +273,7 @@ public class LinearRewriter
 
   private List<Cmd> RewriteLvalGet(CallCmd callCmd)
   {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
+    GetRelevantInfo(callCmd, out Type type, out Type refType,
       out Function lsetConstructor, out Function lvalConstructor);
 
     var cmdSeq = new List<Cmd>();
@@ -553,7 +298,7 @@ public class LinearRewriter
 
   private List<Cmd> RewriteLvalPut(CallCmd callCmd)
   {
-    GetRelevantInfo(callCmd, out Type type, out Type refType, out Function lheapConstructor,
+    GetRelevantInfo(callCmd, out Type type, out Type refType,
       out Function lsetConstructor, out Function lvalConstructor);
 
     var cmdSeq = new List<Cmd>();
@@ -571,7 +316,7 @@ public class LinearRewriter
     return cmdSeq;
   }
 
-  private void GetRelevantInfo(CallCmd callCmd, out Type type, out Type refType, out Function lheapConstructor,
+  private void GetRelevantInfo(CallCmd callCmd, out Type type, out Type refType,
     out Function lsetConstructor, out Function lvalConstructor)
   {
     var instantiation = monomorphizer.GetTypeInstantiation(callCmd.Proc);
@@ -579,22 +324,10 @@ public class LinearRewriter
     var actualTypeParams = new List<Type>() { type };
     var refTypeCtorDecl = monomorphizer.InstantiateTypeCtorDecl("Ref", actualTypeParams);
     refType = new CtorType(Token.NoToken, refTypeCtorDecl, new List<Type>());
-    var lheapTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lheap", actualTypeParams);
-    lheapConstructor = lheapTypeCtorDecl.Constructors[0];
     var lsetTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lset", actualTypeParams);
     lsetConstructor = lsetTypeCtorDecl.Constructors[0];
     var lvalTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lval", actualTypeParams);
     lvalConstructor = lvalTypeCtorDecl.Constructors[0];
-  }
-
-  private void GetRelevantInfo(CallCmd callCmd, out Type keyType, out Type valType, out Function lmapConstructor)
-  {
-    var instantiation = monomorphizer.GetTypeInstantiation(callCmd.Proc);
-    keyType = instantiation["K"];
-    valType = instantiation["V"];
-    var actualTypeParams = new List<Type>() { keyType, valType };
-    var lmapTypeCtorDecl = (DatatypeTypeCtorDecl)monomorphizer.InstantiateTypeCtorDecl("Lmap", actualTypeParams);
-    lmapConstructor = lmapTypeCtorDecl.Constructors[0];
   }
 
   private void ResolveAndTypecheck(CoreOptions options, IEnumerable<Absy> absys)
@@ -623,14 +356,14 @@ public class LinearRewriter
       if (nAryExpr.Fun is MapSelect)
       {
         var mapExpr = nAryExpr.Args[0];
-        if (mapExpr is NAryExpr lheapValExpr &&
-            lheapValExpr.Fun is FieldAccess &&
-            lheapValExpr.Args[0].Type is CtorType ctorType &&
-            Monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lheap")
+        if (mapExpr is NAryExpr lmapValExpr &&
+            lmapValExpr.Fun is FieldAccess &&
+            lmapValExpr.Args[0].Type is CtorType ctorType &&
+            Monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lmap")
         {
-          var cmdSeq = CreateAccessAsserts(lheapValExpr.Args[0], tok, msg);
-          var lheapContainsFunc = LheapContains(nAryExpr.Type);
-          cmdSeq.Add(AssertCmd(tok, ExprHelper.FunctionCall(lheapContainsFunc, lheapValExpr.Args[0], nAryExpr.Args[1]), msg));
+          var cmdSeq = CreateAccessAsserts(lmapValExpr.Args[0], tok, msg);
+          var lmapContainsFunc = LmapContains(nAryExpr.Args[1].Type, nAryExpr.Type);
+          cmdSeq.Add(AssertCmd(tok, ExprHelper.FunctionCall(lmapContainsFunc, lmapValExpr.Args[0], nAryExpr.Args[1]), msg));
           return cmdSeq;
         }
       }
@@ -647,10 +380,10 @@ public class LinearRewriter
     if (assignLhs is MapAssignLhs mapAssignLhs &&
         mapAssignLhs.Map is FieldAssignLhs fieldAssignLhs1 &&
         fieldAssignLhs1.Datatype.Type is CtorType ctorType &&
-        Monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lheap")
+        Monomorphizer.GetOriginalDecl(ctorType.Decl).Name == "Lmap")
     {
       var cmdSeq = CreateAccessAsserts(mapAssignLhs.Map, tok, msg);
-      var lheapContainsFunc = LheapContains(mapAssignLhs.Map.Type);
+      var lheapContainsFunc = LmapContains(mapAssignLhs.Indexes[0].Type, mapAssignLhs.Map.Type);
       cmdSeq.Add(AssertCmd(tok, ExprHelper.FunctionCall(lheapContainsFunc, fieldAssignLhs1.Datatype.AsExpr, mapAssignLhs.Indexes[0]), msg));
       return cmdSeq;
     }

--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -73,16 +73,12 @@ public class LinearRewriter
     switch (Monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
     {
       case "Loc_New":
-        return new List<Cmd>{callCmd};
       case "Lmap_Empty":
-        return new List<Cmd>{callCmd};
       case "Lmap_Alloc":
-        return new List<Cmd>{callCmd};
       case "Lmap_Create":
-        return new List<Cmd>{callCmd};
       case "Lmap_Free":
-        return new List<Cmd>{callCmd};
       case "Lmap_Move":
+      case "Lmap_Assume":
         return new List<Cmd>{callCmd};
       case "Lset_Empty":
         return RewriteLsetEmpty(callCmd);

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -3440,7 +3440,11 @@ namespace Microsoft.Boogie
       else
       {
         Debug.Assert(Proc.IsPure);
-        if (Layers.Count == 0 || Layers.Count > 2)
+        if (Layers.Count == 0)
+        {
+          Layers = new List<int>{LayerRange.Min, callerDecl.Layer};
+        }
+        if (Layers.Count > 2)
         {
           tc.Error(this, "expected layer range");
         }

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Boogie
     public static HashSet<string> LinearPrimitives = new()
     {
       "Loc_New",
-      "Lmap_Empty", "Lmap_Alloc", "Lmap_Create", "Lmap_Free", "Lmap_Move",
+      "Lmap_Empty", "Lmap_Alloc", "Lmap_Create", "Lmap_Free", "Lmap_Move", "Lmap_Assume",
       "Lset_Empty", "Lset_Split", "Lset_Get", "Lset_Put",
       "Lval_Split", "Lval_Get", "Lval_Put"
     };
@@ -214,6 +214,7 @@ namespace Microsoft.Boogie
         case "Lmap_Create":
         case "Lmap_Free":
         case "Lmap_Move":
+        case "Lmap_Assume":
         case "Lset_Empty":
           return null;
         default:

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -178,13 +178,12 @@ namespace Microsoft.Boogie
 
   public static class CivlPrimitives
   {
-    public static HashSet<string> LinearTypes = new() { "Lheap", "Lmap", "Lset", "Lval" };
+    public static HashSet<string> LinearTypes = new() { "Lmap", "Lset", "Lval" };
 
     public static HashSet<string> LinearPrimitives = new()
     {
-      "Ref_Alloc",
-      "Lheap_Empty", "Lheap_Alloc", "Lheap_Free", "Lheap_Get", "Lheap_Put",
-      "Lmap_Empty", "Lmap_Alloc", "Lmap_Free", "Lmap_Get", "Lmap_Put",
+      "Loc_New",
+      "Lmap_Empty", "Lmap_Alloc", "Lmap_Create", "Lmap_Free", "Lmap_Move",
       "Lset_Empty", "Lset_Split", "Lset_Get", "Lset_Put",
       "Lval_Split", "Lval_Get", "Lval_Put"
     };
@@ -209,11 +208,12 @@ namespace Microsoft.Boogie
     {
       switch (Monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
       {
-        case "Ref_Alloc":
-        case "Lheap_Empty":
+        case "Loc_New":
         case "Lmap_Empty":
         case "Lmap_Alloc":
+        case "Lmap_Create":
         case "Lmap_Free":
+        case "Lmap_Move":
         case "Lset_Empty":
           return null;
         default:

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -291,9 +291,12 @@ pure procedure {:inline 1} Lmap_Free<K,V>({:linear_in} l: Lmap K V) returns (k: 
 }
 pure procedure {:inline 1} Lmap_Move<K,V>({:linear_in} src: Lmap K V, dst: Lmap K V, k: K) returns (src': Lmap K V, dst': Lmap K V) {
   assert src->dom[k];
-  assume IsDisjoint(src->dom, dst->dom);
+  assert IsDisjoint(src->dom, dst->dom);
   dst' := Lmap(dst->dom[k := true], dst->val[k := src->val[k]]);
   src' := Lmap(src->dom[k := false], src->val[k := Default()]);
+}
+pure procedure {:inline 1} Lmap_Assume<K,V>(src: Lmap K V, dst: Lmap K V) {
+  assume IsDisjoint(src->dom, dst->dom);
 }
 
 /// linear sets

--- a/Source/Core/node.bpl
+++ b/Source/Core/node.bpl
@@ -5,31 +5,6 @@
 datatype Node<T> { Node(next: RefNode T, val: T) }
 type RefNode T = Ref (Node T);
 
-function {:inline} Empty<T>(): [RefNode T]bool
-{
-  MapConst(false)
-}
-
-function {:inline} Singleton<T>(a: RefNode T): [RefNode T]bool
-{
-  MapOne(a)
-}
-
-function {:inline} Union<T>(x: [RefNode T]bool, y: [RefNode T]bool): [RefNode T]bool
-{
-  MapOr(x, y)
-}
-
-function {:inline} Difference<T>(x: [RefNode T]bool, y: [RefNode T]bool): [RefNode T]bool
-{
-  MapDiff(x, y)
-}
-
-function {:inline} Subset<T>(x: [RefNode T]bool, y: [RefNode T]bool): bool
-{
-  MapDiff(x, y) == MapConst(false)
-}
-
 function Between<T>(f: [RefNode T]Node T, x: RefNode T, y: RefNode T, z: RefNode T): bool;
 function Avoiding<T>(f: [RefNode T]Node T, x: RefNode T, y: RefNode T, z: RefNode T): bool;
 function {:inline} BetweenSet<T>(f:[RefNode T]Node T, x: RefNode T, z: RefNode T): [RefNode T]bool

--- a/Test/civl/regression-tests/linear_types.bpl
+++ b/Test/civl/regression-tests/linear_types.bpl
@@ -1,19 +1,6 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-atomic action {:layer 1, 2} A1({:linear_in} path: Lheap int, k: [Ref int]bool) returns (path': Lheap int, l: Lheap int) {
-    call path' := Lheap_Empty();
-    call Lheap_Put(path', path);
-    call l := Lheap_Get(path', k);
-}
-
-atomic action {:layer 1, 2} A2(v: int) returns (path': Lheap int) {
-    var k: Lval (Ref int);
-    call path' := Lheap_Empty();
-    call k := Lheap_Alloc(path', v);
-    call Lheap_Free(path', k->val);
-}
-
 atomic action {:layer 1, 2} A3({:linear_in} path: Lset int, {:linear_out} l: Lset int) returns (path': Lset int) {
     call path' := Lset_Empty();
     call Lset_Put(path', path);
@@ -33,33 +20,12 @@ atomic action {:layer 1, 2} A5({:linear_in} path: Lheap int) returns (path': Lhe
 
 var {:layer 0, 2} g: Lheap int;
 
-atomic action {:layer 1, 2} A6({:linear_in} path: Lheap int) returns (path': Lheap int)
-modifies g;
-{
-    path' := path;
-    call Lheap_Put(path', g);
-    call g := Lheap_Empty();
-}
-
 datatype Foo { Foo(f: Lheap int) }
-
-atomic action {:layer 1, 2} A7({:linear_in} path: Lheap Foo, x: Ref Foo, y: Ref int) returns (path': Lheap Foo)
-{
-    var l: Lheap int;
-    path' := path;
-    call l := Lheap_Get(path'->val[x]->f, MapOne(y));
-}
 
 atomic action {:layer 1, 2} A8({:linear_out} l: Lval int, {:linear_in} path: Lset int) returns (path': Lset int)
 {
     path' := path;
     call Lval_Split(path', l);
-}
-
-atomic action {:layer 1, 2} A9({:linear_in} path1: Lheap int, x: Ref Foo) returns (path2: Lheap Foo)
-{
-    call path2 := Lheap_Empty();
-    call Lheap_Put(path2->val[x]->f, path1);
 }
 
 atomic action {:layer 1, 2} A10({:linear_in} a: Foo) returns (b: Foo)

--- a/Test/civl/regression-tests/linear_types_error.bpl
+++ b/Test/civl/regression-tests/linear_types_error.bpl
@@ -7,57 +7,16 @@ atomic action {:layer 1, 2} A1(path: Lheap int) returns (path': Lheap int) {
     path' := path;
 }
 
-atomic action {:layer 1, 2} A2(path: Lheap int) returns (path': Lheap int) {
-    call path' := Lheap_Empty();
-    call Lheap_Put(path', path);
+atomic action {:layer 1, 2} A2(path: Lheap int) returns (path': Lheap int) { var k: Lset (Ref int);
+    call path' := Lmap_Empty();
+    call k := Lmap_Free(path);
 }
 
 var {:layer 0, 2} g: Lheap int;
 
-atomic action {:layer 1, 2} A3({:linear_in} path: Lheap int) returns (path': Lheap int)
-{
-    path' := path;
-    call Lheap_Put(path', g);
-}
-
 datatype Foo { Foo(f: Lheap int) }
 
-
-atomic action {:layer 1, 2} A4({:linear_in} path: Lheap Foo, x: Ref Foo, {:linear_in} l: Lheap int) returns (path': Lheap Foo, l': Lheap int)
-{
-    path' := path;
-    l' := l;
-    call Lheap_Put(l', path'->val[x]->f);
-}
-
 atomic action {:layer 1, 2} A5({:linear_out} path: Lheap int) { }
-
-atomic action {:layer 1, 2} A6({:linear_in} path: Lheap int) returns (path': Lheap int)
-{
-    path' := path;
-    call Lheap_Put(path', path');
-}
-
-atomic action {:layer 1, 2} A7(path1: Lheap int, {:linear_in} path2: Lheap int) returns (path': Lheap int)
-{
-    path' := path2;
-    call Lheap_Put(path', path1);
-}
-
-atomic action {:layer 1, 2} A8({:linear_in} path1: Lheap int, x: Ref Foo) returns (path2: Lheap Foo)
-{
-    call Lheap_Put(path2->val[x]->f, path1);
-}
-
-atomic action {:layer 1, 2} A9({:linear_in} l: Lheap int)
-{
-    call Lheap_Put(g, l);
-}
-
-atomic action {:layer 1, 2} A10({:linear_in} l: Lheap int, l': Lheap int)
-{
-    call Lheap_Put(l', l);
-}
 
 atomic action {:layer 1, 2} A11({:linear_in} a: Foo) returns (b: Foo)
 {

--- a/Test/civl/regression-tests/linear_types_error.bpl
+++ b/Test/civl/regression-tests/linear_types_error.bpl
@@ -46,3 +46,14 @@ atomic action {:layer 1, 2} A14({:linear_in} a: Lval int) returns (b: Bar)
 
 type {:linear "X"} X = int;
 yield procedure {:layer 1} A15({:linear_in "X"} a: Lval int);
+
+yield procedure {:layer 1} Foo1(x: Lheap int)
+{
+  call Lmap_Assume(x, x);
+}
+
+yield procedure {:layer 1} Foo2(x: Foo)
+{
+  call Lmap_Assume(x->f, x->f);
+}
+

--- a/Test/civl/regression-tests/linear_types_error.bpl.expect
+++ b/Test/civl/regression-tests/linear_types_error.bpl.expect
@@ -7,4 +7,6 @@ linear_types_error.bpl(25,0): Error: Output variable b must be available at a re
 linear_types_error.bpl(31,14): Error: unavailable source for a linear read
 linear_types_error.bpl(37,9): Error: unavailable source for a linear read
 linear_types_error.bpl(44,6): Error: A source of pack of linear type must be a variable
-9 type checking errors detected in linear_types_error.bpl
+linear_types_error.bpl(52,2): Error: Linear variable x can occur only once as an input parameter
+linear_types_error.bpl(57,2): Error: Linear variable x can occur only once as an input parameter
+11 type checking errors detected in linear_types_error.bpl

--- a/Test/civl/regression-tests/linear_types_error.bpl.expect
+++ b/Test/civl/regression-tests/linear_types_error.bpl.expect
@@ -1,18 +1,10 @@
-linear_types_error.bpl(89,48): Error: Variable of linear type must not have a domain name
+linear_types_error.bpl(48,48): Error: Variable of linear type must not have a domain name
 linear_types_error.bpl(4,73): Error: Output variable l must be available at a return
 linear_types_error.bpl(8,0): Error: Input variable path must be available at a return
 linear_types_error.bpl(13,0): Error: Input variable path must be available at a return
-linear_types_error.bpl(21,0): Error: Global variable g must be available at a return
-linear_types_error.bpl(30,4): Error: Only variable can be passed to linear parameter: path'->val[x]->f
-linear_types_error.bpl(33,64): Error: Input variable path must be available at a return
-linear_types_error.bpl(38,4): Error: Linear variable path' can occur only once as an input parameter
-linear_types_error.bpl(45,0): Error: Input variable path1 must be available at a return
-linear_types_error.bpl(49,19): Error: unavailable source path2 for linear parameter at position 0
-linear_types_error.bpl(50,0): Error: Output variable path2 must be available at a return
-linear_types_error.bpl(54,4): Error: Primitive assigns to a global variable that is not in the enclosing action's modifies clause: g
-linear_types_error.bpl(59,4): Error: Primitive assigns to input variable: l'
-linear_types_error.bpl(66,0): Error: Output variable b must be available at a return
-linear_types_error.bpl(72,14): Error: unavailable source for a linear read
-linear_types_error.bpl(78,9): Error: unavailable source for a linear read
-linear_types_error.bpl(85,6): Error: A source of pack of linear type must be a variable
-17 type checking errors detected in linear_types_error.bpl
+linear_types_error.bpl(19,64): Error: Input variable path must be available at a return
+linear_types_error.bpl(25,0): Error: Output variable b must be available at a return
+linear_types_error.bpl(31,14): Error: unavailable source for a linear read
+linear_types_error.bpl(37,9): Error: unavailable source for a linear read
+linear_types_error.bpl(44,6): Error: A source of pack of linear type must be a variable
+9 type checking errors detected in linear_types_error.bpl

--- a/Test/civl/samples/alloc-mem.bpl
+++ b/Test/civl/samples/alloc-mem.bpl
@@ -22,7 +22,7 @@ preserves call Yield();
 
 yield procedure {:layer 2} Thread ({:layer 1,2} {:linear_in} local_in:Lmap int int, i:int)
 preserves call Yield();
-requires {:layer 1,2} Lmap_Contains(local_in, i);
+requires {:layer 1,2} Map_Contains(local_in->val, i);
 {
   var y, o:int;
   var {:layer 1,2} local:Lmap int int;
@@ -54,7 +54,7 @@ yield procedure {:layer 1}
 Alloc() returns ({:layer 1} l:Lmap int int, i:int)
 refines atomic_Alloc;
 preserves call Yield();
-ensures {:layer 1} Lmap_Contains(l, i);
+ensures {:layer 1} Map_Contains(l->val, i);
 {
   call i := PickAddr();
   call {:layer 1} l, pool := AllocLinear(i, pool);
@@ -64,14 +64,14 @@ left action {:layer 2} atomic_Free({:linear_in} l:Lmap int int, i:int)
 modifies pool;
 {
   var t:Lset int;
-  assert Lmap_Contains(l, i);
+  assert Map_Contains(l->val, i);
   call t := Lmap_Free(l);
   call Lset_Put(pool, t);
 }
 
 yield procedure {:layer 1} Free({:layer 1} {:linear_in} l:Lmap int int, i:int)
 refines atomic_Free;
-requires {:layer 1} Lmap_Contains(l, i);
+requires {:layer 1} Map_Contains(l->val, i);
 preserves call Yield();
 {
   call {:layer 1} pool := FreeLinear(l, i, pool);
@@ -80,15 +80,15 @@ preserves call Yield();
 
 both action {:layer 2} atomic_Read (l:Lmap int int, i:int) returns (o:int)
 {
-  assert Lmap_Contains(l, i);
-  o := l->val[i];
+  assert Map_Contains(l->val, i);
+  o := l->val->val[i];
 }
 
 both action {:layer 2} atomic_Write ({:linear_in} l:Lmap int int, i:int, o:int) returns (l':Lmap int int)
 {
-  assert Lmap_Contains(l, i);
+  assert Map_Contains(l->val, i);
   l' := l;
-  l'->val[i] := o;
+  l'->val->val[i] := o;
 }
 
 yield procedure {:layer 1}
@@ -104,7 +104,7 @@ yield procedure {:layer 1}
 Write ({:layer 1} {:linear_in} l:Lmap int int, i:int, o:int) returns ({:layer 1} l':Lmap int int)
 refines atomic_Write;
 requires call Yield();
-requires {:layer 1} Lmap_Contains(l, i);
+requires {:layer 1} Map_Contains(l->val, i);
 ensures call YieldMem(l', i);
 {
   call WriteLow(i, o);
@@ -124,7 +124,7 @@ pure action AllocLinear (i:int, {:linear_in} pool:Lset int) returns (l:Lmap int 
 pure action FreeLinear ({:linear_in} l:Lmap int int, i:int, {:linear_in} pool:Lset int) returns (pool':Lset int)
 {
   var t: Lset int;
-  assert Lmap_Contains(l, i);
+  assert Map_Contains(l->val, i);
   call t := Lmap_Free(l);
   pool' := pool;
   call Lset_Put(pool', t);
@@ -132,9 +132,9 @@ pure action FreeLinear ({:linear_in} l:Lmap int int, i:int, {:linear_in} pool:Ls
 
 pure action WriteLinear ({:layer 1} {:linear_in} l:Lmap int int, i:int, o:int) returns ({:layer 1} l':Lmap int int)
 {
-  assert Lmap_Contains(l, i);
+  assert Map_Contains(l->val, i);
   l' := l;
-  l'->val[i] := o;
+  l'->val->val[i] := o;
 }
 
 yield invariant {:layer 1} Yield ();
@@ -142,7 +142,7 @@ invariant PoolInv(unallocated, pool);
 
 yield invariant {:layer 1} YieldMem ({:layer 1} l:Lmap int int, i:int);
 invariant PoolInv(unallocated, pool);
-invariant Lmap_Contains(l, i) && Lmap_Deref(l, i) == mem[i];
+invariant Map_Contains(l->val, i) && Map_At(l->val, i) == mem[i];
 
 var {:layer 1, 2} pool:Lset int;
 var {:layer 0, 1} mem:[int]int;

--- a/Test/civl/samples/alloc-mem.bpl
+++ b/Test/civl/samples/alloc-mem.bpl
@@ -118,7 +118,7 @@ pure action AllocLinear (i:int, {:linear_in} pool:Lset int) returns (l:Lmap int 
   assert Lset_Contains(pool, i);
   pool' := pool;
   call t := Lset_Get(pool', MapOne(i));
-  call l := Lmap_Alloc(t, m);
+  call l := Lmap_Create(t, m);
 }
 
 pure action FreeLinear ({:linear_in} l:Lmap int int, i:int, {:linear_in} pool:Lset int) returns (pool':Lset int)

--- a/Test/civl/samples/civl-paper.bpl
+++ b/Test/civl/samples/civl-paper.bpl
@@ -14,7 +14,7 @@ yield invariant {:layer 1} InvLock();
 invariant lock != nil <==> b;
 
 yield invariant {:layer 3} InvMem();
-invariant g->dom[p] && g->dom[p+4] && g->val[p] == g->val[p+4];
+invariant Map_Contains(g->val, p) && Map_Contains(g->val, p+4) && Map_At(g->val, p) == Map_At(g->val, p+4);
 
 yield procedure {:layer 3} P(tid: Lval X)
 requires {:layer 1,3} tid->val != nil;
@@ -130,13 +130,13 @@ yield procedure {:layer 0} TransferFromGlobal(tid: Lval X) returns (l: Lmap int 
 refines AtomicTransferFromGlobal;
 
 both action {:layer 1,3} AtomicLoad(l: Lmap int int, a: int) returns (v: int)
-{ v := l->val[a]; }
+{ v := l->val->val[a]; }
 
 yield procedure {:layer 0} Load(l: Lmap int int, a: int) returns (v: int);
 refines AtomicLoad;
 
 both action {:layer 1,3} AtomicStore({:linear_in} l_in: Lmap int int, a: int, v: int) returns (l_out: Lmap int int)
-{ l_out := l_in; l_out->val[a] := v; }
+{ l_out := l_in; l_out->val->val[a] := v; }
 
 yield procedure {:layer 0} Store({:linear_in} l_in: Lmap int int, a: int, v: int) returns (l_out: Lmap int int);
 refines AtomicStore;

--- a/Test/civl/samples/treiber-stack.bpl
+++ b/Test/civl/samples/treiber-stack.bpl
@@ -278,7 +278,7 @@ function Abs(ref_n: RefNode X, map: Map (RefNode X) (Node X)): Vec X;
 
 pure procedure AbsCompute(ref_n: RefNode X, map: Map (RefNode X) (Node X)) returns (absStack: Vec X)
 requires Between(map->val, ref_n, ref_n, Nil());
-requires Subset(BetweenSet(map->val, ref_n, Nil()), map->dom->val[Nil() := true]);
+requires IsSubset(BetweenSet(map->val, ref_n, Nil()), map->dom->val[Nil() := true]);
 ensures absStack ==
         if ref_n == Nil() then
         Vec_Empty() else
@@ -299,7 +299,7 @@ free ensures absStack == Abs(ref_n, map);
 
 pure procedure AbsLemma(ref_n: RefNode X, map: Map (RefNode X) (Node X))
 requires Between(map->val, ref_n, ref_n, Nil());
-requires Subset(BetweenSet(map->val, ref_n, Nil()), map->dom->val[Nil() := true]);
+requires IsSubset(BetweenSet(map->val, ref_n, Nil()), map->dom->val[Nil() := true]);
 ensures Abs(ref_n, map) ==
         if ref_n == Nil() then
         Vec_Empty() else
@@ -311,8 +311,8 @@ ensures Abs(ref_n, map) ==
 
 pure procedure FrameLemma(ref_n: RefNode X, map: Map (RefNode X) (Node X), map': Map (RefNode X) (Node X));
 requires Between(map->val, ref_n, ref_n, Nil());
-requires Subset(BetweenSet(map->val, ref_n, Nil()), map->dom->val[Nil() := true]);
-requires Subset(map->dom->val, map'->dom->val);
+requires IsSubset(BetweenSet(map->val, ref_n, Nil()), map->dom->val[Nil() := true]);
+requires IsSubset(map->dom->val, map'->dom->val);
 requires MapIte(map->dom->val, map->val, MapConst(Default())) == MapIte(map->dom->val, map'->val, MapConst(Default()));
 ensures Abs(ref_n, map) == Abs(ref_n, map');
 
@@ -320,7 +320,7 @@ yield invariant {:layer 4} YieldInv#4(ref_t: RefTreiber X);
 invariant Map_Contains(ts->val, ref_t);
 invariant Map_At(Stack, ref_t) == (var t := ts->val->val[ref_t]; Abs(t->top, t->stack->val));
 invariant (var t := ts->val->val[ref_t]; Between(t->stack->val->val, t->top, t->top, Nil()));
-invariant (var t := ts->val->val[ref_t]; Subset(BetweenSet(t->stack->val->val, t->top, Nil()), NilDomain(ts, ref_t)));
+invariant (var t := ts->val->val[ref_t]; IsSubset(BetweenSet(t->stack->val->val, t->top, Nil()), NilDomain(ts, ref_t)));
 
 yield invariant {:layer 4} DomYieldInv#4();
 invariant Stack->dom == ts->val->dom;

--- a/Test/civl/samples/treiber-stack.bpl.expect
+++ b/Test/civl/samples/treiber-stack.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 43 verified, 0 errors
+Boogie program verifier finished with 47 verified, 0 errors

--- a/Test/datatypes/node-client.bpl
+++ b/Test/datatypes/node-client.bpl
@@ -8,12 +8,12 @@ type X;
 var ts: Lmap (RefTreiber X) (Treiber X);
 
 procedure YieldInv(ref_t: RefTreiber X)
-requires ts->dom[ref_t];
-requires BetweenSet(ts->val[ref_t]->stack->val, ts->val[ref_t]->top, Nil())[ts->val[ref_t]->top];
-requires Subset(BetweenSet(ts->val[ref_t]->stack->val, ts->val[ref_t]->top, Nil()), Union(Singleton(Nil()), ts->val[ref_t]->stack->dom));
-ensures ts->dom[ref_t];
-ensures BetweenSet(ts->val[ref_t]->stack->val, ts->val[ref_t]->top, Nil())[ts->val[ref_t]->top];
-ensures Subset(BetweenSet(ts->val[ref_t]->stack->val, ts->val[ref_t]->top, Nil()), Union(Singleton(Nil()), ts->val[ref_t]->stack->dom));
+requires Map_Contains(ts->val, ref_t);
+requires (var t := Map_At(ts->val, ref_t); BetweenSet(t->stack->val->val, t->top, Nil())[t->top]);
+requires (var t := Map_At(ts->val, ref_t); (var m := t->stack->val; Subset(BetweenSet(m->val, t->top, Nil()), m->dom->val[Nil() := true])));
+ensures Map_Contains(ts->val, ref_t);
+ensures (var t := Map_At(ts->val, ref_t); BetweenSet(t->stack->val->val, t->top, Nil())[t->top]);
+ensures (var t := Map_At(ts->val, ref_t); (var m := t->stack->val; Subset(BetweenSet(m->val, t->top, Nil()), m->dom->val[Nil() := true])));
 modifies ts;
 {
   var x: X;
@@ -25,10 +25,10 @@ procedure {:inline 1} AtomicPopIntermediate(ref_t: RefTreiber X) returns (x: X)
 modifies ts;
 {
   var ref_n: RefNode X;
-  assert ts->dom[ref_t];
-  assume ts->val[ref_t]->top != Nil() && ts->val[ref_t]->stack->dom[ts->val[ref_t]->top];
-  Node(ref_n, x) := ts->val[ref_t]->stack->val[ts->val[ref_t]->top];
-  ts->val[ref_t]->top := ref_n;
+  assert Map_Contains(ts->val, ref_t);
+  assume ts->val->val[ref_t]->top != Nil() && Map_Contains(ts->val->val[ref_t]->stack->val, ts->val->val[ref_t]->top);
+  Node(ref_n, x) := Map_At(ts->val->val[ref_t]->stack->val, ts->val->val[ref_t]->top);
+  ts->val->val[ref_t]->top := ref_n;
 }
 
 procedure {:inline 1} AtomicPushIntermediate(ref_t: RefTreiber X, x: X)
@@ -39,12 +39,12 @@ modifies ts;
   var loc_n: Lval (Loc (Node X));
   var lmap_n: Lmap (RefNode X) (Node X);
   var lmap_n': Lmap (RefNode X) (Node X);
-  assert ts->dom[ref_t];
-  t := ts->val[ref_t]->top;
+  assert Map_Contains(ts->val, ref_t);
+  t := ts->val->val[ref_t]->top;
   call loc_n, lmap_n := Lmap_Alloc(Node(t, x));
-  call Lmap_Assume(lmap_n, ts->val[ref_t]->stack);
+  call Lmap_Assume(lmap_n, ts->val->val[ref_t]->stack);
   ref_n := Ref(loc_n->val);
-  call lmap_n, lmap_n' := Lmap_Move(lmap_n, ts->val[ref_t]->stack, ref_n);
-  ts->val[ref_t]->stack := lmap_n';
-  ts->val[ref_t]->top := ref_n;
+  call lmap_n, lmap_n' := Lmap_Move(lmap_n, ts->val->val[ref_t]->stack, ref_n);
+  ts->val->val[ref_t]->stack := lmap_n';
+  ts->val->val[ref_t]->top := ref_n;
 }

--- a/Test/datatypes/node-client.bpl
+++ b/Test/datatypes/node-client.bpl
@@ -10,10 +10,10 @@ var ts: Lmap (RefTreiber X) (Treiber X);
 procedure YieldInv(ref_t: RefTreiber X)
 requires Map_Contains(ts->val, ref_t);
 requires (var t := Map_At(ts->val, ref_t); BetweenSet(t->stack->val->val, t->top, Nil())[t->top]);
-requires (var t := Map_At(ts->val, ref_t); (var m := t->stack->val; Subset(BetweenSet(m->val, t->top, Nil()), m->dom->val[Nil() := true])));
+requires (var t := Map_At(ts->val, ref_t); (var m := t->stack->val; IsSubset(BetweenSet(m->val, t->top, Nil()), m->dom->val[Nil() := true])));
 ensures Map_Contains(ts->val, ref_t);
 ensures (var t := Map_At(ts->val, ref_t); BetweenSet(t->stack->val->val, t->top, Nil())[t->top]);
-ensures (var t := Map_At(ts->val, ref_t); (var m := t->stack->val; Subset(BetweenSet(m->val, t->top, Nil()), m->dom->val[Nil() := true])));
+ensures (var t := Map_At(ts->val, ref_t); (var m := t->stack->val; IsSubset(BetweenSet(m->val, t->top, Nil()), m->dom->val[Nil() := true])));
 modifies ts;
 {
   var x: X;

--- a/Test/datatypes/node-client.bpl
+++ b/Test/datatypes/node-client.bpl
@@ -42,6 +42,7 @@ modifies ts;
   assert ts->dom[ref_t];
   t := ts->val[ref_t]->top;
   call loc_n, lmap_n := Lmap_Alloc(Node(t, x));
+  call Lmap_Assume(lmap_n, ts->val[ref_t]->stack);
   ref_n := Ref(loc_n->val);
   call lmap_n, lmap_n' := Lmap_Move(lmap_n, ts->val[ref_t]->stack, ref_n);
   ts->val[ref_t]->stack := lmap_n';


### PR DESCRIPTION
This PR unifies Lmap and Lheap into a single abstraction with the latter being defined in terms of the former.
```
type Lheap T = Lmap (Ref T) T
```
The type ```Ref T``` is explained below.

The implementation of Lmap primitives is done by modeling them directly as pure procedures in Boogie syntax. Thus a lot of rewriting code in LinearRewriter.cs is eliminated. However, inlining of atomic actions had to be adjusted to allow for calling and inlining pure procedures from atomic actions. It is possible that these changes can be reverted by modeling these primitives as pure actions (which are already callable from both yield procedures and actions).

An important innovation is separating the Lmap primitives from the dynamic allocation of keys for which two separate types are provided.

```
type Loc _;
datatype Ref<V> {
  Ref(loc: Loc V),
  Nil()
}
```
The type ```Loc``` models a dynamically-allocated location. The allocation itself is performed by the ```Loc_New``` primitive:
```
pure procedure {:inline 1} Loc_New<V>() returns (k: Lval (Loc V)) { }
```
The caller gets a fresh location (notice the ```Lval``` wrapper) every time ```Loc_New``` is called. An instance of ```Loc T``` may be wrapped into an instance of ```Ref T``` via the ```Ref``` constructor.

Two separate types ```Loc``` and ```Ref``` are needed because we want the domains of different ```Lheap T``` values to be disjoint. At the same time, we want to provide the capability to have unique references to locations. If we unified ```Loc``` and ```Ref```, then we cannot have both capabilities.

This PR appears to be a step in the right direction due to the unification of Lmap and Lheap. However, there is still room for improvement. To avoid the need to write collector functions, we introduced types Lval, Lset, and Lheap that have built-in collector functions. But we have introduced drawbacks.
1. We lost the ability to have both ordinary and linear variables of these types, a flexibility that was always present in Civl. The rules for passing and copying linear values are draconian and sometimes it is convenient to be able to treat a linear value as an ordinary value for the purpose of specification and verification, e.g., using them in a pure procedure written as a lemma.
2. We introduced wrappers Lmap around an ordinary Map and a wrapper Lset around an ordinary Set. These wrappers cause an extra level of indirection when writing code to read/modify these values.

My current assessment is that the wrapper Lval for wrapping a value to convert it into a possibly linear value is fundamental because it influences the definition of the collector function for the value. But the wrappers Lmap and Lset can be eliminated by going back to the original Civl approach.