### PR TITLE
Add disjointness assumption to IS proof obligations

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Boogie
       DeclareTriggerFunctions();
     }
 
+    public IEnumerable<Variable> UsedGlobalVars => UsedGlobalVarsInGate.Union(UsedGlobalVarsInAction);
+
     public IToken tok => ActionDecl.tok;
 
     public string Name => ActionDecl.Name;

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Boogie
     private IEnumerable<Expr> InputDisjointnessExprs()
     {
       return civlTypeChecker.linearTypeChecker.DisjointnessExprForEachDomain(
-        invariantAction.Impl.InParams.Union(invariantAction.ModifiedGlobalVars)
+        invariantAction.Impl.InParams.Union(invariantAction.UsedGlobalVars)
         .Where(x => LinearTypeChecker.InKinds.Contains(LinearTypeChecker.FindLinearKind(x))));
     }
 

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Boogie
 {
   public class LinearTypeChecker : ReadOnlyVisitor
   {
+    public static LinearKind[] InKinds = {LinearKind.LINEAR, LinearKind.LINEAR_IN};
+    public static LinearKind[] OutKinds = {LinearKind.LINEAR, LinearKind.LINEAR_OUT};
+
     public Program program;
     private CheckingContext checkingContext;
     private CivlTypeChecker civlTypeChecker;

--- a/Source/Concurrency/LinearityChecker.cs
+++ b/Source/Concurrency/LinearityChecker.cs
@@ -21,9 +21,6 @@ class LinearityChecker
       }
     }
 
-    private static LinearKind[] InKinds = {LinearKind.LINEAR, LinearKind.LINEAR_IN};
-    private static LinearKind[] OutKinds = {LinearKind.LINEAR, LinearKind.LINEAR_OUT};
-
     private class LinearityCheck
     {
       public LinearDomain domain;
@@ -75,16 +72,18 @@ class LinearityChecker
       
       // Linear in vars
       var inVars = inputs.Union(action.ModifiedGlobalVars)
-          .Where(x => InKinds.Contains(LinearTypeChecker.FindLinearKind(x))).Select(Expr.Ident).ToList();
+          .Where(x => LinearTypeChecker.InKinds.Contains(LinearTypeChecker.FindLinearKind(x)))
+          .Select(Expr.Ident).ToList();
       // Linear out vars
       var outVars = inputs.Union(outputs).Union(action.ModifiedGlobalVars)
-          .Where(x => OutKinds.Contains(LinearTypeChecker.FindLinearKind(x))).Select(Expr.Ident).ToList();
+          .Where(x => LinearTypeChecker.OutKinds.Contains(LinearTypeChecker.FindLinearKind(x)))
+          .Select(Expr.Ident).ToList();
 
-      var inputDisjointnessExpr = linearTypeChecker.DisjointnessExprForEachDomain(
+      var inputDisjointnessExprs = linearTypeChecker.DisjointnessExprForEachDomain(
         inputs.Union(action.ModifiedGlobalVars)
-        .Where(x => InKinds.Contains(LinearTypeChecker.FindLinearKind(x))));
+        .Where(x => LinearTypeChecker.InKinds.Contains(LinearTypeChecker.FindLinearKind(x))));
       List<Requires> requires = action.Gate.Select(a => new Requires(false, a.Expr))
-          .Concat(inputDisjointnessExpr.Select(expr => new Requires(false, expr)))
+          .Concat(inputDisjointnessExprs.Select(expr => new Requires(false, expr)))
           .ToList();
 
       List<LinearityCheck> linearityChecks = new List<LinearityCheck>();
@@ -208,7 +207,7 @@ class LinearityChecker
     private List<Expr> PendingAsyncLinearParams(ActionDecl pendingAsync, IdentifierExpr pa)
     {
       var pendingAsyncLinearParams = pendingAsync.InParams
-        .Where(v => InKinds.Contains(LinearTypeChecker.FindLinearKind(v)))
+        .Where(v => LinearTypeChecker.InKinds.Contains(LinearTypeChecker.FindLinearKind(v)))
         .Select(v => ExprHelper.FieldAccess(pa, v.Name)).ToList<Expr>();
       // These expressions must be typechecked since the types are needed later in PermissionMultiset.
       CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, pendingAsyncLinearParams);

--- a/Test/civl/regression-tests/rec-IS1.bpl
+++ b/Test/civl/regression-tests/rec-IS1.bpl
@@ -1,29 +1,30 @@
 // RUN: %parallel-boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-async left action {:layer 1} main_f''()
+var {:linear} g: One int;
+
+async left action {:layer 1} main_f''({:linear_in} l: One int)
 refines final using Inv;
 creates main_f'';
 {
-    if(*){
-    }
-    else{
-      call create_async(main_f''());
-    }
+  if (*) {
+  } else{
+    call create_async(main_f''(l));
+  }
 }
 
-action {:layer 2} final()
+action {:layer 2} final({:linear_in} l: One int)
 {
-  
+  // conclusion check succeeds due to disjointness assumption
 }
 
-action {:layer 1} Inv()
+action {:layer 1} Inv({:linear_in} l: One int)
 creates main_f'';
 {
-    if(*){
-    }
-    else{
-      call create_async(main_f''());
-      call set_choice(main_f''());
-    }
+  assert l != g;
+  if (*) {
+  } else {
+    call create_async(main_f''(l));
+    call set_choice(main_f''(l));
+  }
 }

--- a/Test/civl/regression-tests/rec-IS1.bpl.expect
+++ b/Test/civl/regression-tests/rec-IS1.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 4 verified, 0 errors
+Boogie program verifier finished with 5 verified, 0 errors


### PR DESCRIPTION
This PR adds disjointness assumptions to IS proof obligations. Surprisingly, they had been missing all this time. These assumptions appear to be necessary for the scatter-gather version of distributed snapshot.

This PR also rewrites ```GeneratePartitionChecker``` to make better use of APIs in ```Action``` and ```ActionDecl```.