### PR TITLE
Fix crash on low rlimit

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>3.1.2</Version>
+    <Version>3.1.3</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -190,10 +190,14 @@ namespace Microsoft.Boogie.SMTLib
           errorModel = ParseErrorModel(modelSExp);
         }
 
-        if (options.LibOptions.ProduceUnsatCores && responseStack.Count > 0) {
-          var unsatCoreSExp = responseStack.Pop();
-          if (result == SolverOutcome.Valid) {
-            ReportCoveredElements(unsatCoreSExp);
+        if (options.LibOptions.ProduceUnsatCores) {
+          if (responseStack.Count > 0) {
+            var unsatCoreSExp = responseStack.Pop();
+            if (result == SolverOutcome.Valid) {
+              ReportCoveredElements(unsatCoreSExp);
+            }
+          } else {
+            currentErrorHandler.OnProverError("Solver did not return an unsat core.");
           }
         }
 

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -229,6 +229,8 @@ namespace Microsoft.Boogie.SMTLib
           if (resp.Arguments.Length == 1 && resp.Arguments[0].IsId) {
             if (resp.Arguments[0].Name.Contains("max. resource limit exceeded")) {
               return resp;
+            } else if (resp.Arguments[0].Name.Contains("push canceled")) {
+              return resp;
             } else if (resp.Arguments[0].Name.Contains("model is not available")) {
               return null;
             } else if (resp.Arguments[0].Name.Contains("unsat core is not available")) {

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1209,6 +1209,7 @@ namespace Microsoft.Boogie.SMTLib
         case "error":
           if (resp.Arguments.Length == 1 && resp.Arguments[0].IsId &&
               (resp.Arguments[0].Name.Contains("max. resource limit exceeded")
+               || resp.Arguments[0].Name.Contains("push canceled")
                || resp.Arguments[0].Name.Contains("resource limits reached")))
           {
             currentErrorHandler.OnResourceExceeded("max resource limit");

--- a/Test/prover/low-rlimit.bpl
+++ b/Test/prover/low-rlimit.bpl
@@ -1,0 +1,6 @@
+// RUN: %boogie /proverOpt:BATCH_MODE=true /rlimit:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+procedure P(x: real) {
+    assert x > 0.0 ==> (x*2.0 + x) / x > x;
+}

--- a/Test/prover/low-rlimit.bpl.expect
+++ b/Test/prover/low-rlimit.bpl.expect
@@ -1,0 +1,5 @@
+low-rlimit.bpl(5,5): Error: this assertion could not be proved
+Execution trace:
+    low-rlimit.bpl(5,5): anon0
+
+Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
Z3 has multiple ways of responding that the resource limit has been exceeded. In some cases it responds with an error message including "push canceled". This updates Boogie to handle more of the strange side cases.