### PR TITLE
[Civl] Fixed bug in typechecking of yielding loops

### DIFF
--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -4121,9 +4121,9 @@ namespace Microsoft.Boogie
     private void TypecheckLoopAnnotations(TypecheckingContext tc, Graph<Block> graph)
     {
       var yieldingProc = (YieldProcedureDecl)Proc;
-      var yieldingLayer = yieldingProc.Layer;
       foreach (var header in graph.Headers)
       {
+        var yieldingLayer = yieldingProc.Layer;
         var yieldCmd = (PredicateCmd)header.Cmds.FirstOrDefault(cmd =>
           cmd is PredicateCmd predCmd && predCmd.HasAttribute(CivlAttributes.YIELDS));
         if (yieldCmd == null)


### PR DESCRIPTION
Each loop in a yield procedure is allowed to yield up to a yielding layer that is bounded by the disappearance layer of the enclosing yield procedure. This yielding layer N is either specified directly in an annotation on the loop header that looks like
```
invariant {:yields} {:layer N} true;
```
or it is inferred.

The inference is done separately for each loop. 

The bug was that the result of the inference for one loop was polluting the result for another. The problem is fixed by moving the ```yieldingLayer``` variable inside the iteration.