### PR TITLE
[Civl] Make atomic keyword on actions optional

### DIFF
--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -2974,9 +2974,13 @@ namespace Microsoft.Boogie
       if (RefinedAction != null)
       {
         RefinedAction.Resolve(rc);
+        if (!HasMoverType)
+        {
+          MoverType = MoverType.Atomic;
+        }
         if (RefinedAction.ActionDecl is { HasMoverType: false })
         {
-          rc.Error(this, $"refined action {RefinedAction.ActionDecl.Name} must have a mover type");
+          RefinedAction.ActionDecl.MoverType = MoverType.Atomic;
         }
       }
       if (InvariantAction != null)
@@ -3298,7 +3302,7 @@ namespace Microsoft.Boogie
         RefinedAction.Resolve(rc);
         if (RefinedAction.ActionDecl is { HasMoverType: false })
         {
-          rc.Error(this, $"refined action {RefinedAction.ActionDecl.Name} must have a mover type");
+          RefinedAction.ActionDecl.MoverType = MoverType.Atomic;
         }
       }
 

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -705,16 +705,16 @@ ActionDecl<bool isPure, out ActionDecl actionDecl, out Implementation impl, out 
        }
      }
      if (isAsync) {
-       if (moverType == MoverType.None)
-       {
-         this.SemErr("async action must have a mover type");
-       }
-       else if (outs.Count > 0)
+       if (outs.Count > 0)
        {
          this.SemErr("async action must not have output parameters");
        }
        else
        {
+         if (moverType == MoverType.None)
+         {
+           moverType = MoverType.Atomic;
+         }
          datatypeTypeCtorDecl = new DatatypeTypeCtorDecl(name, name.val, new List<TypeVariable>(), null);
          var fields = ins.Select(v => new Formal(v.tok, new TypedIdent(v.TypedIdent.tok, v.Name, v.TypedIdent.Type), true, v.Attributes)).ToList<Variable>();
          datatypeTypeCtorDecl.AddConstructor(name, name.val, fields);

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -725,16 +725,16 @@ private class BvBounds : Expr {
 		 }
 		}
 		if (isAsync) {
-		 if (moverType == MoverType.None)
-		 {
-		   this.SemErr("async action must have a mover type");
-		 }
-		 else if (outs.Count > 0)
+		 if (outs.Count > 0)
 		 {
 		   this.SemErr("async action must not have output parameters");
 		 }
 		 else
 		 {
+		   if (moverType == MoverType.None)
+		   {
+		     moverType = MoverType.Atomic;
+		   }
 		   datatypeTypeCtorDecl = new DatatypeTypeCtorDecl(name, name.val, new List<TypeVariable>(), null);
 		   var fields = ins.Select(v => new Formal(v.tok, new TypedIdent(v.TypedIdent.tok, v.Name, v.TypedIdent.Type), true, v.Attributes)).ToList<Variable>();
 		   datatypeTypeCtorDecl.AddConstructor(name, name.val, fields);


### PR DESCRIPTION
This PR allows "atomic" mover type annotation on actions to be dropped in some cases. Atomic mover type is inferred if the action is async or if the action is involved in a refinement.