### PR TITLE
[Civl] Improvements to pool-based quantifier instantiation

### DIFF
--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -320,8 +320,9 @@ pure procedure {:inline 1} Map_Assume<K,V>({:linear} src: Map K V, {:linear} dst
 
 type Loc _;
 
-pure procedure {:inline 1} One_New<V>() returns ({:linear} l: One (Loc V))
+pure procedure {:inline 1} One_New<V>() returns ({:linear} {:pool "One_New"} l: One (Loc V))
 {
+  assume {:add_to_pool "One_New", l} true;
 }
 
 procedure create_async<T>(PA: T);

--- a/Test/civl/samples/treiber-stack.bpl
+++ b/Test/civl/samples/treiber-stack.bpl
@@ -8,34 +8,31 @@ type X; // module type parameter
 var {:layer 4, 5} Stack: Map (Loc (Treiber X)) (Vec X);
 var {:layer 0, 4} {:linear} ts: Map (Loc (Treiber X)) (Treiber X);
 
-atomic action {:layer 5} AtomicAlloc() returns (loc_t: Loc (Treiber X))
+atomic action {:layer 5} AtomicAlloc() returns ({:linear} one_loc_t: One (Loc (Treiber X)))
 modifies Stack;
 {
-  var {:linear} one_loc_t: One (Loc (Treiber X));
-
   call one_loc_t := One_New();
-  loc_t := one_loc_t->val;
-  assume !Map_Contains(Stack, loc_t);
-  Stack := Map_Update(Stack, loc_t, Vec_Empty());
+  assume !Map_Contains(Stack, one_loc_t->val);
+  Stack := Map_Update(Stack, one_loc_t->val, Vec_Empty());
 }
-yield procedure {:layer 4} Alloc() returns (loc_t: Loc (Treiber X))
+yield procedure {:layer 4} Alloc() returns (one_loc_t: One (Loc (Treiber X)))
 refines AtomicAlloc;
 preserves call YieldInvDom#4();
 {
   var top: Option (Loc (Node X));
   var {:linear} stack: Map (Loc (Node X)) (Node X);
   var {:linear} treiber: Treiber X;
-  var {:linear} one_loc_t: One (Loc (Treiber X));
+  var {:linear} local_one_loc_t: One (Loc (Treiber X));
   var {:linear} map_t: Map (Loc (Treiber X)) (Treiber X);
 
   top := None();
   call stack := Map_MakeEmpty();
   treiber := Treiber(top, stack);
-  call one_loc_t := One_New();
-  call map_t := Map_Pack(one_loc_t, treiber);
-  loc_t := one_loc_t->val;
-  call AllocTreiber(loc_t, map_t);
-  call {:layer 4} Stack := Copy(Map_Update(Stack, loc_t, Vec_Empty()));
+  call local_one_loc_t := One_New();
+  call map_t := Map_Pack(local_one_loc_t, treiber);
+  one_loc_t := local_one_loc_t;
+  call AllocTreiber(one_loc_t->val, map_t);
+  call {:layer 4} Stack := Copy(Map_Update(Stack, one_loc_t->val, Vec_Empty()));
   call {:layer 4} AbsLemma(treiber);
 }
 

--- a/Test/civl/samples/treiber-stack.bpl
+++ b/Test/civl/samples/treiber-stack.bpl
@@ -12,6 +12,7 @@ atomic action {:layer 5} AtomicAlloc() returns (loc_t: Loc (Treiber X))
 modifies Stack;
 {
   var {:linear} one_loc_t: One (Loc (Treiber X));
+  
   call one_loc_t := One_New();
   loc_t := one_loc_t->val;
   assume !Map_Contains(Stack, loc_t);

--- a/Test/civl/samples/treiber-stack.bpl
+++ b/Test/civl/samples/treiber-stack.bpl
@@ -12,7 +12,7 @@ atomic action {:layer 5} AtomicAlloc() returns (loc_t: Loc (Treiber X))
 modifies Stack;
 {
   var {:linear} one_loc_t: One (Loc (Treiber X));
-  
+
   call one_loc_t := One_New();
   loc_t := one_loc_t->val;
   assume !Map_Contains(Stack, loc_t);


### PR DESCRIPTION
- Added a pool hint to nondeterministic output parameter of One_New. Since this procedure is polymorphic, the pool name "One_New" may correspond to many types. Therefore, pool-based quantifier instantiation is updated so that it can handle the same pool name attached to bound variables of several types. The main idea is to be permissive in the construction of instantiations but prune out illegal instances just before the instantiation.

- Changed AtomicAllocNode in treiber-stack.bpl so that the output variable ```success``` is explicitly initialized. This prevents quantification over the initial (nondeterministic) value of ```success``` in the construction of the gate of AtomicAllocNode. Ultimately, this results in better behaved VCs.

Together the two changes above reduce flakiness in the proof of treiber-stack.bpl.