### PR TITLE
[Civl] Fixed bug in refinement check for actions

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -74,8 +74,6 @@ namespace Microsoft.Boogie
 
     public LayerRange LayerRange => ActionDecl.LayerRange;
 
-    public int LowerLayer => LayerRange.LowerLayer;
-
     public IEnumerable<ActionDecl> PendingAsyncs => ActionDecl.CreateActionDecls;
     
     public bool HasPendingAsyncs => PendingAsyncs.Any();

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -462,6 +462,11 @@ namespace Microsoft.Boogie
 
     public IEnumerable<Variable> GlobalVariables => program.GlobalVariables;
 
+    public IEnumerable<Variable> GlobalVariablesAtLayer(int layerNum)
+    {
+      return GlobalVariables.Where(v => v.LayerRange.LowerLayer <= layerNum && layerNum < v.LayerRange.UpperLayer);
+    }
+
     public IEnumerable<Action> MoverActions => actionDeclToAction.Keys
       .Where(actionDecl => actionDecl.HasMoverType).Select(actionDecl => actionDeclToAction[actionDecl]);
 

--- a/Source/Concurrency/RefinementInstrumentation.cs
+++ b/Source/Concurrency/RefinementInstrumentation.cs
@@ -74,15 +74,10 @@ namespace Microsoft.Boogie
       this.tok = impl.tok;
       this.oldGlobalMap = new Dictionary<Variable, Variable>();
       var yieldProcedureDecl = (YieldProcedureDecl)originalImpl.Proc;
-      //ActionProc actionProc = civlTypeChecker.procToYieldingProc[originalImpl.Proc] as ActionProc;
       this.layerNum = yieldProcedureDecl.Layer;
-      foreach (Variable v in civlTypeChecker.GlobalVariables)
+      foreach (Variable v in civlTypeChecker.GlobalVariablesAtLayer(layerNum))
       {
-        var layerRange = v.LayerRange;
-        if (layerRange.LowerLayer <= layerNum && layerNum < layerRange.UpperLayer)
-        {
-          this.oldGlobalMap[v] = oldGlobalMap[v];
-        }
+        this.oldGlobalMap[v] = oldGlobalMap[v];
       }
 
       this.newLocalVars = new List<Variable>();

--- a/Test/civl/async/simple-fail.bpl
+++ b/Test/civl/async/simple-fail.bpl
@@ -1,0 +1,25 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,2} x: int;
+var {:layer 0,2} y: int;
+
+atomic action {:layer 1} A()
+modifies x, y;
+refines B;
+{
+    x := x + 1;
+    call X();
+}
+
+action {:layer 1} X()
+modifies y;
+{
+    y := y + 1;
+}
+
+atomic action {:layer 2} B()
+modifies x;
+{
+    havoc x;
+}

--- a/Test/civl/async/simple-fail.bpl.expect
+++ b/Test/civl/async/simple-fail.bpl.expect
@@ -1,0 +1,6 @@
+simple-fail.bpl(13,1): Error: a postcondition could not be proved on this return path
+(0,0): Related location: Refinement check of A failed
+Execution trace:
+    simple-fail.bpl(11,7): anon0
+
+Boogie program verifier finished with 0 verified, 1 error

--- a/Test/civl/async/simple.bpl
+++ b/Test/civl/async/simple.bpl
@@ -1,0 +1,25 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,2} x: int;
+var {:layer 0,1} y: int;
+
+atomic action {:layer 1} A()
+modifies x, y;
+refines B;
+{
+    x := x + 1;
+    call X();
+}
+
+action {:layer 1} X()
+modifies y;
+{
+    y := y + 1;
+}
+
+atomic action {:layer 2} B()
+modifies x;
+{
+    havoc x;
+}

--- a/Test/civl/async/simple.bpl.expect
+++ b/Test/civl/async/simple.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
The refinement check for actions was handling the frame condition correctly. Now the frame condition is handled in the same manner as the refinement check for procedures.