### PR TITLE
[Civl] Add support for preconditions to actions

### DIFF
--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -24,9 +24,13 @@ namespace Microsoft.Boogie
       this.program = program;
       this.Options = options;
       this.linearTypeChecker = new LinearTypeChecker(this);
-      this.AllRefinementLayers = program.TopLevelDeclarations.OfType<Implementation>()
+      var yieldingProcRefinementLayers = program.TopLevelDeclarations.OfType<Implementation>()
         .Where(impl => impl.Proc is YieldProcedureDecl)
-        .Select(decl => ((YieldProcedureDecl)decl.Proc).Layer)
+        .Select(decl => ((YieldProcedureDecl)decl.Proc).Layer);
+      var actionRefinementLayers = program.TopLevelDeclarations.OfType<ActionDecl>()
+        .Where(actionDecl => actionDecl.RefinedAction != null)
+        .Select(actionDecl => actionDecl.LayerRange.UpperLayer);
+      this.AllRefinementLayers = yieldingProcRefinementLayers.Union(actionRefinementLayers)
         .OrderBy(layer => layer).Distinct().ToList();
       
       this.actionDeclToAction = new Dictionary<ActionDecl, Action>();

--- a/Source/Concurrency/CivlTypeChecker.cs
+++ b/Source/Concurrency/CivlTypeChecker.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Boogie
       }
 
       SkipActionDecl = new ActionDecl(Token.NoToken, AddNamePrefix("Skip"), MoverType.Both, new List<Variable>(),
-        new List<Variable>(), true, new List<ActionDeclRef>(), null, null, new List<ElimDecl>(),
+        new List<Variable>(), true, new List<ActionDeclRef>(), null, null, new List<ElimDecl>(), new List<Requires>(), new List<CallCmd>(),
         new List<IdentifierExpr>(), null, null);
       var skipImplementation = DeclHelper.Implementation(
         SkipActionDecl,

--- a/Source/Concurrency/MoverCheck.cs
+++ b/Source/Concurrency/MoverCheck.cs
@@ -6,12 +6,24 @@ namespace Microsoft.Boogie
 {
   public class MoverCheck
   {
+    private class MoverCheckContext
+    {
+      public int layer;
+      public IEnumerable<Expr> extraAssumptions;
+    }
+
     CivlTypeChecker civlTypeChecker;
     List<Declaration> decls;
 
     HashSet<Tuple<Action, Action>> commutativityCheckerCache;
     HashSet<Tuple<Action, Action>> gatePreservationCheckerCache;
     HashSet<Tuple<Action, Action>> failurePreservationCheckerCache;
+    HashSet<Action> cooperationCheckerCache;
+
+    Dictionary<int, HashSet<Tuple<Action, Action>>> perLayerCommutativityCheckerCache;
+    Dictionary<int, HashSet<Tuple<Action, Action>>> perLayerGatePreservationCheckerCache;
+    Dictionary<int, HashSet<Tuple<Action, Action>>> perLayerFailurePreservationCheckerCache;
+    Dictionary<int, HashSet<Action>> perLayerCooperationCheckerCache;
 
     private MoverCheck(CivlTypeChecker civlTypeChecker, List<Declaration> decls)
     {
@@ -20,6 +32,11 @@ namespace Microsoft.Boogie
       this.commutativityCheckerCache = new HashSet<Tuple<Action, Action>>();
       this.gatePreservationCheckerCache = new HashSet<Tuple<Action, Action>>();
       this.failurePreservationCheckerCache = new HashSet<Tuple<Action, Action>>();
+      this.cooperationCheckerCache = new HashSet<Action>();
+      this.perLayerCommutativityCheckerCache = new Dictionary<int, HashSet<Tuple<Action, Action>>>();
+      this.perLayerGatePreservationCheckerCache = new Dictionary<int, HashSet<Tuple<Action, Action>>>();
+      this.perLayerFailurePreservationCheckerCache = new Dictionary<int, HashSet<Tuple<Action, Action>>>();
+      this.perLayerCooperationCheckerCache = new Dictionary<int, HashSet<Action>>();
     }
 
     private ConcurrencyOptions Options => civlTypeChecker.Options;
@@ -50,37 +67,52 @@ namespace Microsoft.Boogie
         }
       }
 
-      var sequentializationMoverChecks =
-        from sequentialization in civlTypeChecker.Sequentializations
-        from leftMover in sequentialization.Abstractions
-        from action in civlTypeChecker.MoverActions
-        where action.LayerRange.Contains(sequentialization.Layer)
-        let extraAssumption1 = sequentialization.GenerateMoverCheckAssumption(action, action.FirstImpl.InParams, leftMover, leftMover.SecondImpl.InParams)
-        let extraAssumption2 = sequentialization.GenerateMoverCheckAssumption(action, action.SecondImpl.InParams, leftMover, leftMover.FirstImpl.InParams)
-        select new {action, leftMover, extraAssumption1, extraAssumption2};
-
-      /*
-       * It is important that the mover checks required for sequentialization are the last ones
-       * to be generated. Each of these mover checks may add an extra assumption. Since mover checks are
-       * cached, if a mover check has already been generated then one generated here with the extra
-       * assumption will get dropped. As a result, we preserve overall soundness.
-       */
-      foreach (var moverCheck in sequentializationMoverChecks)
-      {
-        moverChecking.CreateCommutativityChecker(moverCheck.action, moverCheck.leftMover, moverCheck.extraAssumption1);
-        moverChecking.CreateGatePreservationChecker(moverCheck.leftMover, moverCheck.action, moverCheck.extraAssumption2);
-        moverChecking.CreateFailurePreservationChecker(moverCheck.action, moverCheck.leftMover, moverCheck.extraAssumption1);
-      }
-
       foreach (var action in civlTypeChecker.MoverActions.Where(a => a.IsLeftMover))
       {
         moverChecking.CreateCooperationChecker(action);
       }
 
-      foreach (var action in civlTypeChecker.Sequentializations.SelectMany(sequentialization => sequentialization.Abstractions)
-                 .Where(a => !a.IsLeftMover).Distinct())
+      /*
+       * All the global caches of various mover checks have been populated now.
+       * The global cache is checked before adding per-layer mover checks for sequentializations.
+       * Therefore, it is important that the sequentialization mover checks are generated last.
+       * Each sequentialization mover check is constrained by extra assumptions.
+       * Therefore, presence in global cache of the corresponding unconstrained check
+       * obviates the need to generate it.
+       */
+
+      foreach (var sequentialization in civlTypeChecker.Sequentializations)
       {
-        moverChecking.CreateCooperationChecker(action);
+        foreach (var leftMover in sequentialization.Abstractions)
+        {
+          foreach (var action in civlTypeChecker.MoverActions.Where(x => x.LayerRange.Contains(sequentialization.Layer)))
+          {
+            var moverCheckContext1 = new MoverCheckContext
+            {
+              layer = sequentialization.Layer,
+              extraAssumptions = sequentialization.GenerateMoverCheckAssumptions(action, action.FirstImpl.InParams, leftMover, leftMover.SecondImpl.InParams)
+            };
+            var moverCheckContext2 = new MoverCheckContext
+            {
+              layer = sequentialization.Layer,
+              extraAssumptions = sequentialization.GenerateMoverCheckAssumptions(action, action.SecondImpl.InParams, leftMover, leftMover.FirstImpl.InParams)
+            };
+            moverChecking.CreateCommutativityChecker(action, leftMover, moverCheckContext1);
+            moverChecking.CreateGatePreservationChecker(leftMover, action, moverCheckContext2);
+            moverChecking.CreateFailurePreservationChecker(action, leftMover, moverCheckContext1);
+          }
+          if (!leftMover.IsLeftMover)
+          {
+            var subst = Substituter.SubstitutionFromDictionary(
+              leftMover.ActionDecl.InParams.Zip(leftMover.Impl.InParams.Select(x => (Expr)Expr.Ident(x))).ToDictionary(x => x.Item1, x => x.Item2));
+            var moverCheckContext = new MoverCheckContext
+            {
+              layer = sequentialization.Layer,
+              extraAssumptions = sequentialization.Preconditions(leftMover, subst).Select(assertCmd => assertCmd.Expr)
+            };
+            moverChecking.CreateCooperationChecker(leftMover, moverCheckContext);
+          }
+        }
       }
     }
 
@@ -122,7 +154,9 @@ namespace Microsoft.Boogie
       return CmdHelper.CallCmd(action.Impl.Proc, paramProvider.InParams, paramProvider.OutParams);
     }
 
-    private void CreateCommutativityChecker(Action first, Action second, Expr extraAssumption = null)
+    private void CreateCommutativityChecker(Action first, Action second) => CreateCommutativityChecker(first, second, null);
+
+    private void CreateCommutativityChecker(Action first, Action second, MoverCheckContext moverCheckContext)
     {
       if (first == second && first.FirstImpl.InParams.Count == 0 && first.FirstImpl.OutParams.Count == 0)
       {
@@ -137,6 +171,19 @@ namespace Microsoft.Boogie
       if (!commutativityCheckerCache.Add(Tuple.Create(first, second)))
       {
         return;
+      }
+
+      if (moverCheckContext != null)
+      {
+        var layer = moverCheckContext.layer;
+        if (!perLayerCommutativityCheckerCache.ContainsKey(layer))
+        {
+          perLayerCommutativityCheckerCache[layer] = new HashSet<Tuple<Action, Action>>();
+        }
+        if (!perLayerCommutativityCheckerCache[layer].Add(Tuple.Create(first, second)))
+        {
+          return;
+        }
       }
 
       string checkerName = $"CommutativityChecker_{first.Name}_{second.Name}";
@@ -156,9 +203,12 @@ namespace Microsoft.Boogie
       {
         requires.Add(new Requires(false, assertCmd.Expr));
       }
-      if (extraAssumption != null)
+      if (moverCheckContext != null)
       {
-        requires.Add(new Requires(false, extraAssumption));
+        checkerName = $"CommutativityChecker_{first.Name}_{second.Name}_{moverCheckContext.layer}";
+        moverCheckContext.extraAssumptions.ForEach(extraAssumption => {
+          requires.Add(new Requires(false, extraAssumption));
+        });
       }
 
       var transitionRelation = TransitionRelationComputation.Commutativity(civlTypeChecker, second, first, frame);
@@ -177,9 +227,9 @@ namespace Microsoft.Boogie
       List<Cmd> cmds = new List<Cmd>
       {
         ActionCallCmd(first, first.FirstImpl),
-        ActionCallCmd(second, second.SecondImpl)
+        ActionCallCmd(second, second.SecondImpl),
+        commutativityCheck
       };
-      cmds.Add(commutativityCheck);
 
       List<Variable> inputs = first.FirstImpl.InParams.Union(second.SecondImpl.InParams).ToList();
       List<Variable> outputs = first.FirstImpl.OutParams.Union(second.SecondImpl.OutParams).ToList();
@@ -187,7 +237,9 @@ namespace Microsoft.Boogie
       AddChecker(checkerName, inputs, outputs, new List<Variable>(), requires, cmds);
     }
 
-    private void CreateGatePreservationChecker(Action first, Action second, Expr extraAssumption = null)
+    private void CreateGatePreservationChecker(Action first, Action second) => CreateGatePreservationChecker(first, second, null);
+
+    private void CreateGatePreservationChecker(Action first, Action second, MoverCheckContext moverCheckContext)
     {
       if (!first.UsedGlobalVarsInGate.Intersect(second.ModifiedGlobalVars).Any())
       {
@@ -198,6 +250,21 @@ namespace Microsoft.Boogie
       {
         return;
       }
+
+      if (moverCheckContext != null)
+      {
+        var layer = moverCheckContext.layer;
+        if (!perLayerGatePreservationCheckerCache.ContainsKey(layer))
+        {
+          perLayerGatePreservationCheckerCache[layer] = new HashSet<Tuple<Action, Action>>();
+        }
+        if (!perLayerGatePreservationCheckerCache[layer].Add(Tuple.Create(first, second)))
+        {
+          return;
+        }
+      }
+
+      string checkerName = $"GatePreservationChecker_{first.Name}_{second.Name}";
 
       HashSet<Variable> frame = new HashSet<Variable>();
       frame.UnionWith(first.UsedGlobalVarsInGate);
@@ -213,12 +280,13 @@ namespace Microsoft.Boogie
       {
         requires.Add(new Requires(false, assertCmd.Expr));
       }
-      if (extraAssumption != null)
+      if (moverCheckContext != null)
       {
-        requires.Add(new Requires(false, extraAssumption));
+        checkerName = $"GatePreservationChecker_{first.Name}_{second.Name}_{moverCheckContext.layer}";
+        moverCheckContext.extraAssumptions.ForEach(extraAssumption => {
+          requires.Add(new Requires(false, extraAssumption));
+        });
       }
-
-      string checkerName = $"GatePreservationChecker_{first.Name}_{second.Name}";
 
       List<Variable> inputs = first.FirstImpl.InParams.Union(second.SecondImpl.InParams).ToList();
       List<Variable> outputs = first.FirstImpl.OutParams.Union(second.SecondImpl.OutParams).ToList();
@@ -242,7 +310,9 @@ namespace Microsoft.Boogie
       AddChecker(checkerName, inputs, outputs, new List<Variable>(), requires, cmds);
     }
 
-    private void CreateFailurePreservationChecker(Action first, Action second, Expr extraAssumption = null)
+    private void CreateFailurePreservationChecker(Action first, Action second) => CreateFailurePreservationChecker(first, second, null);
+
+    private void CreateFailurePreservationChecker(Action first, Action second, MoverCheckContext moverCheckContext)
     {
       if (!first.UsedGlobalVarsInGate.Intersect(second.ModifiedGlobalVars).Any())
       {
@@ -253,6 +323,21 @@ namespace Microsoft.Boogie
       {
         return;
       }
+
+      if (moverCheckContext != null)
+      {
+        var layer = moverCheckContext.layer;
+        if (!perLayerFailurePreservationCheckerCache.ContainsKey(layer))
+        {
+          perLayerFailurePreservationCheckerCache[layer] = new HashSet<Tuple<Action, Action>>();
+        }
+        if (!perLayerFailurePreservationCheckerCache[layer].Add(Tuple.Create(first, second)))
+        {
+          return;
+        }
+      }
+
+      string checkerName = $"FailurePreservationChecker_{first.Name}_{second.Name}";
 
       HashSet<Variable> frame = new HashSet<Variable>();
       frame.UnionWith(first.UsedGlobalVarsInGate);
@@ -271,9 +356,12 @@ namespace Microsoft.Boogie
       {
         requires.Add(new Requires(false, assertCmd.Expr));
       }
-      if (extraAssumption != null)
+      if (moverCheckContext != null)
       {
-        requires.Add(new Requires(false, extraAssumption));
+        checkerName = $"FailurePreservationChecker_{first.Name}_{second.Name}_{moverCheckContext.layer}";
+        moverCheckContext.extraAssumptions.ForEach(extraAssumption => {
+          requires.Add(new Requires(false, extraAssumption));
+        });
       }
 
       IEnumerable<Expr> linearityAssumes =
@@ -283,8 +371,6 @@ namespace Microsoft.Boogie
         first.tok,
         Expr.Imp(Expr.And(linearityAssumes), firstNegatedGate),
         $"Gate failure of {first.Name} not preserved by {second.Name}");
-
-      string checkerName = $"FailurePreservationChecker_{first.Name}_{second.Name}";
 
       List<Variable> inputs = first.FirstImpl.InParams.Union(second.SecondImpl.InParams).ToList();
       List<Variable> outputs = first.FirstImpl.OutParams.Union(second.SecondImpl.OutParams).ToList();
@@ -297,11 +383,31 @@ namespace Microsoft.Boogie
       AddChecker(checkerName, inputs, outputs, new List<Variable>(), requires, cmds);
     }
 
-    private void CreateCooperationChecker(Action action)
+    private void CreateCooperationChecker(Action action) => CreateCooperationChecker(action, null);
+
+    private void CreateCooperationChecker(Action action, MoverCheckContext moverCheckContext)
     {
       if (!action.HasAssumeCmd)
       {
         return;
+      }
+
+      if (!cooperationCheckerCache.Add(action))
+      {
+        return;
+      }
+
+      if (moverCheckContext != null)
+      {
+        var layer = moverCheckContext.layer;
+        if (!perLayerCooperationCheckerCache.ContainsKey(layer))
+        {
+          perLayerCooperationCheckerCache[layer] = new HashSet<Action>();
+        }
+        if (!perLayerCooperationCheckerCache[layer].Add(action))
+        {
+          return;
+        }
       }
 
       string checkerName = $"CooperationChecker_{action.Name}";
@@ -314,9 +420,11 @@ namespace Microsoft.Boogie
       List<Requires> requires =
         DisjointnessAndWellFormedRequires(impl.InParams.Where(v => LinearTypeChecker.FindLinearKind(v) != LinearKind.LINEAR_OUT),
           frame).ToList();
-      foreach (AssertCmd assertCmd in action.Gate)
+      requires.AddRange(action.Gate.Select(assertCmd => new Requires(false, assertCmd.Expr)));
+      if (moverCheckContext != null)
       {
-        requires.Add(new Requires(false, assertCmd.Expr));
+        checkerName = $"CooperationChecker_{action.Name}_{moverCheckContext.layer}";
+        requires.AddRange(moverCheckContext.extraAssumptions.Select(expr => new Requires(false, expr)));
       }
 
       AssertCmd cooperationCheck = CmdHelper.AssertCmd(
@@ -325,7 +433,7 @@ namespace Microsoft.Boogie
         $"Cooperation check for {action.Name} failed");
 
       // call action after the cooperation check to exploit quantifier instantiation hints in the body
-      AddChecker(checkerName, new List<Variable>(impl.InParams), new List<Variable>(),
+      AddChecker(checkerName, new List<Variable>(impl.InParams), new List<Variable>(impl.OutParams),
         new List<Variable>(), requires, new List<Cmd> { cooperationCheck, ActionCallCmd(action, impl) });
     }
   }

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -2959,7 +2959,13 @@ namespace Microsoft.Boogie
       base.Resolve(rc);
       rc.PushVarContext();
       RegisterFormals(InParams, rc);
-      YieldRequires.ForEach(callCmd => callCmd.Resolve(rc));
+      YieldRequires.ForEach(callCmd => {
+        callCmd.Resolve(rc);
+        if (callCmd.Proc is not YieldInvariantDecl)
+        {
+          rc.Error(callCmd, "expected call to yield invariant");
+        }
+      });
       rc.PopVarContext();
       rc.Proc = null;
       if (Creates.Any())
@@ -3298,10 +3304,28 @@ namespace Microsoft.Boogie
       rc.StateMode = ResolutionContext.State.Two;
       rc.PushVarContext();
       RegisterFormals(InParams, rc);
-      YieldRequires.ForEach(callCmd => callCmd.Resolve(rc));
-      YieldPreserves.ForEach(callCmd => callCmd.Resolve(rc));
+      YieldRequires.ForEach(callCmd => {
+        callCmd.Resolve(rc);
+        if (callCmd.Proc is not YieldInvariantDecl)
+        {
+          rc.Error(callCmd, "expected call to yield invariant");
+        }
+      });
+      YieldPreserves.ForEach(callCmd => {
+        callCmd.Resolve(rc);
+        if (callCmd.Proc is not YieldInvariantDecl)
+        {
+          rc.Error(callCmd, "expected call to yield invariant");
+        }
+      });
       RegisterFormals(OutParams, rc);
-      YieldEnsures.ForEach(callCmd => callCmd.Resolve(rc));
+      YieldEnsures.ForEach(callCmd => {
+        callCmd.Resolve(rc);
+        if (callCmd.Proc is not YieldInvariantDecl)
+        {
+          rc.Error(callCmd, "expected call to yield invariant");
+        }
+      });
       rc.PopVarContext();
       rc.StateMode = oldStateMode;
       rc.Proc = null;

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -2769,6 +2769,9 @@ namespace Microsoft.Boogie
     public override void Typecheck(TypecheckingContext tc)
     {
       base.Typecheck(tc);
+
+      var oldGlobalAccessOnlyInOld = tc.GlobalAccessOnlyInOld;
+      tc.GlobalAccessOnlyInOld = false;
       foreach (IdentifierExpr ide in Modifies)
       {
         Contract.Assert(ide != null);
@@ -2779,6 +2782,7 @@ namespace Microsoft.Boogie
         }
         ide.Typecheck(tc);
       }
+      tc.GlobalAccessOnlyInOld = oldGlobalAccessOnlyInOld;
 
       foreach (Requires e in Requires)
       {
@@ -3012,9 +3016,14 @@ namespace Microsoft.Boogie
 
     public override void Typecheck(TypecheckingContext tc)
     {
+      var oldProc = tc.Proc;
+      tc.Proc = this;
+      tc.GlobalAccessOnlyInOld = true;
       base.Typecheck(tc);
-      
+      tc.GlobalAccessOnlyInOld = false;
       YieldRequires.ForEach(callCmd => callCmd.Typecheck(tc));
+      Contract.Assert(tc.Proc == this);
+      tc.Proc = oldProc;
 
       Creates.ForEach(actionDeclRef =>
       {

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -4144,6 +4144,7 @@ namespace Microsoft.Boogie
 
       var oldProc = tc.Proc;
       tc.Proc = Proc;
+      tc.Impl = this;
       foreach (Variable /*!*/ v in LocVars)
       {
         Contract.Assert(v != null);
@@ -4154,6 +4155,7 @@ namespace Microsoft.Boogie
         b.Typecheck(tc);
       }
       Contract.Assert(tc.Proc == Proc);
+      tc.Impl = null;
       tc.Proc = oldProc;
 
       if (Proc is ActionDecl || Proc is YieldProcedureDecl)

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -2474,6 +2474,21 @@ namespace Microsoft.Boogie
           rc.Error(this, $"each layer must not be more than {yieldProcedureDecl.Layer}");
         }
       }
+      if (rc.Proc is ActionDecl actionDecl)
+      {
+        if (Layers.Count == 0)
+        {
+          rc.Error(this, "expected layers");
+        }
+        else
+        {
+          var assertLayerRange = new LayerRange(Layers[0], Layers[^1]);
+          if (!assertLayerRange.Subset(actionDecl.LayerRange))
+          {
+            rc.Error(this, $"each layer must be in the range {actionDecl.LayerRange}");
+          }
+        }
+      }
     }
 
     public override void Typecheck(TypecheckingContext tc)

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -1963,7 +1963,7 @@ namespace Microsoft.Boogie
       {
         var e = Rhss[i];
         Contract.Assert(e != null);
-        tc.GlobalAccessOnlyInOld = true;
+        tc.GlobalAccessOnlyInOld = tc.Proc is YieldProcedureDecl;
         tc.ExpectedLayerRange = tc.Proc is YieldProcedureDecl ? expectedLayerRanges[i] : null;
         e.Typecheck(tc);
         tc.GlobalAccessOnlyInOld = false;
@@ -2454,7 +2454,7 @@ namespace Microsoft.Boogie
 
       lhs.Typecheck(tc);
       
-      tc.GlobalAccessOnlyInOld = true;
+      tc.GlobalAccessOnlyInOld = tc.Proc is YieldProcedureDecl;
       tc.ExpectedLayerRange = expectedLayerRange;
       rhs.Typecheck(tc);
       tc.GlobalAccessOnlyInOld = false;
@@ -4605,7 +4605,7 @@ namespace Microsoft.Boogie
     {
       (this as ICarriesAttributes).TypecheckAttributes(tc);
       tc.ExpectedLayerRange = tc.Proc is YieldProcedureDecl decl ? new LayerRange(0, decl.Layer) : null;
-      tc.GlobalAccessOnlyInOld = true;
+      tc.GlobalAccessOnlyInOld = tc.Proc is YieldProcedureDecl;
       Expr.Typecheck(tc);
       tc.ExpectedLayerRange = null;
       tc.GlobalAccessOnlyInOld = false;

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -3540,6 +3540,15 @@ namespace Microsoft.Boogie
             $"caller layer range ({callerActionDecl.LayerRange}) must be subset of callee layer range ({calleeActionDecl.LayerRange})");
         }
       }
+      else if (tc.Impl == null)
+      {
+        // call to yield invariant allowed only in preconditions
+        var yieldInvariantDecl = (YieldInvariantDecl)Proc;
+        if (!callerActionDecl.LayerRange.Contains(yieldInvariantDecl.Layer))
+        {
+          tc.Error(this, "layer of callee must be in the layer range of caller");
+        }
+      }
       else
       {
         tc.Error(this, "an action may only call actions or primitives");

--- a/Source/Core/AST/AbsyExpr.cs
+++ b/Source/Core/AST/AbsyExpr.cs
@@ -1356,6 +1356,10 @@ namespace Microsoft.Boogie
         {
           if (Decl is GlobalVariable)
           {
+            if (!tc.GlobalAccessOk)
+            {
+              tc.Error(this, $"global variable must be accessed inside old expression: {Decl.Name}");
+            }
             var globalVarLayerRange = Decl.LayerRange;
             if (actionDecl.LayerRange.LowerLayer <= globalVarLayerRange.LowerLayer)
             {

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -671,6 +671,8 @@ ActionDecl<bool isPure, out ActionDecl actionDecl, out Implementation impl, out 
      ActionDeclRef refinedAction = null;
      ActionDeclRef invariantAction = null;
      List<ElimDecl> elims = new List<ElimDecl>();
+     List<Requires> requires = new List<Requires>();
+     List<CallCmd> yieldRequires = new List<CallCmd>();
      List<Variable> locals;
      StmtList stmtList;
      QKeyValue kv = null;
@@ -685,8 +687,8 @@ ActionDecl<bool isPure, out ActionDecl actionDecl, out Implementation impl, out 
   ProcFormals<true, true, out ins>
     [ "returns" ProcFormals<false, true, out outs> ]
   ( ";"
-    { SpecAction<ref refinedAction, ref invariantAction, mods, creates, elims> }
-  | { SpecAction<ref refinedAction, ref invariantAction, mods, creates, elims> }
+    { SpecAction<ref refinedAction, ref invariantAction, mods, creates, elims, requires, yieldRequires> }
+  | { SpecAction<ref refinedAction, ref invariantAction, mods, creates, elims, requires, yieldRequires> }
     ImplBody<out locals, out stmtList>
     (.
        impl = new Implementation(name, name.val, new List<TypeVariable>(), Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs),
@@ -720,7 +722,7 @@ ActionDecl<bool isPure, out ActionDecl actionDecl, out Implementation impl, out 
          datatypeTypeCtorDecl.AddConstructor(name, name.val, fields);
        }
      }
-     actionDecl = new ActionDecl(name, name.val, moverType, ins, outs, isPure, creates, refinedAction, invariantAction, elims, mods, datatypeTypeCtorDecl, kv);
+     actionDecl = new ActionDecl(name, name.val, moverType, ins, outs, isPure, creates, refinedAction, invariantAction, elims, requires, yieldRequires, mods, datatypeTypeCtorDecl, kv);
   .)
   .
 
@@ -756,7 +758,7 @@ SpecRefinedAction<ref ActionDeclRef refinedAction>
   .)
   .
 
-SpecAction<.ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, List<IdentifierExpr> mods, List<ActionDeclRef> creates, List<ElimDecl> elims.>
+SpecAction<.ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, List<IdentifierExpr> mods, List<ActionDeclRef> creates, List<ElimDecl> elims, List<Requires> requires, List<CallCmd> yieldRequires.>
 =
   (
     SpecRefinedAction<ref refinedAction>
@@ -766,6 +768,7 @@ SpecAction<.ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, 
   | SpecModifies<mods>
   | SpecCreates<creates>
   | SpecEliminates<elims>
+  | SpecYieldRequires<requires, yieldRequires>
   )
   .
   

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -744,7 +744,7 @@ SpecEliminates<.List<ElimDecl> elims.>
   "eliminates" SpecUsing<elims> { "," SpecUsing<elims> } ";"
   .
 
-SpecRefinedAction<ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction>
+SpecRefinedAction<ref ActionDeclRef refinedAction>
 =
   "refines" (. IToken m; .) Ident<out m>
   (.
@@ -754,14 +754,15 @@ SpecRefinedAction<ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAc
        this.SemErr("a refines specification already exists");
      }
   .)
-  ["using" Ident<out m> (. invariantAction = new ActionDeclRef(m, m.val); .)]
-  ";"
   .
 
 SpecAction<.ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, List<IdentifierExpr> mods, List<ActionDeclRef> creates, List<ElimDecl> elims.>
 =
   (
-    SpecRefinedAction<ref refinedAction, ref invariantAction>
+    SpecRefinedAction<ref refinedAction>
+    (. IToken m; .)
+    ["using" Ident<out m> (. invariantAction = new ActionDeclRef(m, m.val); .)]
+    ";"
   | SpecModifies<mods>
   | SpecCreates<creates>
   | SpecEliminates<elims>
@@ -811,36 +812,47 @@ YieldProcedureDecl<out YieldProcedureDecl ypDecl, out Implementation impl>
     (. ypDecl = new YieldProcedureDecl(name, name.val, moverType, ins, outs, pre, mods, post, yieldRequires, yieldEnsures, yieldPreserves, refinedAction, kv); .)
   .
 
-SpecYieldPrePost<. ref ActionDeclRef refinedAction, List<Requires> pre, List<Ensures> post, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures, List<CallCmd> yieldPreserves, List<IdentifierExpr> mods.>
-= (. Expr e; Cmd cmd; Token tok = null; QKeyValue kv = null; .)
-  (  "refines" (. IToken m; .) Ident<out m>
-      (.
-         if (refinedAction == null) {
-           refinedAction = new ActionDeclRef(m, m.val);
-         } else {
-           this.SemErr("a refines specification already exists");
-         }
-      .)
-  | "requires"              (. tok = t; .)
-    ( 
-      { Attribute<ref kv> }
-      Proposition<out e>  (. pre.Add(new Requires(tok, false, e, null, kv)); .)
-      |
-      CallCmd<out cmd>        (. yieldRequires.Add((CallCmd)cmd); .)
-    )
-  | "ensures"               (. tok = t; .)
-    (
-      { Attribute<ref kv> }
-      Proposition<out e>  (. post.Add(new Ensures(tok, false, e, null, kv)); .)
-      |
-      CallCmd<out cmd>        (. yieldEnsures.Add((CallCmd)cmd); .)
-    )
-  | "preserves"             (. tok = t; .)
-    CallCmd<out cmd>        (. yieldPreserves.Add((CallCmd)cmd); .)
-  | "modifies" (. List<IToken> ms; .)
-    [ Idents<out ms> (. foreach(IToken m in ms) { mods.Add(new IdentifierExpr(m, m.val)); } .) ]
+SpecYieldRequires<. List<Requires> pre, List<CallCmd> yieldRequires .>
+= (. Expr e; Cmd cmd; Token tok; QKeyValue kv = null; .)
+  "requires"              (. tok = t; .)
+  ( 
+    { Attribute<ref kv> }
+    Proposition<out e>  (. pre.Add(new Requires(tok, false, e, null, kv)); .)
+    |
+    CallCmd<out cmd>        (. yieldRequires.Add((CallCmd)cmd); .)
   )
   ";"
+  .
+
+SpecYieldEnsures<. List<Ensures> post, List<CallCmd> yieldEnsures .>
+= (. Expr e; Cmd cmd; Token tok; QKeyValue kv = null; .)
+  "ensures"               (. tok = t; .)
+  (
+    { Attribute<ref kv> }
+    Proposition<out e>  (. post.Add(new Ensures(tok, false, e, null, kv)); .)
+    |
+    CallCmd<out cmd>        (. yieldEnsures.Add((CallCmd)cmd); .)
+  )
+  ";"
+  .
+
+SpecYieldPreserves<. List<CallCmd> yieldPreserves .>
+= (. Cmd cmd; Token tok; .)
+  "preserves"             (. tok = t; .)
+  CallCmd<out cmd>        (. yieldPreserves.Add((CallCmd)cmd); .)
+  ";"
+  .
+
+SpecYieldPrePost<. ref ActionDeclRef refinedAction, List<Requires> pre, List<Ensures> post, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures, List<CallCmd> yieldPreserves, List<IdentifierExpr> mods.>
+=
+  (  
+    SpecRefinedAction<ref refinedAction>
+    ";"
+  | SpecYieldRequires<pre, yieldRequires>
+  | SpecYieldEnsures<post, yieldEnsures>
+  | SpecYieldPreserves<yieldPreserves>
+  | SpecModifies<mods>
+  )
   .
 
 Procedure<bool isPure, out Procedure/*!*/ proc, out /*maybe null*/ Implementation impl>

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -677,6 +677,8 @@ private class BvBounds : Expr {
 		ActionDeclRef refinedAction = null;
 		ActionDeclRef invariantAction = null;
 		List<ElimDecl> elims = new List<ElimDecl>();
+		List<Requires> requires = new List<Requires>();
+		List<CallCmd> yieldRequires = new List<CallCmd>();
 		List<Variable> locals;
 		StmtList stmtList;
 		QKeyValue kv = null;
@@ -703,11 +705,11 @@ private class BvBounds : Expr {
 		if (la.kind == 10) {
 			Get();
 			while (StartOf(10)) {
-				SpecAction(ref refinedAction, ref invariantAction, mods, creates, elims);
+				SpecAction(ref refinedAction, ref invariantAction, mods, creates, elims, requires, yieldRequires);
 			}
 		} else if (StartOf(11)) {
 			while (StartOf(10)) {
-				SpecAction(ref refinedAction, ref invariantAction, mods, creates, elims);
+				SpecAction(ref refinedAction, ref invariantAction, mods, creates, elims, requires, yieldRequires);
 			}
 			ImplBody(out locals, out stmtList);
 			impl = new Implementation(name, name.val, new List<TypeVariable>(), Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs),
@@ -740,7 +742,7 @@ private class BvBounds : Expr {
 		   datatypeTypeCtorDecl.AddConstructor(name, name.val, fields);
 		 }
 		}
-		actionDecl = new ActionDecl(name, name.val, moverType, ins, outs, isPure, creates, refinedAction, invariantAction, elims, mods, datatypeTypeCtorDecl, kv);
+		actionDecl = new ActionDecl(name, name.val, moverType, ins, outs, isPure, creates, refinedAction, invariantAction, elims, requires, yieldRequires, mods, datatypeTypeCtorDecl, kv);
 		
 	}
 
@@ -1118,7 +1120,7 @@ private class BvBounds : Expr {
 		} else SynErr(132);
 	}
 
-	void SpecAction(ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, List<IdentifierExpr> mods, List<ActionDeclRef> creates, List<ElimDecl> elims) {
+	void SpecAction(ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, List<IdentifierExpr> mods, List<ActionDeclRef> creates, List<ElimDecl> elims, List<Requires> requires, List<CallCmd> yieldRequires) {
 		if (la.kind == 41) {
 			SpecRefinedAction(ref refinedAction);
 			IToken m; 
@@ -1134,6 +1136,8 @@ private class BvBounds : Expr {
 			SpecCreates(creates);
 		} else if (la.kind == 40) {
 			SpecEliminates(elims);
+		} else if (la.kind == 47) {
+			SpecYieldRequires(requires, yieldRequires);
 		} else SynErr(133);
 	}
 
@@ -1197,21 +1201,6 @@ private class BvBounds : Expr {
 		Expect(10);
 	}
 
-	void SpecYieldPrePost(ref ActionDeclRef refinedAction, List<Requires> pre, List<Ensures> post, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures, List<CallCmd> yieldPreserves, List<IdentifierExpr> mods) {
-		if (la.kind == 41) {
-			SpecRefinedAction(ref refinedAction);
-			Expect(10);
-		} else if (la.kind == 47) {
-			SpecYieldRequires(pre, yieldRequires);
-		} else if (la.kind == 48) {
-			SpecYieldEnsures(post, yieldEnsures);
-		} else if (la.kind == 49) {
-			SpecYieldPreserves(yieldPreserves);
-		} else if (la.kind == 52) {
-			SpecModifies(mods);
-		} else SynErr(134);
-	}
-
 	void SpecYieldRequires(List<Requires> pre, List<CallCmd> yieldRequires ) {
 		Expr e; Cmd cmd; Token tok; QKeyValue kv = null; 
 		Expect(47);
@@ -1225,8 +1214,23 @@ private class BvBounds : Expr {
 		} else if (la.kind == 36 || la.kind == 51 || la.kind == 65) {
 			CallCmd(out cmd);
 			yieldRequires.Add((CallCmd)cmd); 
-		} else SynErr(135);
+		} else SynErr(134);
 		Expect(10);
+	}
+
+	void SpecYieldPrePost(ref ActionDeclRef refinedAction, List<Requires> pre, List<Ensures> post, List<CallCmd> yieldRequires, List<CallCmd> yieldEnsures, List<CallCmd> yieldPreserves, List<IdentifierExpr> mods) {
+		if (la.kind == 41) {
+			SpecRefinedAction(ref refinedAction);
+			Expect(10);
+		} else if (la.kind == 47) {
+			SpecYieldRequires(pre, yieldRequires);
+		} else if (la.kind == 48) {
+			SpecYieldEnsures(post, yieldEnsures);
+		} else if (la.kind == 49) {
+			SpecYieldPreserves(yieldPreserves);
+		} else if (la.kind == 52) {
+			SpecModifies(mods);
+		} else SynErr(135);
 	}
 
 	void CallCmd(out Cmd c) {
@@ -2649,8 +2653,8 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_T, _T,_T,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _T,_T,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _T,_T,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x},
@@ -2824,8 +2828,8 @@ public class Errors {
 			case 131: s = "invalid TypeArgs"; break;
 			case 132: s = "invalid MoverQualifier"; break;
 			case 133: s = "invalid SpecAction"; break;
-			case 134: s = "invalid SpecYieldPrePost"; break;
-			case 135: s = "invalid SpecYieldRequires"; break;
+			case 134: s = "invalid SpecYieldRequires"; break;
+			case 135: s = "invalid SpecYieldPrePost"; break;
 			case 136: s = "invalid SpecYieldEnsures"; break;
 			case 137: s = "invalid Spec"; break;
 			case 138: s = "invalid SpecPrePost"; break;

--- a/Source/Core/ResolutionContext.cs
+++ b/Source/Core/ResolutionContext.cs
@@ -747,6 +747,7 @@ namespace Microsoft.Boogie
   {
     public CoreOptions Options { get; }
     public Procedure Proc;
+    public Implementation Impl;
     public LayerRange ExpectedLayerRange;
     public bool GlobalAccessOnlyInOld;
     public int InsideOld;

--- a/Source/Core/Scanner.cs
+++ b/Source/Core/Scanner.cs
@@ -543,9 +543,9 @@ public class Scanner {
 			case "requires": t.kind = 47; break;
 			case "ensures": t.kind = 48; break;
 			case "preserves": t.kind = 49; break;
-			case "modifies": t.kind = 50; break;
-			case "implementation": t.kind = 51; break;
-			case "free": t.kind = 52; break;
+			case "implementation": t.kind = 50; break;
+			case "free": t.kind = 51; break;
+			case "modifies": t.kind = 52; break;
 			case "goto": t.kind = 53; break;
 			case "return": t.kind = 54; break;
 			case "if": t.kind = 55; break;

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -678,6 +678,7 @@ namespace Microsoft.Boogie
         node.InvariantAction = VisitActionDeclRef(node.InvariantAction);
       }
       node.Eliminates = VisitElimDeclSeq(node.Eliminates);
+      node.YieldRequires = VisitCallCmdSeq(node.YieldRequires);
       return VisitProcedure(node);
     }
 

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -33,6 +33,11 @@ function {:inline} ToMultiset<T>(set: [T]bool): [T]int
   MapIte(set, MapConst(1), MapConst(0))
 }
 
+function {:inline} IsSet<T>(multiset: [T]int): bool
+{
+  MapOr(MapEq(multiset, MapConst(0)), MapEq(multiset, MapConst(1))) == MapConst(true)
+}
+
 function {:inline} IsSubset<T>(a: [T]bool, b: [T]bool) : bool
 {
   MapImp(a, b) == MapConst(true)

--- a/Test/civl/async/async3.bpl.expect
+++ b/Test/civl/async/async3.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 5 verified, 0 errors
+Boogie program verifier finished with 7 verified, 0 errors

--- a/Test/civl/async/async4.bpl.expect
+++ b/Test/civl/async/async4.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 6 verified, 0 errors
+Boogie program verifier finished with 7 verified, 0 errors

--- a/Test/civl/async/leader.bpl
+++ b/Test/civl/async/leader.bpl
@@ -52,7 +52,7 @@ function {:inline} all_decided' (r_bound:int, init_val:[int]int, dec_dom:[int]bo
 // Main
 
 atomic action {:layer 2} main_atomic ({:linear_in} perms: Set Perm)
-modifies col_dom, col_val, dec_dom, dec_val;
+modifies dec_dom, dec_val;
 {
   havoc dec_dom, dec_val;
   assume all_decided(init_val, dec_dom, dec_val);

--- a/Test/civl/async/lock-service.bpl.expect
+++ b/Test/civl/async/lock-service.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 32 verified, 0 errors
+Boogie program verifier finished with 34 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/2PC.bpl
+++ b/Test/civl/inductive-sequentialization/2PC.bpl
@@ -77,19 +77,14 @@ modifies RequestChannel, VoteChannel, DecisionChannel, votes, decisions;
   call set_choice(PARTICIPANT2(One(k+1)));
 }
 
-action {:layer 5} PARTICIPANT2' ({:linear_in} pid: One int)
-modifies DecisionChannel, decisions;
-{
-  assert DecisionChannel[pid->val][COMMIT()] > 0 || DecisionChannel[pid->val][ABORT()] > 0;
-  call PARTICIPANT2(pid);
-}
+yield invariant {:layer 5} YieldParticipant ({:linear} foo: One int);
+invariant DecisionChannel[foo->val][COMMIT()] > 0 || DecisionChannel[foo->val][ABORT()] > 0;
 
 ////////////////////////////////////////////////////////////////////////////////
 
 atomic action {:layer 5} MAIN4 ({:linear_in} pids: Set int)
 refines MAIN5 using INV4;
 creates PARTICIPANT2;
-eliminates PARTICIPANT2 using PARTICIPANT2';
 modifies RequestChannel, VoteChannel, DecisionChannel, votes, decisions;
 {
   var dec:decision;
@@ -191,6 +186,7 @@ modifies RequestChannel, VoteChannel, votes;
 
 async atomic action {:layer 2,5} PARTICIPANT2 ({:linear_in} pid: One int)
 modifies DecisionChannel, decisions;
+requires call YieldParticipant(pid);
 {
   var d:decision;
   assert pid(pid->val);

--- a/Test/civl/inductive-sequentialization/2PC.bpl.expect
+++ b/Test/civl/inductive-sequentialization/2PC.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 52 verified, 0 errors
+Boogie program verifier finished with 61 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl
+++ b/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl
@@ -107,7 +107,6 @@ atomic action {:layer 3}
 MAIN'({:linear_in} ps: Set perm)
 refines MAIN'' using INV_COLLECT_ELIM;
 creates COLLECT;
-eliminates COLLECT using COLLECT';
 modifies CH;
 {
   assert ps->val == (lambda p:perm :: pid(p->i));
@@ -165,6 +164,7 @@ modifies CH;
 
 async atomic action {:layer 2,3} COLLECT({:linear_in} p: One perm, i:pid)
 modifies decision;
+requires call YieldCollect();
 {
   var received_values:[val]int;
   assert pid(i) && p->val == Collect(i);
@@ -174,14 +174,10 @@ modifies decision;
   decision[i] := max(received_values);
 }
 
-action {:layer 3} COLLECT'({:linear_in} p: One perm, i:pid)
-modifies decision;
-{
-  assert CH == (lambda v:val :: value_card(v, value, 1, n));
-  assert card(CH) == n;
-  assert MultisetSubsetEq(MultisetEmpty, CH);
-  call COLLECT(p, i);
-}
+yield invariant {:layer 3} YieldCollect();
+invariant CH == (lambda v:val :: value_card(v, value, 1, n));
+invariant card(CH) == n;
+invariant MultisetSubsetEq(MultisetEmpty, CH);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl.expect
+++ b/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 23 verified, 0 errors
+Boogie program verifier finished with 24 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/ChangRoberts.bpl.expect
+++ b/Test/civl/inductive-sequentialization/ChangRoberts.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 13 verified, 0 errors
+Boogie program verifier finished with 16 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/Gauss.bpl.expect
+++ b/Test/civl/inductive-sequentialization/Gauss.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 5 verified, 0 errors
+Boogie program verifier finished with 6 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/NoChoice.bpl.expect
+++ b/Test/civl/inductive-sequentialization/NoChoice.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 3 verified, 0 errors
+Boogie program verifier finished with 5 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/PingPong.bpl
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl
@@ -28,7 +28,7 @@ function {:inline} BothHandles(cid: ChannelId): Set ChannelHandle {
 }
 
 function {:inline} EmptyChannel () : [int]int
-{ (lambda m:int :: 0) }
+{ MapConst(0) }
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -75,8 +75,8 @@ action {:layer 2} PING' (x: int, {:linear_in} p: One ChannelHandle)
 creates PING;
 modifies channel;
 {
-  assert (exists {:pool "INV"} m:int :: {:add_to_pool "INV", m} channel[p->val->cid]->left[m] > 0);
-  assert (forall m:int :: channel[p->val->cid]->right[m] == 0);
+  assert channel[p->val->cid]->left[x] == 1;
+  assert channel[p->val->cid]->right == MapConst(0);
   call PING(x, p);
 }
 
@@ -84,8 +84,8 @@ action {:layer 2} PONG' (y: int, {:linear_in} p: One ChannelHandle)
 creates PONG;
 modifies channel;
 {
-  assert (exists {:pool "INV"} m:int :: {:add_to_pool "INV", m} channel[p->val->cid]->right[m] > 0);
-  assert (forall m:int :: channel[p->val->cid]->left[m] == 0);
+  assert channel[p->val->cid]->right[0] == 1 || channel[p->val->cid]->right[y] == 1;
+  assert channel[p->val->cid]->left == MapConst(0);
   call PONG(y, p);
 }
 
@@ -117,7 +117,8 @@ modifies channel;
 
   assert x > 0;
   assert p->val is Left;
-  assert (forall {:pool "INV"} m:int :: {:add_to_pool "INV", m} left_channel[m] > 0 ==> m == x); // assertion to discharge
+  assert IsSet(left_channel);
+  assert left_channel[x := 0] == MapConst(0);
 
   assume left_channel[x] > 0;
   left_channel[x] := left_channel[x] - 1;
@@ -146,7 +147,8 @@ modifies channel;
 
   assert y > 0;
   assert p->val is Right;
-  assert (forall {:pool "INV"} m:int :: {:add_to_pool "INV", m} right_channel[m] > 0 ==> m == y || m == 0); // assertion to discharge
+  assert IsSet(right_channel);
+  assert right_channel[0 := 0] == MapConst(0) || right_channel[y := 0] == MapConst(0);
 
   if (*)
   {

--- a/Test/civl/inductive-sequentialization/PingPong.bpl.expect
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 38 verified, 0 errors
+Boogie program verifier finished with 36 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/PingPong.bpl.expect
+++ b/Test/civl/inductive-sequentialization/PingPong.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 36 verified, 0 errors
+Boogie program verifier finished with 38 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/ProducerConsumer.bpl.expect
+++ b/Test/civl/inductive-sequentialization/ProducerConsumer.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 23 verified, 0 errors
+Boogie program verifier finished with 25 verified, 0 errors

--- a/Test/civl/inductive-sequentialization/ProducerConsumer.bpl.expect
+++ b/Test/civl/inductive-sequentialization/ProducerConsumer.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 25 verified, 0 errors
+Boogie program verifier finished with 24 verified, 0 errors

--- a/Test/civl/paxos/is.sh.expect
+++ b/Test/civl/paxos/is.sh.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 64 verified, 0 errors
+Boogie program verifier finished with 69 verified, 0 errors

--- a/Test/civl/regression-tests/assert-layers.bpl
+++ b/Test/civl/regression-tests/assert-layers.bpl
@@ -7,3 +7,7 @@ ensures false;
 {
   assert false;
 }
+
+action {:layer 1} bar()
+requires false;
+{ }

--- a/Test/civl/regression-tests/assert-layers.bpl.expect
+++ b/Test/civl/regression-tests/assert-layers.bpl.expect
@@ -1,4 +1,5 @@
 assert-layers.bpl(5,0): Error: expected layers
 assert-layers.bpl(6,0): Error: expected layers
 assert-layers.bpl(8,2): Error: expected layers
-3 name resolution errors detected in assert-layers.bpl
+assert-layers.bpl(12,0): Error: expected layers
+4 name resolution errors detected in assert-layers.bpl

--- a/Test/civl/regression-tests/intro-inline-check.bpl.expect
+++ b/Test/civl/regression-tests/intro-inline-check.bpl.expect
@@ -1,4 +1,7 @@
+intro-inline-check.bpl(7,9): Error: global variable must be introduced below the lower layer 1 of action A: g
+intro-inline-check.bpl(13,9): Error: global variable must be introduced below the lower layer 1 of action I: g
 intro-inline-check.bpl(16,4): Error: global variable must be introduced below the lower layer 1 of action I: g
 intro-inline-check.bpl(17,9): Error: global variable must be available across all layers ([1, 1]) of action I: h
+intro-inline-check.bpl(21,9): Error: global variable must be introduced below the lower layer 1 of action B: g
 intro-inline-check.bpl(23,4): Error: caller layer range ([1, 2]) must be subset of callee layer range ([1, 1])
-3 type checking errors detected in intro-inline-check.bpl
+6 type checking errors detected in intro-inline-check.bpl

--- a/Test/civl/regression-tests/yield-pre-post-resolution.bpl
+++ b/Test/civl/regression-tests/yield-pre-post-resolution.bpl
@@ -1,0 +1,10 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+yield procedure {:layer 1} foo();
+requires call foo();
+ensures call foo();
+preserves call foo();
+
+atomic action {:layer 1} bar();
+requires call bar();

--- a/Test/civl/regression-tests/yield-pre-post-resolution.bpl.expect
+++ b/Test/civl/regression-tests/yield-pre-post-resolution.bpl.expect
@@ -1,0 +1,5 @@
+yield-pre-post-resolution.bpl(5,9): Error: expected call to yield invariant
+yield-pre-post-resolution.bpl(7,10): Error: expected call to yield invariant
+yield-pre-post-resolution.bpl(6,8): Error: expected call to yield invariant
+yield-pre-post-resolution.bpl(10,9): Error: expected call to yield invariant
+4 name resolution errors detected in yield-pre-post-resolution.bpl

--- a/Test/civl/regression-tests/yield-pre-post.bpl
+++ b/Test/civl/regression-tests/yield-pre-post.bpl
@@ -7,3 +7,7 @@ yield procedure {:layer 1} foo()
 requires {:layer 1} g > 0;
 ensures {:layer 1} g > 0;
 { }
+
+atomic action {:layer 1} A()
+requires g > 0;
+{}

--- a/Test/civl/regression-tests/yield-pre-post.bpl
+++ b/Test/civl/regression-tests/yield-pre-post.bpl
@@ -9,5 +9,5 @@ ensures {:layer 1} g > 0;
 { }
 
 atomic action {:layer 1} A()
-requires g > 0;
+requires {:layer 1} g > 0;
 {}

--- a/Test/civl/regression-tests/yield-pre-post.bpl.expect
+++ b/Test/civl/regression-tests/yield-pre-post.bpl.expect
@@ -1,3 +1,4 @@
 yield-pre-post.bpl(7,20): Error: global variable must be accessed inside old expression: g
 yield-pre-post.bpl(8,19): Error: global variable must be accessed inside old expression: g
-2 type checking errors detected in yield-pre-post.bpl
+yield-pre-post.bpl(12,9): Error: global variable must be accessed inside old expression: g
+3 type checking errors detected in yield-pre-post.bpl

--- a/Test/civl/regression-tests/yield-pre-post.bpl.expect
+++ b/Test/civl/regression-tests/yield-pre-post.bpl.expect
@@ -1,4 +1,4 @@
 yield-pre-post.bpl(7,20): Error: global variable must be accessed inside old expression: g
 yield-pre-post.bpl(8,19): Error: global variable must be accessed inside old expression: g
-yield-pre-post.bpl(12,9): Error: global variable must be accessed inside old expression: g
+yield-pre-post.bpl(12,20): Error: global variable must be accessed inside old expression: g
 3 type checking errors detected in yield-pre-post.bpl


### PR DESCRIPTION
This PR adds preconditions to actions for the purpose of providing extra contextual information in left mover checks for inductive sequentialization. These preconditions are proved to be interference-free just like other preconditions. Their initiation is established by the IS invariant during the step condition check for the action being moved left. As a result of this enhancement, the use of abstractions (and the eliminates clause) is eliminated from Civl benchmarks, the strengthening achieved by the extra gates of the abstractions now achieved by the preconditions.

The intention is to eliminate abstractions and the eliminates clause from Civl. But that will be done in a separate PR.