### PR TITLE
Some refactoring in the VCGeneration assembly

### DIFF
--- a/Source/ExecutionEngine/ConsolePrinter.cs
+++ b/Source/ExecutionEngine/ConsolePrinter.cs
@@ -206,11 +206,11 @@ public class ConsolePrinter : OutputPrinter
     // Do not print anything to console
   }
 
-  public virtual void ReportEndVerifyImplementation(Implementation implementation, VerificationResult result) {
+  public virtual void ReportEndVerifyImplementation(Implementation implementation, ImplementationRunResult result) {
     // Do not print anything to console
   }
 
-  public virtual void ReportSplitResult(Split split, VCResult splitResult) {
+  public virtual void ReportSplitResult(Split split, VerificationRunResult splitResult) {
     // Do not print anything to console
   }
 }

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -830,7 +830,7 @@ namespace Microsoft.Boogie
     {
       ImplementationRunResult implementationRunResult = GetCachedVerificationResult(implementation, traceWriter);
       if (implementationRunResult != null) {
-        UpdateCachedStatistics(stats, implementationRunResult.Outcome, implementationRunResult.Errors);
+        UpdateCachedStatistics(stats, implementationRunResult.VcOutcome, implementationRunResult.Errors);
         return Observable.Return(new Completed(implementationRunResult));
       }
       Options.Printer.Inform("", traceWriter); // newline
@@ -863,7 +863,7 @@ namespace Microsoft.Boogie
       }
 
       if (Options.VerifySnapshots < 3 ||
-          cachedResults.Outcome == ConditionGeneration.Outcome.Correct) {
+          cachedResults.VcOutcome == VcOutcome.Correct) {
         Options.Printer.Inform($"Retrieving cached verification result for implementation {impl.VerboseName}...", output);
         return cachedResults;
       }
@@ -887,7 +887,7 @@ namespace Microsoft.Boogie
 
         try
         {
-          (verificationResult.Outcome, verificationResult.Errors, verificationResult.VCResults) =
+          (verificationResult.VcOutcome, verificationResult.Errors, verificationResult.VCResults) =
             await vcgen.VerifyImplementation(new ImplementationRun(impl, traceWriter), batchCompleted, cancellationToken);
           processedProgram.PostProcessResult(vcgen, impl, verificationResult);
         }
@@ -906,7 +906,7 @@ namespace Microsoft.Boogie
           }
 
           verificationResult.Errors = null;
-          verificationResult.Outcome = ConditionGeneration.Outcome.Inconclusive;
+          verificationResult.VcOutcome = VcOutcome.Inconclusive;
         }
         catch (ProverDiedException)
         {
@@ -918,14 +918,14 @@ namespace Microsoft.Boogie
             "Advisory: {0} SKIPPED because of internal error: unexpected prover output: {1}",
             impl.VerboseName, upo.Message);
           verificationResult.Errors = null;
-          verificationResult.Outcome = ConditionGeneration.Outcome.Inconclusive;
+          verificationResult.VcOutcome = VcOutcome.Inconclusive;
         }
         catch (IOException e)
         {
           Options.Printer.AdvisoryWriteLine(traceWriter, "Advisory: {0} SKIPPED due to I/O exception: {1}",
             impl.VerboseName, e.Message);
           verificationResult.Errors = null;
-          verificationResult.Outcome = ConditionGeneration.Outcome.SolverException;
+          verificationResult.VcOutcome = VcOutcome.SolverException;
         }
 
         verificationResult.ProofObligationCountAfter = vcgen.CumulativeAssertionCount;
@@ -993,8 +993,8 @@ namespace Microsoft.Boogie
 
       foreach (Houdini.VCGenOutcome x in outcome.implementationOutcomes.Values)
       {
-        ProcessOutcome(Options.Printer, x.outcome, x.errors, "", stats, outputWriter, Options.TimeLimit, er);
-        ProcessErrors(Options.Printer, x.errors, x.outcome, outputWriter, er);
+        ProcessOutcome(Options.Printer, x.VcOutcome, x.errors, "", stats, outputWriter, Options.TimeLimit, er);
+        ProcessErrors(Options.Printer, x.errors, x.VcOutcome, outputWriter, er);
       }
 
       return PipelineOutcome.Done;
@@ -1046,8 +1046,8 @@ namespace Microsoft.Boogie
 
       foreach (Houdini.VCGenOutcome x in outcome.implementationOutcomes.Values)
       {
-        ProcessOutcome(Options.Printer, x.outcome, x.errors, "", stats, Options.OutputWriter, Options.TimeLimit, er);
-        ProcessErrors(Options.Printer, x.errors, x.outcome, Options.OutputWriter, er);
+        ProcessOutcome(Options.Printer, x.VcOutcome, x.errors, "", stats, Options.OutputWriter, Options.TimeLimit, er);
+        ProcessErrors(Options.Printer, x.errors, x.VcOutcome, Options.OutputWriter, er);
       }
 
       return PipelineOutcome.Done;
@@ -1055,24 +1055,24 @@ namespace Microsoft.Boogie
 
     #endregion
 
-    public void ProcessOutcome(OutputPrinter printer, ConditionGeneration.Outcome outcome, List<Counterexample> errors, string timeIndication,
+    public void ProcessOutcome(OutputPrinter printer, VcOutcome vcOutcome, List<Counterexample> errors, string timeIndication,
       PipelineStatistics stats, TextWriter tw, uint timeLimit, ErrorReporterDelegate er = null, string implName = null,
       IToken implTok = null, string msgIfVerifies = null)
     {
       Contract.Requires(stats != null);
 
-      UpdateStatistics(stats, outcome, errors);
+      UpdateStatistics(stats, vcOutcome, errors);
 
-      printer.Inform(timeIndication + OutcomeIndication(outcome, errors), tw);
+      printer.Inform(timeIndication + OutcomeIndication(vcOutcome, errors), tw);
 
-      ReportOutcome(printer, outcome, er, implName, implTok, msgIfVerifies, tw, timeLimit, errors);
+      ReportOutcome(printer, vcOutcome, er, implName, implTok, msgIfVerifies, tw, timeLimit, errors);
     }
 
     public void ReportOutcome(OutputPrinter printer,
-      ConditionGeneration.Outcome outcome, ErrorReporterDelegate er, string implName,
+      VcOutcome vcOutcome, ErrorReporterDelegate er, string implName,
       IToken implTok, string msgIfVerifies, TextWriter tw, uint timeLimit, List<Counterexample> errors) {
 
-      var errorInfo = GetOutcomeError(Options, outcome, implName, implTok, msgIfVerifies, tw, timeLimit, errors);
+      var errorInfo = GetOutcomeError(Options, vcOutcome, implName, implTok, msgIfVerifies, tw, timeLimit, errors);
       if (errorInfo != null)
       {
         errorInfo.ImplementationName = implName;
@@ -1088,25 +1088,25 @@ namespace Microsoft.Boogie
       }
     }
 
-    internal static ErrorInformation GetOutcomeError(ExecutionEngineOptions options, ConditionGeneration.Outcome outcome, string implName, IToken implTok, string msgIfVerifies,
+    internal static ErrorInformation GetOutcomeError(ExecutionEngineOptions options, VcOutcome vcOutcome, string implName, IToken implTok, string msgIfVerifies,
       TextWriter tw, uint timeLimit, List<Counterexample> errors)
     {
       ErrorInformation errorInfo = null;
 
-      switch (outcome) {
-        case VCGen.Outcome.Correct:
+      switch (vcOutcome) {
+        case VcOutcome.Correct:
           if (msgIfVerifies != null) {
             tw.WriteLine(msgIfVerifies);
           }
 
           break;
-        case VCGen.Outcome.ReachedBound:
+        case VcOutcome.ReachedBound:
           tw.WriteLine($"Stratified Inlining: Reached recursion bound of {options.RecursionBound}");
           break;
-        case VCGen.Outcome.Errors:
-        case VCGen.Outcome.TimedOut:
+        case VcOutcome.Errors:
+        case VcOutcome.TimedOut:
           if (implName != null && implTok != null) {
-            if (outcome == ConditionGeneration.Outcome.TimedOut ||
+            if (vcOutcome == VcOutcome.TimedOut ||
                 (errors != null && errors.Any(e => e.IsAuxiliaryCexForDiagnosingTimeouts))) {
               string msg = string.Format("Verification of '{1}' timed out after {0} seconds", timeLimit, implName);
               errorInfo = ErrorInformation.Create(implTok, msg);
@@ -1148,21 +1148,21 @@ namespace Microsoft.Boogie
           }
 
           break;
-        case VCGen.Outcome.OutOfResource:
+        case VcOutcome.OutOfResource:
           if (implName != null && implTok != null) {
             string msg = "Verification out of resource (" + implName + ")";
             errorInfo = ErrorInformation.Create(implTok, msg);
           }
 
           break;
-        case VCGen.Outcome.OutOfMemory:
+        case VcOutcome.OutOfMemory:
           if (implName != null && implTok != null) {
             string msg = "Verification out of memory (" + implName + ")";
             errorInfo = ErrorInformation.Create(implTok, msg);
           }
 
           break;
-        case VCGen.Outcome.SolverException:
+        case VcOutcome.SolverException:
           if (implName != null && implTok != null) {
             string msg = "Verification encountered solver exception (" + implName + ")";
             errorInfo = ErrorInformation.Create(implTok, msg);
@@ -1170,7 +1170,7 @@ namespace Microsoft.Boogie
 
           break;
 
-        case VCGen.Outcome.Inconclusive:
+        case VcOutcome.Inconclusive:
           if (implName != null && implTok != null) {
             string msg = "Verification inconclusive (" + implName + ")";
             errorInfo = ErrorInformation.Create(implTok, msg);
@@ -1183,36 +1183,36 @@ namespace Microsoft.Boogie
     }
 
 
-    private static string OutcomeIndication(VC.VCGen.Outcome outcome, List<Counterexample> errors)
+    private static string OutcomeIndication(VcOutcome vcOutcome, List<Counterexample> errors)
     {
       string traceOutput = "";
-      switch (outcome)
+      switch (vcOutcome)
       {
         default:
           Contract.Assert(false); // unexpected outcome
           throw new cce.UnreachableException();
-        case VCGen.Outcome.ReachedBound:
+        case VcOutcome.ReachedBound:
           traceOutput = "verified";
           break;
-        case VCGen.Outcome.Correct:
+        case VcOutcome.Correct:
           traceOutput = "verified";
           break;
-        case VCGen.Outcome.TimedOut:
+        case VcOutcome.TimedOut:
           traceOutput = "timed out";
           break;
-        case VCGen.Outcome.OutOfResource:
+        case VcOutcome.OutOfResource:
           traceOutput = "out of resource";
           break;
-        case VCGen.Outcome.OutOfMemory:
+        case VcOutcome.OutOfMemory:
           traceOutput = "out of memory";
           break;
-        case VCGen.Outcome.SolverException:
+        case VcOutcome.SolverException:
           traceOutput = "solver exception";
           break;
-        case VCGen.Outcome.Inconclusive:
+        case VcOutcome.Inconclusive:
           traceOutput = "inconclusive";
           break;
-        case VCGen.Outcome.Errors:
+        case VcOutcome.Errors:
           Contract.Assert(errors != null);
           traceOutput = string.Format("error{0}", errors.Count == 1 ? "" : "s");
           break;
@@ -1222,44 +1222,44 @@ namespace Microsoft.Boogie
     }
 
 
-    private static void UpdateStatistics(PipelineStatistics stats, VC.VCGen.Outcome outcome, List<Counterexample> errors)
+    private static void UpdateStatistics(PipelineStatistics stats, VcOutcome vcOutcome, List<Counterexample> errors)
     {
       Contract.Requires(stats != null);
 
-      switch (outcome)
+      switch (vcOutcome)
       {
         default:
           Contract.Assert(false); // unexpected outcome
           throw new cce.UnreachableException();
-        case VCGen.Outcome.ReachedBound:
+        case VcOutcome.ReachedBound:
           Interlocked.Increment(ref stats.VerifiedCount);
 
           break;
-        case VCGen.Outcome.Correct:
+        case VcOutcome.Correct:
           Interlocked.Increment(ref stats.VerifiedCount);
 
           break;
-        case VCGen.Outcome.TimedOut:
+        case VcOutcome.TimedOut:
           Interlocked.Increment(ref stats.TimeoutCount);
 
           break;
-        case VCGen.Outcome.OutOfResource:
+        case VcOutcome.OutOfResource:
           Interlocked.Increment(ref stats.OutOfResourceCount);
 
           break;
-        case VCGen.Outcome.OutOfMemory:
+        case VcOutcome.OutOfMemory:
           Interlocked.Increment(ref stats.OutOfMemoryCount);
 
           break;
-        case VCGen.Outcome.SolverException:
+        case VcOutcome.SolverException:
           Interlocked.Increment(ref stats.SolverExceptionCount);
 
           break;
-        case VCGen.Outcome.Inconclusive:
+        case VcOutcome.Inconclusive:
           Interlocked.Increment(ref stats.InconclusiveCount);
 
           break;
-        case VCGen.Outcome.Errors:
+        case VcOutcome.Errors:
           int cnt = errors.Count(e => !e.IsAuxiliaryCexForDiagnosingTimeouts);
           Interlocked.Add(ref stats.ErrorCount, cnt);
 
@@ -1267,43 +1267,43 @@ namespace Microsoft.Boogie
       }
     }
 
-    private static void UpdateCachedStatistics(PipelineStatistics stats, VC.VCGen.Outcome outcome, List<Counterexample> errors) {
+    private static void UpdateCachedStatistics(PipelineStatistics stats, VcOutcome vcOutcome, List<Counterexample> errors) {
       Contract.Requires(stats != null);
 
-      switch (outcome)
+      switch (vcOutcome)
       {
         default:
           Contract.Assert(false); // unexpected outcome
           throw new cce.UnreachableException();
-        case VCGen.Outcome.ReachedBound:
+        case VcOutcome.ReachedBound:
           Interlocked.Increment(ref stats.CachedVerifiedCount);
 
           break;
-        case VCGen.Outcome.Correct:
+        case VcOutcome.Correct:
           Interlocked.Increment(ref stats.CachedVerifiedCount);
 
           break;
-        case VCGen.Outcome.TimedOut:
+        case VcOutcome.TimedOut:
           Interlocked.Increment(ref stats.CachedTimeoutCount);
 
           break;
-        case VCGen.Outcome.OutOfResource:
+        case VcOutcome.OutOfResource:
           Interlocked.Increment(ref stats.CachedOutOfResourceCount);
 
           break;
-        case VCGen.Outcome.OutOfMemory:
+        case VcOutcome.OutOfMemory:
           Interlocked.Increment(ref stats.CachedOutOfMemoryCount);
 
           break;
-        case VCGen.Outcome.SolverException:
+        case VcOutcome.SolverException:
           Interlocked.Increment(ref stats.CachedSolverExceptionCount);
 
           break;
-        case VCGen.Outcome.Inconclusive:
+        case VcOutcome.Inconclusive:
           Interlocked.Increment(ref stats.CachedInconclusiveCount);
 
           break;
-        case VCGen.Outcome.Errors:
+        case VcOutcome.Errors:
           int cnt = errors.Count(e => !e.IsAuxiliaryCexForDiagnosingTimeouts);
           Interlocked.Add(ref stats.CachedErrorCount, cnt);
 
@@ -1313,7 +1313,7 @@ namespace Microsoft.Boogie
 
     public void ProcessErrors(OutputPrinter printer,
       List<Counterexample> errors,
-      ConditionGeneration.Outcome outcome, TextWriter tw,
+      VcOutcome vcOutcome, TextWriter tw,
       ErrorReporterDelegate er, Implementation impl = null)
     {
       var implName = impl?.VerboseName;
@@ -1331,7 +1331,7 @@ namespace Microsoft.Boogie
           continue;
         }
 
-        var errorInfo = error.CreateErrorInformation(outcome, Options.ForceBplErrors);
+        var errorInfo = error.CreateErrorInformation(vcOutcome, Options.ForceBplErrors);
         errorInfo.ImplementationName = implName;
 
         if (Options.XmlSink != null)

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -19,7 +19,7 @@ using VCGeneration;
 
 namespace Microsoft.Boogie
 {
-  public record ProcessedProgram(Program Program, Action<VCGen, Implementation, VerificationResult> PostProcessResult) {
+  public record ProcessedProgram(Program Program, Action<VCGen, Implementation, ImplementationRunResult> PostProcessResult) {
     public ProcessedProgram(Program program) : this(program, (_, _, _) => { }) {
     }
   }
@@ -828,10 +828,10 @@ namespace Microsoft.Boogie
       string programId,
       TextWriter traceWriter)
     {
-      VerificationResult verificationResult = GetCachedVerificationResult(implementation, traceWriter);
-      if (verificationResult != null) {
-        UpdateCachedStatistics(stats, verificationResult.Outcome, verificationResult.Errors);
-        return Observable.Return(new Completed(verificationResult));
+      ImplementationRunResult implementationRunResult = GetCachedVerificationResult(implementation, traceWriter);
+      if (implementationRunResult != null) {
+        UpdateCachedStatistics(stats, implementationRunResult.Outcome, implementationRunResult.Errors);
+        return Observable.Return(new Completed(implementationRunResult));
       }
       Options.Printer.Inform("", traceWriter); // newline
       Options.Printer.Inform($"Verifying {implementation.VerboseName} ...", traceWriter);
@@ -849,7 +849,7 @@ namespace Microsoft.Boogie
       return Observable.Return(new Running()).Concat(afterRunningStates);
     }
 
-    public VerificationResult GetCachedVerificationResult(Implementation impl, TextWriter output)
+    public ImplementationRunResult GetCachedVerificationResult(Implementation impl, TextWriter output)
     {
       if (0 >= Options.VerifySnapshots)
       {
@@ -875,9 +875,9 @@ namespace Microsoft.Boogie
       PipelineStatistics stats, ErrorReporterDelegate er, CancellationToken cancellationToken,
       string programId, Implementation impl, TextWriter traceWriter)
     {
-      var verificationResult = new VerificationResult(impl, programId);
+      var verificationResult = new ImplementationRunResult(impl, programId);
 
-      var batchCompleted = new Subject<(Split split, VCResult vcResult)>();
+      var batchCompleted = new Subject<(Split split, VerificationRunResult vcResult)>();
       var completeVerification = largeThreadTaskFactory.StartNew(async () =>
       {
         var vcgen = new VCGen(processedProgram.Program, checkerPool);

--- a/Source/ExecutionEngine/ImplementationRunResult.cs
+++ b/Source/ExecutionEngine/ImplementationRunResult.cs
@@ -7,7 +7,7 @@ using VCGeneration;
 
 namespace Microsoft.Boogie;
 
-public sealed class VerificationResult
+public sealed class ImplementationRunResult
 {
   private readonly Implementation implementation;
   public readonly string ProgramId;
@@ -39,11 +39,11 @@ public sealed class VerificationResult
 
   public ConditionGeneration.Outcome Outcome { get; set; }
   public List<Counterexample> Errors = new();
-  public List<VCResult> VCResults;
+  public List<VerificationRunResult> VCResults;
 
   public ErrorInformation ErrorBeforeVerification { get; set; }
 
-  public VerificationResult(Implementation implementation, string programId = null)
+  public ImplementationRunResult(Implementation implementation, string programId = null)
   {
     this.implementation = implementation;
     ProgramId = programId;
@@ -79,9 +79,9 @@ public sealed class VerificationResult
     lock (engine.Options.XmlSink) {
       engine.Options.XmlSink.WriteStartMethod(implementation.VerboseName, Start);
 
-      foreach (var vcResult in VCResults.OrderBy(s => (s.vcNum, s.iteration))) {
-        engine.Options.XmlSink.WriteSplit(vcResult.vcNum, vcResult.iteration, vcResult.asserts, vcResult.startTime,
-          vcResult.outcome.ToString().ToLowerInvariant(), vcResult.runTime, vcResult.resourceCount);
+      foreach (var vcResult in VCResults.OrderBy(s => (vcNum: s.VcNum, iteration: s.Iteration))) {
+        engine.Options.XmlSink.WriteSplit(vcResult.VcNum, vcResult.Iteration, vcResult.Asserts, vcResult.StartTime,
+          vcResult.Outcome.ToString().ToLowerInvariant(), vcResult.RunTime, vcResult.ResourceCount);
       }
 
       engine.Options.XmlSink.WriteEndMethod(Outcome.ToString().ToLowerInvariant(),

--- a/Source/ExecutionEngine/ImplementationRunResult.cs
+++ b/Source/ExecutionEngine/ImplementationRunResult.cs
@@ -37,7 +37,7 @@ public sealed class ImplementationRunResult
   public int ProofObligationCountBefore { get; set; }
   public int ProofObligationCountAfter { get; set; }
 
-  public ConditionGeneration.Outcome Outcome { get; set; }
+  public VcOutcome VcOutcome { get; set; }
   public List<Counterexample> Errors = new();
   public List<VerificationRunResult> VCResults;
 
@@ -50,7 +50,7 @@ public sealed class ImplementationRunResult
   }
 
   public ErrorInformation GetOutcomeError(ExecutionEngineOptions options) {
-    return ExecutionEngine.GetOutcomeError(options, Outcome, implementation.VerboseName, implementation.tok, MessageIfVerifies,
+    return ExecutionEngine.GetOutcomeError(options, VcOutcome, implementation.VerboseName, implementation.tok, MessageIfVerifies,
       TextWriter.Null, implementation.GetTimeLimit(options), Errors);
   }
 
@@ -62,11 +62,11 @@ public sealed class ImplementationRunResult
       printer.WriteErrorInformation(ErrorBeforeVerification, result);
     }
 
-    engine.ProcessOutcome(printer, Outcome, Errors, TimeIndication(engine.Options), stats,
+    engine.ProcessOutcome(printer, VcOutcome, Errors, TimeIndication(engine.Options), stats,
       result, implementation.GetTimeLimit(engine.Options), er, implementation.VerboseName, implementation.tok,
       MessageIfVerifies);
 
-    engine.ProcessErrors(printer, Errors, Outcome, result, er, implementation);
+    engine.ProcessErrors(printer, Errors, VcOutcome, result, er, implementation);
 
     return result.ToString();
   }
@@ -84,7 +84,7 @@ public sealed class ImplementationRunResult
           vcResult.Outcome.ToString().ToLowerInvariant(), vcResult.RunTime, vcResult.ResourceCount);
       }
 
-      engine.Options.XmlSink.WriteEndMethod(Outcome.ToString().ToLowerInvariant(),
+      engine.Options.XmlSink.WriteEndMethod(VcOutcome.ToString().ToLowerInvariant(),
         End, Elapsed,
         ResourceCount);
     }

--- a/Source/ExecutionEngine/ImplementationTask.cs
+++ b/Source/ExecutionEngine/ImplementationTask.cs
@@ -15,7 +15,7 @@ public interface IVerificationStatus {}
 /// <summary>
 /// Results are available
 /// </summary>
-public record Completed(VerificationResult Result) : IVerificationStatus;
+public record Completed(ImplementationRunResult Result) : IVerificationStatus;
 
 /// <summary>
 /// Scheduled to be run but waiting for resources
@@ -32,7 +32,7 @@ public record Stale : IVerificationStatus;
 /// </summary>
 public record Running : IVerificationStatus;
 
-public record BatchCompleted(Split Split, VCResult VcResult) : IVerificationStatus;
+public record BatchCompleted(Split Split, VerificationRunResult VerificationRunResult) : IVerificationStatus;
 
 public interface IImplementationTask {
   IVerificationStatus CacheStatus { get; }

--- a/Source/ExecutionEngine/OutputPrinter.cs
+++ b/Source/ExecutionEngine/OutputPrinter.cs
@@ -14,5 +14,5 @@ public interface OutputPrinter
   void WriteTrailer(TextWriter textWriter, PipelineStatistics stats);
   void WriteErrorInformation(ErrorInformation errorInfo, TextWriter tw, bool skipExecutionTrace = true);
   void ReportBplError(IToken tok, string message, bool error, TextWriter tw, string category = null);
-  void ReportEndVerifyImplementation(Implementation implementation, VerificationResult result);
+  void ReportEndVerifyImplementation(Implementation implementation, ImplementationRunResult result);
 }

--- a/Source/ExecutionEngine/VerificationResultCache.cs
+++ b/Source/ExecutionEngine/VerificationResultCache.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Boogie
     }
 
     private void SetErrorAndAssertionChecksumsInCachedSnapshot(Implementation implementation,
-      VerificationResult result)
+      ImplementationRunResult result)
     {
       if (result.Outcome == ConditionGeneration.Outcome.Errors && result.Errors != null &&
           result.Errors.Count < options.ErrorLimit)
@@ -690,7 +690,7 @@ namespace Microsoft.Boogie
     private readonly CacheItemPolicy Policy = new CacheItemPolicy
       {SlidingExpiration = new TimeSpan(0, 10, 0), Priority = CacheItemPriority.Default};
 
-    public void Insert(Implementation impl, VerificationResult result)
+    public void Insert(Implementation impl, ImplementationRunResult result)
     {
       Contract.Requires(impl != null);
       Contract.Requires(result != null);
@@ -699,11 +699,11 @@ namespace Microsoft.Boogie
     }
 
 
-    public VerificationResult Lookup(Implementation impl, bool runDiagnosticsOnTimeout, out int priority)
+    public ImplementationRunResult Lookup(Implementation impl, bool runDiagnosticsOnTimeout, out int priority)
     {
       Contract.Requires(impl != null);
 
-      var result = Cache.Get(impl.Id) as VerificationResult;
+      var result = Cache.Get(impl.Id) as ImplementationRunResult;
       if (result == null)
       {
         priority = Priority.HIGH;

--- a/Source/ExecutionEngine/VerificationResultCache.cs
+++ b/Source/ExecutionEngine/VerificationResultCache.cs
@@ -231,14 +231,14 @@ namespace Microsoft.Boogie
     private void SetErrorAndAssertionChecksumsInCachedSnapshot(Implementation implementation,
       ImplementationRunResult result)
     {
-      if (result.Outcome == ConditionGeneration.Outcome.Errors && result.Errors != null &&
+      if (result.VcOutcome == VcOutcome.Errors && result.Errors != null &&
           result.Errors.Count < options.ErrorLimit)
       {
         implementation.SetErrorChecksumToCachedError(result.Errors.Select(cex =>
           new Tuple<byte[], byte[], object>(cex.Checksum, cex.SugaredCmdChecksum, cex)));
         implementation.AssertionChecksumsInCachedSnapshot = result.AssertionChecksums;
       }
-      else if (result.Outcome == ConditionGeneration.Outcome.Correct)
+      else if (result.VcOutcome == VcOutcome.Correct)
       {
         implementation.SetErrorChecksumToCachedError(new List<Tuple<byte[], byte[], object>>());
         implementation.AssertionChecksumsInCachedSnapshot = result.AssertionChecksums;
@@ -716,7 +716,7 @@ namespace Microsoft.Boogie
       {
         priority = Priority.LOW;
       }
-      else if (result.Outcome == ConditionGeneration.Outcome.TimedOut && runDiagnosticsOnTimeout)
+      else if (result.VcOutcome == VcOutcome.TimedOut && runDiagnosticsOnTimeout)
       {
         priority = Priority.MEDIUM;
       }

--- a/Source/Houdini/Houdini.cs
+++ b/Source/Houdini/Houdini.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Boogie.Houdini
     {
     }
 
-    public virtual void UpdateOutcome(ProverInterface.Outcome outcome)
+    public virtual void UpdateOutcome(Outcome outcome)
     {
     }
 
@@ -158,7 +158,7 @@ namespace Microsoft.Boogie.Houdini
       curImp = implementation;
     }
 
-    public override void UpdateOutcome(ProverInterface.Outcome o)
+    public override void UpdateOutcome(Outcome o)
     {
       Contract.Assert(curImp != null);
       DateTime endT = DateTime.UtcNow;
@@ -237,7 +237,7 @@ namespace Microsoft.Boogie.Houdini
       wr.Flush();
     }
 
-    public override void UpdateOutcome(ProverInterface.Outcome outcome)
+    public override void UpdateOutcome(Outcome outcome)
     {
       wr.WriteLine("analysis outcome :" + outcome);
       wr.Flush();
@@ -335,7 +335,7 @@ namespace Microsoft.Boogie.Houdini
       Notify((NotifyDelegate) delegate(HoudiniObserver r) { r.UpdateAssignment(assignment); });
     }
 
-    protected void NotifyOutcome(ProverInterface.Outcome outcome)
+    protected void NotifyOutcome(Outcome outcome)
     {
       Notify((NotifyDelegate) delegate(HoudiniObserver r) { r.UpdateOutcome(outcome); });
     }
@@ -837,13 +837,13 @@ namespace Microsoft.Boogie.Houdini
       return initial;
     }
 
-    private bool IsOutcomeNotHoudini(ProverInterface.Outcome outcome, List<Counterexample> errors)
+    private bool IsOutcomeNotHoudini(Outcome outcome, List<Counterexample> errors)
     {
       switch (outcome)
       {
-        case ProverInterface.Outcome.Valid:
+        case Outcome.Valid:
           return false;
-        case ProverInterface.Outcome.Invalid:
+        case Outcome.Invalid:
           Contract.Assume(errors != null);
           foreach (Counterexample error in errors)
           {
@@ -863,14 +863,14 @@ namespace Microsoft.Boogie.Houdini
     // Return true if there was at least one non-candidate error
     protected bool UpdateHoudiniOutcome(HoudiniOutcome houdiniOutcome,
       Implementation implementation,
-      ProverInterface.Outcome outcome,
+      Outcome outcome,
       List<Counterexample> errors)
     {
       string implName = implementation.Name;
       houdiniOutcome.implementationOutcomes.Remove(implName);
       List<Counterexample> nonCandidateErrors = new List<Counterexample>();
 
-      if (outcome == ProverInterface.Outcome.Invalid)
+      if (outcome == Outcome.Invalid)
       {
         foreach (Counterexample error in errors)
         {
@@ -937,7 +937,7 @@ namespace Microsoft.Boogie.Houdini
 
     // Updates the worklist and current assignment
     // @return true if the current function is dequeued
-    protected bool UpdateAssignmentWorkList(ProverInterface.Outcome outcome,
+    protected bool UpdateAssignmentWorkList(Outcome outcome,
       List<Counterexample> errors)
     {
       Contract.Assume(currentHoudiniState.Implementation != null);
@@ -945,11 +945,11 @@ namespace Microsoft.Boogie.Houdini
 
       switch (outcome)
       {
-        case ProverInterface.Outcome.Valid:
+        case Outcome.Valid:
           //yeah, dequeue
           break;
 
-        case ProverInterface.Outcome.Invalid:
+        case Outcome.Invalid:
           Contract.Assume(errors != null);
 
           foreach (Counterexample error in errors)
@@ -1489,7 +1489,7 @@ namespace Microsoft.Boogie.Houdini
       return null;
     }
 
-    private async Task<(ProverInterface.Outcome, List<Counterexample> errors)> TryCatchVerify(HoudiniSession session, int stage, IReadOnlyList<int> completedStages)
+    private async Task<(Outcome, List<Counterexample> errors)> TryCatchVerify(HoudiniSession session, int stage, IReadOnlyList<int> completedStages)
     {
       try {
         return await session.Verify(proverInterface, GetAssignmentWithStages(stage, completedStages), GetErrorLimit());
@@ -1497,7 +1497,7 @@ namespace Microsoft.Boogie.Houdini
       catch (UnexpectedProverOutputException upo)
       {
         Contract.Assume(upo != null);
-        return (ProverInterface.Outcome.Undetermined, null);
+        return (Outcome.Undetermined, null);
       }
 
     }
@@ -1551,7 +1551,7 @@ namespace Microsoft.Boogie.Houdini
 
         #region Explain Houdini
 
-        if (Options.ExplainHoudini && outcome == ProverInterface.Outcome.Invalid)
+        if (Options.ExplainHoudini && outcome == Outcome.Invalid)
         {
           Contract.Assume(errors != null);
           // make a copy of this variable
@@ -1587,7 +1587,7 @@ namespace Microsoft.Boogie.Houdini
 
         if (UpdateAssignmentWorkList(outcome, errors))
         {
-          if (Options.UseUnsatCoreForContractInfer && outcome == ProverInterface.Outcome.Valid)
+          if (Options.UseUnsatCoreForContractInfer && outcome == Outcome.Valid)
           {
             await session.UpdateUnsatCore(proverInterface, currentHoudiniState.Assignment);
           }
@@ -1704,12 +1704,12 @@ namespace Microsoft.Boogie.Houdini
 
   public class VCGenOutcome
   {
-    public VCGen.Outcome outcome;
+    public VcOutcome VcOutcome;
     public List<Counterexample> errors;
 
-    public VCGenOutcome(ProverInterface.Outcome outcome, List<Counterexample> errors)
+    public VCGenOutcome(Outcome outcome, List<Counterexample> errors)
     {
-      this.outcome = ConditionGeneration.ProverInterfaceOutcomeToConditionGenerationOutcome(outcome);
+      this.VcOutcome = ConditionGeneration.ProverInterfaceOutcomeToConditionGenerationOutcome(outcome);
       this.errors = errors;
     }
   }
@@ -1724,12 +1724,12 @@ namespace Microsoft.Boogie.Houdini
 
     // statistics 
 
-    private int CountResults(VCGen.Outcome outcome)
+    private int CountResults(VcOutcome vcOutcome)
     {
       int outcomeCount = 0;
       foreach (VCGenOutcome verifyOutcome in implementationOutcomes.Values)
       {
-        if (verifyOutcome.outcome == outcome)
+        if (verifyOutcome.VcOutcome == vcOutcome)
         {
           outcomeCount++;
         }
@@ -1738,12 +1738,12 @@ namespace Microsoft.Boogie.Houdini
       return outcomeCount;
     }
 
-    private List<string> ListOutcomeMatches(VCGen.Outcome outcome)
+    private List<string> ListOutcomeMatches(VcOutcome vcOutcome)
     {
       List<string> result = new List<string>();
       foreach (KeyValuePair<string, VCGenOutcome> kvpair in implementationOutcomes)
       {
-        if (kvpair.Value.outcome == outcome)
+        if (kvpair.Value.VcOutcome == vcOutcome)
         {
           result.Add(kvpair.Key);
         }
@@ -1754,37 +1754,37 @@ namespace Microsoft.Boogie.Houdini
 
     public int ErrorCount
     {
-      get { return CountResults(VCGen.Outcome.Errors); }
+      get { return CountResults(VcOutcome.Errors); }
     }
 
     public int Verified
     {
-      get { return CountResults(VCGen.Outcome.Correct); }
+      get { return CountResults(VcOutcome.Correct); }
     }
 
     public int Inconclusives
     {
-      get { return CountResults(VCGen.Outcome.Inconclusive); }
+      get { return CountResults(VcOutcome.Inconclusive); }
     }
 
     public int TimeOuts
     {
-      get { return CountResults(VCGen.Outcome.TimedOut); }
+      get { return CountResults(VcOutcome.TimedOut); }
     }
 
     public List<string> ListOfTimeouts
     {
-      get { return ListOutcomeMatches(VCGen.Outcome.TimedOut); }
+      get { return ListOutcomeMatches(VcOutcome.TimedOut); }
     }
 
     public List<string> ListOfInconclusives
     {
-      get { return ListOutcomeMatches(VCGen.Outcome.Inconclusive); }
+      get { return ListOutcomeMatches(VcOutcome.Inconclusive); }
     }
 
     public List<string> ListOfErrors
     {
-      get { return ListOutcomeMatches(VCGen.Outcome.Errors); }
+      get { return ListOutcomeMatches(VcOutcome.Errors); }
     }
   }
 }

--- a/Source/Houdini/HoudiniSession.cs
+++ b/Source/Houdini/HoudiniSession.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Boogie.Houdini
     public HashSet<TrackedNodeComponent> CoveredElements { get; } = new();
     private VCExpr conjecture;
     private ProverInterface.ErrorHandler handler;
-    ConditionGeneration.VerificationResultCollector collector;
+    VerificationResultCollector collector;
     HashSet<Variable> unsatCoreSet;
     HashSet<Variable> houdiniConstants;
     public HashSet<Variable> houdiniAssertConstants;
@@ -163,7 +163,7 @@ namespace Microsoft.Boogie.Houdini
       this.Description = impl.Name;
       this.houdini = houdini;
       this.stats = stats;
-      collector = new ConditionGeneration.VerificationResultCollector(houdini.Options);
+      collector = new VerificationResultCollector(houdini.Options);
       collector.OnProgress?.Invoke("HdnVCGen", 0, 0, 0.0);
 
       vcgen.ConvertCFG2DAG(run, taskID: taskID);

--- a/Source/Houdini/HoudiniSession.cs
+++ b/Source/Houdini/HoudiniSession.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Boogie.Houdini
 
     public HoudiniOptions Options => houdini.Options;
 
-    public async Task<(ProverInterface.Outcome, List<Counterexample> errors)> Verify(
+    public async Task<(Outcome, List<Counterexample> errors)> Verify(
       ProverInterface proverInterface,
       Dictionary<Variable, bool> assignment,
       int errorLimit)
@@ -393,7 +393,7 @@ namespace Microsoft.Boogie.Houdini
       var el = Options.ErrorLimit;
       Options.ErrorLimit = 1;
 
-      var outcome = ProverInterface.Outcome.Undetermined;
+      var outcome = Outcome.Undetermined;
 
       do
       {
@@ -402,8 +402,8 @@ namespace Microsoft.Boogie.Houdini
           handler, CancellationToken.None);
         hardAssumptions.RemoveAt(hardAssumptions.Count - 1);
 
-        if (outcome == ProverInterface.Outcome.TimeOut || outcome == ProverInterface.Outcome.OutOfMemory ||
-            outcome == ProverInterface.Outcome.OutOfResource || outcome == ProverInterface.Outcome.Undetermined)
+        if (outcome == Outcome.TimeOut || outcome == Outcome.OutOfMemory ||
+            outcome == Outcome.OutOfResource || outcome == Outcome.Undetermined)
         {
           break;
         }
@@ -436,8 +436,8 @@ namespace Microsoft.Boogie.Houdini
         (outcome, var unsatisfiedSoftAssumptions2) = await proverInterface.CheckAssumptions(hardAssumptions, softAssumptions2,
           handler, CancellationToken.None);
 
-        if (outcome == ProverInterface.Outcome.TimeOut || outcome == ProverInterface.Outcome.OutOfMemory ||
-            outcome == ProverInterface.Outcome.OutOfResource || outcome == ProverInterface.Outcome.Undetermined)
+        if (outcome == Outcome.TimeOut || outcome == Outcome.OutOfMemory ||
+            outcome == Outcome.OutOfResource || outcome == Outcome.Undetermined)
         {
           break;
         }
@@ -467,8 +467,8 @@ namespace Microsoft.Boogie.Houdini
         }
       } while (false);
 
-      if (outcome == ProverInterface.Outcome.TimeOut || outcome == ProverInterface.Outcome.OutOfMemory ||
-          outcome == ProverInterface.Outcome.OutOfResource || outcome == ProverInterface.Outcome.Undetermined)
+      if (outcome == Outcome.TimeOut || outcome == Outcome.OutOfMemory ||
+          outcome == Outcome.OutOfResource || outcome == Outcome.Undetermined)
       {
         Houdini.explainHoudiniDottyFile.WriteLine("{0} -> {1} [ label = \"{2}\" color=red ];", refutedConstant.Name,
           "TimeOut", Description);
@@ -515,8 +515,8 @@ namespace Microsoft.Boogie.Houdini
         assumptionExprs.Add(exprTranslator.LookupVariable(v));
       }
 
-      (ProverInterface.Outcome tmp, var unsatCore) = await proverInterface.CheckAssumptions(assumptionExprs, handler, CancellationToken.None);
-      System.Diagnostics.Debug.Assert(tmp == ProverInterface.Outcome.Valid);
+      (Outcome tmp, var unsatCore) = await proverInterface.CheckAssumptions(assumptionExprs, handler, CancellationToken.None);
+      System.Diagnostics.Debug.Assert(tmp == Outcome.Valid);
       unsatCoreSet = new HashSet<Variable>();
       foreach (int i in unsatCore)
       {

--- a/Source/Houdini/StagedHoudini.cs
+++ b/Source/Houdini/StagedHoudini.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Threading;
 using Microsoft.Boogie.GraphUtil;
+using VC;
 
 namespace Microsoft.Boogie.Houdini
 {
@@ -308,8 +309,8 @@ namespace Microsoft.Boogie.Houdini
 
     private static VCGenOutcome ChooseOutcome(VCGenOutcome o1, VCGenOutcome o2)
     {
-      var vcOutcome1 = o1.outcome;
-      var vcOutcome2 = o2.outcome;
+      var vcOutcome1 = o1.VcOutcome;
+      var vcOutcome2 = o2.VcOutcome;
 
       if (vcOutcome1 == vcOutcome2)
       {
@@ -317,34 +318,34 @@ namespace Microsoft.Boogie.Houdini
       }
 
       // Errors trump everything else
-      if (vcOutcome1 == VC.ConditionGeneration.Outcome.Errors)
+      if (vcOutcome1 == VcOutcome.Errors)
       {
         return o1;
       }
 
-      if (vcOutcome2 == VC.ConditionGeneration.Outcome.Errors)
+      if (vcOutcome2 == VcOutcome.Errors)
       {
         return o2;
       }
 
       // If one outcome is Correct, return the other in case it is "worse"
-      if (vcOutcome1 == VC.ConditionGeneration.Outcome.Correct)
+      if (vcOutcome1 == VcOutcome.Correct)
       {
         return o2;
       }
 
-      if (vcOutcome2 == VC.ConditionGeneration.Outcome.Correct)
+      if (vcOutcome2 == VcOutcome.Correct)
       {
         return o1;
       }
 
       // Neither outcome is correct, so if one outcome is ReachedBound, return the other in case it is "worse"
-      if (vcOutcome1 == VC.ConditionGeneration.Outcome.ReachedBound)
+      if (vcOutcome1 == VcOutcome.ReachedBound)
       {
         return o2;
       }
 
-      if (vcOutcome2 == VC.ConditionGeneration.Outcome.ReachedBound)
+      if (vcOutcome2 == VcOutcome.ReachedBound)
       {
         return o1;
       }

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -90,17 +90,6 @@ public abstract class ProverInterface
     return libOptions.TheProverFactory.SpawnProver(libOptions, options, ctx);
   }
 
-  public enum Outcome
-  {
-    Valid,
-    Invalid,
-    TimeOut,
-    OutOfMemory,
-    OutOfResource,
-    Undetermined,
-    Bounded
-  }
-
   public readonly ISet<VCExprVar> NamedAssumes = new HashSet<VCExprVar>();
 
   public class ErrorHandler
@@ -305,6 +294,18 @@ public abstract class ProverInterface
 
   public abstract Task GoBackToIdle();
 }
+
+public enum Outcome
+{
+  Valid,
+  Invalid,
+  TimeOut,
+  OutOfMemory,
+  OutOfResource,
+  Undetermined,
+  Bounded
+}
+
 public class UnexpectedProverOutputException : ProverException
 {
   public UnexpectedProverOutputException(string s)

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -347,8 +347,8 @@ procedure {:priority 2} {:checksum ""stable""} Good(y: int)
     
     var batchResult = (BatchCompleted) statusList[2].Item2;
     
-    var assertion = batchResult.VcResult.asserts[0];
-    batchResult.VcResult.ComputePerAssertOutcomes(out var perAssertOutcome, out var perAssertCounterExamples);
+    var assertion = batchResult.VerificationRunResult.Asserts[0];
+    batchResult.VerificationRunResult.ComputePerAssertOutcomes(out var perAssertOutcome, out var perAssertCounterExamples);
     Assert.Contains(assertion, perAssertOutcome.Keys);
     Assert.Contains(assertion, perAssertCounterExamples.Keys);
     var outcomeAssertion = perAssertOutcome[assertion];

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -71,7 +71,7 @@ procedure Second(y: int)
     Assert.NotNull(tasks[0].Implementation);
     var result1 = await tasks[0].TryRun()!.ToTask();
     var verificationResult1 = ((Completed)result1).Result;
-    Assert.AreEqual(ConditionGeneration.Outcome.Errors, verificationResult1.Outcome);
+    Assert.AreEqual(VcOutcome.Errors, verificationResult1.VcOutcome);
     Assert.AreEqual(true, verificationResult1.Errors[0].Model.ModelHasStatesAlready);
 
     Assert.IsTrue(tasks[1].IsIdle);
@@ -80,7 +80,7 @@ procedure Second(y: int)
     var result2 = await runningStates.ToTask();
     Assert.IsTrue(tasks[1].IsIdle);
     var verificationResult2 = ((Completed)result2).Result;
-    Assert.AreEqual(ConditionGeneration.Outcome.Correct, verificationResult2.Outcome);
+    Assert.AreEqual(VcOutcome.Correct, verificationResult2.VcOutcome);
   }
 
   [Test]
@@ -340,10 +340,10 @@ procedure {:priority 2} {:checksum ""stable""} Good(y: int)
     
     var tasks2 = engine.GetImplementationTasks(program);
     Assert.True(tasks2[0].CacheStatus is Completed);
-    Assert.AreEqual(ConditionGeneration.Outcome.Errors, ((Completed)tasks2[0].CacheStatus).Result.Outcome);
+    Assert.AreEqual(VcOutcome.Errors, ((Completed)tasks2[0].CacheStatus).Result.VcOutcome);
 
     Assert.True(tasks2[1].CacheStatus is Completed);
-    Assert.AreEqual(ConditionGeneration.Outcome.Correct, ((Completed)tasks2[1].CacheStatus).Result.Outcome);
+    Assert.AreEqual(VcOutcome.Correct, ((Completed)tasks2[1].CacheStatus).Result.VcOutcome);
     
     var batchResult = (BatchCompleted) statusList[2].Item2;
     
@@ -353,7 +353,7 @@ procedure {:priority 2} {:checksum ""stable""} Good(y: int)
     Assert.Contains(assertion, perAssertCounterExamples.Keys);
     var outcomeAssertion = perAssertOutcome[assertion];
     var counterExampleAssertion = perAssertCounterExamples[assertion];
-    Assert.AreEqual(ProverInterface.Outcome.Invalid, outcomeAssertion);
+    Assert.AreEqual(Outcome.Invalid, outcomeAssertion);
     Assert.AreEqual(true, counterExampleAssertion is AssertCounterexample);
     var assertCounterexample = (AssertCounterexample)counterExampleAssertion;
     Assert.AreEqual(assertCounterexample.FailingAssert, assertion);
@@ -374,10 +374,10 @@ procedure {:priority 2} {:checksum ""stable""} Good(y: int)
     options.VcsCores = 1;
 
     var outcome1 = await executionEngine.GetImplementationTasks(terminatingProgram)[0].TryRun()!.ToTask();
-    Assert.IsTrue(outcome1 is Completed completed && completed.Result.Outcome == ConditionGeneration.Outcome.Inconclusive);
+    Assert.IsTrue(outcome1 is Completed completed && completed.Result.VcOutcome == VcOutcome.Inconclusive);
     options.CreateSolver = (_ ,_ ) => new UnsatSolver();
     var outcome2 = await executionEngine.GetImplementationTasks(terminatingProgram)[0].TryRun()!.ToTask();
-    Assert.IsTrue(outcome2 is Completed completed2 && completed2.Result.Outcome == ConditionGeneration.Outcome.Correct);
+    Assert.IsTrue(outcome2 is Completed completed2 && completed2.Result.VcOutcome == VcOutcome.Correct);
   }
 
   [Test]

--- a/Source/UnitTests/ExecutionEngineTests/NullPrinter.cs
+++ b/Source/UnitTests/ExecutionEngineTests/NullPrinter.cs
@@ -30,7 +30,7 @@ public class NullPrinter : OutputPrinter {
   public void ReportBplError(IToken tok, string message, bool error, TextWriter tw, string category = null) {
   }
 
-  public void ReportEndVerifyImplementation(Implementation implementation, VerificationResult result)
+  public void ReportEndVerifyImplementation(Implementation implementation, ImplementationRunResult result)
   {
   }
 }

--- a/Source/VCGeneration/BlockListComparer.cs
+++ b/Source/VCGeneration/BlockListComparer.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.Boogie;
+
+namespace VC;
+
+class BlockListComparer : IEqualityComparer<List<Block>>
+{
+  public bool Equals(List<Block> x, List<Block> y)
+  {
+    return x == y || x.SequenceEqual(y);
+  }
+
+  public int GetHashCode(List<Block> obj)
+  {
+    int h = 0;
+    Contract.Assume(obj != null);
+    foreach (var b in obj)
+    {
+      if (b != null)
+      {
+        h += b.GetHashCode();
+      }
+    }
+
+    return h;
+  }
+}

--- a/Source/VCGeneration/BlockStats.cs
+++ b/Source/VCGeneration/BlockStats.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using Microsoft.Boogie;
+
+namespace VC;
+
+class BlockStats
+{
+  public bool bigBlock;
+  public int id;
+  public double assertionCost;
+  public double assumptionCost; // before multiplier
+  public double incomingPaths;
+
+  public List<Block> /*!>!*/
+    virtualSuccessors = new List<Block>();
+
+  public List<Block> /*!>!*/
+    virtualPredecessors = new List<Block>();
+
+  public HashSet<Block> reachableBlocks;
+  public readonly Block block;
+
+  [ContractInvariantMethod]
+  void ObjectInvariant()
+  {
+    Contract.Invariant(cce.NonNullElements(virtualSuccessors));
+    Contract.Invariant(cce.NonNullElements(virtualPredecessors));
+    Contract.Invariant(block != null);
+  }
+
+
+  public BlockStats(Block b, int i)
+  {
+    Contract.Requires(b != null);
+    block = b;
+    assertionCost = -1;
+    id = i;
+  }
+}

--- a/Source/VCGeneration/BlockTransformations.cs
+++ b/Source/VCGeneration/BlockTransformations.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.Boogie;
+
+namespace VCGeneration;
+
+public static class BlockTransformations
+{
+    public static List<Block> PostProcess(List<Block> blocks)
+    {
+      void DeleteFalseGotos (Block b)
+      {
+        var firstFalseIdx = b.Cmds.FindIndex(IsAssumeFalse);
+        if (firstFalseIdx != -1)
+        {
+          b.Cmds = b.Cmds.Take(firstFalseIdx + 1).ToList();
+          b.TransferCmd = (b.TransferCmd is GotoCmd) ? new ReturnCmd(b.tok) : b.TransferCmd;
+        }
+
+        return;
+
+        bool IsAssumeFalse (Cmd c) { return c is AssumeCmd ac && ac.Expr is LiteralExpr le && !le.asBool; }
+      }
+
+      bool ContainsAssert(Block b)
+      {
+        return b.Cmds.Exists(IsNonTrivialAssert);
+        bool IsNonTrivialAssert (Cmd c) { return c is AssertCmd ac && !(ac.Expr is LiteralExpr le && le.asBool); }
+      }
+
+      blocks.ForEach(DeleteFalseGotos); // make blocks ending in assume false leaves of the CFG-DAG -- this is probably unnecessary, may have been done previously
+      var todo = new Stack<Block>();
+      var peeked = new HashSet<Block>();
+      var interestingBlocks = new HashSet<Block>();
+      todo.Push(blocks[0]);
+      while(todo.Any())
+      {
+        var currentBlock = todo.Peek();
+        var pop = peeked.Contains(currentBlock);
+        peeked.Add(currentBlock);
+        var interesting = false;
+        var exit = currentBlock.TransferCmd as GotoCmd;
+        if (exit != null && !pop) {
+          exit.labelTargets.ForEach(b => todo.Push(b));
+        } else if (exit != null) {
+          Contract.Assert(pop);
+          var gtc = new GotoCmd(exit.tok, exit.labelTargets.Where(l => interestingBlocks.Contains(l)).ToList());
+          currentBlock.TransferCmd = gtc;
+          interesting = interesting || gtc.labelTargets.Count() != 0;
+        }
+        if (pop)
+        {
+          interesting = interesting || ContainsAssert(currentBlock);
+          if (interesting) {
+            interestingBlocks.Add(currentBlock);
+          }
+          todo.Pop();
+        }
+      }
+      interestingBlocks.Add(blocks[0]); // must not be empty
+      return blocks.Where(b => interestingBlocks.Contains(b)).ToList(); // this is not the same as interestingBlocks.ToList() because the resulting lists will have different orders.
+    }
+}

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Boogie
     private ProverInterface thmProver;
 
     // state for the async interface
-    private volatile ProverInterface.Outcome outcome;
+    private volatile Outcome outcome;
     private volatile bool hasOutput;
     private volatile UnexpectedProverOutputException outputExn;
     public DateTime ProverStart { get; private set; }
@@ -292,22 +292,22 @@ namespace Microsoft.Boogie
 
       switch (outcome)
       {
-        case ProverInterface.Outcome.Valid:
+        case Outcome.Valid:
           thmProver.LogComment("Valid");
           break;
-        case ProverInterface.Outcome.Invalid:
+        case Outcome.Invalid:
           thmProver.LogComment("Invalid");
           break;
-        case ProverInterface.Outcome.TimeOut:
+        case Outcome.TimeOut:
           thmProver.LogComment("Timed out");
           break;
-        case ProverInterface.Outcome.OutOfResource:
+        case Outcome.OutOfResource:
           thmProver.LogComment("Out of resource");
           break;
-        case ProverInterface.Outcome.OutOfMemory:
+        case Outcome.OutOfMemory:
           thmProver.LogComment("Out of memory");
           break;
-        case ProverInterface.Outcome.Undetermined:
+        case Outcome.Undetermined:
           thmProver.LogComment("Undetermined");
           break;
       }
@@ -341,7 +341,7 @@ namespace Microsoft.Boogie
       ProverTask = Check(descriptiveName, vc, cancellationToken);
     }
 
-    public ProverInterface.Outcome ReadOutcome()
+    public Outcome ReadOutcome()
     {
       Contract.Requires(IsBusy);
       Contract.Requires(HasOutput);

--- a/Source/VCGeneration/CommandTransformations.cs
+++ b/Source/VCGeneration/CommandTransformations.cs
@@ -1,0 +1,17 @@
+using Microsoft.Boogie;
+using VC;
+
+namespace VCGeneration;
+
+public class CommandTransformations
+{
+  public static Cmd AssertIntoAssume(VCGenOptions options, Cmd c)
+  {
+    if (c is AssertCmd assrt)
+    {
+      return VCGen.AssertTurnedIntoAssume(options, assrt);
+    }
+
+    return c;
+  }
+}

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -28,7 +28,7 @@ namespace VC
   public abstract class ConditionGenerationContracts : ConditionGeneration
   {
     public override Task<Outcome> VerifyImplementation(ImplementationRun run, VerifierCallback callback,
-      CancellationToken cancellationToken, IObserver<(Split split, VCResult vcResult)> batchCompletedObserver)
+      CancellationToken cancellationToken, IObserver<(Split split, VerificationRunResult vcResult)> batchCompletedObserver)
     {
       Contract.Requires(run != null);
       Contract.Requires(callback != null);
@@ -120,8 +120,8 @@ namespace VC
     /// <param name="batchCompletedObserver"></param>
     /// <param name="cancellationToken"></param>
     /// <param name="impl"></param>
-    public async Task<(Outcome, List<Counterexample> errors, List<VCResult> vcResults)> VerifyImplementation(
-      ImplementationRun run, IObserver<(Split split, VCResult vcResult)> batchCompletedObserver,
+    public async Task<(Outcome, List<Counterexample> errors, List<VerificationRunResult> vcResults)> VerifyImplementation(
+      ImplementationRun run, IObserver<(Split split, VerificationRunResult vcResult)> batchCompletedObserver,
       CancellationToken cancellationToken)
     {
       Contract.Requires(run != null);
@@ -144,7 +144,7 @@ namespace VC
     private VCGenOptions Options => CheckerPool.Options;
 
     public abstract Task<Outcome> VerifyImplementation(ImplementationRun run, VerifierCallback callback,
-      CancellationToken cancellationToken, IObserver<(Split split, VCResult vcResult)> batchCompletedObserver);
+      CancellationToken cancellationToken, IObserver<(Split split, VerificationRunResult vcResult)> batchCompletedObserver);
 
     /////////////////////////////////// Common Methods and Classes //////////////////////////////////////////
 
@@ -540,7 +540,7 @@ namespace VC
       }
 
       public readonly ConcurrentQueue<Counterexample> examples = new();
-      public readonly ConcurrentQueue<VCResult> vcResults = new();
+      public readonly ConcurrentQueue<VerificationRunResult> vcResults = new();
 
       public override void OnCounterexample(Counterexample ce, string /*?*/ reason)
       {
@@ -557,7 +557,7 @@ namespace VC
         // TODO report error about next to last in seq
       }
 
-      public override void OnVCResult(VCResult result)
+      public override void OnVCResult(VerificationRunResult result)
       {
         vcResults.Enqueue(result);
       }

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -510,46 +509,6 @@ namespace VC
     {
     }
 
-
-    public class VerificationResultCollector : VerifierCallback
-    {
-      private readonly VCGenOptions options;
-
-      public VerificationResultCollector(VCGenOptions options) : base(options.PrintProverWarnings)
-      {
-        this.options = options;
-      }
-
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(cce.NonNullElements(examples));
-        Contract.Invariant(cce.NonNullElements(vcResults));
-      }
-
-      public readonly ConcurrentQueue<Counterexample> examples = new();
-      public readonly ConcurrentQueue<VerificationRunResult> vcResults = new();
-
-      public override void OnCounterexample(Counterexample ce, string /*?*/ reason)
-      {
-        //Contract.Requires(ce != null);
-        ce.InitializeModelStates();
-        examples.Enqueue(ce);
-      }
-
-      public override void OnUnreachableCode(ImplementationRun run)
-      {
-        //Contract.Requires(impl != null);
-        run.OutputWriter.WriteLine("found unreachable code:");
-        EmitImpl(options, run, false);
-        // TODO report error about next to last in seq
-      }
-
-      public override void OnVCResult(VerificationRunResult result)
-      {
-        vcResults.Enqueue(result);
-      }
-    }
 
     public static void EmitImpl(VCGenOptions options, ImplementationRun run, bool printDesugarings)
     {

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -766,7 +766,7 @@ namespace Microsoft.Boogie
       }
     }
 
-    public virtual void OnVCResult(VCResult result)
+    public virtual void OnVCResult(VerificationRunResult result)
     {
       Contract.Requires(result != null);
     }

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -388,14 +388,14 @@ namespace Microsoft.Boogie
 
     public abstract int GetLocation();
 
-    public ErrorInformation CreateErrorInformation(ConditionGeneration.Outcome outcome, bool forceBplErrors)
+    public ErrorInformation CreateErrorInformation(VcOutcome vcOutcome, bool forceBplErrors)
     {
       ErrorInformation errorInfo;
-      var cause = outcome switch {
-        VCGen.Outcome.TimedOut => "Timed out on",
-        VCGen.Outcome.OutOfMemory => "Out of memory on",
-        VCGen.Outcome.SolverException => "Solver exception on",
-        VCGen.Outcome.OutOfResource => "Out of resource on",
+      var cause = vcOutcome switch {
+        VcOutcome.TimedOut => "Timed out on",
+        VcOutcome.OutOfMemory => "Out of memory on",
+        VcOutcome.SolverException => "Solver exception on",
+        VcOutcome.OutOfResource => "Out of resource on",
         _ => "Error"
       };
 

--- a/Source/VCGeneration/FocusAttribute.cs
+++ b/Source/VCGeneration/FocusAttribute.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.Boogie;
+using VC;
+using Block = Microsoft.Boogie.Block;
+using Cmd = Microsoft.Boogie.Cmd;
+using PredicateCmd = Microsoft.Boogie.PredicateCmd;
+using QKeyValue = Microsoft.Boogie.QKeyValue;
+using ReturnCmd = Microsoft.Boogie.ReturnCmd;
+using TransferCmd = Microsoft.Boogie.TransferCmd;
+using VCGenOptions = Microsoft.Boogie.VCGenOptions;
+
+namespace VCGeneration;
+
+public static class FocusAttribute
+{
+  public static List<Split> FocusImpl(VCGenOptions options, ImplementationRun run, Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins, VCGen par)
+  {
+    bool IsFocusCmd(Cmd c) {
+      return c is PredicateCmd p && QKeyValue.FindBoolAttribute(p.Attributes, "focus");
+    }
+
+    List<Block> GetFocusBlocks(List<Block> blocks) {
+      return blocks.Where(blk => blk.Cmds.Any(c => IsFocusCmd(c))).ToList();
+    }
+
+    var impl = run.Implementation;
+    var dag = Program.GraphFromImpl(impl);
+    var topoSorted = dag.TopologicalSort().ToList();
+    // By default, we process the foci in a top-down fashion, i.e., in the topological order.
+    // If the user sets the RelaxFocus flag, we use the reverse (topological) order.
+    var focusBlocks = GetFocusBlocks(topoSorted);
+    if (par.CheckerPool.Options.RelaxFocus) {
+      focusBlocks.Reverse();
+    }
+    if (!focusBlocks.Any()) {
+      var f = new List<Split>();
+      f.Add(new Split(options, impl.Blocks, gotoCmdOrigins, par, run));
+      return f;
+    }
+    // finds all the blocks dominated by focusBlock in the subgraph
+    // which only contains vertices of subgraph.
+    HashSet<Block> DominatedBlocks(Block focusBlock, IEnumerable<Block> subgraph)
+    {
+      var dominators = new Dictionary<Block, HashSet<Block>>();
+      var todo = new Queue<Block>();
+      foreach (var b in topoSorted.Where(blk => subgraph.Contains(blk)))
+      {
+        var s = new HashSet<Block>();
+        var pred = b.Predecessors.Where(subgraph.Contains).ToList();
+        if (pred.Count != 0)
+        {
+          s.UnionWith(dominators[pred[0]]);
+          pred.ForEach(blk => s.IntersectWith(dominators[blk]));
+        }
+        s.Add(b);
+        dominators[b] = s;
+      }
+      return subgraph.Where(blk => dominators[blk].Contains(focusBlock)).ToHashSet();
+    }
+
+    Cmd DisableSplits(Cmd c)
+    {
+      if (c is PredicateCmd pc)
+      {
+        for (var kv = pc.Attributes; kv != null; kv = kv.Next)
+        {
+          if (kv.Key == "split")
+          {
+            kv.AddParam(new LiteralExpr(Token.NoToken, false));
+          }
+        }
+      }
+      return c;
+    }
+
+    var Ancestors = new Dictionary<Block, HashSet<Block>>();
+    var Descendants = new Dictionary<Block, HashSet<Block>>();
+    focusBlocks.ForEach(fb => Ancestors[fb] = dag.ComputeReachability(fb, false).ToHashSet());
+    focusBlocks.ForEach(fb => Descendants[fb] = dag.ComputeReachability(fb, true).ToHashSet());
+    var s = new List<Split>();
+    var duplicator = new Duplicator();
+    void FocusRec(int focusIdx, IEnumerable<Block> blocks, IEnumerable<Block> freeBlocks)
+    {
+      if (focusIdx == focusBlocks.Count())
+      {
+        // it is important for l to be consistent with reverse topological order.
+        var l = dag.TopologicalSort().Where(blk => blocks.Contains(blk)).Reverse();
+        // assert that the root block, impl.Blocks[0], is in l
+        Contract.Assert(l.ElementAt(l.Count() - 1) == impl.Blocks[0]);
+        var newBlocks = new List<Block>();
+        var oldToNewBlockMap = new Dictionary<Block, Block>(blocks.Count());
+        foreach (Block b in l)
+        {
+          var newBlock = (Block)duplicator.Visit(b);
+          newBlocks.Add(newBlock);
+          oldToNewBlockMap[b] = newBlock;
+          // freeBlocks consist of the predecessors of the relevant foci.
+          // Their assertions turn into assumes and any splits inside them are disabled.
+          if(freeBlocks.Contains(b))
+          {
+            newBlock.Cmds = b.Cmds.Select(c => CommandTransformations.AssertIntoAssume(options, c)).Select(c => DisableSplits(c)).ToList();
+          }
+          if (b.TransferCmd is GotoCmd gtc)
+          {
+            var targets = gtc.labelTargets.Where(blk => blocks.Contains(blk));
+            newBlock.TransferCmd = new GotoCmd(gtc.tok,
+                                          targets.Select(blk => oldToNewBlockMap[blk].Label).ToList(),
+                                          targets.Select(blk => oldToNewBlockMap[blk]).ToList());
+          }
+        }
+        newBlocks.Reverse();
+        Contract.Assert(newBlocks[0] == oldToNewBlockMap[impl.Blocks[0]]);
+        s.Add(new Split(options, BlockTransformations.PostProcess(newBlocks), gotoCmdOrigins, par, run));
+      }
+      else if (!blocks.Contains(focusBlocks[focusIdx])
+                || freeBlocks.Contains(focusBlocks[focusIdx]))
+      {
+        FocusRec(focusIdx + 1, blocks, freeBlocks);
+      }
+      else
+      {
+        var b = focusBlocks[focusIdx]; // assert b in blocks
+        var dominatedBlocks = DominatedBlocks(b, blocks);
+        // the first part takes all blocks except the ones dominated by the focus block
+        FocusRec(focusIdx + 1, blocks.Where(blk => !dominatedBlocks.Contains(blk)), freeBlocks);
+        var ancestors = Ancestors[b];
+        ancestors.Remove(b);
+        var descendants = Descendants[b];
+        // the other part takes all the ancestors, the focus block, and the descendants.
+        FocusRec(focusIdx + 1, ancestors.Union(descendants).Intersect(blocks), ancestors.Union(freeBlocks));
+      }
+    }
+
+    FocusRec(0, impl.Blocks, new List<Block>());
+    return s;
+  }
+}

--- a/Source/VCGeneration/ManualSplitFinder.cs
+++ b/Source/VCGeneration/ManualSplitFinder.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.Boogie;
+using VC;
+
+namespace VCGeneration;
+
+public static class ManualSplitFinder
+{
+  
+  public static List<Split> FocusAndSplit(VCGenOptions options, ImplementationRun run, Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins, VCGen par, bool splitOnEveryAssert)
+  {
+    List<Split> focussedImpl = FocusAttribute.FocusImpl(options, run, gotoCmdOrigins, par);
+    var splits = focussedImpl.Select(s => FindManualSplits(s, splitOnEveryAssert)).SelectMany(x => x).ToList();
+    return splits;
+  }
+  
+  public static List<Split> FindManualSplits(Split initialSplit, bool splitOnEveryAssert)
+  {
+    Contract.Requires(initialSplit.Implementation != null);
+    Contract.Ensures(Contract.Result<List<Split>>() == null || cce.NonNullElements(Contract.Result<List<Split>>()));
+
+    var splitPoints = new Dictionary<Block, int>();
+    foreach (var b in initialSplit.Blocks)
+    {
+      foreach (Cmd c in b.Cmds)
+      {
+        var p = c as PredicateCmd;
+        if (ShouldSplitHere(c, splitOnEveryAssert))
+        {
+          splitPoints.TryGetValue(b, out var count);
+          splitPoints[b] = count + 1;
+        }
+      }
+    }
+    var splits = new List<Split>();
+    if (!splitPoints.Any())
+    {
+      splits.Add(initialSplit);
+    }
+    else
+    {
+      Block entryPoint = initialSplit.Blocks[0];
+      var blockAssignments = PickBlocksToVerify(initialSplit.Blocks, splitPoints);
+      var entryBlockHasSplit = splitPoints.Keys.Contains(entryPoint);
+      var baseSplitBlocks = BlockTransformations.PostProcess(DoPreAssignedManualSplit(initialSplit.Options, initialSplit.Blocks, blockAssignments, -1, entryPoint, !entryBlockHasSplit, splitOnEveryAssert));
+      splits.Add(new Split(initialSplit.Options, baseSplitBlocks, initialSplit.GotoCmdOrigins, initialSplit.parent, initialSplit.Run));
+      foreach (KeyValuePair<Block, int> pair in splitPoints)
+      {
+        for (int i = 0; i < pair.Value; i++)
+        {
+          bool lastSplitInBlock = i == pair.Value - 1;
+          var newBlocks = DoPreAssignedManualSplit(initialSplit.Options, initialSplit.Blocks, blockAssignments, i, pair.Key, lastSplitInBlock, splitOnEveryAssert);
+          splits.Add(new Split(initialSplit.Options, BlockTransformations.PostProcess(newBlocks), initialSplit.GotoCmdOrigins, initialSplit.parent, initialSplit.Run)); // REVIEW: Does gotoCmdOrigins need to be changed at all?
+        }
+      }
+    }
+    return splits;
+  }
+
+  private static bool ShouldSplitHere(Cmd c, bool splitOnEveryAssert) {
+    return c is PredicateCmd p && QKeyValue.FindBoolAttribute(p.Attributes, "split_here")
+           || c is AssertCmd && splitOnEveryAssert;
+  }
+  
+
+  // Verify b with the last split in blockAssignments[b]
+
+  private static Dictionary<Block, Block> PickBlocksToVerify (List<Block> blocks, Dictionary<Block, int> splitPoints)
+  {
+    var todo = new Stack<Block>();
+    var blockAssignments = new Dictionary<Block, Block>();
+    var immediateDominator = (Program.GraphFromBlocks(blocks)).ImmediateDominator();
+    todo.Push(blocks[0]);
+    while(todo.Count > 0)
+    {
+      var currentBlock = todo.Pop();
+      if (blockAssignments.Keys.Contains(currentBlock))
+      {
+        continue;
+      }
+      else if (immediateDominator[currentBlock] == currentBlock) // if the currentBlock doesn't have a predecessor.
+      {
+        blockAssignments[currentBlock] = currentBlock;
+      }
+      else if (splitPoints.Keys.Contains(immediateDominator[currentBlock])) // if the currentBlock's dominator has a split then it will be associated with that split
+      {
+        blockAssignments[currentBlock] = immediateDominator[currentBlock];
+      }
+      else
+      {
+        Contract.Assert(blockAssignments.Keys.Contains(immediateDominator[currentBlock]));
+        blockAssignments[currentBlock] = blockAssignments[immediateDominator[currentBlock]];
+      }
+      if (currentBlock.TransferCmd is GotoCmd exit)
+      {
+        exit.labelTargets.ForEach(blk => todo.Push(blk));
+      }
+    }
+    return blockAssignments;
+  }
+
+  private static List<Block> DoPreAssignedManualSplit(VCGenOptions options, List<Block> blocks, Dictionary<Block, Block> blockAssignments, int splitNumberWithinBlock,
+    Block containingBlock, bool lastSplitInBlock, bool splitOnEveryAssert)
+  {
+    var newBlocks = new List<Block>(blocks.Count()); // Copies of the original blocks
+    var duplicator = new Duplicator();
+    var oldToNewBlockMap = new Dictionary<Block, Block>(blocks.Count()); // Maps original blocks to their new copies in newBlocks
+    foreach (var currentBlock in blocks)
+    {
+      var newBlock = (Block)duplicator.VisitBlock(currentBlock);
+      oldToNewBlockMap[currentBlock] = newBlock;
+      newBlocks.Add(newBlock);
+      if (currentBlock == containingBlock)
+      {
+        var newCmds = new List<Cmd>();
+        var splitCount = -1;
+        var verify = splitCount == splitNumberWithinBlock;
+        foreach (Cmd c in currentBlock.Cmds)
+        {
+          if (ShouldSplitHere(c, splitOnEveryAssert))
+          {
+            splitCount++;
+            verify = splitCount == splitNumberWithinBlock;
+          }
+          newCmds.Add(verify ? c : CommandTransformations.AssertIntoAssume(options, c));
+        }
+        newBlock.Cmds = newCmds;
+      }
+      else if (lastSplitInBlock && blockAssignments[currentBlock] == containingBlock)
+      {
+        var verify = true;
+        var newCmds = new List<Cmd>();
+        foreach(Cmd c in currentBlock.Cmds) {
+          verify = !ShouldSplitHere(c, splitOnEveryAssert) && verify;
+          newCmds.Add(verify ? c : CommandTransformations.AssertIntoAssume(options, c));
+        }
+        newBlock.Cmds = newCmds;
+      }
+      else
+      {
+        newBlock.Cmds = currentBlock.Cmds.Select<Cmd, Cmd>(x => CommandTransformations.AssertIntoAssume(options, x)).ToList();
+      }
+    }
+    // Patch the edges between the new blocks
+    foreach (var oldBlock in blocks)
+    {
+      if (oldBlock.TransferCmd is ReturnCmd)
+      {
+        continue;
+      }
+
+      var gotoCmd = (GotoCmd)oldBlock.TransferCmd;
+      var newLabelTargets = new List<Block>(gotoCmd.labelTargets.Count());
+      var newLabelNames = new List<string>(gotoCmd.labelTargets.Count());
+      foreach (var target in gotoCmd.labelTargets)
+      {
+        newLabelTargets.Add(oldToNewBlockMap[target]);
+        newLabelNames.Add(oldToNewBlockMap[target].Label);
+      }
+
+      oldToNewBlockMap[oldBlock].TransferCmd = new GotoCmd(gotoCmd.tok, newLabelNames, newLabelTargets);
+    }
+    return newBlocks;
+  }
+}

--- a/Source/VCGeneration/SmokeTester.cs
+++ b/Source/VCGeneration/SmokeTester.cs
@@ -278,7 +278,7 @@ class SmokeTester
     Checker checker = await parent.CheckerPool.FindCheckerFor(parent, null, CancellationToken.None);
     Contract.Assert(checker != null);
 
-    ProverInterface.Outcome outcome = ProverInterface.Outcome.Undetermined;
+    Outcome outcome = Outcome.Undetermined;
     try
     {
       VCExpr vc;
@@ -327,12 +327,12 @@ class SmokeTester
     if (Options.Trace)
     {
       traceWriter.WriteLine("  [{0} s] {1}", elapsed.TotalSeconds,
-        outcome == ProverInterface.Outcome.Valid
+        outcome == Outcome.Valid
           ? "OOPS"
-          : "OK" + (outcome == ProverInterface.Outcome.Invalid ? "" : " (" + outcome + ")"));
+          : "OK" + (outcome == Outcome.Invalid ? "" : " (" + outcome + ")"));
     }
 
-    if (outcome == ProverInterface.Outcome.Valid)
+    if (outcome == Outcome.Valid)
     {
       // copy it again, so we get the version with calls, assignments and such
       copy = CopyBlock(cur);

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -21,1040 +21,1040 @@ namespace VC
     public VCGenOptions Options { get; }
 
     public int? RandomSeed => Implementation.RandomSeed ?? Options.RandomSeed;
-      private readonly Random randomGen;
+    private readonly Random randomGen;
 
-      public ImplementationRun Run { get; }
+    public ImplementationRun Run { get; }
 
-      [ContractInvariantMethod]
-      void ObjectInvariant()
+    [ContractInvariantMethod]
+    void ObjectInvariant()
+    {
+      Contract.Invariant(cce.NonNullElements(Blocks));
+      Contract.Invariant(cce.NonNullElements(bigBlocks));
+      Contract.Invariant(cce.NonNullDictionaryAndValues(stats));
+      Contract.Invariant(cce.NonNullElements(assumizedBranches));
+      Contract.Invariant(GotoCmdOrigins != null);
+      Contract.Invariant(parent != null);
+      Contract.Invariant(Implementation != null);
+      Contract.Invariant(copies != null);
+      Contract.Invariant(cce.NonNull(protectedFromAssertToAssume));
+      Contract.Invariant(cce.NonNull(keepAtAll));
+    }
+
+
+    public List<Block> Blocks { get; }
+    public List<AssertCmd> Asserts => Blocks.SelectMany(block => block.cmds.OfType<AssertCmd>()).ToList();
+    public readonly IReadOnlyList<Declaration> TopLevelDeclarations;
+    readonly List<Block> bigBlocks = new();
+
+    readonly Dictionary<Block /*!*/, BlockStats /*!*/> /*!*/
+      stats = new Dictionary<Block /*!*/, BlockStats /*!*/>();
+    static int currentId = -1;
+
+    Block splitBlock;
+    bool assertToAssume;
+
+    List<Block /*!*/> /*!*/
+      assumizedBranches = new List<Block /*!*/>();
+
+    double score;
+    bool scoreComputed;
+    double totalCost;
+    int assertionCount;
+    double assertionCost; // without multiplication by paths
+
+    public Dictionary<TransferCmd, ReturnCmd> GotoCmdOrigins { get; }
+
+    public readonly VCGen /*!*/ parent;
+
+    public Implementation /*!*/ Implementation => Run.Implementation;
+
+    Dictionary<Block /*!*/, Block /*!*/> /*!*/
+      copies = new Dictionary<Block /*!*/, Block /*!*/>();
+
+    bool doingSlice;
+    double sliceInitialLimit;
+    double sliceLimit;
+    bool slicePos;
+
+    HashSet<Block /*!*/> /*!*/
+      protectedFromAssertToAssume = new HashSet<Block /*!*/>();
+
+    HashSet<Block /*!*/> /*!*/
+      keepAtAll = new HashSet<Block /*!*/>();
+
+    // async interface
+    public int SplitIndex { get; set; }
+    internal VCGen.ErrorReporter reporter;
+
+    public Split(VCGenOptions options, List<Block /*!*/> /*!*/ blocks,
+      Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
+      VCGen /*!*/ par, ImplementationRun run)
+    {
+      Contract.Requires(cce.NonNullElements(blocks));
+      Contract.Requires(gotoCmdOrigins != null);
+      Contract.Requires(par != null);
+      this.Blocks = blocks;
+      this.GotoCmdOrigins = gotoCmdOrigins;
+      this.parent = par;
+      this.Run = run;
+      this.Options = options;
+      Interlocked.Increment(ref currentId);
+
+      TopLevelDeclarations = par.program.TopLevelDeclarations;
+      PrintTopLevelDeclarationsForPruning(par.program, Implementation, "before");
+      TopLevelDeclarations = Prune.GetLiveDeclarations(options, par.program, blocks).ToList();
+      PrintTopLevelDeclarationsForPruning(par.program, Implementation, "after");
+      randomGen = new Random(RandomSeed ?? 0);
+    }
+
+    private void PrintTopLevelDeclarationsForPruning(Program program, Implementation implementation, string suffix)
+    {
+      if (!Options.Prune || Options.PrintPrunedFile == null)
       {
-        Contract.Invariant(cce.NonNullElements(Blocks));
-        Contract.Invariant(cce.NonNullElements(bigBlocks));
-        Contract.Invariant(cce.NonNullDictionaryAndValues(stats));
-        Contract.Invariant(cce.NonNullElements(assumizedBranches));
-        Contract.Invariant(GotoCmdOrigins != null);
-        Contract.Invariant(parent != null);
-        Contract.Invariant(Implementation != null);
-        Contract.Invariant(copies != null);
-        Contract.Invariant(cce.NonNull(protectedFromAssertToAssume));
-        Contract.Invariant(cce.NonNull(keepAtAll));
+        return;
       }
 
+      using var writer = new TokenTextWriter(
+        $"{Options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}.bpl", false,
+        Options.PrettyPrint, Options);
 
-      public List<Block> Blocks { get; }
-      public List<AssertCmd> Asserts => Blocks.SelectMany(block => block.cmds.OfType<AssertCmd>()).ToList();
-      public readonly IReadOnlyList<Declaration> TopLevelDeclarations;
-      readonly List<Block> bigBlocks = new();
+      var functionAxioms = 
+        program.Functions.Where(f => f.DefinitionAxioms.Any()).SelectMany(f => f.DefinitionAxioms);
+      var constantAxioms = 
+        program.Constants.Where(f => f.DefinitionAxioms.Any()).SelectMany(c => c.DefinitionAxioms);
 
-      readonly Dictionary<Block /*!*/, BlockStats /*!*/> /*!*/
-        stats = new Dictionary<Block /*!*/, BlockStats /*!*/>();
-      static int currentId = -1;
-
-      Block splitBlock;
-      bool assertToAssume;
-
-      List<Block /*!*/> /*!*/
-        assumizedBranches = new List<Block /*!*/>();
-
-      double score;
-      bool scoreComputed;
-      double totalCost;
-      int assertionCount;
-      double assertionCost; // without multiplication by paths
-
-      public Dictionary<TransferCmd, ReturnCmd> GotoCmdOrigins { get; }
-
-      public readonly VCGen /*!*/ parent;
-
-      public Implementation /*!*/ Implementation => Run.Implementation;
-
-      Dictionary<Block /*!*/, Block /*!*/> /*!*/
-        copies = new Dictionary<Block /*!*/, Block /*!*/>();
-
-      bool doingSlice;
-      double sliceInitialLimit;
-      double sliceLimit;
-      bool slicePos;
-
-      HashSet<Block /*!*/> /*!*/
-        protectedFromAssertToAssume = new HashSet<Block /*!*/>();
-
-      HashSet<Block /*!*/> /*!*/
-        keepAtAll = new HashSet<Block /*!*/>();
-
-      // async interface
-      public int SplitIndex { get; set; }
-      internal VCGen.ErrorReporter reporter;
-
-      public Split(VCGenOptions options, List<Block /*!*/> /*!*/ blocks,
-        Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
-        VCGen /*!*/ par, ImplementationRun run)
-      {
-        Contract.Requires(cce.NonNullElements(blocks));
-        Contract.Requires(gotoCmdOrigins != null);
-        Contract.Requires(par != null);
-        this.Blocks = blocks;
-        this.GotoCmdOrigins = gotoCmdOrigins;
-        this.parent = par;
-        this.Run = run;
-        this.Options = options;
-        Interlocked.Increment(ref currentId);
-
-        TopLevelDeclarations = par.program.TopLevelDeclarations;
-        PrintTopLevelDeclarationsForPruning(par.program, Implementation, "before");
-        TopLevelDeclarations = Prune.GetLiveDeclarations(options, par.program, blocks).ToList();
-        PrintTopLevelDeclarationsForPruning(par.program, Implementation, "after");
-        randomGen = new Random(RandomSeed ?? 0);
+      foreach (var declaration in (TopLevelDeclarations ?? program.TopLevelDeclarations).
+               Except(functionAxioms.Concat(constantAxioms)).ToList()) {
+        declaration.Emit(writer, 0);
       }
 
-      private void PrintTopLevelDeclarationsForPruning(Program program, Implementation implementation, string suffix)
+      writer.Close();
+    }
+
+    public double Cost
+    {
+      get
       {
-        if (!Options.Prune || Options.PrintPrunedFile == null)
-        {
-          return;
-        }
-
-        using var writer = new TokenTextWriter(
-          $"{Options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}.bpl", false,
-          Options.PrettyPrint, Options);
-
-        var functionAxioms = 
-          program.Functions.Where(f => f.DefinitionAxioms.Any()).SelectMany(f => f.DefinitionAxioms);
-        var constantAxioms = 
-          program.Constants.Where(f => f.DefinitionAxioms.Any()).SelectMany(c => c.DefinitionAxioms);
-
-        foreach (var declaration in (TopLevelDeclarations ?? program.TopLevelDeclarations).
-                 Except(functionAxioms.Concat(constantAxioms)).ToList()) {
-          declaration.Emit(writer, 0);
-        }
-
-        writer.Close();
+        ComputeBestSplit();
+        return totalCost;
       }
+    }
 
-      public double Cost
+    public bool LastChance
+    {
+      get
       {
-        get
-        {
-          ComputeBestSplit();
-          return totalCost;
-        }
+        ComputeBestSplit();
+        return assertionCount == 1 && score < 0;
       }
+    }
 
-      public bool LastChance
+    public string Stats
+    {
+      get
       {
-        get
-        {
-          ComputeBestSplit();
-          return assertionCount == 1 && score < 0;
-        }
+        ComputeBestSplit();
+        return $"(cost:{totalCost:0}/{assertionCost:0}{(LastChance ? " last" : "")})";
       }
+    }
 
-      public string Stats
+    public void DumpDot(int splitNum)
+    {
+      using (System.IO.StreamWriter sw = System.IO.File.CreateText($"{Implementation.Name}.split.{splitNum}.dot"))
       {
-        get
-        {
-          ComputeBestSplit();
-          return $"(cost:{totalCost:0}/{assertionCost:0}{(LastChance ? " last" : "")})";
-        }
-      }
+        sw.WriteLine("digraph G {");
 
-      public void DumpDot(int splitNum)
-      {
-        using (System.IO.StreamWriter sw = System.IO.File.CreateText($"{Implementation.Name}.split.{splitNum}.dot"))
-        {
-          sw.WriteLine("digraph G {");
-
-          ComputeBestSplit();
-          List<Block> saved = assumizedBranches;
-          Contract.Assert(saved != null);
-          assumizedBranches = new List<Block>();
-          DoComputeScore(false);
-          assumizedBranches = saved;
-
-          foreach (Block b in bigBlocks)
-          {
-            Contract.Assert(b != null);
-            BlockStats s = GetBlockStats(b);
-            foreach (Block t in s.virtualSuccessors)
-            {
-              Contract.Assert(t != null);
-              sw.WriteLine("n{0} -> n{1};", s.id, GetBlockStats(t).id);
-            }
-
-            sw.WriteLine("n{0} [label=\"{1}:\\n({2:0.0}+{3:0.0})*{4:0.0}\"{5}];",
-              s.id, b.Label,
-              s.assertionCost, s.assumptionCost, s.incomingPaths,
-              s.assertionCost > 0 ? ",shape=box" : "");
-          }
-
-          sw.WriteLine("}");
-          sw.Close();
-        }
-
-        string filename = string.Format("{0}.split.{1}.bpl", Implementation.Name, splitNum);
-        using (System.IO.StreamWriter sw = System.IO.File.CreateText(filename))
-        {
-          int oldPrintUnstructured = Options.PrintUnstructured;
-          Options.PrintUnstructured = 2; // print only the unstructured program
-          bool oldPrintDesugaringSetting = Options.PrintDesugarings;
-          Options.PrintDesugarings = false;
-          List<Block> backup = Implementation.Blocks;
-          Contract.Assert(backup != null);
-          Implementation.Blocks = Blocks;
-          Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false, Options), 0);
-          Implementation.Blocks = backup;
-          Options.PrintDesugarings = oldPrintDesugaringSetting;
-          Options.PrintUnstructured = oldPrintUnstructured;
-        }
-      }
-
-      int bsid;
-
-      BlockStats GetBlockStats(Block b)
-      {
-        Contract.Requires(b != null);
-        Contract.Ensures(Contract.Result<BlockStats>() != null);
-
-        if (!stats.TryGetValue(b, out var s))
-        {
-          s = new BlockStats(b, bsid++);
-          stats[b] = s;
-        }
-
-        return cce.NonNull(s);
-      }
-
-      double AssertionCost(PredicateCmd c)
-      {
-        return 1.0;
-      }
-
-      void CountAssertions(Block b)
-      {
-        Contract.Requires(b != null);
-        BlockStats s = GetBlockStats(b);
-        if (s.assertionCost >= 0)
-        {
-          return; // already done
-        }
-
-        s.bigBlock = true;
-        s.assertionCost = 0;
-        s.assumptionCost = 0;
-        foreach (Cmd c in b.Cmds)
-        {
-          if (c is AssertCmd)
-          {
-            double cost = AssertionCost((AssertCmd) c);
-            s.assertionCost += cost;
-            assertionCount++;
-            assertionCost += cost;
-          }
-          else if (c is AssumeCmd)
-          {
-            s.assumptionCost += AssertionCost((AssumeCmd) c);
-          }
-        }
-
-        foreach (Block c in b.Exits())
-        {
-          Contract.Assert(c != null);
-          s.virtualSuccessors.Add(c);
-        }
-
-        if (s.virtualSuccessors.Count == 1)
-        {
-          Block next = s.virtualSuccessors[0];
-          BlockStats se = GetBlockStats(next);
-          CountAssertions(next);
-          if (next.Predecessors.Count > 1 || se.virtualSuccessors.Count != 1)
-          {
-            return;
-          }
-
-          s.virtualSuccessors[0] = se.virtualSuccessors[0];
-          s.assertionCost += se.assertionCost;
-          s.assumptionCost += se.assumptionCost;
-          se.bigBlock = false;
-        }
-      }
-
-      HashSet<Block /*!*/> /*!*/ ComputeReachableNodes(Block /*!*/ b)
-      {
-        Contract.Requires(b != null);
-        Contract.Ensures(cce.NonNull(Contract.Result<HashSet<Block /*!*/>>()));
-        BlockStats s = GetBlockStats(b);
-        if (s.reachableBlocks != null)
-        {
-          return s.reachableBlocks;
-        }
-
-        HashSet<Block /*!*/> blocks = new HashSet<Block /*!*/>();
-        s.reachableBlocks = blocks;
-        blocks.Add(b);
-        foreach (Block /*!*/ succ in b.Exits())
-        {
-          Contract.Assert(succ != null);
-          foreach (Block r in ComputeReachableNodes(succ))
-          {
-            Contract.Assert(r != null);
-            blocks.Add(r);
-          }
-        }
-
-        return blocks;
-      }
-
-      double ProverCost(double vcCost)
-      {
-        return vcCost * vcCost;
-      }
-
-      void ComputeBestSplit()
-      {
-        if (scoreComputed)
-        {
-          return;
-        }
-
-        scoreComputed = true;
-
-        assertionCount = 0;
-
-        foreach (Block b in Blocks)
-        {
-          Contract.Assert(b != null);
-          CountAssertions(b);
-        }
-
-        foreach (Block b in Blocks)
-        {
-          Contract.Assert(b != null);
-          BlockStats bs = GetBlockStats(b);
-          if (bs.bigBlock)
-          {
-            bigBlocks.Add(b);
-            foreach (Block ch in bs.virtualSuccessors)
-            {
-              Contract.Assert(ch != null);
-              BlockStats chs = GetBlockStats(ch);
-              if (!chs.bigBlock)
-              {
-                Options.OutputWriter.WriteLine("non-big {0} accessed from {1}", ch, b);
-                DumpDot(-1);
-                Contract.Assert(false);
-                throw new cce.UnreachableException();
-              }
-
-              chs.virtualPredecessors.Add(b);
-            }
-          }
-        }
-
-        assumizedBranches.Clear();
-        totalCost = ProverCost(DoComputeScore(false));
-
-        score = double.PositiveInfinity;
-        Block bestSplit = null;
-        List<Block> savedBranches = new List<Block>();
+        ComputeBestSplit();
+        List<Block> saved = assumizedBranches;
+        Contract.Assert(saved != null);
+        assumizedBranches = new List<Block>();
+        DoComputeScore(false);
+        assumizedBranches = saved;
 
         foreach (Block b in bigBlocks)
         {
           Contract.Assert(b != null);
-          GotoCmd gt = b.TransferCmd as GotoCmd;
-          if (gt == null)
+          BlockStats s = GetBlockStats(b);
+          foreach (Block t in s.virtualSuccessors)
           {
-            continue;
+            Contract.Assert(t != null);
+            sw.WriteLine("n{0} -> n{1};", s.id, GetBlockStats(t).id);
           }
 
-          List<Block> targ = cce.NonNull(gt.labelTargets);
-          if (targ.Count < 2)
-          {
-            continue;
-          }
-          // caution, we only consider two first exits
-
-          double left0, right0, left1, right1;
-          splitBlock = b;
-
-          assumizedBranches.Clear();
-          assumizedBranches.Add(cce.NonNull(targ[0]));
-          left0 = DoComputeScore(true);
-          right0 = DoComputeScore(false);
-
-          assumizedBranches.Clear();
-          for (int idx = 1; idx < targ.Count; idx++)
-          {
-            assumizedBranches.Add(cce.NonNull(targ[idx]));
-          }
-
-          left1 = DoComputeScore(true);
-          right1 = DoComputeScore(false);
-
-          double currentScore = ProverCost(left1) + ProverCost(right1);
-          double otherScore = ProverCost(left0) + ProverCost(right0);
-
-          if (otherScore < currentScore)
-          {
-            currentScore = otherScore;
-            assumizedBranches.Clear();
-            assumizedBranches.Add(cce.NonNull(targ[0]));
-          }
-
-          if (currentScore < score)
-          {
-            score = currentScore;
-            bestSplit = splitBlock;
-            savedBranches.Clear();
-            savedBranches.AddRange(assumizedBranches);
-          }
+          sw.WriteLine("n{0} [label=\"{1}:\\n({2:0.0}+{3:0.0})*{4:0.0}\"{5}];",
+            s.id, b.Label,
+            s.assertionCost, s.assumptionCost, s.incomingPaths,
+            s.assertionCost > 0 ? ",shape=box" : "");
         }
 
-        if (Options.VcsPathSplitMult * score > totalCost)
+        sw.WriteLine("}");
+        sw.Close();
+      }
+
+      string filename = string.Format("{0}.split.{1}.bpl", Implementation.Name, splitNum);
+      using (System.IO.StreamWriter sw = System.IO.File.CreateText(filename))
+      {
+        int oldPrintUnstructured = Options.PrintUnstructured;
+        Options.PrintUnstructured = 2; // print only the unstructured program
+        bool oldPrintDesugaringSetting = Options.PrintDesugarings;
+        Options.PrintDesugarings = false;
+        List<Block> backup = Implementation.Blocks;
+        Contract.Assert(backup != null);
+        Implementation.Blocks = Blocks;
+        Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false, Options), 0);
+        Implementation.Blocks = backup;
+        Options.PrintDesugarings = oldPrintDesugaringSetting;
+        Options.PrintUnstructured = oldPrintUnstructured;
+      }
+    }
+
+    int bsid;
+
+    BlockStats GetBlockStats(Block b)
+    {
+      Contract.Requires(b != null);
+      Contract.Ensures(Contract.Result<BlockStats>() != null);
+
+      if (!stats.TryGetValue(b, out var s))
+      {
+        s = new BlockStats(b, bsid++);
+        stats[b] = s;
+      }
+
+      return cce.NonNull(s);
+    }
+
+    double AssertionCost(PredicateCmd c)
+    {
+      return 1.0;
+    }
+
+    void CountAssertions(Block b)
+    {
+      Contract.Requires(b != null);
+      BlockStats s = GetBlockStats(b);
+      if (s.assertionCost >= 0)
+      {
+        return; // already done
+      }
+
+      s.bigBlock = true;
+      s.assertionCost = 0;
+      s.assumptionCost = 0;
+      foreach (Cmd c in b.Cmds)
+      {
+        if (c is AssertCmd)
         {
-          splitBlock = null;
-          score = -1;
+          double cost = AssertionCost((AssertCmd) c);
+          s.assertionCost += cost;
+          assertionCount++;
+          assertionCost += cost;
         }
-        else
+        else if (c is AssumeCmd)
         {
-          assumizedBranches = savedBranches;
-          splitBlock = bestSplit;
+          s.assumptionCost += AssertionCost((AssumeCmd) c);
         }
       }
 
-      void UpdateIncommingPaths(BlockStats s)
+      foreach (Block c in b.Exits())
       {
-        Contract.Requires(s != null);
-        if (s.incomingPaths < 0.0)
-        {
-          int count = 0;
-          s.incomingPaths = 0.0;
-          if (!keepAtAll.Contains(s.block))
-          {
-            return;
-          }
-
-          foreach (Block b in s.virtualPredecessors)
-          {
-            Contract.Assert(b != null);
-            BlockStats ch = GetBlockStats(b);
-            Contract.Assert(ch != null);
-            UpdateIncommingPaths(ch);
-            if (ch.incomingPaths > 0.0)
-            {
-              s.incomingPaths += ch.incomingPaths;
-              count++;
-            }
-          }
-
-          if (count > 1)
-          {
-            s.incomingPaths *= Options.VcsPathJoinMult;
-          }
-        }
+        Contract.Assert(c != null);
+        s.virtualSuccessors.Add(c);
       }
 
-      void ComputeBlockSetsHelper(Block b, bool allowSmall)
+      if (s.virtualSuccessors.Count == 1)
       {
-        Contract.Requires(b != null);
-        if (keepAtAll.Contains(b))
+        Block next = s.virtualSuccessors[0];
+        BlockStats se = GetBlockStats(next);
+        CountAssertions(next);
+        if (next.Predecessors.Count > 1 || se.virtualSuccessors.Count != 1)
         {
           return;
         }
 
-        keepAtAll.Add(b);
+        s.virtualSuccessors[0] = se.virtualSuccessors[0];
+        s.assertionCost += se.assertionCost;
+        s.assumptionCost += se.assumptionCost;
+        se.bigBlock = false;
+      }
+    }
 
-        if (allowSmall)
+    HashSet<Block /*!*/> /*!*/ ComputeReachableNodes(Block /*!*/ b)
+    {
+      Contract.Requires(b != null);
+      Contract.Ensures(cce.NonNull(Contract.Result<HashSet<Block /*!*/>>()));
+      BlockStats s = GetBlockStats(b);
+      if (s.reachableBlocks != null)
+      {
+        return s.reachableBlocks;
+      }
+
+      HashSet<Block /*!*/> blocks = new HashSet<Block /*!*/>();
+      s.reachableBlocks = blocks;
+      blocks.Add(b);
+      foreach (Block /*!*/ succ in b.Exits())
+      {
+        Contract.Assert(succ != null);
+        foreach (Block r in ComputeReachableNodes(succ))
         {
-          foreach (Block ch in b.Exits())
+          Contract.Assert(r != null);
+          blocks.Add(r);
+        }
+      }
+
+      return blocks;
+    }
+
+    double ProverCost(double vcCost)
+    {
+      return vcCost * vcCost;
+    }
+
+    void ComputeBestSplit()
+    {
+      if (scoreComputed)
+      {
+        return;
+      }
+
+      scoreComputed = true;
+
+      assertionCount = 0;
+
+      foreach (Block b in Blocks)
+      {
+        Contract.Assert(b != null);
+        CountAssertions(b);
+      }
+
+      foreach (Block b in Blocks)
+      {
+        Contract.Assert(b != null);
+        BlockStats bs = GetBlockStats(b);
+        if (bs.bigBlock)
+        {
+          bigBlocks.Add(b);
+          foreach (Block ch in bs.virtualSuccessors)
           {
             Contract.Assert(ch != null);
-            if (b == splitBlock && assumizedBranches.Contains(ch))
+            BlockStats chs = GetBlockStats(ch);
+            if (!chs.bigBlock)
             {
-              continue;
-            }
-
-            ComputeBlockSetsHelper(ch, allowSmall);
-          }
-        }
-        else
-        {
-          foreach (Block ch in GetBlockStats(b).virtualSuccessors)
-          {
-            Contract.Assert(ch != null);
-            if (b == splitBlock && assumizedBranches.Contains(ch))
-            {
-              continue;
-            }
-
-            ComputeBlockSetsHelper(ch, allowSmall);
-          }
-        }
-      }
-
-      void ComputeBlockSets(bool allowSmall)
-      {
-        protectedFromAssertToAssume.Clear();
-        keepAtAll.Clear();
-
-        Debug.Assert(splitBlock == null || GetBlockStats(splitBlock).bigBlock);
-        Debug.Assert(GetBlockStats(Blocks[0]).bigBlock);
-
-        if (assertToAssume)
-        {
-          foreach (Block b in allowSmall ? Blocks : bigBlocks)
-          {
-            Contract.Assert(b != null);
-            if (ComputeReachableNodes(b).Contains(cce.NonNull(splitBlock)))
-            {
-              keepAtAll.Add(b);
-            }
-          }
-
-          foreach (Block b in assumizedBranches)
-          {
-            Contract.Assert(b != null);
-            foreach (Block r in ComputeReachableNodes(b))
-            {
-              Contract.Assert(r != null);
-              if (allowSmall || GetBlockStats(r).bigBlock)
-              {
-                keepAtAll.Add(r);
-                protectedFromAssertToAssume.Add(r);
-              }
-            }
-          }
-        }
-        else
-        {
-          ComputeBlockSetsHelper(Blocks[0], allowSmall);
-        }
-      }
-
-      bool ShouldAssumize(Block b)
-      {
-        Contract.Requires(b != null);
-        return assertToAssume && !protectedFromAssertToAssume.Contains(b);
-      }
-
-      double DoComputeScore(bool aa)
-      {
-        assertToAssume = aa;
-        ComputeBlockSets(false);
-
-        foreach (Block b in bigBlocks)
-        {
-          Contract.Assert(b != null);
-          GetBlockStats(b).incomingPaths = -1.0;
-        }
-
-        GetBlockStats(Blocks[0]).incomingPaths = 1.0;
-
-        double cost = 0.0;
-        foreach (Block b in bigBlocks)
-        {
-          Contract.Assert(b != null);
-          if (keepAtAll.Contains(b))
-          {
-            BlockStats s = GetBlockStats(b);
-            UpdateIncommingPaths(s);
-            double local = s.assertionCost;
-            if (ShouldAssumize(b))
-            {
-              local = (s.assertionCost + s.assumptionCost) * Options.VcsAssumeMult;
-            }
-            else
-            {
-              local = s.assumptionCost * Options.VcsAssumeMult + s.assertionCost;
-            }
-
-            local = local + local * s.incomingPaths * Options.VcsPathCostMult;
-            cost += local;
-          }
-        }
-
-        return cost;
-      }
-
-      List<Cmd> SliceCmds(Block b)
-      {
-        Contract.Requires(b != null);
-        Contract.Ensures(Contract.Result<List<Cmd>>() != null);
-
-        List<Cmd> seq = b.Cmds;
-        Contract.Assert(seq != null);
-        if (!doingSlice && !ShouldAssumize(b))
-        {
-          return seq;
-        }
-
-        List<Cmd> res = new List<Cmd>();
-        foreach (Cmd c in seq)
-        {
-          Contract.Assert(c != null);
-          AssertCmd a = c as AssertCmd;
-          Cmd theNewCmd = c;
-          bool swap = false;
-          if (a != null)
-          {
-            if (doingSlice)
-            {
-              double cost = AssertionCost(a);
-              bool first = (sliceLimit - cost) >= 0 || sliceInitialLimit == sliceLimit;
-              sliceLimit -= cost;
-              swap = slicePos == first;
-            }
-            else if (assertToAssume)
-            {
-              swap = true;
-            }
-            else
-            {
+              Options.OutputWriter.WriteLine("non-big {0} accessed from {1}", ch, b);
+              DumpDot(-1);
               Contract.Assert(false);
               throw new cce.UnreachableException();
             }
 
-            if (swap)
-            {
-              theNewCmd = VCGen.AssertTurnedIntoAssume(Options, a);
-            }
+            chs.virtualPredecessors.Add(b);
           }
-
-          res.Add(theNewCmd);
         }
-
-        return res;
       }
 
-      Block CloneBlock(Block b)
+      assumizedBranches.Clear();
+      totalCost = ProverCost(DoComputeScore(false));
+
+      score = double.PositiveInfinity;
+      Block bestSplit = null;
+      List<Block> savedBranches = new List<Block>();
+
+      foreach (Block b in bigBlocks)
       {
-        Contract.Requires(b != null);
-        Contract.Ensures(Contract.Result<Block>() != null);
-
-        if (copies.TryGetValue(b, out var res))
-        {
-          return cce.NonNull(res);
-        }
-
-        res = new Block(b.tok, b.Label, SliceCmds(b), b.TransferCmd);
+        Contract.Assert(b != null);
         GotoCmd gt = b.TransferCmd as GotoCmd;
-        copies[b] = res;
-        if (gt != null)
+        if (gt == null)
         {
-          GotoCmd newGoto = new GotoCmd(gt.tok, new List<String>(), new List<Block>());
-          res.TransferCmd = newGoto;
-          int pos = 0;
-          foreach (Block ch in cce.NonNull(gt.labelTargets))
-          {
-            Contract.Assert(ch != null);
-            Contract.Assert(doingSlice ||
-                            (assertToAssume || (keepAtAll.Contains(ch) || assumizedBranches.Contains(ch))));
-            if (doingSlice ||
-                ((b != splitBlock || assumizedBranches.Contains(ch) == assertToAssume) &&
-                 keepAtAll.Contains(ch)))
-            {
-              newGoto.AddTarget(CloneBlock(ch));
-            }
-
-            pos++;
-          }
+          continue;
         }
 
-        return res;
+        List<Block> targ = cce.NonNull(gt.labelTargets);
+        if (targ.Count < 2)
+        {
+          continue;
+        }
+        // caution, we only consider two first exits
+
+        double left0, right0, left1, right1;
+        splitBlock = b;
+
+        assumizedBranches.Clear();
+        assumizedBranches.Add(cce.NonNull(targ[0]));
+        left0 = DoComputeScore(true);
+        right0 = DoComputeScore(false);
+
+        assumizedBranches.Clear();
+        for (int idx = 1; idx < targ.Count; idx++)
+        {
+          assumizedBranches.Add(cce.NonNull(targ[idx]));
+        }
+
+        left1 = DoComputeScore(true);
+        right1 = DoComputeScore(false);
+
+        double currentScore = ProverCost(left1) + ProverCost(right1);
+        double otherScore = ProverCost(left0) + ProverCost(right0);
+
+        if (otherScore < currentScore)
+        {
+          currentScore = otherScore;
+          assumizedBranches.Clear();
+          assumizedBranches.Add(cce.NonNull(targ[0]));
+        }
+
+        if (currentScore < score)
+        {
+          score = currentScore;
+          bestSplit = splitBlock;
+          savedBranches.Clear();
+          savedBranches.AddRange(assumizedBranches);
+        }
       }
 
-      Split DoSplit()
+      if (Options.VcsPathSplitMult * score > totalCost)
       {
-        Contract.Ensures(Contract.Result<Split>() != null);
+        splitBlock = null;
+        score = -1;
+      }
+      else
+      {
+        assumizedBranches = savedBranches;
+        splitBlock = bestSplit;
+      }
+    }
 
-        copies.Clear();
-        CloneBlock(Blocks[0]);
-        List<Block> newBlocks = new List<Block>();
-        Dictionary<TransferCmd, ReturnCmd> newGotoCmdOrigins = new Dictionary<TransferCmd, ReturnCmd>();
-        foreach (Block b in Blocks)
+    void UpdateIncommingPaths(BlockStats s)
+    {
+      Contract.Requires(s != null);
+      if (s.incomingPaths < 0.0)
+      {
+        int count = 0;
+        s.incomingPaths = 0.0;
+        if (!keepAtAll.Contains(s.block))
+        {
+          return;
+        }
+
+        foreach (Block b in s.virtualPredecessors)
         {
           Contract.Assert(b != null);
-          if (copies.TryGetValue(b, out var tmp))
+          BlockStats ch = GetBlockStats(b);
+          Contract.Assert(ch != null);
+          UpdateIncommingPaths(ch);
+          if (ch.incomingPaths > 0.0)
           {
-            newBlocks.Add(cce.NonNull(tmp));
-            if (GotoCmdOrigins.ContainsKey(b.TransferCmd))
-            {
-              newGotoCmdOrigins[tmp.TransferCmd] = GotoCmdOrigins[b.TransferCmd];
-            }
-
-            foreach (Block p in b.Predecessors)
-            {
-              Contract.Assert(p != null);
-              if (copies.TryGetValue(p, out var tmp2))
-              {
-                tmp.Predecessors.Add(tmp2);
-              }
-            }
+            s.incomingPaths += ch.incomingPaths;
+            count++;
           }
         }
 
-        return new Split(Options, newBlocks, newGotoCmdOrigins, parent, Run);
+        if (count > 1)
+        {
+          s.incomingPaths *= Options.VcsPathJoinMult;
+        }
+      }
+    }
+
+    void ComputeBlockSetsHelper(Block b, bool allowSmall)
+    {
+      Contract.Requires(b != null);
+      if (keepAtAll.Contains(b))
+      {
+        return;
       }
 
-      Split SplitAt(int idx)
+      keepAtAll.Add(b);
+
+      if (allowSmall)
       {
-        Contract.Ensures(Contract.Result<Split>() != null);
+        foreach (Block ch in b.Exits())
+        {
+          Contract.Assert(ch != null);
+          if (b == splitBlock && assumizedBranches.Contains(ch))
+          {
+            continue;
+          }
 
-        assertToAssume = idx == 0;
-        doingSlice = false;
-        ComputeBlockSets(true);
-
-        return DoSplit();
+          ComputeBlockSetsHelper(ch, allowSmall);
+        }
       }
-
-      Split SliceAsserts(double limit, bool pos)
+      else
       {
-        Contract.Ensures(Contract.Result<Split>() != null);
+        foreach (Block ch in GetBlockStats(b).virtualSuccessors)
+        {
+          Contract.Assert(ch != null);
+          if (b == splitBlock && assumizedBranches.Contains(ch))
+          {
+            continue;
+          }
 
-        slicePos = pos;
-        sliceLimit = limit;
-        sliceInitialLimit = limit;
-        doingSlice = true;
-        Split r = DoSplit();
-        /*
-        Console.WriteLine("split {0} / {1} -->", limit, pos);
-        List<Block!> tmp = impl.Blocks;
-        impl.Blocks = r.blocks;
-        EmitImpl(impl, false);
-        impl.Blocks = tmp;
-        */
-
-        return r;
+          ComputeBlockSetsHelper(ch, allowSmall);
+        }
       }
+    }
 
-      void Print()
+    void ComputeBlockSets(bool allowSmall)
+    {
+      protectedFromAssertToAssume.Clear();
+      keepAtAll.Clear();
+
+      Debug.Assert(splitBlock == null || GetBlockStats(splitBlock).bigBlock);
+      Debug.Assert(GetBlockStats(Blocks[0]).bigBlock);
+
+      if (assertToAssume)
       {
-        List<Block> tmp = Implementation.Blocks;
-        Contract.Assert(tmp != null);
-        Implementation.Blocks = Blocks;
-        ConditionGeneration.EmitImpl(Options, Run, false);
-        Implementation.Blocks = tmp;
-      }
-
-      public Counterexample ToCounterexample(ProverContext context)
-      {
-        Contract.Requires(context != null);
-        Contract.Ensures(Contract.Result<Counterexample>() != null);
-
-        List<Block> trace = new List<Block>();
-        foreach (Block b in Blocks)
+        foreach (Block b in allowSmall ? Blocks : bigBlocks)
         {
           Contract.Assert(b != null);
-          trace.Add(b);
+          if (ComputeReachableNodes(b).Contains(cce.NonNull(splitBlock)))
+          {
+            keepAtAll.Add(b);
+          }
         }
 
-        foreach (Block b in Blocks)
+        foreach (Block b in assumizedBranches)
         {
           Contract.Assert(b != null);
-          foreach (Cmd c in b.Cmds)
+          foreach (Block r in ComputeReachableNodes(b))
           {
-            Contract.Assert(c != null);
-            if (c is AssertCmd)
+            Contract.Assert(r != null);
+            if (allowSmall || GetBlockStats(r).bigBlock)
             {
-              var counterexample = VCGen.AssertCmdToCounterexample(Options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context, this);
-              Counterexamples.Add(counterexample);
-              return counterexample;
+              keepAtAll.Add(r);
+              protectedFromAssertToAssume.Add(r);
             }
           }
         }
+      }
+      else
+      {
+        ComputeBlockSetsHelper(Blocks[0], allowSmall);
+      }
+    }
 
-        Contract.Assume(false);
-        throw new cce.UnreachableException();
+    bool ShouldAssumize(Block b)
+    {
+      Contract.Requires(b != null);
+      return assertToAssume && !protectedFromAssertToAssume.Contains(b);
+    }
+
+    double DoComputeScore(bool aa)
+    {
+      assertToAssume = aa;
+      ComputeBlockSets(false);
+
+      foreach (Block b in bigBlocks)
+      {
+        Contract.Assert(b != null);
+        GetBlockStats(b).incomingPaths = -1.0;
       }
 
-      public static List<Split /*!*/> /*!*/ DoSplit(Split initial, double splitThreshold, int maxSplits)
+      GetBlockStats(Blocks[0]).incomingPaths = 1.0;
+
+      double cost = 0.0;
+      foreach (Block b in bigBlocks)
       {
-        Contract.Requires(initial != null);
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<Split>>()));
-
-        var run = initial.Run;
-        var result = new List<Split> { initial };
-
-        while (result.Count < maxSplits)
+        Contract.Assert(b != null);
+        if (keepAtAll.Contains(b))
         {
-          Split best = null;
-          int bestIndex = 0;
-          for (var index = 0; index < result.Count; index++) {
-            var split = result[index];
-            Contract.Assert(split != null);
-            split.ComputeBestSplit(); // TODO check totalCost first
-            if (split.totalCost > splitThreshold &&
-                (best == null || best.totalCost < split.totalCost) &&
-                (split.assertionCount > 1 || split.splitBlock != null)) {
-              best = split;
-              bestIndex = index;
-            }
-          }
-
-          if (best == null)
+          BlockStats s = GetBlockStats(b);
+          UpdateIncommingPaths(s);
+          double local = s.assertionCost;
+          if (ShouldAssumize(b))
           {
-            break; // no split found
-          }
-
-          Split s0, s1;
-
-          bool splitStats = initial.Options.TraceVerify;
-
-          if (splitStats)
-          {
-            run.OutputWriter.WriteLine("{0} {1} -->", best.splitBlock == null ? "SLICE" : ("SPLIT@" + best.splitBlock.Label),
-              best.Stats);
-            if (best.splitBlock != null)
-            {
-              GotoCmd g = best.splitBlock.TransferCmd as GotoCmd;
-              if (g != null)
-              {
-                run.OutputWriter.Write("    exits: ");
-                foreach (Block b in cce.NonNull(g.labelTargets))
-                {
-                  Contract.Assert(b != null);
-                  run.OutputWriter.Write("{0} ", b.Label);
-                }
-
-                run.OutputWriter.WriteLine("");
-                run.OutputWriter.Write("    assumized: ");
-                foreach (Block b in best.assumizedBranches)
-                {
-                  Contract.Assert(b != null);
-                  run.OutputWriter.Write("{0} ", b.Label);
-                }
-
-                run.OutputWriter.WriteLine("");
-              }
-            }
-          }
-
-          if (best.splitBlock != null)
-          {
-            s0 = best.SplitAt(0);
-            s1 = best.SplitAt(1);
+            local = (s.assertionCost + s.assumptionCost) * Options.VcsAssumeMult;
           }
           else
           {
-            best.splitBlock = null;
-            s0 = best.SliceAsserts(best.assertionCost / 2, true);
-            s1 = best.SliceAsserts(best.assertionCost / 2, false);
+            local = s.assumptionCost * Options.VcsAssumeMult + s.assertionCost;
           }
 
-          if (true)
+          local = local + local * s.incomingPaths * Options.VcsPathCostMult;
+          cost += local;
+        }
+      }
+
+      return cost;
+    }
+
+    List<Cmd> SliceCmds(Block b)
+    {
+      Contract.Requires(b != null);
+      Contract.Ensures(Contract.Result<List<Cmd>>() != null);
+
+      List<Cmd> seq = b.Cmds;
+      Contract.Assert(seq != null);
+      if (!doingSlice && !ShouldAssumize(b))
+      {
+        return seq;
+      }
+
+      List<Cmd> res = new List<Cmd>();
+      foreach (Cmd c in seq)
+      {
+        Contract.Assert(c != null);
+        AssertCmd a = c as AssertCmd;
+        Cmd theNewCmd = c;
+        bool swap = false;
+        if (a != null)
+        {
+          if (doingSlice)
           {
-            var ss = new List<Block>
+            double cost = AssertionCost(a);
+            bool first = (sliceLimit - cost) >= 0 || sliceInitialLimit == sliceLimit;
+            sliceLimit -= cost;
+            swap = slicePos == first;
+          }
+          else if (assertToAssume)
+          {
+            swap = true;
+          }
+          else
+          {
+            Contract.Assert(false);
+            throw new cce.UnreachableException();
+          }
+
+          if (swap)
+          {
+            theNewCmd = VCGen.AssertTurnedIntoAssume(Options, a);
+          }
+        }
+
+        res.Add(theNewCmd);
+      }
+
+      return res;
+    }
+
+    Block CloneBlock(Block b)
+    {
+      Contract.Requires(b != null);
+      Contract.Ensures(Contract.Result<Block>() != null);
+
+      if (copies.TryGetValue(b, out var res))
+      {
+        return cce.NonNull(res);
+      }
+
+      res = new Block(b.tok, b.Label, SliceCmds(b), b.TransferCmd);
+      GotoCmd gt = b.TransferCmd as GotoCmd;
+      copies[b] = res;
+      if (gt != null)
+      {
+        GotoCmd newGoto = new GotoCmd(gt.tok, new List<String>(), new List<Block>());
+        res.TransferCmd = newGoto;
+        int pos = 0;
+        foreach (Block ch in cce.NonNull(gt.labelTargets))
+        {
+          Contract.Assert(ch != null);
+          Contract.Assert(doingSlice ||
+                          (assertToAssume || (keepAtAll.Contains(ch) || assumizedBranches.Contains(ch))));
+          if (doingSlice ||
+              ((b != splitBlock || assumizedBranches.Contains(ch) == assertToAssume) &&
+               keepAtAll.Contains(ch)))
+          {
+            newGoto.AddTarget(CloneBlock(ch));
+          }
+
+          pos++;
+        }
+      }
+
+      return res;
+    }
+
+    Split DoSplit()
+    {
+      Contract.Ensures(Contract.Result<Split>() != null);
+
+      copies.Clear();
+      CloneBlock(Blocks[0]);
+      List<Block> newBlocks = new List<Block>();
+      Dictionary<TransferCmd, ReturnCmd> newGotoCmdOrigins = new Dictionary<TransferCmd, ReturnCmd>();
+      foreach (Block b in Blocks)
+      {
+        Contract.Assert(b != null);
+        if (copies.TryGetValue(b, out var tmp))
+        {
+          newBlocks.Add(cce.NonNull(tmp));
+          if (GotoCmdOrigins.ContainsKey(b.TransferCmd))
+          {
+            newGotoCmdOrigins[tmp.TransferCmd] = GotoCmdOrigins[b.TransferCmd];
+          }
+
+          foreach (Block p in b.Predecessors)
+          {
+            Contract.Assert(p != null);
+            if (copies.TryGetValue(p, out var tmp2))
             {
-              s0.Blocks[0],
-              s1.Blocks[0]
-            };
-            try
-            {
-              best.SoundnessCheck(new HashSet<List<Block>>(new BlockListComparer()), best.Blocks[0], ss);
+              tmp.Predecessors.Add(tmp2);
             }
-            catch (System.Exception e)
+          }
+        }
+      }
+
+      return new Split(Options, newBlocks, newGotoCmdOrigins, parent, Run);
+    }
+
+    Split SplitAt(int idx)
+    {
+      Contract.Ensures(Contract.Result<Split>() != null);
+
+      assertToAssume = idx == 0;
+      doingSlice = false;
+      ComputeBlockSets(true);
+
+      return DoSplit();
+    }
+
+    Split SliceAsserts(double limit, bool pos)
+    {
+      Contract.Ensures(Contract.Result<Split>() != null);
+
+      slicePos = pos;
+      sliceLimit = limit;
+      sliceInitialLimit = limit;
+      doingSlice = true;
+      Split r = DoSplit();
+      /*
+      Console.WriteLine("split {0} / {1} -->", limit, pos);
+      List<Block!> tmp = impl.Blocks;
+      impl.Blocks = r.blocks;
+      EmitImpl(impl, false);
+      impl.Blocks = tmp;
+      */
+
+      return r;
+    }
+
+    void Print()
+    {
+      List<Block> tmp = Implementation.Blocks;
+      Contract.Assert(tmp != null);
+      Implementation.Blocks = Blocks;
+      ConditionGeneration.EmitImpl(Options, Run, false);
+      Implementation.Blocks = tmp;
+    }
+
+    public Counterexample ToCounterexample(ProverContext context)
+    {
+      Contract.Requires(context != null);
+      Contract.Ensures(Contract.Result<Counterexample>() != null);
+
+      List<Block> trace = new List<Block>();
+      foreach (Block b in Blocks)
+      {
+        Contract.Assert(b != null);
+        trace.Add(b);
+      }
+
+      foreach (Block b in Blocks)
+      {
+        Contract.Assert(b != null);
+        foreach (Cmd c in b.Cmds)
+        {
+          Contract.Assert(c != null);
+          if (c is AssertCmd)
+          {
+            var counterexample = VCGen.AssertCmdToCounterexample(Options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context, this);
+            Counterexamples.Add(counterexample);
+            return counterexample;
+          }
+        }
+      }
+
+      Contract.Assume(false);
+      throw new cce.UnreachableException();
+    }
+
+    public static List<Split /*!*/> /*!*/ DoSplit(Split initial, double splitThreshold, int maxSplits)
+    {
+      Contract.Requires(initial != null);
+      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Split>>()));
+
+      var run = initial.Run;
+      var result = new List<Split> { initial };
+
+      while (result.Count < maxSplits)
+      {
+        Split best = null;
+        int bestIndex = 0;
+        for (var index = 0; index < result.Count; index++) {
+          var split = result[index];
+          Contract.Assert(split != null);
+          split.ComputeBestSplit(); // TODO check totalCost first
+          if (split.totalCost > splitThreshold &&
+              (best == null || best.totalCost < split.totalCost) &&
+              (split.assertionCount > 1 || split.splitBlock != null)) {
+            best = split;
+            bestIndex = index;
+          }
+        }
+
+        if (best == null)
+        {
+          break; // no split found
+        }
+
+        Split s0, s1;
+
+        bool splitStats = initial.Options.TraceVerify;
+
+        if (splitStats)
+        {
+          run.OutputWriter.WriteLine("{0} {1} -->", best.splitBlock == null ? "SLICE" : ("SPLIT@" + best.splitBlock.Label),
+            best.Stats);
+          if (best.splitBlock != null)
+          {
+            GotoCmd g = best.splitBlock.TransferCmd as GotoCmd;
+            if (g != null)
             {
-              run.OutputWriter.WriteLine(e);
-              best.DumpDot(-1);
-              s0.DumpDot(-2);
-              s1.DumpDot(-3);
-              Contract.Assert(false);
-              throw new cce.UnreachableException();
-            }
-          }
-
-          if (splitStats)
-          {
-            s0.ComputeBestSplit();
-            s1.ComputeBestSplit();
-            run.OutputWriter.WriteLine("    --> {0}", s0.Stats);
-            run.OutputWriter.WriteLine("    --> {0}", s1.Stats);
-          }
-
-          if (initial.Options.TraceVerify)
-          {
-            best.Print();
-          }
-
-          result[bestIndex] = s0;
-          result.Add(s1);
-        }
-
-        return result;
-      }
-
-      public (Bpl.Outcome outcome, VerificationRunResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
-      {
-        Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
-        Bpl.Outcome outcome = cce.NonNull(checker).ReadOutcome();
-
-        if (Options.Trace && SplitIndex >= 0)
-        {
-          Run.OutputWriter.WriteLine("      --> split #{0} done,  [{1} s] {2}", SplitIndex + 1,
-            checker.ProverRunTime.TotalSeconds, outcome);
-        }
-        if (Options.Trace && Options.TrackVerificationCoverage) {
-          Run.OutputWriter.WriteLine("Proof dependencies:\n  {0}",
-            string.Join("\n  ", CoveredElements.Select(s => s.Description).OrderBy(s => s)));
-        }
-
-        var resourceCount = checker.GetProverResourceCount();
-        var result = new VerificationRunResult(
-          VcNum: SplitIndex + 1,
-          Iteration: iteration,
-          StartTime: checker.ProverStart,
-          Outcome: outcome,
-          RunTime: checker.ProverRunTime,
-          MaxCounterExamples: checker.Options.ErrorLimit,
-          CounterExamples: Counterexamples,
-          Asserts: Asserts,
-          CoveredElements: CoveredElements,
-          ResourceCount: resourceCount,
-          SolverUsed: (Options as SMTLibSolverOptions)?.Solver);
-        callback.OnVCResult(result);
-
-        if (Options.VcsDumpSplits)
-        {
-          DumpDot(SplitIndex);
-        }
-
-        return (outcome, result, resourceCount);
-      }
-
-      public List<Counterexample> Counterexamples { get; } = new();
-
-      public HashSet<TrackedNodeComponent> CoveredElements { get; } = new();
-
-      /// <summary>
-      /// As a side effect, updates "this.parent.CumulativeAssertionCount".
-      /// </summary>
-      public async Task BeginCheck(TextWriter traceWriter, Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, uint timeout,
-        uint rlimit, CancellationToken cancellationToken)
-      {
-        Contract.Requires(checker != null);
-        Contract.Requires(callback != null);
-
-        VCExpr vc;
-        // Lock impl since we're setting impl.Blocks that is used to generate the VC.
-        lock (Implementation) {
-          Implementation.Blocks = Blocks;
-
-          var absyIds = new ControlFlowIdMap<Absy>();
-
-          ProverContext ctx = checker.TheoremProver.Context;
-          Boogie2VCExprTranslator bet = ctx.BoogieExprTranslator;
-          var cc = new VCGen.CodeExprConversionClosure(traceWriter, checker.Pool.Options, absyIds, ctx);
-          bet.SetCodeExprConverter(cc.CodeExprToVerificationCondition);
-
-          var exprGen = ctx.ExprGen;
-          VCExpr controlFlowVariableExpr = exprGen.Integer(BigNum.ZERO);
-          vc = parent.GenerateVCAux(Implementation, controlFlowVariableExpr, absyIds, checker.TheoremProver.Context);
-          Contract.Assert(vc != null);
-
-          vc = QuantifierInstantiationEngine.Instantiate(Implementation, exprGen, bet, vc);
-
-          VCExpr controlFlowFunctionAppl =
-            exprGen.ControlFlowFunctionApplication(exprGen.Integer(BigNum.ZERO), exprGen.Integer(BigNum.ZERO));
-          VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(Implementation.Blocks[0]))));
-          vc = exprGen.Implies(eqExpr, vc);
-          reporter = new VCGen.ErrorReporter(Options, GotoCmdOrigins, absyIds, Implementation.Blocks, Implementation.debugInfos, callback,
-            mvInfo, checker.TheoremProver.Context, parent.program, this);
-        }
-
-        if (Options.TraceVerify && SplitIndex >= 0)
-        {
-          Run.OutputWriter.WriteLine("-- after split #{0}", SplitIndex);
-          Print();
-        }
-
-        checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions().Select(kv => new OptionValue(kv.Key, kv.Value)));
-        await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
-      }
-
-      public string Description
-      {
-        get
-        {
-          string description = cce.NonNull(Implementation.Name);
-          if (SplitIndex >= 0) {
-            description += "_split" + SplitIndex;
-          }
-
-          return description;
-        }
-      }
-
-      private void SoundnessCheck(HashSet<List<Block> /*!*/> /*!*/ cache, Block /*!*/ orig,
-        List<Block /*!*/> /*!*/ copies)
-      {
-        Contract.Requires(cce.NonNull(cache));
-        Contract.Requires(orig != null);
-        Contract.Requires(copies != null);
-        {
-          var t = new List<Block> {orig};
-          foreach (Block b in copies)
-          {
-            Contract.Assert(b != null);
-            t.Add(b);
-          }
-
-          if (cache.Contains(t))
-          {
-            return;
-          }
-
-          cache.Add(t);
-        }
-
-        for (int i = 0; i < orig.Cmds.Count; ++i)
-        {
-          Cmd cmd = orig.Cmds[i];
-          if (cmd is AssertCmd)
-          {
-            int found = 0;
-            foreach (Block c in copies)
-            {
-              Contract.Assert(c != null);
-              if (c.Cmds[i] == cmd)
+              run.OutputWriter.Write("    exits: ");
+              foreach (Block b in cce.NonNull(g.labelTargets))
               {
-                found++;
+                Contract.Assert(b != null);
+                run.OutputWriter.Write("{0} ", b.Label);
               }
-            }
 
-            if (found == 0)
-            {
-              throw new System.Exception(string.Format("missing assertion: {0}({1})", cmd.tok.filename, cmd.tok.line));
+              run.OutputWriter.WriteLine("");
+              run.OutputWriter.Write("    assumized: ");
+              foreach (Block b in best.assumizedBranches)
+              {
+                Contract.Assert(b != null);
+                run.OutputWriter.Write("{0} ", b.Label);
+              }
+
+              run.OutputWriter.WriteLine("");
             }
           }
         }
 
-        foreach (Block exit in orig.Exits())
+        if (best.splitBlock != null)
         {
-          Contract.Assert(exit != null);
-          List<Block> newcopies = new List<Block>();
+          s0 = best.SplitAt(0);
+          s1 = best.SplitAt(1);
+        }
+        else
+        {
+          best.splitBlock = null;
+          s0 = best.SliceAsserts(best.assertionCost / 2, true);
+          s1 = best.SliceAsserts(best.assertionCost / 2, false);
+        }
+
+        if (true)
+        {
+          var ss = new List<Block>
+          {
+            s0.Blocks[0],
+            s1.Blocks[0]
+          };
+          try
+          {
+            best.SoundnessCheck(new HashSet<List<Block>>(new BlockListComparer()), best.Blocks[0], ss);
+          }
+          catch (System.Exception e)
+          {
+            run.OutputWriter.WriteLine(e);
+            best.DumpDot(-1);
+            s0.DumpDot(-2);
+            s1.DumpDot(-3);
+            Contract.Assert(false);
+            throw new cce.UnreachableException();
+          }
+        }
+
+        if (splitStats)
+        {
+          s0.ComputeBestSplit();
+          s1.ComputeBestSplit();
+          run.OutputWriter.WriteLine("    --> {0}", s0.Stats);
+          run.OutputWriter.WriteLine("    --> {0}", s1.Stats);
+        }
+
+        if (initial.Options.TraceVerify)
+        {
+          best.Print();
+        }
+
+        result[bestIndex] = s0;
+        result.Add(s1);
+      }
+
+      return result;
+    }
+
+    public (Bpl.Outcome outcome, VerificationRunResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
+    {
+      Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
+      Bpl.Outcome outcome = cce.NonNull(checker).ReadOutcome();
+
+      if (Options.Trace && SplitIndex >= 0)
+      {
+        Run.OutputWriter.WriteLine("      --> split #{0} done,  [{1} s] {2}", SplitIndex + 1,
+          checker.ProverRunTime.TotalSeconds, outcome);
+      }
+      if (Options.Trace && Options.TrackVerificationCoverage) {
+        Run.OutputWriter.WriteLine("Proof dependencies:\n  {0}",
+          string.Join("\n  ", CoveredElements.Select(s => s.Description).OrderBy(s => s)));
+      }
+
+      var resourceCount = checker.GetProverResourceCount();
+      var result = new VerificationRunResult(
+        VcNum: SplitIndex + 1,
+        Iteration: iteration,
+        StartTime: checker.ProverStart,
+        Outcome: outcome,
+        RunTime: checker.ProverRunTime,
+        MaxCounterExamples: checker.Options.ErrorLimit,
+        CounterExamples: Counterexamples,
+        Asserts: Asserts,
+        CoveredElements: CoveredElements,
+        ResourceCount: resourceCount,
+        SolverUsed: (Options as SMTLibSolverOptions)?.Solver);
+      callback.OnVCResult(result);
+
+      if (Options.VcsDumpSplits)
+      {
+        DumpDot(SplitIndex);
+      }
+
+      return (outcome, result, resourceCount);
+    }
+
+    public List<Counterexample> Counterexamples { get; } = new();
+
+    public HashSet<TrackedNodeComponent> CoveredElements { get; } = new();
+
+    /// <summary>
+    /// As a side effect, updates "this.parent.CumulativeAssertionCount".
+    /// </summary>
+    public async Task BeginCheck(TextWriter traceWriter, Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, uint timeout,
+      uint rlimit, CancellationToken cancellationToken)
+    {
+      Contract.Requires(checker != null);
+      Contract.Requires(callback != null);
+
+      VCExpr vc;
+      // Lock impl since we're setting impl.Blocks that is used to generate the VC.
+      lock (Implementation) {
+        Implementation.Blocks = Blocks;
+
+        var absyIds = new ControlFlowIdMap<Absy>();
+
+        ProverContext ctx = checker.TheoremProver.Context;
+        Boogie2VCExprTranslator bet = ctx.BoogieExprTranslator;
+        var cc = new VCGen.CodeExprConversionClosure(traceWriter, checker.Pool.Options, absyIds, ctx);
+        bet.SetCodeExprConverter(cc.CodeExprToVerificationCondition);
+
+        var exprGen = ctx.ExprGen;
+        VCExpr controlFlowVariableExpr = exprGen.Integer(BigNum.ZERO);
+        vc = parent.GenerateVCAux(Implementation, controlFlowVariableExpr, absyIds, checker.TheoremProver.Context);
+        Contract.Assert(vc != null);
+
+        vc = QuantifierInstantiationEngine.Instantiate(Implementation, exprGen, bet, vc);
+
+        VCExpr controlFlowFunctionAppl =
+          exprGen.ControlFlowFunctionApplication(exprGen.Integer(BigNum.ZERO), exprGen.Integer(BigNum.ZERO));
+        VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(Implementation.Blocks[0]))));
+        vc = exprGen.Implies(eqExpr, vc);
+        reporter = new VCGen.ErrorReporter(Options, GotoCmdOrigins, absyIds, Implementation.Blocks, Implementation.debugInfos, callback,
+          mvInfo, checker.TheoremProver.Context, parent.program, this);
+      }
+
+      if (Options.TraceVerify && SplitIndex >= 0)
+      {
+        Run.OutputWriter.WriteLine("-- after split #{0}", SplitIndex);
+        Print();
+      }
+
+      checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions().Select(kv => new OptionValue(kv.Key, kv.Value)));
+      await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
+    }
+
+    public string Description
+    {
+      get
+      {
+        string description = cce.NonNull(Implementation.Name);
+        if (SplitIndex >= 0) {
+          description += "_split" + SplitIndex;
+        }
+
+        return description;
+      }
+    }
+
+    private void SoundnessCheck(HashSet<List<Block> /*!*/> /*!*/ cache, Block /*!*/ orig,
+      List<Block /*!*/> /*!*/ copies)
+    {
+      Contract.Requires(cce.NonNull(cache));
+      Contract.Requires(orig != null);
+      Contract.Requires(copies != null);
+      {
+        var t = new List<Block> {orig};
+        foreach (Block b in copies)
+        {
+          Contract.Assert(b != null);
+          t.Add(b);
+        }
+
+        if (cache.Contains(t))
+        {
+          return;
+        }
+
+        cache.Add(t);
+      }
+
+      for (int i = 0; i < orig.Cmds.Count; ++i)
+      {
+        Cmd cmd = orig.Cmds[i];
+        if (cmd is AssertCmd)
+        {
+          int found = 0;
           foreach (Block c in copies)
           {
-            foreach (Block cexit in c.Exits())
+            Contract.Assert(c != null);
+            if (c.Cmds[i] == cmd)
             {
-              Contract.Assert(cexit != null);
-              if (cexit.Label == exit.Label)
-              {
-                newcopies.Add(cexit);
-              }
+              found++;
             }
           }
 
-          if (newcopies.Count == 0)
+          if (found == 0)
           {
-            throw new System.Exception("missing exit " + exit.Label);
+            throw new System.Exception(string.Format("missing assertion: {0}({1})", cmd.tok.filename, cmd.tok.line));
           }
-
-          SoundnessCheck(cache, exit, newcopies);
         }
       }
 
-      public int NextRandom() {
-        return randomGen.Next();
+      foreach (Block exit in orig.Exits())
+      {
+        Contract.Assert(exit != null);
+        List<Block> newcopies = new List<Block>();
+        foreach (Block c in copies)
+        {
+          foreach (Block cexit in c.Exits())
+          {
+            Contract.Assert(cexit != null);
+            if (cexit.Label == exit.Label)
+            {
+              newcopies.Add(cexit);
+            }
+          }
+        }
+
+        if (newcopies.Count == 0)
+        {
+          throw new System.Exception("missing exit " + exit.Label);
+        }
+
+        SoundnessCheck(cache, exit, newcopies);
       }
+    }
+
+    public int NextRandom() {
+      return randomGen.Next();
+    }
   }
 }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1269,10 +1269,10 @@ namespace VC
         }
       }
 
-      public (ProverInterface.Outcome outcome, VerificationRunResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
+      public (Bpl.Outcome outcome, VerificationRunResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
       {
         Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
-        ProverInterface.Outcome outcome = cce.NonNull(checker).ReadOutcome();
+        Bpl.Outcome outcome = cce.NonNull(checker).ReadOutcome();
 
         if (options.Trace && SplitIndex >= 0)
         {

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -18,1043 +18,1043 @@ namespace VC
 
   public class Split : ProofRun
   {
-    public VCGenOptions Options { get; }
+      public VCGenOptions Options { get; }
 
-    public int? RandomSeed => Implementation.RandomSeed ?? Options.RandomSeed;
-    private readonly Random randomGen;
+      public int? RandomSeed => Implementation.RandomSeed ?? Options.RandomSeed;
+      private readonly Random randomGen;
 
-    public ImplementationRun Run { get; }
+      public ImplementationRun Run { get; }
 
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(cce.NonNullElements(Blocks));
-      Contract.Invariant(cce.NonNullElements(bigBlocks));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(stats));
-      Contract.Invariant(cce.NonNullElements(assumizedBranches));
-      Contract.Invariant(GotoCmdOrigins != null);
-      Contract.Invariant(parent != null);
-      Contract.Invariant(Implementation != null);
-      Contract.Invariant(copies != null);
-      Contract.Invariant(cce.NonNull(protectedFromAssertToAssume));
-      Contract.Invariant(cce.NonNull(keepAtAll));
-    }
-
-
-    public List<Block> Blocks { get; }
-    public List<AssertCmd> Asserts => Blocks.SelectMany(block => block.cmds.OfType<AssertCmd>()).ToList();
-    public readonly IReadOnlyList<Declaration> TopLevelDeclarations;
-    readonly List<Block> bigBlocks = new();
-
-    readonly Dictionary<Block /*!*/, BlockStats /*!*/> /*!*/
-      stats = new Dictionary<Block /*!*/, BlockStats /*!*/>();
-    static int currentId = -1;
-
-    Block splitBlock;
-    bool assertToAssume;
-
-    List<Block /*!*/> /*!*/
-      assumizedBranches = new List<Block /*!*/>();
-
-    double score;
-    bool scoreComputed;
-    double totalCost;
-    int assertionCount;
-    double assertionCost; // without multiplication by paths
-
-    public Dictionary<TransferCmd, ReturnCmd> GotoCmdOrigins { get; }
-
-    public readonly VCGen /*!*/ parent;
-
-    public Implementation /*!*/ Implementation => Run.Implementation;
-
-    Dictionary<Block /*!*/, Block /*!*/> /*!*/
-      copies = new Dictionary<Block /*!*/, Block /*!*/>();
-
-    bool doingSlice;
-    double sliceInitialLimit;
-    double sliceLimit;
-    bool slicePos;
-
-    HashSet<Block /*!*/> /*!*/
-      protectedFromAssertToAssume = new HashSet<Block /*!*/>();
-
-    HashSet<Block /*!*/> /*!*/
-      keepAtAll = new HashSet<Block /*!*/>();
-
-    // async interface
-    public int SplitIndex { get; set; }
-    internal VCGen.ErrorReporter reporter;
-
-    public Split(VCGenOptions options, List<Block /*!*/> /*!*/ blocks,
-      Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
-      VCGen /*!*/ par, ImplementationRun run)
-    {
-      Contract.Requires(cce.NonNullElements(blocks));
-      Contract.Requires(gotoCmdOrigins != null);
-      Contract.Requires(par != null);
-      this.Blocks = blocks;
-      this.GotoCmdOrigins = gotoCmdOrigins;
-      this.parent = par;
-      this.Run = run;
-      this.Options = options;
-      Interlocked.Increment(ref currentId);
-
-      TopLevelDeclarations = par.program.TopLevelDeclarations;
-      PrintTopLevelDeclarationsForPruning(par.program, Implementation, "before");
-      TopLevelDeclarations = Prune.GetLiveDeclarations(options, par.program, blocks).ToList();
-      PrintTopLevelDeclarationsForPruning(par.program, Implementation, "after");
-      randomGen = new Random(RandomSeed ?? 0);
-    }
-
-    private void PrintTopLevelDeclarationsForPruning(Program program, Implementation implementation, string suffix)
-    {
-      if (!Options.Prune || Options.PrintPrunedFile == null)
+      [ContractInvariantMethod]
+      void ObjectInvariant()
       {
-        return;
+        Contract.Invariant(cce.NonNullElements(Blocks));
+        Contract.Invariant(cce.NonNullElements(bigBlocks));
+        Contract.Invariant(cce.NonNullDictionaryAndValues(stats));
+        Contract.Invariant(cce.NonNullElements(assumizedBranches));
+        Contract.Invariant(GotoCmdOrigins != null);
+        Contract.Invariant(parent != null);
+        Contract.Invariant(Implementation != null);
+        Contract.Invariant(copies != null);
+        Contract.Invariant(cce.NonNull(protectedFromAssertToAssume));
+        Contract.Invariant(cce.NonNull(keepAtAll));
       }
 
-      using var writer = new TokenTextWriter(
-        $"{Options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}.bpl", false,
-        Options.PrettyPrint, Options);
 
-      var functionAxioms = 
-        program.Functions.Where(f => f.DefinitionAxioms.Any()).SelectMany(f => f.DefinitionAxioms);
-      var constantAxioms = 
-        program.Constants.Where(f => f.DefinitionAxioms.Any()).SelectMany(c => c.DefinitionAxioms);
+      public List<Block> Blocks { get; }
+      public List<AssertCmd> Asserts => Blocks.SelectMany(block => block.cmds.OfType<AssertCmd>()).ToList();
+      public readonly IReadOnlyList<Declaration> TopLevelDeclarations;
+      readonly List<Block> bigBlocks = new();
 
-      foreach (var declaration in (TopLevelDeclarations ?? program.TopLevelDeclarations).
-               Except(functionAxioms.Concat(constantAxioms)).ToList()) {
-        declaration.Emit(writer, 0);
+      readonly Dictionary<Block /*!*/, BlockStats /*!*/> /*!*/
+        stats = new Dictionary<Block /*!*/, BlockStats /*!*/>();
+      static int currentId = -1;
+
+      Block splitBlock;
+      bool assertToAssume;
+
+      List<Block /*!*/> /*!*/
+        assumizedBranches = new List<Block /*!*/>();
+
+      double score;
+      bool scoreComputed;
+      double totalCost;
+      int assertionCount;
+      double assertionCost; // without multiplication by paths
+
+      public Dictionary<TransferCmd, ReturnCmd> GotoCmdOrigins { get; }
+
+      public readonly VCGen /*!*/ parent;
+
+      public Implementation /*!*/ Implementation => Run.Implementation;
+
+      Dictionary<Block /*!*/, Block /*!*/> /*!*/
+        copies = new Dictionary<Block /*!*/, Block /*!*/>();
+
+      bool doingSlice;
+      double sliceInitialLimit;
+      double sliceLimit;
+      bool slicePos;
+
+      HashSet<Block /*!*/> /*!*/
+        protectedFromAssertToAssume = new HashSet<Block /*!*/>();
+
+      HashSet<Block /*!*/> /*!*/
+        keepAtAll = new HashSet<Block /*!*/>();
+
+      // async interface
+      public int SplitIndex { get; set; }
+      internal VCGen.ErrorReporter reporter;
+
+      public Split(VCGenOptions options, List<Block /*!*/> /*!*/ blocks,
+        Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
+        VCGen /*!*/ par, ImplementationRun run)
+      {
+        Contract.Requires(cce.NonNullElements(blocks));
+        Contract.Requires(gotoCmdOrigins != null);
+        Contract.Requires(par != null);
+        this.Blocks = blocks;
+        this.GotoCmdOrigins = gotoCmdOrigins;
+        this.parent = par;
+        this.Run = run;
+        this.Options = options;
+        Interlocked.Increment(ref currentId);
+
+        TopLevelDeclarations = par.program.TopLevelDeclarations;
+        PrintTopLevelDeclarationsForPruning(par.program, Implementation, "before");
+        TopLevelDeclarations = Prune.GetLiveDeclarations(options, par.program, blocks).ToList();
+        PrintTopLevelDeclarationsForPruning(par.program, Implementation, "after");
+        randomGen = new Random(RandomSeed ?? 0);
       }
 
-      writer.Close();
-    }
-
-    public double Cost
-    {
-      get
+      private void PrintTopLevelDeclarationsForPruning(Program program, Implementation implementation, string suffix)
       {
-        ComputeBestSplit();
-        return totalCost;
+        if (!Options.Prune || Options.PrintPrunedFile == null)
+        {
+          return;
+        }
+
+        using var writer = new TokenTextWriter(
+          $"{Options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}.bpl", false,
+          Options.PrettyPrint, Options);
+
+        var functionAxioms = 
+          program.Functions.Where(f => f.DefinitionAxioms.Any()).SelectMany(f => f.DefinitionAxioms);
+        var constantAxioms = 
+          program.Constants.Where(f => f.DefinitionAxioms.Any()).SelectMany(c => c.DefinitionAxioms);
+
+        foreach (var declaration in (TopLevelDeclarations ?? program.TopLevelDeclarations).
+                 Except(functionAxioms.Concat(constantAxioms)).ToList()) {
+          declaration.Emit(writer, 0);
+        }
+
+        writer.Close();
       }
-    }
 
-    public bool LastChance
-    {
-      get
+      public double Cost
       {
-        ComputeBestSplit();
-        return assertionCount == 1 && score < 0;
+        get
+        {
+          ComputeBestSplit();
+          return totalCost;
+        }
       }
-    }
 
-    public string Stats
-    {
-      get
+      public bool LastChance
       {
-        ComputeBestSplit();
-        return $"(cost:{totalCost:0}/{assertionCost:0}{(LastChance ? " last" : "")})";
+        get
+        {
+          ComputeBestSplit();
+          return assertionCount == 1 && score < 0;
+        }
       }
-    }
 
-    public void DumpDot(int splitNum)
-    {
-      using (System.IO.StreamWriter sw = System.IO.File.CreateText($"{Implementation.Name}.split.{splitNum}.dot"))
+      public string Stats
       {
-        sw.WriteLine("digraph G {");
+        get
+        {
+          ComputeBestSplit();
+          return $"(cost:{totalCost:0}/{assertionCost:0}{(LastChance ? " last" : "")})";
+        }
+      }
 
-        ComputeBestSplit();
-        List<Block> saved = assumizedBranches;
-        Contract.Assert(saved != null);
-        assumizedBranches = new List<Block>();
-        DoComputeScore(false);
-        assumizedBranches = saved;
+      public void DumpDot(int splitNum)
+      {
+        using (System.IO.StreamWriter sw = System.IO.File.CreateText($"{Implementation.Name}.split.{splitNum}.dot"))
+        {
+          sw.WriteLine("digraph G {");
+
+          ComputeBestSplit();
+          List<Block> saved = assumizedBranches;
+          Contract.Assert(saved != null);
+          assumizedBranches = new List<Block>();
+          DoComputeScore(false);
+          assumizedBranches = saved;
+
+          foreach (Block b in bigBlocks)
+          {
+            Contract.Assert(b != null);
+            BlockStats s = GetBlockStats(b);
+            foreach (Block t in s.virtualSuccessors)
+            {
+              Contract.Assert(t != null);
+              sw.WriteLine("n{0} -> n{1};", s.id, GetBlockStats(t).id);
+            }
+
+            sw.WriteLine("n{0} [label=\"{1}:\\n({2:0.0}+{3:0.0})*{4:0.0}\"{5}];",
+              s.id, b.Label,
+              s.assertionCost, s.assumptionCost, s.incomingPaths,
+              s.assertionCost > 0 ? ",shape=box" : "");
+          }
+
+          sw.WriteLine("}");
+          sw.Close();
+        }
+
+        string filename = string.Format("{0}.split.{1}.bpl", Implementation.Name, splitNum);
+        using (System.IO.StreamWriter sw = System.IO.File.CreateText(filename))
+        {
+          int oldPrintUnstructured = Options.PrintUnstructured;
+          Options.PrintUnstructured = 2; // print only the unstructured program
+          bool oldPrintDesugaringSetting = Options.PrintDesugarings;
+          Options.PrintDesugarings = false;
+          List<Block> backup = Implementation.Blocks;
+          Contract.Assert(backup != null);
+          Implementation.Blocks = Blocks;
+          Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false, Options), 0);
+          Implementation.Blocks = backup;
+          Options.PrintDesugarings = oldPrintDesugaringSetting;
+          Options.PrintUnstructured = oldPrintUnstructured;
+        }
+      }
+
+      int bsid;
+
+      BlockStats GetBlockStats(Block b)
+      {
+        Contract.Requires(b != null);
+        Contract.Ensures(Contract.Result<BlockStats>() != null);
+
+        if (!stats.TryGetValue(b, out var s))
+        {
+          s = new BlockStats(b, bsid++);
+          stats[b] = s;
+        }
+
+        return cce.NonNull(s);
+      }
+
+      double AssertionCost(PredicateCmd c)
+      {
+        return 1.0;
+      }
+
+      void CountAssertions(Block b)
+      {
+        Contract.Requires(b != null);
+        BlockStats s = GetBlockStats(b);
+        if (s.assertionCost >= 0)
+        {
+          return; // already done
+        }
+
+        s.bigBlock = true;
+        s.assertionCost = 0;
+        s.assumptionCost = 0;
+        foreach (Cmd c in b.Cmds)
+        {
+          if (c is AssertCmd)
+          {
+            double cost = AssertionCost((AssertCmd) c);
+            s.assertionCost += cost;
+            assertionCount++;
+            assertionCost += cost;
+          }
+          else if (c is AssumeCmd)
+          {
+            s.assumptionCost += AssertionCost((AssumeCmd) c);
+          }
+        }
+
+        foreach (Block c in b.Exits())
+        {
+          Contract.Assert(c != null);
+          s.virtualSuccessors.Add(c);
+        }
+
+        if (s.virtualSuccessors.Count == 1)
+        {
+          Block next = s.virtualSuccessors[0];
+          BlockStats se = GetBlockStats(next);
+          CountAssertions(next);
+          if (next.Predecessors.Count > 1 || se.virtualSuccessors.Count != 1)
+          {
+            return;
+          }
+
+          s.virtualSuccessors[0] = se.virtualSuccessors[0];
+          s.assertionCost += se.assertionCost;
+          s.assumptionCost += se.assumptionCost;
+          se.bigBlock = false;
+        }
+      }
+
+      HashSet<Block /*!*/> /*!*/ ComputeReachableNodes(Block /*!*/ b)
+      {
+        Contract.Requires(b != null);
+        Contract.Ensures(cce.NonNull(Contract.Result<HashSet<Block /*!*/>>()));
+        BlockStats s = GetBlockStats(b);
+        if (s.reachableBlocks != null)
+        {
+          return s.reachableBlocks;
+        }
+
+        HashSet<Block /*!*/> blocks = new HashSet<Block /*!*/>();
+        s.reachableBlocks = blocks;
+        blocks.Add(b);
+        foreach (Block /*!*/ succ in b.Exits())
+        {
+          Contract.Assert(succ != null);
+          foreach (Block r in ComputeReachableNodes(succ))
+          {
+            Contract.Assert(r != null);
+            blocks.Add(r);
+          }
+        }
+
+        return blocks;
+      }
+
+      double ProverCost(double vcCost)
+      {
+        return vcCost * vcCost;
+      }
+
+      void ComputeBestSplit()
+      {
+        if (scoreComputed)
+        {
+          return;
+        }
+
+        scoreComputed = true;
+
+        assertionCount = 0;
+
+        foreach (Block b in Blocks)
+        {
+          Contract.Assert(b != null);
+          CountAssertions(b);
+        }
+
+        foreach (Block b in Blocks)
+        {
+          Contract.Assert(b != null);
+          BlockStats bs = GetBlockStats(b);
+          if (bs.bigBlock)
+          {
+            bigBlocks.Add(b);
+            foreach (Block ch in bs.virtualSuccessors)
+            {
+              Contract.Assert(ch != null);
+              BlockStats chs = GetBlockStats(ch);
+              if (!chs.bigBlock)
+              {
+                Options.OutputWriter.WriteLine("non-big {0} accessed from {1}", ch, b);
+                DumpDot(-1);
+                Contract.Assert(false);
+                throw new cce.UnreachableException();
+              }
+
+              chs.virtualPredecessors.Add(b);
+            }
+          }
+        }
+
+        assumizedBranches.Clear();
+        totalCost = ProverCost(DoComputeScore(false));
+
+        score = double.PositiveInfinity;
+        Block bestSplit = null;
+        List<Block> savedBranches = new List<Block>();
 
         foreach (Block b in bigBlocks)
         {
           Contract.Assert(b != null);
-          BlockStats s = GetBlockStats(b);
-          foreach (Block t in s.virtualSuccessors)
+          GotoCmd gt = b.TransferCmd as GotoCmd;
+          if (gt == null)
           {
-            Contract.Assert(t != null);
-            sw.WriteLine("n{0} -> n{1};", s.id, GetBlockStats(t).id);
+            continue;
           }
 
-          sw.WriteLine("n{0} [label=\"{1}:\\n({2:0.0}+{3:0.0})*{4:0.0}\"{5}];",
-            s.id, b.Label,
-            s.assertionCost, s.assumptionCost, s.incomingPaths,
-            s.assertionCost > 0 ? ",shape=box" : "");
+          List<Block> targ = cce.NonNull(gt.labelTargets);
+          if (targ.Count < 2)
+          {
+            continue;
+          }
+          // caution, we only consider two first exits
+
+          double left0, right0, left1, right1;
+          splitBlock = b;
+
+          assumizedBranches.Clear();
+          assumizedBranches.Add(cce.NonNull(targ[0]));
+          left0 = DoComputeScore(true);
+          right0 = DoComputeScore(false);
+
+          assumizedBranches.Clear();
+          for (int idx = 1; idx < targ.Count; idx++)
+          {
+            assumizedBranches.Add(cce.NonNull(targ[idx]));
+          }
+
+          left1 = DoComputeScore(true);
+          right1 = DoComputeScore(false);
+
+          double currentScore = ProverCost(left1) + ProverCost(right1);
+          double otherScore = ProverCost(left0) + ProverCost(right0);
+
+          if (otherScore < currentScore)
+          {
+            currentScore = otherScore;
+            assumizedBranches.Clear();
+            assumizedBranches.Add(cce.NonNull(targ[0]));
+          }
+
+          if (currentScore < score)
+          {
+            score = currentScore;
+            bestSplit = splitBlock;
+            savedBranches.Clear();
+            savedBranches.AddRange(assumizedBranches);
+          }
         }
 
-        sw.WriteLine("}");
-        sw.Close();
-      }
-
-      string filename = string.Format("{0}.split.{1}.bpl", Implementation.Name, splitNum);
-      using (System.IO.StreamWriter sw = System.IO.File.CreateText(filename))
-      {
-        int oldPrintUnstructured = Options.PrintUnstructured;
-        Options.PrintUnstructured = 2; // print only the unstructured program
-        bool oldPrintDesugaringSetting = Options.PrintDesugarings;
-        Options.PrintDesugarings = false;
-        List<Block> backup = Implementation.Blocks;
-        Contract.Assert(backup != null);
-        Implementation.Blocks = Blocks;
-        Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false, Options), 0);
-        Implementation.Blocks = backup;
-        Options.PrintDesugarings = oldPrintDesugaringSetting;
-        Options.PrintUnstructured = oldPrintUnstructured;
-      }
-    }
-
-    int bsid;
-
-    BlockStats GetBlockStats(Block b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<BlockStats>() != null);
-
-      if (!stats.TryGetValue(b, out var s))
-      {
-        s = new BlockStats(b, bsid++);
-        stats[b] = s;
-      }
-
-      return cce.NonNull(s);
-    }
-
-    double AssertionCost(PredicateCmd c)
-    {
-      return 1.0;
-    }
-
-    void CountAssertions(Block b)
-    {
-      Contract.Requires(b != null);
-      BlockStats s = GetBlockStats(b);
-      if (s.assertionCost >= 0)
-      {
-        return; // already done
-      }
-
-      s.bigBlock = true;
-      s.assertionCost = 0;
-      s.assumptionCost = 0;
-      foreach (Cmd c in b.Cmds)
-      {
-        if (c is AssertCmd)
+        if (Options.VcsPathSplitMult * score > totalCost)
         {
-          double cost = AssertionCost((AssertCmd) c);
-          s.assertionCost += cost;
-          assertionCount++;
-          assertionCost += cost;
+          splitBlock = null;
+          score = -1;
         }
-        else if (c is AssumeCmd)
+        else
         {
-          s.assumptionCost += AssertionCost((AssumeCmd) c);
+          assumizedBranches = savedBranches;
+          splitBlock = bestSplit;
         }
       }
 
-      foreach (Block c in b.Exits())
+      void UpdateIncommingPaths(BlockStats s)
       {
-        Contract.Assert(c != null);
-        s.virtualSuccessors.Add(c);
+        Contract.Requires(s != null);
+        if (s.incomingPaths < 0.0)
+        {
+          int count = 0;
+          s.incomingPaths = 0.0;
+          if (!keepAtAll.Contains(s.block))
+          {
+            return;
+          }
+
+          foreach (Block b in s.virtualPredecessors)
+          {
+            Contract.Assert(b != null);
+            BlockStats ch = GetBlockStats(b);
+            Contract.Assert(ch != null);
+            UpdateIncommingPaths(ch);
+            if (ch.incomingPaths > 0.0)
+            {
+              s.incomingPaths += ch.incomingPaths;
+              count++;
+            }
+          }
+
+          if (count > 1)
+          {
+            s.incomingPaths *= Options.VcsPathJoinMult;
+          }
+        }
       }
 
-      if (s.virtualSuccessors.Count == 1)
+      void ComputeBlockSetsHelper(Block b, bool allowSmall)
       {
-        Block next = s.virtualSuccessors[0];
-        BlockStats se = GetBlockStats(next);
-        CountAssertions(next);
-        if (next.Predecessors.Count > 1 || se.virtualSuccessors.Count != 1)
+        Contract.Requires(b != null);
+        if (keepAtAll.Contains(b))
         {
           return;
         }
 
-        s.virtualSuccessors[0] = se.virtualSuccessors[0];
-        s.assertionCost += se.assertionCost;
-        s.assumptionCost += se.assumptionCost;
-        se.bigBlock = false;
-      }
-    }
+        keepAtAll.Add(b);
 
-    HashSet<Block /*!*/> /*!*/ ComputeReachableNodes(Block /*!*/ b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(cce.NonNull(Contract.Result<HashSet<Block /*!*/>>()));
-      BlockStats s = GetBlockStats(b);
-      if (s.reachableBlocks != null)
-      {
-        return s.reachableBlocks;
-      }
-
-      HashSet<Block /*!*/> blocks = new HashSet<Block /*!*/>();
-      s.reachableBlocks = blocks;
-      blocks.Add(b);
-      foreach (Block /*!*/ succ in b.Exits())
-      {
-        Contract.Assert(succ != null);
-        foreach (Block r in ComputeReachableNodes(succ))
+        if (allowSmall)
         {
-          Contract.Assert(r != null);
-          blocks.Add(r);
+          foreach (Block ch in b.Exits())
+          {
+            Contract.Assert(ch != null);
+            if (b == splitBlock && assumizedBranches.Contains(ch))
+            {
+              continue;
+            }
+
+            ComputeBlockSetsHelper(ch, allowSmall);
+          }
+        }
+        else
+        {
+          foreach (Block ch in GetBlockStats(b).virtualSuccessors)
+          {
+            Contract.Assert(ch != null);
+            if (b == splitBlock && assumizedBranches.Contains(ch))
+            {
+              continue;
+            }
+
+            ComputeBlockSetsHelper(ch, allowSmall);
+          }
         }
       }
 
-      return blocks;
-    }
-
-    double ProverCost(double vcCost)
-    {
-      return vcCost * vcCost;
-    }
-
-    void ComputeBestSplit()
-    {
-      if (scoreComputed)
+      void ComputeBlockSets(bool allowSmall)
       {
-        return;
-      }
+        protectedFromAssertToAssume.Clear();
+        keepAtAll.Clear();
 
-      scoreComputed = true;
+        Debug.Assert(splitBlock == null || GetBlockStats(splitBlock).bigBlock);
+        Debug.Assert(GetBlockStats(Blocks[0]).bigBlock);
 
-      assertionCount = 0;
-
-      foreach (Block b in Blocks)
-      {
-        Contract.Assert(b != null);
-        CountAssertions(b);
-      }
-
-      foreach (Block b in Blocks)
-      {
-        Contract.Assert(b != null);
-        BlockStats bs = GetBlockStats(b);
-        if (bs.bigBlock)
+        if (assertToAssume)
         {
-          bigBlocks.Add(b);
-          foreach (Block ch in bs.virtualSuccessors)
+          foreach (Block b in allowSmall ? Blocks : bigBlocks)
           {
-            Contract.Assert(ch != null);
-            BlockStats chs = GetBlockStats(ch);
-            if (!chs.bigBlock)
+            Contract.Assert(b != null);
+            if (ComputeReachableNodes(b).Contains(cce.NonNull(splitBlock)))
             {
-              Options.OutputWriter.WriteLine("non-big {0} accessed from {1}", ch, b);
-              DumpDot(-1);
+              keepAtAll.Add(b);
+            }
+          }
+
+          foreach (Block b in assumizedBranches)
+          {
+            Contract.Assert(b != null);
+            foreach (Block r in ComputeReachableNodes(b))
+            {
+              Contract.Assert(r != null);
+              if (allowSmall || GetBlockStats(r).bigBlock)
+              {
+                keepAtAll.Add(r);
+                protectedFromAssertToAssume.Add(r);
+              }
+            }
+          }
+        }
+        else
+        {
+          ComputeBlockSetsHelper(Blocks[0], allowSmall);
+        }
+      }
+
+      bool ShouldAssumize(Block b)
+      {
+        Contract.Requires(b != null);
+        return assertToAssume && !protectedFromAssertToAssume.Contains(b);
+      }
+
+      double DoComputeScore(bool aa)
+      {
+        assertToAssume = aa;
+        ComputeBlockSets(false);
+
+        foreach (Block b in bigBlocks)
+        {
+          Contract.Assert(b != null);
+          GetBlockStats(b).incomingPaths = -1.0;
+        }
+
+        GetBlockStats(Blocks[0]).incomingPaths = 1.0;
+
+        double cost = 0.0;
+        foreach (Block b in bigBlocks)
+        {
+          Contract.Assert(b != null);
+          if (keepAtAll.Contains(b))
+          {
+            BlockStats s = GetBlockStats(b);
+            UpdateIncommingPaths(s);
+            double local = s.assertionCost;
+            if (ShouldAssumize(b))
+            {
+              local = (s.assertionCost + s.assumptionCost) * Options.VcsAssumeMult;
+            }
+            else
+            {
+              local = s.assumptionCost * Options.VcsAssumeMult + s.assertionCost;
+            }
+
+            local = local + local * s.incomingPaths * Options.VcsPathCostMult;
+            cost += local;
+          }
+        }
+
+        return cost;
+      }
+
+      List<Cmd> SliceCmds(Block b)
+      {
+        Contract.Requires(b != null);
+        Contract.Ensures(Contract.Result<List<Cmd>>() != null);
+
+        List<Cmd> seq = b.Cmds;
+        Contract.Assert(seq != null);
+        if (!doingSlice && !ShouldAssumize(b))
+        {
+          return seq;
+        }
+
+        List<Cmd> res = new List<Cmd>();
+        foreach (Cmd c in seq)
+        {
+          Contract.Assert(c != null);
+          AssertCmd a = c as AssertCmd;
+          Cmd theNewCmd = c;
+          bool swap = false;
+          if (a != null)
+          {
+            if (doingSlice)
+            {
+              double cost = AssertionCost(a);
+              bool first = (sliceLimit - cost) >= 0 || sliceInitialLimit == sliceLimit;
+              sliceLimit -= cost;
+              swap = slicePos == first;
+            }
+            else if (assertToAssume)
+            {
+              swap = true;
+            }
+            else
+            {
               Contract.Assert(false);
               throw new cce.UnreachableException();
             }
 
-            chs.virtualPredecessors.Add(b);
+            if (swap)
+            {
+              theNewCmd = VCGen.AssertTurnedIntoAssume(Options, a);
+            }
           }
+
+          res.Add(theNewCmd);
         }
+
+        return res;
       }
 
-      assumizedBranches.Clear();
-      totalCost = ProverCost(DoComputeScore(false));
-
-      score = double.PositiveInfinity;
-      Block bestSplit = null;
-      List<Block> savedBranches = new List<Block>();
-
-      foreach (Block b in bigBlocks)
+      Block CloneBlock(Block b)
       {
-        Contract.Assert(b != null);
+        Contract.Requires(b != null);
+        Contract.Ensures(Contract.Result<Block>() != null);
+
+        if (copies.TryGetValue(b, out var res))
+        {
+          return cce.NonNull(res);
+        }
+
+        res = new Block(b.tok, b.Label, SliceCmds(b), b.TransferCmd);
         GotoCmd gt = b.TransferCmd as GotoCmd;
-        if (gt == null)
+        copies[b] = res;
+        if (gt != null)
         {
-          continue;
-        }
-
-        List<Block> targ = cce.NonNull(gt.labelTargets);
-        if (targ.Count < 2)
-        {
-          continue;
-        }
-        // caution, we only consider two first exits
-
-        double left0, right0, left1, right1;
-        splitBlock = b;
-
-        assumizedBranches.Clear();
-        assumizedBranches.Add(cce.NonNull(targ[0]));
-        left0 = DoComputeScore(true);
-        right0 = DoComputeScore(false);
-
-        assumizedBranches.Clear();
-        for (int idx = 1; idx < targ.Count; idx++)
-        {
-          assumizedBranches.Add(cce.NonNull(targ[idx]));
-        }
-
-        left1 = DoComputeScore(true);
-        right1 = DoComputeScore(false);
-
-        double currentScore = ProverCost(left1) + ProverCost(right1);
-        double otherScore = ProverCost(left0) + ProverCost(right0);
-
-        if (otherScore < currentScore)
-        {
-          currentScore = otherScore;
-          assumizedBranches.Clear();
-          assumizedBranches.Add(cce.NonNull(targ[0]));
-        }
-
-        if (currentScore < score)
-        {
-          score = currentScore;
-          bestSplit = splitBlock;
-          savedBranches.Clear();
-          savedBranches.AddRange(assumizedBranches);
-        }
-      }
-
-      if (Options.VcsPathSplitMult * score > totalCost)
-      {
-        splitBlock = null;
-        score = -1;
-      }
-      else
-      {
-        assumizedBranches = savedBranches;
-        splitBlock = bestSplit;
-      }
-    }
-
-    void UpdateIncommingPaths(BlockStats s)
-    {
-      Contract.Requires(s != null);
-      if (s.incomingPaths < 0.0)
-      {
-        int count = 0;
-        s.incomingPaths = 0.0;
-        if (!keepAtAll.Contains(s.block))
-        {
-          return;
-        }
-
-        foreach (Block b in s.virtualPredecessors)
-        {
-          Contract.Assert(b != null);
-          BlockStats ch = GetBlockStats(b);
-          Contract.Assert(ch != null);
-          UpdateIncommingPaths(ch);
-          if (ch.incomingPaths > 0.0)
+          GotoCmd newGoto = new GotoCmd(gt.tok, new List<String>(), new List<Block>());
+          res.TransferCmd = newGoto;
+          int pos = 0;
+          foreach (Block ch in cce.NonNull(gt.labelTargets))
           {
-            s.incomingPaths += ch.incomingPaths;
-            count++;
-          }
-        }
-
-        if (count > 1)
-        {
-          s.incomingPaths *= Options.VcsPathJoinMult;
-        }
-      }
-    }
-
-    void ComputeBlockSetsHelper(Block b, bool allowSmall)
-    {
-      Contract.Requires(b != null);
-      if (keepAtAll.Contains(b))
-      {
-        return;
-      }
-
-      keepAtAll.Add(b);
-
-      if (allowSmall)
-      {
-        foreach (Block ch in b.Exits())
-        {
-          Contract.Assert(ch != null);
-          if (b == splitBlock && assumizedBranches.Contains(ch))
-          {
-            continue;
-          }
-
-          ComputeBlockSetsHelper(ch, allowSmall);
-        }
-      }
-      else
-      {
-        foreach (Block ch in GetBlockStats(b).virtualSuccessors)
-        {
-          Contract.Assert(ch != null);
-          if (b == splitBlock && assumizedBranches.Contains(ch))
-          {
-            continue;
-          }
-
-          ComputeBlockSetsHelper(ch, allowSmall);
-        }
-      }
-    }
-
-    void ComputeBlockSets(bool allowSmall)
-    {
-      protectedFromAssertToAssume.Clear();
-      keepAtAll.Clear();
-
-      Debug.Assert(splitBlock == null || GetBlockStats(splitBlock).bigBlock);
-      Debug.Assert(GetBlockStats(Blocks[0]).bigBlock);
-
-      if (assertToAssume)
-      {
-        foreach (Block b in allowSmall ? Blocks : bigBlocks)
-        {
-          Contract.Assert(b != null);
-          if (ComputeReachableNodes(b).Contains(cce.NonNull(splitBlock)))
-          {
-            keepAtAll.Add(b);
-          }
-        }
-
-        foreach (Block b in assumizedBranches)
-        {
-          Contract.Assert(b != null);
-          foreach (Block r in ComputeReachableNodes(b))
-          {
-            Contract.Assert(r != null);
-            if (allowSmall || GetBlockStats(r).bigBlock)
+            Contract.Assert(ch != null);
+            Contract.Assert(doingSlice ||
+                            (assertToAssume || (keepAtAll.Contains(ch) || assumizedBranches.Contains(ch))));
+            if (doingSlice ||
+                ((b != splitBlock || assumizedBranches.Contains(ch) == assertToAssume) &&
+                 keepAtAll.Contains(ch)))
             {
-              keepAtAll.Add(r);
-              protectedFromAssertToAssume.Add(r);
+              newGoto.AddTarget(CloneBlock(ch));
             }
-          }
-        }
-      }
-      else
-      {
-        ComputeBlockSetsHelper(Blocks[0], allowSmall);
-      }
-    }
 
-    bool ShouldAssumize(Block b)
-    {
-      Contract.Requires(b != null);
-      return assertToAssume && !protectedFromAssertToAssume.Contains(b);
-    }
-
-    double DoComputeScore(bool aa)
-    {
-      assertToAssume = aa;
-      ComputeBlockSets(false);
-
-      foreach (Block b in bigBlocks)
-      {
-        Contract.Assert(b != null);
-        GetBlockStats(b).incomingPaths = -1.0;
-      }
-
-      GetBlockStats(Blocks[0]).incomingPaths = 1.0;
-
-      double cost = 0.0;
-      foreach (Block b in bigBlocks)
-      {
-        Contract.Assert(b != null);
-        if (keepAtAll.Contains(b))
-        {
-          BlockStats s = GetBlockStats(b);
-          UpdateIncommingPaths(s);
-          double local = s.assertionCost;
-          if (ShouldAssumize(b))
-          {
-            local = (s.assertionCost + s.assumptionCost) * Options.VcsAssumeMult;
-          }
-          else
-          {
-            local = s.assumptionCost * Options.VcsAssumeMult + s.assertionCost;
-          }
-
-          local = local + local * s.incomingPaths * Options.VcsPathCostMult;
-          cost += local;
-        }
-      }
-
-      return cost;
-    }
-
-    List<Cmd> SliceCmds(Block b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<List<Cmd>>() != null);
-
-      List<Cmd> seq = b.Cmds;
-      Contract.Assert(seq != null);
-      if (!doingSlice && !ShouldAssumize(b))
-      {
-        return seq;
-      }
-
-      List<Cmd> res = new List<Cmd>();
-      foreach (Cmd c in seq)
-      {
-        Contract.Assert(c != null);
-        AssertCmd a = c as AssertCmd;
-        Cmd theNewCmd = c;
-        bool swap = false;
-        if (a != null)
-        {
-          if (doingSlice)
-          {
-            double cost = AssertionCost(a);
-            bool first = (sliceLimit - cost) >= 0 || sliceInitialLimit == sliceLimit;
-            sliceLimit -= cost;
-            swap = slicePos == first;
-          }
-          else if (assertToAssume)
-          {
-            swap = true;
-          }
-          else
-          {
-            Contract.Assert(false);
-            throw new cce.UnreachableException();
-          }
-
-          if (swap)
-          {
-            theNewCmd = VCGen.AssertTurnedIntoAssume(Options, a);
+            pos++;
           }
         }
 
-        res.Add(theNewCmd);
+        return res;
       }
 
-      return res;
-    }
-
-    Block CloneBlock(Block b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<Block>() != null);
-
-      if (copies.TryGetValue(b, out var res))
+      Split DoSplit()
       {
-        return cce.NonNull(res);
-      }
+        Contract.Ensures(Contract.Result<Split>() != null);
 
-      res = new Block(b.tok, b.Label, SliceCmds(b), b.TransferCmd);
-      GotoCmd gt = b.TransferCmd as GotoCmd;
-      copies[b] = res;
-      if (gt != null)
-      {
-        GotoCmd newGoto = new GotoCmd(gt.tok, new List<String>(), new List<Block>());
-        res.TransferCmd = newGoto;
-        int pos = 0;
-        foreach (Block ch in cce.NonNull(gt.labelTargets))
+        copies.Clear();
+        CloneBlock(Blocks[0]);
+        List<Block> newBlocks = new List<Block>();
+        Dictionary<TransferCmd, ReturnCmd> newGotoCmdOrigins = new Dictionary<TransferCmd, ReturnCmd>();
+        foreach (Block b in Blocks)
         {
-          Contract.Assert(ch != null);
-          Contract.Assert(doingSlice ||
-                          (assertToAssume || (keepAtAll.Contains(ch) || assumizedBranches.Contains(ch))));
-          if (doingSlice ||
-              ((b != splitBlock || assumizedBranches.Contains(ch) == assertToAssume) &&
-               keepAtAll.Contains(ch)))
+          Contract.Assert(b != null);
+          if (copies.TryGetValue(b, out var tmp))
           {
-            newGoto.AddTarget(CloneBlock(ch));
-          }
-
-          pos++;
-        }
-      }
-
-      return res;
-    }
-
-    Split DoSplit()
-    {
-      Contract.Ensures(Contract.Result<Split>() != null);
-
-      copies.Clear();
-      CloneBlock(Blocks[0]);
-      List<Block> newBlocks = new List<Block>();
-      Dictionary<TransferCmd, ReturnCmd> newGotoCmdOrigins = new Dictionary<TransferCmd, ReturnCmd>();
-      foreach (Block b in Blocks)
-      {
-        Contract.Assert(b != null);
-        if (copies.TryGetValue(b, out var tmp))
-        {
-          newBlocks.Add(cce.NonNull(tmp));
-          if (GotoCmdOrigins.ContainsKey(b.TransferCmd))
-          {
-            newGotoCmdOrigins[tmp.TransferCmd] = GotoCmdOrigins[b.TransferCmd];
-          }
-
-          foreach (Block p in b.Predecessors)
-          {
-            Contract.Assert(p != null);
-            if (copies.TryGetValue(p, out var tmp2))
+            newBlocks.Add(cce.NonNull(tmp));
+            if (GotoCmdOrigins.ContainsKey(b.TransferCmd))
             {
-              tmp.Predecessors.Add(tmp2);
+              newGotoCmdOrigins[tmp.TransferCmd] = GotoCmdOrigins[b.TransferCmd];
             }
-          }
-        }
-      }
 
-      return new Split(Options, newBlocks, newGotoCmdOrigins, parent, Run);
-    }
-
-    Split SplitAt(int idx)
-    {
-      Contract.Ensures(Contract.Result<Split>() != null);
-
-      assertToAssume = idx == 0;
-      doingSlice = false;
-      ComputeBlockSets(true);
-
-      return DoSplit();
-    }
-
-    Split SliceAsserts(double limit, bool pos)
-    {
-      Contract.Ensures(Contract.Result<Split>() != null);
-
-      slicePos = pos;
-      sliceLimit = limit;
-      sliceInitialLimit = limit;
-      doingSlice = true;
-      Split r = DoSplit();
-      /*
-      Console.WriteLine("split {0} / {1} -->", limit, pos);
-      List<Block!> tmp = impl.Blocks;
-      impl.Blocks = r.blocks;
-      EmitImpl(impl, false);
-      impl.Blocks = tmp;
-      */
-
-      return r;
-    }
-
-    void Print()
-    {
-      List<Block> tmp = Implementation.Blocks;
-      Contract.Assert(tmp != null);
-      Implementation.Blocks = Blocks;
-      ConditionGeneration.EmitImpl(Options, Run, false);
-      Implementation.Blocks = tmp;
-    }
-
-    public Counterexample ToCounterexample(ProverContext context)
-    {
-      Contract.Requires(context != null);
-      Contract.Ensures(Contract.Result<Counterexample>() != null);
-
-      List<Block> trace = new List<Block>();
-      foreach (Block b in Blocks)
-      {
-        Contract.Assert(b != null);
-        trace.Add(b);
-      }
-
-      foreach (Block b in Blocks)
-      {
-        Contract.Assert(b != null);
-        foreach (Cmd c in b.Cmds)
-        {
-          Contract.Assert(c != null);
-          if (c is AssertCmd)
-          {
-            var counterexample = VCGen.AssertCmdToCounterexample(Options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context, this);
-            Counterexamples.Add(counterexample);
-            return counterexample;
-          }
-        }
-      }
-
-      Contract.Assume(false);
-      throw new cce.UnreachableException();
-    }
-
-    public static List<Split /*!*/> /*!*/ DoSplit(Split initial, double splitThreshold, int maxSplits)
-    {
-      Contract.Requires(initial != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Split>>()));
-
-      var run = initial.Run;
-      var result = new List<Split> { initial };
-
-      while (result.Count < maxSplits)
-      {
-        Split best = null;
-        int bestIndex = 0;
-        for (var index = 0; index < result.Count; index++) {
-          var split = result[index];
-          Contract.Assert(split != null);
-          split.ComputeBestSplit(); // TODO check totalCost first
-          if (split.totalCost > splitThreshold &&
-              (best == null || best.totalCost < split.totalCost) &&
-              (split.assertionCount > 1 || split.splitBlock != null)) {
-            best = split;
-            bestIndex = index;
-          }
-        }
-
-        if (best == null)
-        {
-          break; // no split found
-        }
-
-        Split s0, s1;
-
-        bool splitStats = initial.Options.TraceVerify;
-
-        if (splitStats)
-        {
-          run.OutputWriter.WriteLine("{0} {1} -->", best.splitBlock == null ? "SLICE" : ("SPLIT@" + best.splitBlock.Label),
-            best.Stats);
-          if (best.splitBlock != null)
-          {
-            GotoCmd g = best.splitBlock.TransferCmd as GotoCmd;
-            if (g != null)
+            foreach (Block p in b.Predecessors)
             {
-              run.OutputWriter.Write("    exits: ");
-              foreach (Block b in cce.NonNull(g.labelTargets))
+              Contract.Assert(p != null);
+              if (copies.TryGetValue(p, out var tmp2))
               {
-                Contract.Assert(b != null);
-                run.OutputWriter.Write("{0} ", b.Label);
+                tmp.Predecessors.Add(tmp2);
               }
-
-              run.OutputWriter.WriteLine("");
-              run.OutputWriter.Write("    assumized: ");
-              foreach (Block b in best.assumizedBranches)
-              {
-                Contract.Assert(b != null);
-                run.OutputWriter.Write("{0} ", b.Label);
-              }
-
-              run.OutputWriter.WriteLine("");
             }
           }
         }
 
-        if (best.splitBlock != null)
-        {
-          s0 = best.SplitAt(0);
-          s1 = best.SplitAt(1);
-        }
-        else
-        {
-          best.splitBlock = null;
-          s0 = best.SliceAsserts(best.assertionCost / 2, true);
-          s1 = best.SliceAsserts(best.assertionCost / 2, false);
-        }
-
-        if (true)
-        {
-          var ss = new List<Block>
-          {
-            s0.Blocks[0],
-            s1.Blocks[0]
-          };
-          try
-          {
-            best.SoundnessCheck(new HashSet<List<Block>>(new BlockListComparer()), best.Blocks[0], ss);
-          }
-          catch (System.Exception e)
-          {
-            run.OutputWriter.WriteLine(e);
-            best.DumpDot(-1);
-            s0.DumpDot(-2);
-            s1.DumpDot(-3);
-            Contract.Assert(false);
-            throw new cce.UnreachableException();
-          }
-        }
-
-        if (splitStats)
-        {
-          s0.ComputeBestSplit();
-          s1.ComputeBestSplit();
-          run.OutputWriter.WriteLine("    --> {0}", s0.Stats);
-          run.OutputWriter.WriteLine("    --> {0}", s1.Stats);
-        }
-
-        if (initial.Options.TraceVerify)
-        {
-          best.Print();
-        }
-
-        result[bestIndex] = s0;
-        result.Add(s1);
+        return new Split(Options, newBlocks, newGotoCmdOrigins, parent, Run);
       }
 
-      return result;
-    }
-
-    public (Bpl.Outcome outcome, VerificationRunResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
-    {
-      Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
-      Bpl.Outcome outcome = cce.NonNull(checker).ReadOutcome();
-
-      if (Options.Trace && SplitIndex >= 0)
+      Split SplitAt(int idx)
       {
-        Run.OutputWriter.WriteLine("      --> split #{0} done,  [{1} s] {2}", SplitIndex + 1,
-          checker.ProverRunTime.TotalSeconds, outcome);
-      }
-      if (Options.Trace && Options.TrackVerificationCoverage) {
-        Run.OutputWriter.WriteLine("Proof dependencies:\n  {0}",
-          string.Join("\n  ", CoveredElements.Select(s => s.Description).OrderBy(s => s)));
+        Contract.Ensures(Contract.Result<Split>() != null);
+
+        assertToAssume = idx == 0;
+        doingSlice = false;
+        ComputeBlockSets(true);
+
+        return DoSplit();
       }
 
-      var resourceCount = checker.GetProverResourceCount();
-      var result = new VerificationRunResult(
-        VcNum: SplitIndex + 1,
-        Iteration: iteration,
-        StartTime: checker.ProverStart,
-        Outcome: outcome,
-        RunTime: checker.ProverRunTime,
-        MaxCounterExamples: checker.Options.ErrorLimit,
-        CounterExamples: Counterexamples,
-        Asserts: Asserts,
-        CoveredElements: CoveredElements,
-        ResourceCount: resourceCount,
-        SolverUsed: (Options as SMTLibSolverOptions)?.Solver);
-      callback.OnVCResult(result);
-
-      if (Options.VcsDumpSplits)
+      Split SliceAsserts(double limit, bool pos)
       {
-        DumpDot(SplitIndex);
+        Contract.Ensures(Contract.Result<Split>() != null);
+
+        slicePos = pos;
+        sliceLimit = limit;
+        sliceInitialLimit = limit;
+        doingSlice = true;
+        Split r = DoSplit();
+        /*
+        Console.WriteLine("split {0} / {1} -->", limit, pos);
+        List<Block!> tmp = impl.Blocks;
+        impl.Blocks = r.blocks;
+        EmitImpl(impl, false);
+        impl.Blocks = tmp;
+        */
+
+        return r;
       }
 
-      return (outcome, result, resourceCount);
-    }
-
-    public List<Counterexample> Counterexamples { get; } = new();
-
-    public HashSet<TrackedNodeComponent> CoveredElements { get; } = new();
-
-    /// <summary>
-    /// As a side effect, updates "this.parent.CumulativeAssertionCount".
-    /// </summary>
-    public async Task BeginCheck(TextWriter traceWriter, Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, uint timeout,
-      uint rlimit, CancellationToken cancellationToken)
-    {
-      Contract.Requires(checker != null);
-      Contract.Requires(callback != null);
-
-      VCExpr vc;
-      // Lock impl since we're setting impl.Blocks that is used to generate the VC.
-      lock (Implementation) {
+      void Print()
+      {
+        List<Block> tmp = Implementation.Blocks;
+        Contract.Assert(tmp != null);
         Implementation.Blocks = Blocks;
-
-        var absyIds = new ControlFlowIdMap<Absy>();
-
-        ProverContext ctx = checker.TheoremProver.Context;
-        Boogie2VCExprTranslator bet = ctx.BoogieExprTranslator;
-        var cc = new VCGen.CodeExprConversionClosure(traceWriter, checker.Pool.Options, absyIds, ctx);
-        bet.SetCodeExprConverter(cc.CodeExprToVerificationCondition);
-
-        var exprGen = ctx.ExprGen;
-        VCExpr controlFlowVariableExpr = exprGen.Integer(BigNum.ZERO);
-        vc = parent.GenerateVCAux(Implementation, controlFlowVariableExpr, absyIds, checker.TheoremProver.Context);
-        Contract.Assert(vc != null);
-
-        vc = QuantifierInstantiationEngine.Instantiate(Implementation, exprGen, bet, vc);
-
-        VCExpr controlFlowFunctionAppl =
-          exprGen.ControlFlowFunctionApplication(exprGen.Integer(BigNum.ZERO), exprGen.Integer(BigNum.ZERO));
-        VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(Implementation.Blocks[0]))));
-        vc = exprGen.Implies(eqExpr, vc);
-        reporter = new VCGen.ErrorReporter(Options, GotoCmdOrigins, absyIds, Implementation.Blocks, Implementation.debugInfos, callback,
-          mvInfo, checker.TheoremProver.Context, parent.program, this);
+        ConditionGeneration.EmitImpl(Options, Run, false);
+        Implementation.Blocks = tmp;
       }
 
-      if (Options.TraceVerify && SplitIndex >= 0)
+      public Counterexample ToCounterexample(ProverContext context)
       {
-        Run.OutputWriter.WriteLine("-- after split #{0}", SplitIndex);
-        Print();
-      }
+        Contract.Requires(context != null);
+        Contract.Ensures(Contract.Result<Counterexample>() != null);
 
-      checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions().Select(kv => new OptionValue(kv.Key, kv.Value)));
-      await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
-    }
-
-    public string Description
-    {
-      get
-      {
-        string description = cce.NonNull(Implementation.Name);
-        if (SplitIndex >= 0) {
-          description += "_split" + SplitIndex;
-        }
-
-        return description;
-      }
-    }
-
-    private void SoundnessCheck(HashSet<List<Block> /*!*/> /*!*/ cache, Block /*!*/ orig,
-      List<Block /*!*/> /*!*/ copies)
-    {
-      Contract.Requires(cce.NonNull(cache));
-      Contract.Requires(orig != null);
-      Contract.Requires(copies != null);
-      {
-        var t = new List<Block> {orig};
-        foreach (Block b in copies)
+        List<Block> trace = new List<Block>();
+        foreach (Block b in Blocks)
         {
           Contract.Assert(b != null);
-          t.Add(b);
+          trace.Add(b);
         }
 
-        if (cache.Contains(t))
+        foreach (Block b in Blocks)
         {
-          return;
-        }
-
-        cache.Add(t);
-      }
-
-      for (int i = 0; i < orig.Cmds.Count; ++i)
-      {
-        Cmd cmd = orig.Cmds[i];
-        if (cmd is AssertCmd)
-        {
-          int found = 0;
-          foreach (Block c in copies)
+          Contract.Assert(b != null);
+          foreach (Cmd c in b.Cmds)
           {
             Contract.Assert(c != null);
-            if (c.Cmds[i] == cmd)
+            if (c is AssertCmd)
             {
-              found++;
+              var counterexample = VCGen.AssertCmdToCounterexample(Options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context, this);
+              Counterexamples.Add(counterexample);
+              return counterexample;
             }
           }
-
-          if (found == 0)
-          {
-            throw new System.Exception(string.Format("missing assertion: {0}({1})", cmd.tok.filename, cmd.tok.line));
-          }
         }
+
+        Contract.Assume(false);
+        throw new cce.UnreachableException();
       }
 
-      foreach (Block exit in orig.Exits())
+      public static List<Split /*!*/> /*!*/ DoSplit(Split initial, double splitThreshold, int maxSplits)
       {
-        Contract.Assert(exit != null);
-        List<Block> newcopies = new List<Block>();
-        foreach (Block c in copies)
+        Contract.Requires(initial != null);
+        Contract.Ensures(cce.NonNullElements(Contract.Result<List<Split>>()));
+
+        var run = initial.Run;
+        var result = new List<Split> { initial };
+
+        while (result.Count < maxSplits)
         {
-          foreach (Block cexit in c.Exits())
+          Split best = null;
+          int bestIndex = 0;
+          for (var index = 0; index < result.Count; index++) {
+            var split = result[index];
+            Contract.Assert(split != null);
+            split.ComputeBestSplit(); // TODO check totalCost first
+            if (split.totalCost > splitThreshold &&
+                (best == null || best.totalCost < split.totalCost) &&
+                (split.assertionCount > 1 || split.splitBlock != null)) {
+              best = split;
+              bestIndex = index;
+            }
+          }
+
+          if (best == null)
           {
-            Contract.Assert(cexit != null);
-            if (cexit.Label == exit.Label)
+            break; // no split found
+          }
+
+          Split s0, s1;
+
+          bool splitStats = initial.Options.TraceVerify;
+
+          if (splitStats)
+          {
+            run.OutputWriter.WriteLine("{0} {1} -->", best.splitBlock == null ? "SLICE" : ("SPLIT@" + best.splitBlock.Label),
+              best.Stats);
+            if (best.splitBlock != null)
             {
-              newcopies.Add(cexit);
+              GotoCmd g = best.splitBlock.TransferCmd as GotoCmd;
+              if (g != null)
+              {
+                run.OutputWriter.Write("    exits: ");
+                foreach (Block b in cce.NonNull(g.labelTargets))
+                {
+                  Contract.Assert(b != null);
+                  run.OutputWriter.Write("{0} ", b.Label);
+                }
+
+                run.OutputWriter.WriteLine("");
+                run.OutputWriter.Write("    assumized: ");
+                foreach (Block b in best.assumizedBranches)
+                {
+                  Contract.Assert(b != null);
+                  run.OutputWriter.Write("{0} ", b.Label);
+                }
+
+                run.OutputWriter.WriteLine("");
+              }
+            }
+          }
+
+          if (best.splitBlock != null)
+          {
+            s0 = best.SplitAt(0);
+            s1 = best.SplitAt(1);
+          }
+          else
+          {
+            best.splitBlock = null;
+            s0 = best.SliceAsserts(best.assertionCost / 2, true);
+            s1 = best.SliceAsserts(best.assertionCost / 2, false);
+          }
+
+          if (true)
+          {
+            var ss = new List<Block>
+            {
+              s0.Blocks[0],
+              s1.Blocks[0]
+            };
+            try
+            {
+              best.SoundnessCheck(new HashSet<List<Block>>(new BlockListComparer()), best.Blocks[0], ss);
+            }
+            catch (System.Exception e)
+            {
+              run.OutputWriter.WriteLine(e);
+              best.DumpDot(-1);
+              s0.DumpDot(-2);
+              s1.DumpDot(-3);
+              Contract.Assert(false);
+              throw new cce.UnreachableException();
+            }
+          }
+
+          if (splitStats)
+          {
+            s0.ComputeBestSplit();
+            s1.ComputeBestSplit();
+            run.OutputWriter.WriteLine("    --> {0}", s0.Stats);
+            run.OutputWriter.WriteLine("    --> {0}", s1.Stats);
+          }
+
+          if (initial.Options.TraceVerify)
+          {
+            best.Print();
+          }
+
+          result[bestIndex] = s0;
+          result.Add(s1);
+        }
+
+        return result;
+      }
+
+      public (Bpl.Outcome outcome, VerificationRunResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
+      {
+        Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
+        Bpl.Outcome outcome = cce.NonNull(checker).ReadOutcome();
+
+        if (Options.Trace && SplitIndex >= 0)
+        {
+          Run.OutputWriter.WriteLine("      --> split #{0} done,  [{1} s] {2}", SplitIndex + 1,
+            checker.ProverRunTime.TotalSeconds, outcome);
+        }
+        if (Options.Trace && Options.TrackVerificationCoverage) {
+          Run.OutputWriter.WriteLine("Proof dependencies:\n  {0}",
+            string.Join("\n  ", CoveredElements.Select(s => s.Description).OrderBy(s => s)));
+        }
+
+        var resourceCount = checker.GetProverResourceCount();
+        var result = new VerificationRunResult(
+          VcNum: SplitIndex + 1,
+          Iteration: iteration,
+          StartTime: checker.ProverStart,
+          Outcome: outcome,
+          RunTime: checker.ProverRunTime,
+          MaxCounterExamples: checker.Options.ErrorLimit,
+          CounterExamples: Counterexamples,
+          Asserts: Asserts,
+          CoveredElements: CoveredElements,
+          ResourceCount: resourceCount,
+          SolverUsed: (Options as SMTLibSolverOptions)?.Solver);
+        callback.OnVCResult(result);
+
+        if (Options.VcsDumpSplits)
+        {
+          DumpDot(SplitIndex);
+        }
+
+        return (outcome, result, resourceCount);
+      }
+
+      public List<Counterexample> Counterexamples { get; } = new();
+
+      public HashSet<TrackedNodeComponent> CoveredElements { get; } = new();
+
+      /// <summary>
+      /// As a side effect, updates "this.parent.CumulativeAssertionCount".
+      /// </summary>
+      public async Task BeginCheck(TextWriter traceWriter, Checker checker, VerifierCallback callback, ModelViewInfo mvInfo, uint timeout,
+        uint rlimit, CancellationToken cancellationToken)
+      {
+        Contract.Requires(checker != null);
+        Contract.Requires(callback != null);
+
+        VCExpr vc;
+        // Lock impl since we're setting impl.Blocks that is used to generate the VC.
+        lock (Implementation) {
+          Implementation.Blocks = Blocks;
+
+          var absyIds = new ControlFlowIdMap<Absy>();
+
+          ProverContext ctx = checker.TheoremProver.Context;
+          Boogie2VCExprTranslator bet = ctx.BoogieExprTranslator;
+          var cc = new VCGen.CodeExprConversionClosure(traceWriter, checker.Pool.Options, absyIds, ctx);
+          bet.SetCodeExprConverter(cc.CodeExprToVerificationCondition);
+
+          var exprGen = ctx.ExprGen;
+          VCExpr controlFlowVariableExpr = exprGen.Integer(BigNum.ZERO);
+          vc = parent.GenerateVCAux(Implementation, controlFlowVariableExpr, absyIds, checker.TheoremProver.Context);
+          Contract.Assert(vc != null);
+
+          vc = QuantifierInstantiationEngine.Instantiate(Implementation, exprGen, bet, vc);
+
+          VCExpr controlFlowFunctionAppl =
+            exprGen.ControlFlowFunctionApplication(exprGen.Integer(BigNum.ZERO), exprGen.Integer(BigNum.ZERO));
+          VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(Implementation.Blocks[0]))));
+          vc = exprGen.Implies(eqExpr, vc);
+          reporter = new VCGen.ErrorReporter(Options, GotoCmdOrigins, absyIds, Implementation.Blocks, Implementation.debugInfos, callback,
+            mvInfo, checker.TheoremProver.Context, parent.program, this);
+        }
+
+        if (Options.TraceVerify && SplitIndex >= 0)
+        {
+          Run.OutputWriter.WriteLine("-- after split #{0}", SplitIndex);
+          Print();
+        }
+
+        checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions().Select(kv => new OptionValue(kv.Key, kv.Value)));
+        await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
+      }
+
+      public string Description
+      {
+        get
+        {
+          string description = cce.NonNull(Implementation.Name);
+          if (SplitIndex >= 0) {
+            description += "_split" + SplitIndex;
+          }
+
+          return description;
+        }
+      }
+
+      private void SoundnessCheck(HashSet<List<Block> /*!*/> /*!*/ cache, Block /*!*/ orig,
+        List<Block /*!*/> /*!*/ copies)
+      {
+        Contract.Requires(cce.NonNull(cache));
+        Contract.Requires(orig != null);
+        Contract.Requires(copies != null);
+        {
+          var t = new List<Block> {orig};
+          foreach (Block b in copies)
+          {
+            Contract.Assert(b != null);
+            t.Add(b);
+          }
+
+          if (cache.Contains(t))
+          {
+            return;
+          }
+
+          cache.Add(t);
+        }
+
+        for (int i = 0; i < orig.Cmds.Count; ++i)
+        {
+          Cmd cmd = orig.Cmds[i];
+          if (cmd is AssertCmd)
+          {
+            int found = 0;
+            foreach (Block c in copies)
+            {
+              Contract.Assert(c != null);
+              if (c.Cmds[i] == cmd)
+              {
+                found++;
+              }
+            }
+
+            if (found == 0)
+            {
+              throw new System.Exception(string.Format("missing assertion: {0}({1})", cmd.tok.filename, cmd.tok.line));
             }
           }
         }
 
-        if (newcopies.Count == 0)
+        foreach (Block exit in orig.Exits())
         {
-          throw new System.Exception("missing exit " + exit.Label);
+          Contract.Assert(exit != null);
+          List<Block> newcopies = new List<Block>();
+          foreach (Block c in copies)
+          {
+            foreach (Block cexit in c.Exits())
+            {
+              Contract.Assert(cexit != null);
+              if (cexit.Label == exit.Label)
+              {
+                newcopies.Add(cexit);
+              }
+            }
+          }
+
+          if (newcopies.Count == 0)
+          {
+            throw new System.Exception("missing exit " + exit.Label);
+          }
+
+          SoundnessCheck(cache, exit, newcopies);
         }
-
-        SoundnessCheck(cache, exit, newcopies);
       }
-    }
 
-    public int NextRandom() {
-      return randomGen.Next();
-    }
+      public int NextRandom() {
+        return randomGen.Next();
+      }
   }
 }

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -1269,7 +1269,7 @@ namespace VC
         }
       }
 
-      public (ProverInterface.Outcome outcome, VCResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
+      public (ProverInterface.Outcome outcome, VerificationRunResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
       {
         Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
         ProverInterface.Outcome outcome = cce.NonNull(checker).ReadOutcome();
@@ -1285,18 +1285,18 @@ namespace VC
         }
 
         var resourceCount = checker.GetProverResourceCount();
-        var result = new VCResult(
-          vcNum: SplitIndex + 1,
-          iteration: iteration,
-          startTime: checker.ProverStart,
-          outcome: outcome,
-          runTime: checker.ProverRunTime,
-          maxCounterExamples: checker.Options.ErrorLimit,
-          counterExamples: Counterexamples,
-          asserts: Asserts,
-          coveredElements: CoveredElements,
-          resourceCount: resourceCount,
-          solverUsed: (options as SMTLibSolverOptions)?.Solver);
+        var result = new VerificationRunResult(
+          VcNum: SplitIndex + 1,
+          Iteration: iteration,
+          StartTime: checker.ProverStart,
+          Outcome: outcome,
+          RunTime: checker.ProverRunTime,
+          MaxCounterExamples: checker.Options.ErrorLimit,
+          CounterExamples: Counterexamples,
+          Asserts: Asserts,
+          CoveredElements: CoveredElements,
+          ResourceCount: resourceCount,
+          SolverUsed: (options as SMTLibSolverOptions)?.Solver);
         callback.OnVCResult(result);
 
         if (options.VcsDumpSplits)

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -9,6 +9,7 @@ using System.IO;
 using Microsoft.BaseTypes;
 using Microsoft.Boogie.VCExprAST;
 using Microsoft.Boogie.SMTLib;
+using VCGeneration;
 
 namespace VC
 {
@@ -17,56 +18,21 @@ namespace VC
 
   public class Split : ProofRun
   {
-      private VCGenOptions options;
+    public VCGenOptions Options { get; }
 
-      public int? RandomSeed => Implementation.RandomSeed ?? options.RandomSeed;
-      private Random randomGen;
+    public int? RandomSeed => Implementation.RandomSeed ?? Options.RandomSeed;
+      private readonly Random randomGen;
 
-      private ImplementationRun run;
-
-      class BlockStats
-      {
-        public bool bigBlock;
-        public int id;
-        public double assertionCost;
-        public double assumptionCost; // before multiplier
-        public double incomingPaths;
-
-        public List<Block> /*!>!*/
-          virtualSuccessors = new List<Block>();
-
-        public List<Block> /*!>!*/
-          virtualPredecessors = new List<Block>();
-
-        public HashSet<Block> reachableBlocks;
-        public readonly Block block;
-
-        [ContractInvariantMethod]
-        void ObjectInvariant()
-        {
-          Contract.Invariant(cce.NonNullElements(virtualSuccessors));
-          Contract.Invariant(cce.NonNullElements(virtualPredecessors));
-          Contract.Invariant(block != null);
-        }
-
-
-        public BlockStats(Block b, int i)
-        {
-          Contract.Requires(b != null);
-          block = b;
-          assertionCost = -1;
-          id = i;
-        }
-      }
+      public ImplementationRun Run { get; }
 
       [ContractInvariantMethod]
       void ObjectInvariant()
       {
-        Contract.Invariant(cce.NonNullElements(blocks));
+        Contract.Invariant(cce.NonNullElements(Blocks));
         Contract.Invariant(cce.NonNullElements(bigBlocks));
         Contract.Invariant(cce.NonNullDictionaryAndValues(stats));
         Contract.Invariant(cce.NonNullElements(assumizedBranches));
-        Contract.Invariant(gotoCmdOrigins != null);
+        Contract.Invariant(GotoCmdOrigins != null);
         Contract.Invariant(parent != null);
         Contract.Invariant(Implementation != null);
         Contract.Invariant(copies != null);
@@ -75,8 +41,8 @@ namespace VC
       }
 
 
-      private readonly List<Block> blocks;
-      public List<AssertCmd> Asserts => blocks.SelectMany(block => block.cmds.OfType<AssertCmd>()).ToList();
+      public List<Block> Blocks { get; }
+      public List<AssertCmd> Asserts => Blocks.SelectMany(block => block.cmds.OfType<AssertCmd>()).ToList();
       public readonly IReadOnlyList<Declaration> TopLevelDeclarations;
       readonly List<Block> bigBlocks = new();
 
@@ -96,13 +62,11 @@ namespace VC
       int assertionCount;
       double assertionCost; // without multiplication by paths
 
-      Dictionary<TransferCmd, ReturnCmd> /*!*/
-        gotoCmdOrigins;
+      public Dictionary<TransferCmd, ReturnCmd> GotoCmdOrigins { get; }
 
-      readonly public VCGen /*!*/
-        parent;
+      public readonly VCGen /*!*/ parent;
 
-      public Implementation /*!*/ Implementation => run.Implementation;
+      public Implementation /*!*/ Implementation => Run.Implementation;
 
       Dictionary<Block /*!*/, Block /*!*/> /*!*/
         copies = new Dictionary<Block /*!*/, Block /*!*/>();
@@ -129,11 +93,11 @@ namespace VC
         Contract.Requires(cce.NonNullElements(blocks));
         Contract.Requires(gotoCmdOrigins != null);
         Contract.Requires(par != null);
-        this.blocks = blocks;
-        this.gotoCmdOrigins = gotoCmdOrigins;
+        this.Blocks = blocks;
+        this.GotoCmdOrigins = gotoCmdOrigins;
         this.parent = par;
-        this.run = run;
-        this.options = options;
+        this.Run = run;
+        this.Options = options;
         Interlocked.Increment(ref currentId);
 
         TopLevelDeclarations = par.program.TopLevelDeclarations;
@@ -145,14 +109,14 @@ namespace VC
 
       private void PrintTopLevelDeclarationsForPruning(Program program, Implementation implementation, string suffix)
       {
-        if (!options.Prune || options.PrintPrunedFile == null)
+        if (!Options.Prune || Options.PrintPrunedFile == null)
         {
           return;
         }
 
         using var writer = new TokenTextWriter(
-          $"{options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}.bpl", false,
-          options.PrettyPrint, options);
+          $"{Options.PrintPrunedFile}-{suffix}-{Util.EscapeFilename(implementation.Name)}.bpl", false,
+          Options.PrettyPrint, Options);
 
         var functionAxioms = 
           program.Functions.Where(f => f.DefinitionAxioms.Any()).SelectMany(f => f.DefinitionAxioms);
@@ -230,17 +194,17 @@ namespace VC
         string filename = string.Format("{0}.split.{1}.bpl", Implementation.Name, splitNum);
         using (System.IO.StreamWriter sw = System.IO.File.CreateText(filename))
         {
-          int oldPrintUnstructured = options.PrintUnstructured;
-          options.PrintUnstructured = 2; // print only the unstructured program
-          bool oldPrintDesugaringSetting = options.PrintDesugarings;
-          options.PrintDesugarings = false;
+          int oldPrintUnstructured = Options.PrintUnstructured;
+          Options.PrintUnstructured = 2; // print only the unstructured program
+          bool oldPrintDesugaringSetting = Options.PrintDesugarings;
+          Options.PrintDesugarings = false;
           List<Block> backup = Implementation.Blocks;
           Contract.Assert(backup != null);
-          Implementation.Blocks = blocks;
-          Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false, options), 0);
+          Implementation.Blocks = Blocks;
+          Implementation.Emit(new TokenTextWriter(filename, sw, /*setTokens=*/ false, /*pretty=*/ false, Options), 0);
           Implementation.Blocks = backup;
-          options.PrintDesugarings = oldPrintDesugaringSetting;
-          options.PrintUnstructured = oldPrintUnstructured;
+          Options.PrintDesugarings = oldPrintDesugaringSetting;
+          Options.PrintUnstructured = oldPrintUnstructured;
         }
       }
 
@@ -357,13 +321,13 @@ namespace VC
 
         assertionCount = 0;
 
-        foreach (Block b in blocks)
+        foreach (Block b in Blocks)
         {
           Contract.Assert(b != null);
           CountAssertions(b);
         }
 
-        foreach (Block b in blocks)
+        foreach (Block b in Blocks)
         {
           Contract.Assert(b != null);
           BlockStats bs = GetBlockStats(b);
@@ -376,7 +340,7 @@ namespace VC
               BlockStats chs = GetBlockStats(ch);
               if (!chs.bigBlock)
               {
-                options.OutputWriter.WriteLine("non-big {0} accessed from {1}", ch, b);
+                Options.OutputWriter.WriteLine("non-big {0} accessed from {1}", ch, b);
                 DumpDot(-1);
                 Contract.Assert(false);
                 throw new cce.UnreachableException();
@@ -446,7 +410,7 @@ namespace VC
           }
         }
 
-        if (options.VcsPathSplitMult * score > totalCost)
+        if (Options.VcsPathSplitMult * score > totalCost)
         {
           splitBlock = null;
           score = -1;
@@ -485,7 +449,7 @@ namespace VC
 
           if (count > 1)
           {
-            s.incomingPaths *= options.VcsPathJoinMult;
+            s.incomingPaths *= Options.VcsPathJoinMult;
           }
         }
       }
@@ -534,11 +498,11 @@ namespace VC
         keepAtAll.Clear();
 
         Debug.Assert(splitBlock == null || GetBlockStats(splitBlock).bigBlock);
-        Debug.Assert(GetBlockStats(blocks[0]).bigBlock);
+        Debug.Assert(GetBlockStats(Blocks[0]).bigBlock);
 
         if (assertToAssume)
         {
-          foreach (Block b in allowSmall ? blocks : bigBlocks)
+          foreach (Block b in allowSmall ? Blocks : bigBlocks)
           {
             Contract.Assert(b != null);
             if (ComputeReachableNodes(b).Contains(cce.NonNull(splitBlock)))
@@ -563,7 +527,7 @@ namespace VC
         }
         else
         {
-          ComputeBlockSetsHelper(blocks[0], allowSmall);
+          ComputeBlockSetsHelper(Blocks[0], allowSmall);
         }
       }
 
@@ -584,7 +548,7 @@ namespace VC
           GetBlockStats(b).incomingPaths = -1.0;
         }
 
-        GetBlockStats(blocks[0]).incomingPaths = 1.0;
+        GetBlockStats(Blocks[0]).incomingPaths = 1.0;
 
         double cost = 0.0;
         foreach (Block b in bigBlocks)
@@ -597,14 +561,14 @@ namespace VC
             double local = s.assertionCost;
             if (ShouldAssumize(b))
             {
-              local = (s.assertionCost + s.assumptionCost) * options.VcsAssumeMult;
+              local = (s.assertionCost + s.assumptionCost) * Options.VcsAssumeMult;
             }
             else
             {
-              local = s.assumptionCost * options.VcsAssumeMult + s.assertionCost;
+              local = s.assumptionCost * Options.VcsAssumeMult + s.assertionCost;
             }
 
-            local = local + local * s.incomingPaths * options.VcsPathCostMult;
+            local = local + local * s.incomingPaths * Options.VcsPathCostMult;
             cost += local;
           }
         }
@@ -652,7 +616,7 @@ namespace VC
 
             if (swap)
             {
-              theNewCmd = VCGen.AssertTurnedIntoAssume(options, a);
+              theNewCmd = VCGen.AssertTurnedIntoAssume(Options, a);
             }
           }
 
@@ -704,18 +668,18 @@ namespace VC
         Contract.Ensures(Contract.Result<Split>() != null);
 
         copies.Clear();
-        CloneBlock(blocks[0]);
+        CloneBlock(Blocks[0]);
         List<Block> newBlocks = new List<Block>();
         Dictionary<TransferCmd, ReturnCmd> newGotoCmdOrigins = new Dictionary<TransferCmd, ReturnCmd>();
-        foreach (Block b in blocks)
+        foreach (Block b in Blocks)
         {
           Contract.Assert(b != null);
           if (copies.TryGetValue(b, out var tmp))
           {
             newBlocks.Add(cce.NonNull(tmp));
-            if (gotoCmdOrigins.ContainsKey(b.TransferCmd))
+            if (GotoCmdOrigins.ContainsKey(b.TransferCmd))
             {
-              newGotoCmdOrigins[tmp.TransferCmd] = gotoCmdOrigins[b.TransferCmd];
+              newGotoCmdOrigins[tmp.TransferCmd] = GotoCmdOrigins[b.TransferCmd];
             }
 
             foreach (Block p in b.Predecessors)
@@ -729,7 +693,7 @@ namespace VC
           }
         }
 
-        return new Split(options, newBlocks, newGotoCmdOrigins, parent, run);
+        return new Split(Options, newBlocks, newGotoCmdOrigins, parent, Run);
       }
 
       Split SplitAt(int idx)
@@ -767,8 +731,8 @@ namespace VC
       {
         List<Block> tmp = Implementation.Blocks;
         Contract.Assert(tmp != null);
-        Implementation.Blocks = blocks;
-        ConditionGeneration.EmitImpl(options, run, false);
+        Implementation.Blocks = Blocks;
+        ConditionGeneration.EmitImpl(Options, Run, false);
         Implementation.Blocks = tmp;
       }
 
@@ -778,13 +742,13 @@ namespace VC
         Contract.Ensures(Contract.Result<Counterexample>() != null);
 
         List<Block> trace = new List<Block>();
-        foreach (Block b in blocks)
+        foreach (Block b in Blocks)
         {
           Contract.Assert(b != null);
           trace.Add(b);
         }
 
-        foreach (Block b in blocks)
+        foreach (Block b in Blocks)
         {
           Contract.Assert(b != null);
           foreach (Cmd c in b.Cmds)
@@ -792,7 +756,7 @@ namespace VC
             Contract.Assert(c != null);
             if (c is AssertCmd)
             {
-              var counterexample = VCGen.AssertCmdToCounterexample(options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context, this);
+              var counterexample = VCGen.AssertCmdToCounterexample(Options, (AssertCmd) c, cce.NonNull(b.TransferCmd), trace, null, null, null, context, this);
               Counterexamples.Add(counterexample);
               return counterexample;
             }
@@ -803,339 +767,12 @@ namespace VC
         throw new cce.UnreachableException();
       }
 
-      // Verify b with the last split in blockAssignments[b]
-      private static Dictionary<Block, Block> PickBlocksToVerify (List<Block> blocks, Dictionary<Block, int> splitPoints)
-      {
-        var todo = new Stack<Block>();
-        var blockAssignments = new Dictionary<Block, Block>();
-        var immediateDominator = (Program.GraphFromBlocks(blocks)).ImmediateDominator();
-        todo.Push(blocks[0]);
-        while(todo.Count > 0)
-        {
-          var currentBlock = todo.Pop();
-          if (blockAssignments.Keys.Contains(currentBlock))
-          {
-            continue;
-          }
-          else if (immediateDominator[currentBlock] == currentBlock) // if the currentBlock doesn't have a predecessor.
-          {
-            blockAssignments[currentBlock] = currentBlock;
-          }
-          else if (splitPoints.Keys.Contains(immediateDominator[currentBlock])) // if the currentBlock's dominator has a split then it will be associated with that split
-          {
-            blockAssignments[currentBlock] = immediateDominator[currentBlock];
-          }
-          else
-          {
-            Contract.Assert(blockAssignments.Keys.Contains(immediateDominator[currentBlock]));
-            blockAssignments[currentBlock] = blockAssignments[immediateDominator[currentBlock]];
-          }
-          if (currentBlock.TransferCmd is GotoCmd exit)
-          {
-            exit.labelTargets.ForEach(blk => todo.Push(blk));
-          }
-        }
-        return blockAssignments;
-      }
-      private static List<Block> DoPreAssignedManualSplit(VCGenOptions options, List<Block> blocks, Dictionary<Block, Block> blockAssignments, int splitNumberWithinBlock,
-        Block containingBlock, bool lastSplitInBlock, bool splitOnEveryAssert)
-      {
-        var newBlocks = new List<Block>(blocks.Count()); // Copies of the original blocks
-        var duplicator = new Duplicator();
-        var oldToNewBlockMap = new Dictionary<Block, Block>(blocks.Count()); // Maps original blocks to their new copies in newBlocks
-        foreach (var currentBlock in blocks)
-        {
-          var newBlock = (Block)duplicator.VisitBlock(currentBlock);
-          oldToNewBlockMap[currentBlock] = newBlock;
-          newBlocks.Add(newBlock);
-          if (currentBlock == containingBlock)
-          {
-            var newCmds = new List<Cmd>();
-            var splitCount = -1;
-            var verify = splitCount == splitNumberWithinBlock;
-            foreach (Cmd c in currentBlock.Cmds)
-            {
-              if (ShouldSplitHere(c, splitOnEveryAssert))
-              {
-                splitCount++;
-                verify = splitCount == splitNumberWithinBlock;
-              }
-              newCmds.Add(verify ? c : AssertIntoAssume(options, c));
-            }
-            newBlock.Cmds = newCmds;
-          }
-          else if (lastSplitInBlock && blockAssignments[currentBlock] == containingBlock)
-          {
-            var verify = true;
-            var newCmds = new List<Cmd>();
-            foreach(Cmd c in currentBlock.Cmds) {
-              verify = !ShouldSplitHere(c, splitOnEveryAssert) && verify;
-              newCmds.Add(verify ? c : AssertIntoAssume(options, c));
-            }
-            newBlock.Cmds = newCmds;
-          }
-          else
-          {
-            newBlock.Cmds = currentBlock.Cmds.Select<Cmd, Cmd>(x => AssertIntoAssume(options, x)).ToList();
-          }
-        }
-        // Patch the edges between the new blocks
-        foreach (var oldBlock in blocks)
-        {
-          if (oldBlock.TransferCmd is ReturnCmd)
-          {
-            continue;
-          }
-
-          var gotoCmd = (GotoCmd)oldBlock.TransferCmd;
-          var newLabelTargets = new List<Block>(gotoCmd.labelTargets.Count());
-          var newLabelNames = new List<string>(gotoCmd.labelTargets.Count());
-          foreach (var target in gotoCmd.labelTargets)
-          {
-            newLabelTargets.Add(oldToNewBlockMap[target]);
-            newLabelNames.Add(oldToNewBlockMap[target].Label);
-          }
-
-          oldToNewBlockMap[oldBlock].TransferCmd = new GotoCmd(gotoCmd.tok, newLabelNames, newLabelTargets);
-        }
-        return newBlocks;
-      }
-
-      private static List<Block> PostProcess(List<Block> blocks)
-      {
-        void DeleteFalseGotos (Block b)
-        {
-          bool isAssumeFalse (Cmd c) { return c is AssumeCmd ac && ac.Expr is LiteralExpr le && !le.asBool; }
-          var firstFalseIdx = b.Cmds.FindIndex(c => isAssumeFalse(c));
-          if (firstFalseIdx != -1)
-          {
-            b.Cmds = b.Cmds.Take(firstFalseIdx + 1).ToList();
-            b.TransferCmd = (b.TransferCmd is GotoCmd) ? new ReturnCmd(b.tok) : b.TransferCmd;
-          }
-        }
-
-        bool ContainsAssert(Block b)
-        {
-          bool isNonTrivialAssert (Cmd c) { return c is AssertCmd ac && !(ac.Expr is LiteralExpr le && le.asBool); }
-          return b.Cmds.Exists(cmd => isNonTrivialAssert(cmd));
-        }
-
-        blocks.ForEach(b => DeleteFalseGotos(b)); // make blocks ending in assume false leaves of the CFG-DAG -- this is probably unnecessary, may have been done previously
-        var todo = new Stack<Block>();
-        var peeked = new HashSet<Block>();
-        var interestingBlocks = new HashSet<Block>();
-        todo.Push(blocks[0]);
-        while(todo.Count() > 0)
-        {
-          var currentBlock = todo.Peek();
-          var pop = peeked.Contains(currentBlock);
-          peeked.Add(currentBlock);
-          var interesting = false;
-          var exit = currentBlock.TransferCmd as GotoCmd;
-          if (exit != null && !pop) {
-            exit.labelTargets.ForEach(b => todo.Push(b));
-          } else if (exit != null) {
-            Contract.Assert(pop);
-            var gtc = new GotoCmd(exit.tok, exit.labelTargets.Where(l => interestingBlocks.Contains(l)).ToList());
-            currentBlock.TransferCmd = gtc;
-            interesting = interesting || gtc.labelTargets.Count() != 0;
-          }
-          if (pop)
-          {
-            interesting = interesting || ContainsAssert(currentBlock);
-            if (interesting) {
-              interestingBlocks.Add(currentBlock);
-            }
-            todo.Pop();
-          }
-        }
-        interestingBlocks.Add(blocks[0]); // must not be empty
-        return blocks.Where(b => interestingBlocks.Contains(b)).ToList(); // this is not the same as interestingBlocks.ToList() because the resulting lists will have different orders.
-      }
-
-      private static bool ShouldSplitHere(Cmd c, bool splitOnEveryAssert) {
-        return c is PredicateCmd p && QKeyValue.FindBoolAttribute(p.Attributes, "split_here")
-               || c is AssertCmd && splitOnEveryAssert;
-      }
-      
-      public static List<Split /*!*/> FindManualSplits(Split initialSplit, bool splitOnEveryAssert)
-      {
-        Contract.Requires(initialSplit.Implementation != null);
-        Contract.Ensures(Contract.Result<List<Split>>() == null || cce.NonNullElements(Contract.Result<List<Split>>()));
-
-        var splitPoints = new Dictionary<Block, int>();
-        foreach (var b in initialSplit.blocks)
-        {
-          foreach (Cmd c in b.Cmds)
-          {
-            var p = c as PredicateCmd;
-            if (ShouldSplitHere(c, splitOnEveryAssert))
-            {
-              splitPoints.TryGetValue(b, out var count);
-              splitPoints[b] = count + 1;
-            }
-          }
-        }
-        var splits = new List<Split>();
-        if (!splitPoints.Any())
-        {
-          splits.Add(initialSplit);
-        }
-        else
-        {
-          Block entryPoint = initialSplit.blocks[0];
-          var blockAssignments = PickBlocksToVerify(initialSplit.blocks, splitPoints);
-          var entryBlockHasSplit = splitPoints.Keys.Contains(entryPoint);
-          var baseSplitBlocks = PostProcess(DoPreAssignedManualSplit(initialSplit.options, initialSplit.blocks, blockAssignments, -1, entryPoint, !entryBlockHasSplit, splitOnEveryAssert));
-          splits.Add(new Split(initialSplit.options, baseSplitBlocks, initialSplit.gotoCmdOrigins, initialSplit.parent, initialSplit.run));
-          foreach (KeyValuePair<Block, int> pair in splitPoints)
-          {
-            for (int i = 0; i < pair.Value; i++)
-            {
-              bool lastSplitInBlock = i == pair.Value - 1;
-              var newBlocks = DoPreAssignedManualSplit(initialSplit.options, initialSplit.blocks, blockAssignments, i, pair.Key, lastSplitInBlock, splitOnEveryAssert);
-              splits.Add(new Split(initialSplit.options, PostProcess(newBlocks), initialSplit.gotoCmdOrigins, initialSplit.parent, initialSplit.run)); // REVIEW: Does gotoCmdOrigins need to be changed at all?
-            }
-          }
-        }
-        return splits;
-      }
-
-      public static List<Split> FocusImpl(VCGenOptions options, ImplementationRun run, Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins, VCGen par)
-      {
-        bool IsFocusCmd(Cmd c) {
-          return c is PredicateCmd p && QKeyValue.FindBoolAttribute(p.Attributes, "focus");
-        }
-
-        List<Block> GetFocusBlocks(List<Block> blocks) {
-          return blocks.Where(blk => blk.Cmds.Any(c => IsFocusCmd(c))).ToList();
-        }
-
-        var impl = run.Implementation;
-        var dag = Program.GraphFromImpl(impl);
-        var topoSorted = dag.TopologicalSort().ToList();
-        // By default, we process the foci in a top-down fashion, i.e., in the topological order.
-        // If the user sets the RelaxFocus flag, we use the reverse (topological) order.
-        var focusBlocks = GetFocusBlocks(topoSorted);
-        if (par.CheckerPool.Options.RelaxFocus) {
-          focusBlocks.Reverse();
-        }
-        if (!focusBlocks.Any()) {
-          var f = new List<Split>();
-          f.Add(new Split(options, impl.Blocks, gotoCmdOrigins, par, run));
-          return f;
-        }
-        // finds all the blocks dominated by focusBlock in the subgraph
-        // which only contains vertices of subgraph.
-        HashSet<Block> DominatedBlocks(Block focusBlock, IEnumerable<Block> subgraph)
-        {
-          var dominators = new Dictionary<Block, HashSet<Block>>();
-          var todo = new Queue<Block>();
-          foreach (var b in topoSorted.Where(blk => subgraph.Contains(blk)))
-          {
-            var s = new HashSet<Block>();
-            var pred = b.Predecessors.Where(blk => subgraph.Contains(blk)).ToList();
-            if (pred.Count != 0)
-            {
-              s.UnionWith(dominators[pred[0]]);
-              pred.ForEach(blk => s.IntersectWith(dominators[blk]));
-            }
-            s.Add(b);
-            dominators[b] = s;
-          }
-          return subgraph.Where(blk => dominators[blk].Contains(focusBlock)).ToHashSet();
-        }
-
-        Cmd DisableSplits(Cmd c)
-        {
-          if (c is PredicateCmd pc)
-          {
-            for (var kv = pc.Attributes; kv != null; kv = kv.Next)
-            {
-              if (kv.Key == "split")
-              {
-                kv.AddParam(new LiteralExpr(Token.NoToken, false));
-              }
-            }
-          }
-          return c;
-        }
-
-        var Ancestors = new Dictionary<Block, HashSet<Block>>();
-        var Descendants = new Dictionary<Block, HashSet<Block>>();
-        focusBlocks.ForEach(fb => Ancestors[fb] = dag.ComputeReachability(fb, false).ToHashSet());
-        focusBlocks.ForEach(fb => Descendants[fb] = dag.ComputeReachability(fb, true).ToHashSet());
-        var s = new List<Split>();
-        var duplicator = new Duplicator();
-        void FocusRec(int focusIdx, IEnumerable<Block> blocks, IEnumerable<Block> freeBlocks)
-        {
-          if (focusIdx == focusBlocks.Count())
-          {
-            // it is important for l to be consistent with reverse topological order.
-            var l = dag.TopologicalSort().Where(blk => blocks.Contains(blk)).Reverse();
-            // assert that the root block, impl.Blocks[0], is in l
-            Contract.Assert(l.ElementAt(l.Count() - 1) == impl.Blocks[0]);
-            var newBlocks = new List<Block>();
-            var oldToNewBlockMap = new Dictionary<Block, Block>(blocks.Count());
-            foreach (Block b in l)
-            {
-              var newBlock = (Block)duplicator.Visit(b);
-              newBlocks.Add(newBlock);
-              oldToNewBlockMap[b] = newBlock;
-              // freeBlocks consist of the predecessors of the relevant foci.
-              // Their assertions turn into assumes and any splits inside them are disabled.
-              if(freeBlocks.Contains(b))
-              {
-                newBlock.Cmds = b.Cmds.Select(c => Split.AssertIntoAssume(options, c)).Select(c => DisableSplits(c)).ToList();
-              }
-              if (b.TransferCmd is GotoCmd gtc)
-              {
-                var targets = gtc.labelTargets.Where(blk => blocks.Contains(blk));
-                newBlock.TransferCmd = new GotoCmd(gtc.tok,
-                                              targets.Select(blk => oldToNewBlockMap[blk].Label).ToList(),
-                                              targets.Select(blk => oldToNewBlockMap[blk]).ToList());
-              }
-            }
-            newBlocks.Reverse();
-            Contract.Assert(newBlocks[0] == oldToNewBlockMap[impl.Blocks[0]]);
-            s.Add(new Split(options, PostProcess(newBlocks), gotoCmdOrigins, par, run));
-          }
-          else if (!blocks.Contains(focusBlocks[focusIdx])
-                    || freeBlocks.Contains(focusBlocks[focusIdx]))
-          {
-            FocusRec(focusIdx + 1, blocks, freeBlocks);
-          }
-          else
-          {
-            var b = focusBlocks[focusIdx]; // assert b in blocks
-            var dominatedBlocks = DominatedBlocks(b, blocks);
-            // the first part takes all blocks except the ones dominated by the focus block
-            FocusRec(focusIdx + 1, blocks.Where(blk => !dominatedBlocks.Contains(blk)), freeBlocks);
-            var ancestors = Ancestors[b];
-            ancestors.Remove(b);
-            var descendants = Descendants[b];
-            // the other part takes all the ancestors, the focus block, and the descendants.
-            FocusRec(focusIdx + 1, ancestors.Union(descendants).Intersect(blocks), ancestors.Union(freeBlocks));
-          }
-        }
-
-        FocusRec(0, impl.Blocks, new List<Block>());
-        return s;
-      }
-
-      public static List<Split> FocusAndSplit(VCGenOptions options, ImplementationRun run, Dictionary<TransferCmd, ReturnCmd> gotoCmdOrigins, VCGen par, bool splitOnEveryAssert)
-      {
-        List<Split> focussedImpl = FocusImpl(options, run, gotoCmdOrigins, par);
-        var splits = focussedImpl.Select(s => FindManualSplits(s, splitOnEveryAssert)).SelectMany(x => x).ToList();
-        return splits;
-      }
-
       public static List<Split /*!*/> /*!*/ DoSplit(Split initial, double splitThreshold, int maxSplits)
       {
         Contract.Requires(initial != null);
         Contract.Ensures(cce.NonNullElements(Contract.Result<List<Split>>()));
 
-        var run = initial.run;
+        var run = initial.Run;
         var result = new List<Split> { initial };
 
         while (result.Count < maxSplits)
@@ -1161,7 +798,7 @@ namespace VC
 
           Split s0, s1;
 
-          bool splitStats = initial.options.TraceVerify;
+          bool splitStats = initial.Options.TraceVerify;
 
           if (splitStats)
           {
@@ -1208,12 +845,12 @@ namespace VC
           {
             var ss = new List<Block>
             {
-              s0.blocks[0],
-              s1.blocks[0]
+              s0.Blocks[0],
+              s1.Blocks[0]
             };
             try
             {
-              best.SoundnessCheck(new HashSet<List<Block>>(new BlockListComparer()), best.blocks[0], ss);
+              best.SoundnessCheck(new HashSet<List<Block>>(new BlockListComparer()), best.Blocks[0], ss);
             }
             catch (System.Exception e)
             {
@@ -1234,7 +871,7 @@ namespace VC
             run.OutputWriter.WriteLine("    --> {0}", s1.Stats);
           }
 
-          if (initial.options.TraceVerify)
+          if (initial.Options.TraceVerify)
           {
             best.Print();
           }
@@ -1246,41 +883,18 @@ namespace VC
         return result;
       }
 
-      class BlockListComparer : IEqualityComparer<List<Block>>
-      {
-        public bool Equals(List<Block> x, List<Block> y)
-        {
-          return x == y || x.SequenceEqual(y);
-        }
-
-        public int GetHashCode(List<Block> obj)
-        {
-          int h = 0;
-          Contract.Assume(obj != null);
-          foreach (var b in obj)
-          {
-            if (b != null)
-            {
-              h += b.GetHashCode();
-            }
-          }
-
-          return h;
-        }
-      }
-
       public (Bpl.Outcome outcome, VerificationRunResult result, int resourceCount) ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
       {
         Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
         Bpl.Outcome outcome = cce.NonNull(checker).ReadOutcome();
 
-        if (options.Trace && SplitIndex >= 0)
+        if (Options.Trace && SplitIndex >= 0)
         {
-          run.OutputWriter.WriteLine("      --> split #{0} done,  [{1} s] {2}", SplitIndex + 1,
+          Run.OutputWriter.WriteLine("      --> split #{0} done,  [{1} s] {2}", SplitIndex + 1,
             checker.ProverRunTime.TotalSeconds, outcome);
         }
-        if (options.Trace && options.TrackVerificationCoverage) {
-          run.OutputWriter.WriteLine("Proof dependencies:\n  {0}",
+        if (Options.Trace && Options.TrackVerificationCoverage) {
+          Run.OutputWriter.WriteLine("Proof dependencies:\n  {0}",
             string.Join("\n  ", CoveredElements.Select(s => s.Description).OrderBy(s => s)));
         }
 
@@ -1296,10 +910,10 @@ namespace VC
           Asserts: Asserts,
           CoveredElements: CoveredElements,
           ResourceCount: resourceCount,
-          SolverUsed: (options as SMTLibSolverOptions)?.Solver);
+          SolverUsed: (Options as SMTLibSolverOptions)?.Solver);
         callback.OnVCResult(result);
 
-        if (options.VcsDumpSplits)
+        if (Options.VcsDumpSplits)
         {
           DumpDot(SplitIndex);
         }
@@ -1323,7 +937,7 @@ namespace VC
         VCExpr vc;
         // Lock impl since we're setting impl.Blocks that is used to generate the VC.
         lock (Implementation) {
-          Implementation.Blocks = blocks;
+          Implementation.Blocks = Blocks;
 
           var absyIds = new ControlFlowIdMap<Absy>();
 
@@ -1343,13 +957,13 @@ namespace VC
             exprGen.ControlFlowFunctionApplication(exprGen.Integer(BigNum.ZERO), exprGen.Integer(BigNum.ZERO));
           VCExpr eqExpr = exprGen.Eq(controlFlowFunctionAppl, exprGen.Integer(BigNum.FromInt(absyIds.GetId(Implementation.Blocks[0]))));
           vc = exprGen.Implies(eqExpr, vc);
-          reporter = new VCGen.ErrorReporter(options, gotoCmdOrigins, absyIds, Implementation.Blocks, Implementation.debugInfos, callback,
+          reporter = new VCGen.ErrorReporter(Options, GotoCmdOrigins, absyIds, Implementation.Blocks, Implementation.debugInfos, callback,
             mvInfo, checker.TheoremProver.Context, parent.program, this);
         }
 
-        if (options.TraceVerify && SplitIndex >= 0)
+        if (Options.TraceVerify && SplitIndex >= 0)
         {
-          run.OutputWriter.WriteLine("-- after split #{0}", SplitIndex);
+          Run.OutputWriter.WriteLine("-- after split #{0}", SplitIndex);
           Print();
         }
 
@@ -1368,16 +982,6 @@ namespace VC
 
           return description;
         }
-      }
-
-      private static Cmd AssertIntoAssume(VCGenOptions options, Cmd c)
-      {
-        if (c is AssertCmd assrt)
-        {
-          return VCGen.AssertTurnedIntoAssume(options, assrt);
-        }
-
-        return c;
       }
 
       private void SoundnessCheck(HashSet<List<Block> /*!*/> /*!*/ cache, Block /*!*/ orig,

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -13,8 +13,8 @@ namespace VC
 {
   class SplitAndVerifyWorker
   {
-    public IObservable<(Split split, VCResult vcResult)> BatchCompletions => batchCompletions;
-    private readonly Subject<(Split split, VCResult vcResult)> batchCompletions = new();
+    public IObservable<(Split split, VerificationRunResult vcResult)> BatchCompletions => batchCompletions;
+    private readonly Subject<(Split split, VerificationRunResult vcResult)> batchCompletions = new();
 
     private readonly VCGenOptions options;
     private readonly VerifierCallback callback;
@@ -254,7 +254,7 @@ namespace VC
       }
     }
 
-    private async Task HandleProverFailure(Split split, Checker checker, VerifierCallback callback, VCResult vcResult, CancellationToken cancellationToken)
+    private async Task HandleProverFailure(Split split, Checker checker, VerifierCallback callback, VerificationRunResult verificationRunResult, CancellationToken cancellationToken)
     {
       if (split.LastChance) {
         string msg = "some timeout";
@@ -266,8 +266,8 @@ namespace VC
         callback.OnCounterexample(cex, msg);
         split.Counterexamples.Add(cex);
         // Update one last time the result with the dummy counter-example to indicate the position of the timeout
-        var result = vcResult with {
-          counterExamples = split.Counterexamples
+        var result = verificationRunResult with {
+          CounterExamples = split.Counterexamples
         };
         batchCompletions.OnNext((split, result));
         outcome = Outcome.Errors;
@@ -317,7 +317,7 @@ namespace VC
         callback.OnOutOfResource(msg);
       }
 
-      batchCompletions.OnNext((split, vcResult));
+      batchCompletions.OnNext((split, verificationRunResult));
     }
   }
 }

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -7,6 +7,7 @@ using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Boogie;
+using VCGeneration;
 using static VC.ConditionGeneration;
 using Outcome = Microsoft.Boogie.Outcome;
 
@@ -68,7 +69,7 @@ namespace VC
       Implementation.CheckBooleanAttribute("vcs_split_on_every_assert", ref splitOnEveryAssert);
 
       ResetPredecessors(Implementation.Blocks);
-      manualSplits = Split.FocusAndSplit(options, run, gotoCmdOrigins, vcGen, splitOnEveryAssert);
+      manualSplits = ManualSplitFinder.FocusAndSplit(options, run, gotoCmdOrigins, vcGen, splitOnEveryAssert);
       
       if (manualSplits.Count == 1 && maxSplits > 1) {
         manualSplits = Split.DoSplit(manualSplits[0], maxVcCost, maxSplits);

--- a/Source/VCGeneration/StratifiedVC.cs
+++ b/Source/VCGeneration/StratifiedVC.cs
@@ -990,7 +990,7 @@ namespace VC
       return true;
     }
 
-    public abstract Outcome FindLeastToVerify(Implementation impl, ref HashSet<string> allBoolVars);
+    public abstract VcOutcome FindLeastToVerify(Implementation impl, ref HashSet<string> allBoolVars);
   }
 
 } // namespace VC

--- a/Source/VCGeneration/VCGen.cs
+++ b/Source/VCGeneration/VCGen.cs
@@ -356,7 +356,7 @@ namespace VC
     private static ConditionalWeakTable<Implementation, ImplementationTransformationData> implementationData = new();
 
     public override async Task<Outcome> VerifyImplementation(ImplementationRun run, VerifierCallback callback,
-      CancellationToken cancellationToken, IObserver<(Split split, VCResult vcResult)> batchCompletedObserver)
+      CancellationToken cancellationToken, IObserver<(Split split, VerificationRunResult vcResult)> batchCompletedObserver)
     {
       Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
 

--- a/Source/VCGeneration/VerificationResultCollector.cs
+++ b/Source/VCGeneration/VerificationResultCollector.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Contracts;
+using Microsoft.Boogie;
+
+namespace VC;
+
+public class VerificationResultCollector : VerifierCallback
+{
+  private readonly VCGenOptions options;
+
+  public VerificationResultCollector(VCGenOptions options) : base(options.PrintProverWarnings)
+  {
+    this.options = options;
+  }
+
+  [ContractInvariantMethod]
+  void ObjectInvariant()
+  {
+    Contract.Invariant(cce.NonNullElements(examples));
+    Contract.Invariant(cce.NonNullElements(vcResults));
+  }
+
+  public readonly ConcurrentQueue<Counterexample> examples = new();
+  public readonly ConcurrentQueue<VerificationRunResult> vcResults = new();
+
+  public override void OnCounterexample(Counterexample ce, string /*?*/ reason)
+  {
+    //Contract.Requires(ce != null);
+    ce.InitializeModelStates();
+    examples.Enqueue(ce);
+  }
+
+  public override void OnUnreachableCode(ImplementationRun run)
+  {
+    //Contract.Requires(impl != null);
+    run.OutputWriter.WriteLine("found unreachable code:");
+    ConditionGeneration.EmitImpl(options, run, false);
+    // TODO report error about next to last in seq
+  }
+
+  public override void OnVCResult(VerificationRunResult result)
+  {
+    vcResults.Enqueue(result);
+  }
+}

--- a/Source/VCGeneration/VerificationRunResult.cs
+++ b/Source/VCGeneration/VerificationRunResult.cs
@@ -15,28 +15,28 @@ namespace VC
   using Bpl = Microsoft.Boogie;
   using System.Threading.Tasks;
 
-  public record VCResult
+  public record VerificationRunResult
   (
-    int vcNum,
-    int iteration,
-    DateTime startTime,
-    ProverInterface.Outcome outcome,
-    TimeSpan runTime,
-    int maxCounterExamples,
-    List<Counterexample> counterExamples,
-    List<AssertCmd> asserts,
-    IEnumerable<TrackedNodeComponent> coveredElements,
-    int resourceCount,
-    SolverKind? solverUsed
+    int VcNum,
+    int Iteration,
+    DateTime StartTime,
+    ProverInterface.Outcome Outcome,
+    TimeSpan RunTime,
+    int MaxCounterExamples,
+    List<Counterexample> CounterExamples,
+    List<AssertCmd> Asserts,
+    IEnumerable<TrackedNodeComponent> CoveredElements,
+    int ResourceCount,
+    SolverKind? SolverUsed
   ) {
     public void ComputePerAssertOutcomes(out Dictionary<AssertCmd, ProverInterface.Outcome> perAssertOutcome,
       out Dictionary<AssertCmd, Counterexample> perAssertCounterExamples) {
       perAssertOutcome = new();
       perAssertCounterExamples = new();
-      if (outcome == ProverInterface.Outcome.Valid) {
-        perAssertOutcome = asserts.ToDictionary(cmd => cmd, assertCmd => ProverInterface.Outcome.Valid);
+      if (Outcome == ProverInterface.Outcome.Valid) {
+        perAssertOutcome = Asserts.ToDictionary(cmd => cmd, assertCmd => ProverInterface.Outcome.Valid);
       } else {
-        foreach (var counterExample in counterExamples) {
+        foreach (var counterExample in CounterExamples) {
           AssertCmd underlyingAssert;
           if (counterExample is AssertCounterexample assertCounterexample) {
             underlyingAssert = assertCounterexample.FailingAssert;
@@ -49,7 +49,7 @@ namespace VC
           }
 
           // We ensure that the underlyingAssert is among the original asserts
-          if (!asserts.Contains(underlyingAssert)) {
+          if (!Asserts.Contains(underlyingAssert)) {
             continue;
           }
 
@@ -58,16 +58,16 @@ namespace VC
         }
 
         var remainingOutcome =
-          outcome == ProverInterface.Outcome.Invalid && counterExamples.Count < maxCounterExamples
+          Outcome == ProverInterface.Outcome.Invalid && CounterExamples.Count < MaxCounterExamples
             // We could not extract more counterexamples, remaining assertions are thus valid 
             ? ProverInterface.Outcome.Valid
-            : outcome == ProverInterface.Outcome.Invalid
+            : Outcome == ProverInterface.Outcome.Invalid
               // We reached the maximum number of counterexamples, we can't infer anything for the remaining assertions
               ? ProverInterface.Outcome.Undetermined
               // TimeOut, OutOfMemory, OutOfResource, Undetermined for a single split also applies to assertions
-              : outcome;
+              : Outcome;
 
-        foreach (var assert in asserts) {
+        foreach (var assert in Asserts) {
           perAssertOutcome.TryAdd(assert, remainingOutcome);
         }
       }

--- a/Source/VCGeneration/VerificationRunResult.cs
+++ b/Source/VCGeneration/VerificationRunResult.cs
@@ -20,7 +20,7 @@ namespace VC
     int VcNum,
     int Iteration,
     DateTime StartTime,
-    ProverInterface.Outcome Outcome,
+    Bpl.Outcome Outcome,
     TimeSpan RunTime,
     int MaxCounterExamples,
     List<Counterexample> CounterExamples,
@@ -29,12 +29,12 @@ namespace VC
     int ResourceCount,
     SolverKind? SolverUsed
   ) {
-    public void ComputePerAssertOutcomes(out Dictionary<AssertCmd, ProverInterface.Outcome> perAssertOutcome,
+    public void ComputePerAssertOutcomes(out Dictionary<AssertCmd, Bpl.Outcome> perAssertOutcome,
       out Dictionary<AssertCmd, Counterexample> perAssertCounterExamples) {
       perAssertOutcome = new();
       perAssertCounterExamples = new();
-      if (Outcome == ProverInterface.Outcome.Valid) {
-        perAssertOutcome = Asserts.ToDictionary(cmd => cmd, assertCmd => ProverInterface.Outcome.Valid);
+      if (Outcome == Bpl.Outcome.Valid) {
+        perAssertOutcome = Asserts.ToDictionary(cmd => cmd, assertCmd => Bpl.Outcome.Valid);
       } else {
         foreach (var counterExample in CounterExamples) {
           AssertCmd underlyingAssert;
@@ -53,17 +53,17 @@ namespace VC
             continue;
           }
 
-          perAssertOutcome.TryAdd(underlyingAssert, ProverInterface.Outcome.Invalid);
+          perAssertOutcome.TryAdd(underlyingAssert, Bpl.Outcome.Invalid);
           perAssertCounterExamples.TryAdd(underlyingAssert, counterExample);
         }
 
         var remainingOutcome =
-          Outcome == ProverInterface.Outcome.Invalid && CounterExamples.Count < MaxCounterExamples
+          Outcome == Bpl.Outcome.Invalid && CounterExamples.Count < MaxCounterExamples
             // We could not extract more counterexamples, remaining assertions are thus valid 
-            ? ProverInterface.Outcome.Valid
-            : Outcome == ProverInterface.Outcome.Invalid
+            ? Bpl.Outcome.Valid
+            : Outcome == Bpl.Outcome.Invalid
               // We reached the maximum number of counterexamples, we can't infer anything for the remaining assertions
-              ? ProverInterface.Outcome.Undetermined
+              ? Bpl.Outcome.Undetermined
               // TimeOut, OutOfMemory, OutOfResource, Undetermined for a single split also applies to assertions
               : Outcome;
 


### PR DESCRIPTION
### Changes
- Rename VCGen to VerificationConditionGenerator
- Rename VerificationResult to ImplementationRunResult
- Rename VCResult to VerificationRunResult
- Move several classes into separate files: BlockListComparer, BlockStats, VerificationResultCollector
- Move several methods from Split into several new files: BlockTransformation.cs, CommandTransformations.cs, ManualSplitFinder.cs and FocusAttribute.cs
- Rename `ConditionGeneration.Outcome` to `VcOutcome` and move it to the outer scope
- Move `ProverInterface.Outcome` to the outer scope

### Testing
This is pure almost fully automated refactoring, so this is covered by existing automated tests