### PR TITLE
[Civl] small fixes to Treiber stack example

### DIFF
--- a/Test/civl/inductive-sequentialization/2PC.bpl
+++ b/Test/civl/inductive-sequentialization/2PC.bpl
@@ -77,8 +77,8 @@ modifies RequestChannel, VoteChannel, DecisionChannel, votes, decisions;
   call set_choice(PARTICIPANT2(One(k+1)));
 }
 
-yield invariant {:layer 5} YieldParticipant ({:linear} foo: One int);
-invariant DecisionChannel[foo->val][COMMIT()] > 0 || DecisionChannel[foo->val][ABORT()] > 0;
+yield invariant {:layer 5} YieldParticipant ({:linear} pid: One int);
+invariant DecisionChannel[pid->val][COMMIT()] > 0 || DecisionChannel[pid->val][ABORT()] > 0;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/Test/civl/samples/treiber-stack.bpl.expect
+++ b/Test/civl/samples/treiber-stack.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 47 verified, 0 errors
+Boogie program verifier finished with 58 verified, 0 errors


### PR DESCRIPTION
This PR updates the primitive atomic actions in treiber stack so that they uniformly follow the pattern of Map_Get, Map_Put, Cell_Unpack, Cell_Pack, etc.

The outstanding problems are as follows:
- Most primitive atomic actions do Map_Get on ts at the beginning and Map_Put on ts at the end. The proof would be better if each primitive atomic action did at most one Map_Get or Map_Put.
- There is a problematic assume in AtomicLoadNode#0 without which the proof does not succeed. The issue seems related to the first point. To clean up the proof, it seems that we need to maintain and prove an invariant at the lowest level---either top is nil or top is a member of stack.