### PR TITLE
Add missing string interpolation

### DIFF
--- a/Source/Houdini/README.md
+++ b/Source/Houdini/README.md
@@ -1,0 +1,8 @@
+Houdini is annotation assistance system that can infer missing contracts.
+
+The original approach was implemented for ESC/Java, and is described in
+this paper:
+
+https://link.springer.com/chapter/10.1007/3-540-45251-6_29
+
+This project adapts that approach to Boogie programs.

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -809,7 +809,7 @@ namespace Microsoft.Boogie.SMTLib
         {
           foreach (var relaxVar in relaxVars)
           {
-            var resp = await SendVcRequest("(get-value ({relaxVar}))").WaitAsync(cancellationToken);
+            var resp = await SendVcRequest($"(get-value ({relaxVar}))").WaitAsync(cancellationToken);
             if (resp == null)
             {
               break;


### PR DESCRIPTION
The fact that we didn't detect this earlier makes it clear that this functionality wasn't being tested. Unfortunately, it's not immediately clear to me how to write a test that would exercise the relevant code.

This should fix #863, even though we don't have tests to confirm that.