### PR TITLE
goto bug

### DIFF
--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -162,10 +162,15 @@ namespace Microsoft.Boogie
       }
 
       string checkerName = civlTypeChecker.AddNamePrefix($"PartitionChecker_{action.Name}");
-      List<Block> blocks = new List<Block>(checkerBlocks.Count + 1)
+      List<Block> blocks = new List<Block>(checkerBlocks.Count + 1);
+      if(checkerBlocks.Count != 0)
       {
-        BlockHelper.Block(checkerName, cmds, checkerBlocks)
-      };
+        blocks.Add(BlockHelper.Block(checkerName, cmds, checkerBlocks));
+      }
+      else
+      {
+        blocks.Add(BlockHelper.Block(checkerName, cmds));
+      }
       blocks.AddRange(checkerBlocks);
 
       Procedure proc = DeclHelper.Procedure(


### PR DESCRIPTION
If the blocks list is empty, then a dangling goto is created in the desugared file. Fixed it by checking if it is empty. 