### PR TITLE
Remove code that causes memory leaks

### DIFF
--- a/Source/Core/AST/Program.cs
+++ b/Source/Core/AST/Program.cs
@@ -401,7 +401,7 @@ public class Program : Absy
     }
   }
 
-  public readonly ConcurrentBag<TrackedNodeComponent> AllCoveredElements = new();
+  public readonly ConcurrentStack<TrackedNodeComponent> AllCoveredElements = new();
 
   public IEnumerable<Block> Blocks()
   {

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>3.1.5</Version>
+    <Version>3.1.6</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
+++ b/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
@@ -78,8 +78,16 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
 
   private void RunItem()
   {
-    var task = queue.Dequeue().Result;
-    TryExecuteTask(task);
+    try {
+      var task = queue.Dequeue().Result;
+      TryExecuteTask(task);
+    } catch(Exception e) {
+      if (e.GetBaseException() is OperationCanceledException) {
+        // Async queue cancels tasks when it is disposed, which happens when this scheduler is disposed
+      } else {
+        throw;
+      }
+    }
   }
 
   public void Dispose()

--- a/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
+++ b/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
@@ -68,6 +68,9 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
        * So values assigned in iteration X can only be garbage collected until they have been reassigned
        * in iteration X+1. If there is a long pause between that reassignment, which is the case here,
        * then it may take a long time before dead memory can be garbage collected.
+       *
+       * Inlining RunItem and manually setting variables to null at the end of the loop body does not work,
+       * probably because such assignments are removed during C# compilation since they seem unused.
        */
       RunItem();
     }
@@ -75,8 +78,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
 
   private void RunItem()
   {
-    var taskTask = queue.Dequeue();
-    var task = taskTask.Result;
+    var task = queue.Dequeue().Result;
     TryExecuteTask(task);
   }
 

--- a/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
+++ b/Source/ExecutionEngine/CustomStackSizePoolTaskScheduler.cs
@@ -64,7 +64,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
     {
       try
       {
-        var task = queue.Dequeue(disposeTokenSource.Token).Result;
+        var task = queue.Dequeue().Result;
         TryExecuteTask(task);
       }
       catch (AggregateException e)
@@ -80,6 +80,7 @@ public class CustomStackSizePoolTaskScheduler : TaskScheduler, IDisposable
   public void Dispose()
   {
     disposeTokenSource.Cancel();
+    queue.Clear();
     foreach (var thread in threads)
     {
       thread.Join();

--- a/Source/Provers/SMTLib/SExprParser.cs
+++ b/Source/Provers/SMTLib/SExprParser.cs
@@ -23,7 +23,7 @@ public class SExprParser
 
   Task<string> ReadLine()
   {
-    return sexpLines.Dequeue(CancellationToken.None);
+    return sexpLines.Dequeue();
   }
   
   async Task<char> SkipWs()

--- a/Source/Provers/SMTLib/SMTLibProcess.cs
+++ b/Source/Provers/SMTLib/SMTLibProcess.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Boogie.SMTLib
     /// </summary>
     Task<string> ReadProver()
     {
-      return solverOutput.Dequeue(CancellationToken.None);
+      return solverOutput.Dequeue();
     }
 
     void DisposeProver()

--- a/Source/UnitTests/CoreTests/AsyncQueueTest.cs
+++ b/Source/UnitTests/CoreTests/AsyncQueueTest.cs
@@ -16,36 +16,14 @@ public class AsyncQueueTest
     var queue = new AsyncQueue<int>();
     var firstValue = 1;
     var secondValue = 2;
-    var waitingDequeueTask = queue.Dequeue(CancellationToken.None);
+    var waitingDequeueTask = queue.Dequeue();
     queue.Enqueue(firstValue);
     queue.Enqueue(secondValue);
     var firstResult = await waitingDequeueTask;
-    var secondResult = await queue.Dequeue(CancellationToken.None);
+    var secondResult = await queue.Dequeue();
 
     Assert.AreEqual(firstValue, firstResult);
     Assert.AreEqual(secondValue, secondResult);
-  }
-
-  [Test]
-  public async Task CancellationSupport()
-  {
-    var queue = new AsyncQueue<int>();
-    var source = new CancellationTokenSource();
-    var firstResultTask = queue.Dequeue(source.Token);
-    var secondResultTask = queue.Dequeue(CancellationToken.None);
-    var firstValue = 3;
-    source.Cancel();
-    queue.Enqueue(firstValue);
-
-    try {
-      await firstResultTask;
-      Assert.True(false);
-    }
-    catch (TaskCanceledException) {
-      Assert.True(firstResultTask.IsCanceled);
-    }
-    var secondResult = await secondResultTask;
-    Assert.AreEqual(firstValue, secondResult);
   }
 
   [Test]
@@ -54,7 +32,7 @@ public class AsyncQueueTest
     var queue = new AsyncQueue<int>();
     var tasks = new List<Task<int>>();
     for (int i = 0; i < 100; i++) {
-      tasks.Add(queue.Dequeue(CancellationToken.None));
+      tasks.Add(queue.Dequeue());
     }
     for (int i = 0; i < 100; i++) {
       queue.Enqueue(i);
@@ -72,7 +50,7 @@ public class AsyncQueueTest
     var queue = new AsyncQueue<int>();
     var semaphore = new Semaphore(0, 1);
 
-    var firstResultTask = queue.Dequeue(CancellationToken.None);
+    var firstResultTask = queue.Dequeue();
     var secondValue = 2;
     var mappedTask = firstResultTask.ContinueWith(t =>
     {
@@ -105,13 +83,13 @@ public class AsyncQueueTest
     void DequeueAction1()
     {
       for (int i = 0; i < amount; i++) {
-        tasks1.Add(queue.Dequeue(CancellationToken.None));
+        tasks1.Add(queue.Dequeue());
       }
     }
     void DequeueAction2()
     {
       for (int i = 0; i < amount; i++) {
-        tasks2.Add(queue.Dequeue(CancellationToken.None));
+        tasks2.Add(queue.Dequeue());
       }
     }
 

--- a/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
+++ b/Source/UnitTests/ExecutionEngineTests/ExecutionEngineTest.cs
@@ -31,7 +31,8 @@ public class ExecutionEngineTest {
     var options = new CommandLineOptions(TextWriter.Null, new ConsolePrinter());
     options.VcsCores = 10;
     int beforeCreation = Process.GetCurrentProcess().Threads.Count;
-    var engine = new ExecutionEngine(options, new VerificationResultCache());
+    var engine = new ExecutionEngine(options, new VerificationResultCache(), 
+      CustomStackSizePoolTaskScheduler.Create(ExecutionEngine.StackSize, options.VcsCores), true);
     engine.Dispose();
     for (int i = 0; i < 50; i++)
     {

--- a/Source/VCGeneration/VerificationConditionGenerator.cs
+++ b/Source/VCGeneration/VerificationConditionGenerator.cs
@@ -493,7 +493,7 @@ namespace VC
 
       public override void AddCoveredElement(TrackedNodeComponent elt)
       {
-        program.AllCoveredElements.Add(elt);
+        program.AllCoveredElements.Push(elt);
         split.CoveredElements.Add(elt);
       }
 


### PR DESCRIPTION
### Changes
- Replace two usages of `ConcurrentBag` with `ConcurrentStack`, which has a much simpler implementation that has no risk of memory leaks. ConcurrentBag was causing leaks. More information is here: https://stackoverflow.com/questions/5353164/possible-memoryleak-in-concurrentbag
- Remove cancellation support from AsyncQueue, since the cancellation token would gain a reference to the item being dequeued, which a caller might not expect and which causes a memory leak if the cancellation token is kept alive.
- Add a 'Clear' method to 'AsyncQueue' to allow cancelling all customers
- Fix a surprising memory leak in `CustomStackSizePoolTaskScheduler`
- Enable using an ExecutionEngine with a custom TaskScheduler

### Testing
- Tested with a profiler that the above changes resolve the issue that each Boogie program created by Dafny was never garbage collected.
