### PR TITLE
Print resource counts when using -smoke

### DIFF
--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -1288,7 +1288,11 @@ namespace Microsoft.Boogie
               ps.CheckBooleanFlag("checkInfer", x => InstrumentWithAsserts = x) ||
               ps.CheckBooleanFlag("restartProver", x => restartProverPerVc = x) ||
               ps.CheckBooleanFlag("printInlined", x => printInlined = x) ||
-              ps.CheckBooleanFlag("smoke", x => SoundnessSmokeTest = x) ||
+              ps.CheckBooleanFlag("smoke", x =>
+              {
+                SoundnessSmokeTest = x;
+                Prune = false;
+              }) ||
               ps.CheckBooleanFlag("vcsDumpSplits", x => VcsDumpSplits = x) ||
               ps.CheckBooleanFlag("dbgRefuted", x => DebugRefuted = x) ||
               ps.CheckBooleanFlag("reflectAdd", x => ReflectAdd = x) ||

--- a/Source/VCGeneration/SmokeTester.cs
+++ b/Source/VCGeneration/SmokeTester.cs
@@ -279,6 +279,7 @@ public class SmokeTester
     Contract.Assert(checker != null);
 
     SolverOutcome outcome = SolverOutcome.Undetermined;
+    var resourceCount = 0;
     try
     {
       VCExpr vc;
@@ -309,6 +310,7 @@ public class SmokeTester
         Options.SmokeTimeout, Options.ResourceLimit, CancellationToken.None);
 
       await checker.ProverTask;
+      resourceCount = checker.GetProverResourceCount();
 
       lock (checker)
       {
@@ -326,7 +328,9 @@ public class SmokeTester
     TimeSpan elapsed = end - start;
     if (Options.Trace)
     {
-      traceWriter.WriteLine("  [{0} s] {1}", elapsed.TotalSeconds,
+      traceWriter.WriteLine("  [{0} s, resource count: {1}] {2}",
+        elapsed.TotalSeconds,
+        resourceCount,
         outcome == SolverOutcome.Valid
           ? "OOPS"
           : "OK" + (outcome == SolverOutcome.Invalid ? "" : " (" + outcome + ")"));


### PR DESCRIPTION
Previously, the output of `-trace` when using `-smoke` didn't indicate the resource count for each attempt to prove `false`, only the time. Now it prints both. This PR also disables pruning when `-smoke` is enabled, because pruning currently leads to SMT syntax errors.