### PR TITLE
Use larger stack when preprocessing

### DIFF
--- a/Source/AbstractInterpretation/Traverse.cs
+++ b/Source/AbstractInterpretation/Traverse.cs
@@ -18,44 +18,44 @@ namespace Microsoft.Boogie
     public static void Compute(Program program)
     {
       Contract.Requires(program != null);
-      cce.BeginExpose(program);
+      Cce.BeginExpose(program);
 
       foreach (var impl in program.Implementations)
       {
         if (impl.Blocks != null && impl.Blocks.Count > 0)
         {
-          Contract.Assume(cce.IsConsistent(impl));
-          cce.BeginExpose(impl);
+          Contract.Assume(Cce.IsConsistent(impl));
+          Cce.BeginExpose(impl);
           Block start = impl.Blocks[0];
           Contract.Assume(start != null);
-          Contract.Assume(cce.IsConsistent(start));
+          Contract.Assume(Cce.IsConsistent(start));
           Visit(start);
 
           // We reset the state...
           foreach (Block b in impl.Blocks)
           {
-            cce.BeginExpose(b);
+            Cce.BeginExpose(b);
             b.TraversingStatus = Block.VisitState.ToVisit;
-            cce.EndExpose();
+            Cce.EndExpose();
           }
 
-          cce.EndExpose();
+          Cce.EndExpose();
         }
       }
 
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     static void Visit(Block b)
     {
       Contract.Requires(b != null);
-      Contract.Assume(cce.IsExposable(b));
+      Contract.Assume(Cce.IsExposable(b));
       if (b.TraversingStatus == Block.VisitState.BeingVisited)
       {
-        cce.BeginExpose(b);
+        Cce.BeginExpose(b);
         // we got here through a back-edge
         b.widenBlock = true;
-        cce.EndExpose();
+        Cce.EndExpose();
       }
       else if (b.TraversingStatus == Block.VisitState.AlreadyVisited)
       {
@@ -66,15 +66,15 @@ namespace Microsoft.Boogie
         Contract.Assert(b.TraversingStatus == Block.VisitState.ToVisit);
 
         GotoCmd g = (GotoCmd) b.TransferCmd;
-        cce.BeginExpose(b);
+        Cce.BeginExpose(b);
 
-        cce.BeginExpose(g); //PM: required for the subsequent expose (g.labelTargets)
+        Cce.BeginExpose(g); //PM: required for the subsequent expose (g.labelTargets)
         b.TraversingStatus = Block.VisitState.BeingVisited;
 
         // labelTargets is made non-null by Resolve, which we assume
         // has already called in a prior pass.
         Contract.Assume(g.labelTargets != null);
-        cce.BeginExpose(g.labelTargets);
+        Cce.BeginExpose(g.labelTargets);
         foreach (Block succ in g.labelTargets)
           //              invariant b.currentlyTraversed;
           //PM: The following loop invariant will work once properties are axiomatized
@@ -84,7 +84,7 @@ namespace Microsoft.Boogie
           Visit(succ);
         }
 
-        cce.EndExpose();
+        Cce.EndExpose();
 
         Contract.Assert(b.TraversingStatus == Block.VisitState.BeingVisited);
         //            System.Diagnostics.Debug.Assert(b.currentlyTraversed);
@@ -94,7 +94,7 @@ namespace Microsoft.Boogie
         //PM: The folowing assumption is needed because we cannot prove that a simple field update
         //PM: leaves the value of a property unchanged.
         Contract.Assume(g.labelNames == null || g.labelNames.Count == g.labelTargets.Count);
-        cce.EndExpose();
+        Cce.EndExpose();
       }
       else
       {
@@ -113,7 +113,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(block.widenBlock);
       Contract.Requires(block != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Block>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
 
       Contract.Assert(rootBlock == null);
       rootBlock = block;
@@ -141,8 +141,8 @@ namespace Microsoft.Boogie
     private static void DoDFSVisit(Block block, List<Block> path, List<Block> blocksInPath)
     {
       Contract.Requires(block != null);
-      Contract.Requires(cce.NonNullElements(path));
-      Contract.Requires(cce.NonNullElements(path));
+      Contract.Requires(Cce.NonNullElements(path));
+      Contract.Requires(Cce.NonNullElements(path));
 
       #region case 1. We visit the root => We are done, "path" is a path inside the loop
 

--- a/Source/BaseTypes/BigNum.cs
+++ b/Source/BaseTypes/BigNum.cs
@@ -148,7 +148,7 @@ namespace Microsoft.BaseTypes
     public override string /*!*/ ToString()
     {
       Contract.Ensures(Contract.Result<string>() != null);
-      return cce.NonNull(val.ToString());
+      return Cce.NonNull(val.ToString());
     }
 
     //////////////////////////////////////////////////////////////////////////////

--- a/Source/BaseTypes/Set.cs
+++ b/Source/BaseTypes/Set.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<GSet<T>>() != null);
       //Contract.Ensures(Contract.ForAll(result, x => a[x] && b[x] ));
       GSet<T> /*!*/
-        res = (GSet<T> /*!*/) cce.NonNull(a.Clone());
+        res = (GSet<T> /*!*/) Cce.NonNull(a.Clone());
       res.Intersect(b);
       return res;
     }
@@ -286,7 +286,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<GSet<T>>() != null);
       //  Contract.Ensures(Contract.ForAll(result, x => a[x] || b[x] ));
       GSet<T> /*!*/
-        res = (GSet<T> /*!*/) cce.NonNull(a.Clone());
+        res = (GSet<T> /*!*/) Cce.NonNull(a.Clone());
       res.AddRange(b);
       return res;
     }

--- a/Source/BoogieDriver/BoogieDriver.cs
+++ b/Source/BoogieDriver/BoogieDriver.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Boogie
   {
     public static int Main(string[] args)
     {
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
 
       var options = new CommandLineOptions(Console.Out, new ConsolePrinter())
       {

--- a/Source/CodeContractsExtender/cce.cs
+++ b/Source/CodeContractsExtender/cce.cs
@@ -10,7 +10,7 @@ public static class Cce
 {
   //[Pure]
   //public static bool NonNullElements<T>(Microsoft.Dafny.Graph<T> collection) {
-  //  return collection != null && cce.NonNullElements(collection.TopologicallySortedComponents());
+  //  return collection != null && Cce.NonNullElements(collection.TopologicallySortedComponents());
   //}
   [Pure]
   public static T NonNull<T>(T t) where T : class
@@ -50,7 +50,7 @@ public static class Cce
     //Should be the same as:
     /*if(nullability&&collection==null)
      * return true;
-     * return cce.NonNullElements(collection)
+     * return Cce.NonNullElements(collection)
      */
   }
 
@@ -75,7 +75,7 @@ public static class Cce
 
   //[Pure]
   //public static bool NonNullElements<T>(Graphing.Graph<T> graph) {
-  //  return cce.NonNullElements(graph.TopologicalSort());
+  //  return Cce.NonNullElements(graph.TopologicalSort());
   //}
   [Pure]
   public static void BeginExpose(object o)

--- a/Source/CodeContractsExtender/cce.cs
+++ b/Source/CodeContractsExtender/cce.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.Contracts;
 /// <summary>
 /// A class containing static methods to extend the functionality of Code Contracts
 /// </summary>
-public static class cce
+public static class Cce
 {
   //[Pure]
   //public static bool NonNullElements<T>(Microsoft.Dafny.Graph<T> collection) {
@@ -29,7 +29,7 @@ public static class cce
   [Pure]
   public static bool NonNullDictionaryAndValues<TKey, TValue>(IDictionary<TKey, TValue> collection) where TValue : class
   {
-    return collection != null && cce.NonNullElements(collection.Values);
+    return collection != null && Cce.NonNullElements(collection.Values);
   }
 
   //[Pure]
@@ -46,7 +46,7 @@ public static class cce
   [Pure]
   public static bool NonNullElements<T>(IEnumerable<T> collection, bool nullability) where T : class
   {
-    return (nullability && collection == null) || cce.NonNullElements(collection);
+    return (nullability && collection == null) || Cce.NonNullElements(collection);
     //Should be the same as:
     /*if(nullability&&collection==null)
      * return true;

--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
       }
       return wlps[impl.Blocks[0]].Select(assertCmd => Forall(impl.LocVars.Union(impl.OutParams), assertCmd)).ToList();
@@ -383,7 +383,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
       }
       cmds.RemoveAll(cmd => cmd is AssertCmd);

--- a/Source/Concurrency/CivlUtil.cs
+++ b/Source/Concurrency/CivlUtil.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
       }
     }
@@ -108,7 +108,7 @@ namespace Microsoft.Boogie
         liveVars.ExceptWith(stateCmd.Locals);
         return liveVars;
       }
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
   }
 

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<Absy>() != null);
       Absy /*!*/
-        result = cce.NonNull((Absy /*!*/) this.MemberwiseClone());
+        result = Cce.NonNull((Absy /*!*/) this.MemberwiseClone());
       result.UniqueId = System.Threading.Interlocked.Increment(ref CurrentAbsyNodeId); // BUGBUG??
 
       if (InternalNumberedMetadata != null)
@@ -763,7 +763,7 @@ namespace Microsoft.Boogie
     [Pure]
     public override string ToString()
     {
-      return cce.NonNull(Name);
+      return Cce.NonNull(Name);
     }
     
     public virtual bool MayRename => true;
@@ -1129,7 +1129,7 @@ namespace Microsoft.Boogie
 
     public static void ResolveTypeSynonyms(List<TypeSynonymDecl /*!*/> /*!*/ synonymDecls, ResolutionContext /*!*/ rc)
     {
-      Contract.Requires(cce.NonNullElements(synonymDecls));
+      Contract.Requires(Cce.NonNullElements(synonymDecls));
       Contract.Requires(rc != null);
       // then discover all dependencies between type synonyms
       IDictionary<TypeSynonymDecl /*!*/, List<TypeSynonymDecl /*!*/> /*!*/> /*!*/
@@ -1197,7 +1197,7 @@ namespace Microsoft.Boogie
       ResolutionContext /*!*/ rc)
     {
       Contract.Requires(type != null);
-      Contract.Requires(cce.NonNullElements(deps));
+      Contract.Requires(Cce.NonNullElements(deps));
       Contract.Requires(rc != null);
       if (type.IsVariable || type.IsBasic)
       {
@@ -1399,7 +1399,7 @@ namespace Microsoft.Boogie
         throw new ArgumentException("VariableComparer works only on objects of type Variable");
       }
 
-      return cce.NonNull(A.Name).CompareTo(B.Name);
+      return Cce.NonNull(A.Name).CompareTo(B.Name);
     }
   }
 
@@ -1742,12 +1742,12 @@ namespace Microsoft.Boogie
     }
 
     protected DeclWithFormals(DeclWithFormals that)
-      : base(that.tok, cce.NonNull(that.Name))
+      : base(that.tok, Cce.NonNull(that.Name))
     {
       Contract.Requires(that != null);
       this.TypeParameters = that.TypeParameters;
-      this.inParams = cce.NonNull(that.InParams);
-      this.outParams = cce.NonNull(that.OutParams);
+      this.inParams = Cce.NonNull(that.InParams);
+      this.outParams = Cce.NonNull(that.OutParams);
     }
 
     public byte[] MD5Checksum_;
@@ -1939,7 +1939,7 @@ namespace Microsoft.Boogie
       {
         Contract.Assert(OutParams.Count == 1);
         stream.Write(" : ");
-        cce.NonNull(OutParams[0]).TypedIdent.Type.Emit(stream);
+        Cce.NonNull(OutParams[0]).TypedIdent.Type.Emit(stream);
       }
       else if (OutParams.Count > 0)
       {
@@ -2241,11 +2241,11 @@ namespace Microsoft.Boogie
       {
         Contract.Assert(DefinitionBody == null);
         Body.Typecheck(tc);
-        if (!cce.NonNull(Body.Type).Unify(cce.NonNull(OutParams[0]).TypedIdent.Type))
+        if (!Cce.NonNull(Body.Type).Unify(Cce.NonNull(OutParams[0]).TypedIdent.Type))
         {
           tc.Error(Body,
             "function body with invalid type: {0} (expected: {1})",
-            Body.Type, cce.NonNull(OutParams[0]).TypedIdent.Type);
+            Body.Type, Cce.NonNull(OutParams[0]).TypedIdent.Type);
         }
       }
       else if (DefinitionBody != null)
@@ -2254,11 +2254,11 @@ namespace Microsoft.Boogie
 
         // We are matching the type of the function body with output param, and not the type
         // of DefinitionBody, which is always going to be bool (since it is of the form func_call == func_body)
-        if (!cce.NonNull(DefinitionBody.Args[1].Type).Unify(cce.NonNull(OutParams[0]).TypedIdent.Type))
+        if (!Cce.NonNull(DefinitionBody.Args[1].Type).Unify(Cce.NonNull(OutParams[0]).TypedIdent.Type))
         {
           tc.Error(DefinitionBody.Args[1],
             "function body with invalid type: {0} (expected: {1})",
-            DefinitionBody.Args[1].Type, cce.NonNull(OutParams[0]).TypedIdent.Type);
+            DefinitionBody.Args[1].Type, Cce.NonNull(OutParams[0]).TypedIdent.Type);
         }
       }
     }
@@ -3627,9 +3627,9 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(LocVars != null);
-      Contract.Invariant(cce.NonNullElements(Blocks));
-      Contract.Invariant(cce.NonNullElements(OriginalBlocks, true));
-      Contract.Invariant(cce.NonNullElements(scc, true));
+      Contract.Invariant(Cce.NonNullElements(Blocks));
+      Contract.Invariant(Cce.NonNullElements(OriginalBlocks, true));
+      Contract.Invariant(Cce.NonNullElements(scc, true));
     }
 
     private bool BlockPredecessorsComputed;
@@ -3642,7 +3642,7 @@ namespace Microsoft.Boogie
     public bool IsSkipVerification(CoreOptions options)
     {
       bool verify = true;
-      cce.NonNull(this.Proc).CheckBooleanAttribute("verify", ref verify);
+      Cce.NonNull(this.Proc).CheckBooleanAttribute("verify", ref verify);
       this.CheckBooleanAttribute("verify", ref verify);
       if (!verify) {
         return true;
@@ -3909,7 +3909,7 @@ namespace Microsoft.Boogie
       List<Variable> outParams, List<Variable> localVariables, [Captured] List<Block /*!*/> block)
       : this(tok, name, typeParams, inParams, outParams, localVariables, block, null)
     {
-      Contract.Requires(cce.NonNullElements(block));
+      Contract.Requires(Cce.NonNullElements(block));
       Contract.Requires(localVariables != null);
       Contract.Requires(outParams != null);
       Contract.Requires(inParams != null);
@@ -3933,7 +3933,7 @@ namespace Microsoft.Boogie
       Contract.Requires(inParams != null);
       Contract.Requires(outParams != null);
       Contract.Requires(localVariables != null);
-      Contract.Requires(cce.NonNullElements(blocks));
+      Contract.Requires(Cce.NonNullElements(blocks));
       LocVars = localVariables;
       Blocks = blocks;
       BlockPredecessorsComputed = false;
@@ -4008,7 +4008,7 @@ namespace Microsoft.Boogie
         return;
       }
 
-      Proc = rc.LookUpProcedure(cce.NonNull(this.Name));
+      Proc = rc.LookUpProcedure(Cce.NonNull(this.Name));
       if (Proc == null)
       {
         rc.Error(this, "implementation given for undeclared procedure: {0}", this.Name);
@@ -4240,15 +4240,15 @@ namespace Microsoft.Boogie
           // the names of the formals are allowed to change from the proc to the impl
 
           // but types must be identical
-          Type t = cce.NonNull((Variable) implFormals[i]).TypedIdent.Type.Substitute(subst2);
-          Type u = cce.NonNull((Variable) procFormals[i]).TypedIdent.Type.Substitute(subst1);
+          Type t = Cce.NonNull((Variable) implFormals[i]).TypedIdent.Type.Substitute(subst2);
+          Type u = Cce.NonNull((Variable) procFormals[i]).TypedIdent.Type.Substitute(subst1);
           if (!t.Equals(u))
           {
             string /*!*/
-              a = cce.NonNull((Variable) implFormals[i]).Name;
+              a = Cce.NonNull((Variable) implFormals[i]).Name;
             Contract.Assert(a != null);
             string /*!*/
-              b = cce.NonNull((Variable) procFormals[i]).Name;
+              b = Cce.NonNull((Variable) procFormals[i]).Name;
             Contract.Assert(b != null);
             string /*!*/
               c;
@@ -4306,9 +4306,9 @@ namespace Microsoft.Boogie
         for (int i = 0; i < OutParams.Count; i++)
         {
           Variable /*!*/
-            v = cce.NonNull(OutParams[i]);
+            v = Cce.NonNull(OutParams[i]);
           IdentifierExpr ie = new IdentifierExpr(v.tok, v);
-          Variable pv = cce.NonNull(Proc.OutParams[i]);
+          Variable pv = Cce.NonNull(Proc.OutParams[i]);
           map.Add(pv, ie);
         }
 
@@ -4322,9 +4322,9 @@ namespace Microsoft.Boogie
           foreach (var e in map)
           {
             options.OutputWriter.Write("  ");
-            cce.NonNull((Variable /*!*/) e.Key).Emit(stream, 0);
+            Cce.NonNull((Variable /*!*/) e.Key).Emit(stream, 0);
             options.OutputWriter.Write("  --> ");
-            cce.NonNull((Expr) e.Value).Emit(stream);
+            Cce.NonNull((Expr) e.Value).Emit(stream);
             options.OutputWriter.WriteLine();
           }
         }
@@ -4340,7 +4340,7 @@ namespace Microsoft.Boogie
     public ICollection<Block /*!*/> GetConnectedComponents(Block startingBlock)
     {
       Contract.Requires(startingBlock != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<ICollection<Block>>(), true));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<ICollection<Block>>(), true));
       Contract.Assert(this.Blocks.Contains(startingBlock));
 
       if (!this.BlockPredecessorsComputed)
@@ -4352,7 +4352,7 @@ namespace Microsoft.Boogie
       System.Console.WriteLine("* Strongly connected components * \n{0} \n ** ", scc);
 #endif
 
-      foreach (ICollection<Block /*!*/> component in cce.NonNull(this.scc))
+      foreach (ICollection<Block /*!*/> component in Cce.NonNull(this.scc))
       {
         foreach (Block /*!*/ b in component)
         {
@@ -4366,7 +4366,7 @@ namespace Microsoft.Boogie
 
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       } // if we are here, it means that the block is not in one of the components. This is an error.
     }
 
@@ -4758,7 +4758,7 @@ namespace Microsoft.Boogie
     public static void Emit(this List<Declaration /*!*/> /*!*/ decls, TokenTextWriter stream)
     {
       Contract.Requires(stream != null);
-      Contract.Requires(cce.NonNullElements(decls));
+      Contract.Requires(Cce.NonNullElements(decls));
       bool first = true;
       foreach (Declaration d in decls)
       {
@@ -5107,7 +5107,7 @@ namespace Microsoft.Boogie
         Contract.Assume(g.labelTargets != null);
         if (g.labelTargets.Count == 1)
         {
-          return new Sequential(new AtomicRE(b), Transform(cce.NonNull(g.labelTargets[0])));
+          return new Sequential(new AtomicRE(b), Transform(Cce.NonNull(g.labelTargets[0])));
         }
         else
         {
@@ -5126,7 +5126,7 @@ namespace Microsoft.Boogie
       else
       {
         Contract.Assume(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
   }

--- a/Source/Core/AST/AbsyCmd.cs
+++ b/Source/Core/AST/AbsyCmd.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<string /*!*/> /*!*/>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<string /*!*/> /*!*/>()));
         return this.labels.AsEnumerable<string>();
       }
     }
@@ -171,14 +171,14 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(EndCurly != null);
-      Contract.Invariant(cce.NonNullElements(this.bigBlocks));
-      Contract.Invariant(cce.NonNullElements(this.labels));
+      Contract.Invariant(Cce.NonNullElements(this.bigBlocks));
+      Contract.Invariant(Cce.NonNullElements(this.labels));
     }
 
     public StmtList(IList<BigBlock /*!*/> /*!*/ bigblocks, IToken endCurly)
     {
       Contract.Requires(endCurly != null);
-      Contract.Requires(cce.NonNullElements(bigblocks));
+      Contract.Requires(Cce.NonNullElements(bigblocks));
       Contract.Requires(bigblocks.Count > 0);
       this.bigBlocks = new List<BigBlock>(bigblocks);
       this.EndCurly = endCurly;
@@ -192,7 +192,7 @@ namespace Microsoft.Boogie
       foreach (BigBlock b in BigBlocks)
       {
         Contract.Assert(b != null);
-        Contract.Assume(cce.IsPeerConsistent(b));
+        Contract.Assume(Cce.IsPeerConsistent(b));
         if (needSeperator)
         {
           stream.WriteLine();
@@ -219,7 +219,7 @@ namespace Microsoft.Boogie
       Contract.Requires(suggestedLabel != null);
       Contract.Requires(prefixCmds != null);
       Contract.Ensures(Contract.Result<bool>() ||
-                       cce.Owner.None(prefixCmds)); // "prefixCmds" is captured only on success
+                       Cce.Owner.None(prefixCmds)); // "prefixCmds" is captured only on success
       Contract.Assume(PrefixCommands == null); // prefix has not been used
 
       BigBlock bb0 = BigBlocks[0];
@@ -272,7 +272,7 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(bigBlocks));
+      Contract.Invariant(Cce.NonNullElements(bigBlocks));
     }
 
     void Dump(StructuredCmd scmd, TransferCmd tcmd)
@@ -377,9 +377,9 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(stmtList != null);
-      Contract.Invariant(cce.NonNullElements(blocks, true));
+      Contract.Invariant(Cce.NonNullElements(blocks, true));
       Contract.Invariant(prefix != null);
-      Contract.Invariant(cce.NonNullElements(allLabels, true));
+      Contract.Invariant(Cce.NonNullElements(allLabels, true));
       Contract.Invariant(errorHandler != null);
     }
 
@@ -438,7 +438,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<Block>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
         if (blocks == null)
         {
           blocks = new List<Block /*!*/>();
@@ -539,7 +539,7 @@ namespace Microsoft.Boogie
         if (b.tc is GotoCmd)
         {
           GotoCmd g = (GotoCmd) b.tc;
-          foreach (string /*!*/ lbl in cce.NonNull(g.labelNames))
+          foreach (string /*!*/ lbl in Cce.NonNull(g.labelNames))
           {
             Contract.Assert(lbl != null);
             /*
@@ -569,7 +569,7 @@ namespace Microsoft.Boogie
           bool found = false;
           for (StmtList sl = stmtList; sl.ParentBigBlock != null; sl = sl.ParentContext)
           {
-            cce.LoopInvariant(sl != null);
+            Cce.LoopInvariant(sl != null);
             BigBlock bb = sl.ParentBigBlock;
 
             if (bcmd.Label == null)
@@ -1105,14 +1105,14 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(Body != null);
-      Contract.Invariant(cce.NonNullElements(Invariants));
+      Contract.Invariant(Cce.NonNullElements(Invariants));
     }
 
 
     public WhileCmd(IToken tok, [Captured] Expr guard, List<PredicateCmd> invariants, List<CallCmd> yields, StmtList body)
       : base(tok)
     {
-      Contract.Requires(cce.NonNullElements(invariants));
+      Contract.Requires(Cce.NonNullElements(invariants));
       Contract.Requires(body != null);
       Contract.Requires(tok != null);
       this.Guard = guard;
@@ -1227,7 +1227,7 @@ namespace Microsoft.Boogie
     {
       if (TransferCmd is GotoCmd g)
       {
-        return cce.NonNull(g.labelTargets);
+        return Cce.NonNull(g.labelTargets);
       }
       return new List<Block>();
     }
@@ -1269,7 +1269,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<Variable /*!*/>>(), true));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<Variable /*!*/>>(), true));
         if (this._liveVarsBefore == null)
         {
           return null;
@@ -1281,7 +1281,7 @@ namespace Microsoft.Boogie
       }
       set
       {
-        Contract.Requires(cce.NonNullElements(value, true));
+        Contract.Requires(Cce.NonNullElements(value, true));
         if (value == null)
         {
           this._liveVarsBefore = null;
@@ -1298,7 +1298,7 @@ namespace Microsoft.Boogie
     {
       Contract.Invariant(this.label != null);
       Contract.Invariant(this.cmds != null);
-      Contract.Invariant(cce.NonNullElements(this._liveVarsBefore, true));
+      Contract.Invariant(Cce.NonNullElements(this._liveVarsBefore, true));
     }
 
     public bool IsLive(Variable v)
@@ -1635,7 +1635,7 @@ namespace Microsoft.Boogie
 
       foreach (Expr e in indexes)
       {
-        indexesList.Add(cce.NonNull(e));
+        indexesList.Add(Cce.NonNull(e));
       }
 
       lhss.Add(new MapAssignLhs(map.tok,
@@ -1666,13 +1666,13 @@ namespace Microsoft.Boogie
 
       for (int i = 0; i < args.Length - 1; ++i)
       {
-        indexesList.Add(cce.NonNull(args[i]));
+        indexesList.Add(Cce.NonNull(args[i]));
       }
 
       lhss.Add(new MapAssignLhs(map.tok,
         new SimpleAssignLhs(map.tok, map),
         indexesList));
-      rhss.Add(cce.NonNull(args[args.Length - 1]));
+      rhss.Add(Cce.NonNull(args[args.Length - 1]));
 
       return new AssignCmd(tok, lhss, rhss);
     }
@@ -1773,13 +1773,13 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IList<AssignLhs>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IList<AssignLhs>>()));
         Contract.Ensures(Contract.Result<IList<AssignLhs>>().IsReadOnly);
         return this._lhss.AsReadOnly();
       }
       set
       {
-        Contract.Requires(cce.NonNullElements(value));
+        Contract.Requires(Cce.NonNullElements(value));
         this._lhss = new List<AssignLhs>(value);
       }
     }
@@ -1798,13 +1798,13 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IList<Expr>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IList<Expr>>()));
         Contract.Ensures(Contract.Result<IList<Expr>>().IsReadOnly);
         return this._rhss.AsReadOnly();
       }
       set
       {
-        Contract.Requires(cce.NonNullElements(value));
+        Contract.Requires(Cce.NonNullElements(value));
         this._rhss = new List<Expr>(value);
       }
     }
@@ -1820,16 +1820,16 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(this._lhss));
-      Contract.Invariant(cce.NonNullElements(this._rhss));
+      Contract.Invariant(Cce.NonNullElements(this._lhss));
+      Contract.Invariant(Cce.NonNullElements(this._rhss));
     }
 
     public AssignCmd(IToken tok, IList<AssignLhs> lhss, IList<Expr> rhss, QKeyValue kv)
       : base(tok)
     {
       Contract.Requires(tok != null);
-      Contract.Requires(cce.NonNullElements(rhss));
-      Contract.Requires(cce.NonNullElements(lhss));
+      Contract.Requires(Cce.NonNullElements(rhss));
+      Contract.Requires(Cce.NonNullElements(lhss));
       this._lhss = new List<AssignLhs>(lhss);
       this._rhss = new List<Expr>(rhss);
       this.Attributes = kv;
@@ -1839,8 +1839,8 @@ namespace Microsoft.Boogie
       : base(tok)
     {
       Contract.Requires(tok != null);
-      Contract.Requires(cce.NonNullElements(rhss));
-      Contract.Requires(cce.NonNullElements(lhss));
+      Contract.Requires(Cce.NonNullElements(rhss));
+      Contract.Requires(Cce.NonNullElements(lhss));
       this._lhss = new List<AssignLhs>(lhss);
       this._rhss = new List<Expr>(rhss);
     }
@@ -1900,7 +1900,7 @@ namespace Microsoft.Boogie
       {
         for (int j = i + 1; j < Lhss.Count; ++j)
         {
-          if (cce.NonNull(Lhss[i].DeepAssignedVariable).Equals(
+          if (Cce.NonNull(Lhss[i].DeepAssignedVariable).Equals(
             Lhss[j].DeepAssignedVariable))
           {
             rc.Error(Lhss[j],
@@ -2190,7 +2190,7 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(Map != null);
-      Contract.Invariant(cce.NonNullElements(Indexes));
+      Contract.Invariant(Cce.NonNullElements(Indexes));
     }
 
 
@@ -2233,7 +2233,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(map != null);
       Contract.Requires(tok != null);
-      Contract.Requires(cce.NonNullElements(indexes));
+      Contract.Requires(Cce.NonNullElements(indexes));
 
       Map = map;
       Indexes = indexes;
@@ -2268,7 +2268,7 @@ namespace Microsoft.Boogie
       }
 
       TypeAttr =
-        MapSelect.Typecheck(cce.NonNull(Map.Type), Map,
+        MapSelect.Typecheck(Cce.NonNull(Map.Type), Map,
           selectArgs, out var tpInsts, tc, tok, "map assignment");
       TypeParameters = tpInsts;
     }
@@ -2857,7 +2857,7 @@ namespace Microsoft.Boogie
         default:
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // unexpected kind
       }
 
@@ -3187,12 +3187,12 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<Expr>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<Expr>>()));
         return this.exprList.AsReadOnly();
       }
       set
       {
-        Contract.Requires(cce.NonNullElements(value));
+        Contract.Requires(Cce.NonNullElements(value));
         this.exprList = new List<Expr>(value);
       }
     }
@@ -3202,13 +3202,13 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(this._reason != null);
-      Contract.Invariant(cce.NonNullElements(this.exprList));
+      Contract.Invariant(Cce.NonNullElements(this.exprList));
     }
 
     public EEDTemplate(string reason, List<Expr /*!*/> /*!*/ exprList)
     {
       Contract.Requires(reason != null);
-      Contract.Requires(cce.NonNullElements(exprList));
+      Contract.Requires(Cce.NonNullElements(exprList));
       this._reason = reason;
       this.exprList = exprList;
     }
@@ -3735,7 +3735,7 @@ namespace Microsoft.Boogie
       Debug.Assert(labelSeq.Count == blockSeq.Count);
       for (int i = 0; i < labelSeq.Count; i++)
       {
-        Debug.Assert(Equals(labelSeq[i], cce.NonNull(blockSeq[i]).Label));
+        Debug.Assert(Equals(labelSeq[i], Cce.NonNull(blockSeq[i]).Label));
       }
 
       this.labelNames = labelSeq;
@@ -3751,7 +3751,7 @@ namespace Microsoft.Boogie
       List<String> labelSeq = new List<String>();
       for (int i = 0; i < blockSeq.Count; i++)
       {
-        labelSeq.Add(cce.NonNull(blockSeq[i]).Label);
+        labelSeq.Add(Cce.NonNull(blockSeq[i]).Label);
       }
 
       this.labelNames = labelSeq;
@@ -3771,7 +3771,7 @@ namespace Microsoft.Boogie
     public void AddTargets(IEnumerable<Block> blocks)
     {
       Contract.Requires(blocks != null);
-      Contract.Requires(cce.NonNullElements(blocks));
+      Contract.Requires(Cce.NonNullElements(blocks));
       Contract.Requires(this.labelTargets != null);
       Contract.Requires(this.labelNames != null);
       foreach (var block in blocks)

--- a/Source/Core/AST/AbsyQuant.cs
+++ b/Source/Core/AST/AbsyQuant.cs
@@ -346,7 +346,7 @@ namespace Microsoft.Boogie
 
     public void AddParams(IEnumerable<object> ps)
     {
-      Contract.Requires(cce.NonNullElements(ps));
+      Contract.Requires(Cce.NonNullElements(ps));
       this._params.AddRange(ps);
     }
 
@@ -359,7 +359,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IList<object>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IList<object>>()));
         Contract.Ensures(Contract.Result<IList<object>>().IsReadOnly);
         return this._params.AsReadOnly();
       }
@@ -371,7 +371,7 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(Key != null);
-      Contract.Invariant(cce.NonNullElements(this._params));
+      Contract.Invariant(Cce.NonNullElements(this._params));
     }
 
     public QKeyValue(IToken tok, string key, IList<object /*!*/> /*!*/ parameters, QKeyValue next)
@@ -379,7 +379,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(key != null);
       Contract.Requires(tok != null);
-      Contract.Requires(cce.NonNullElements(parameters));
+      Contract.Requires(Cce.NonNullElements(parameters));
       Key = key;
       this._params = new List<object>(parameters);
       Next = next;
@@ -965,7 +965,7 @@ namespace Microsoft.Boogie
         //Contract.Requires(node != null);
         Contract.Ensures(Contract.Result<Expr>() != null);
         FunctionCall fn = node.Fun as FunctionCall;
-        if (fn != null && cce.NonNull(fn.Func).NeverTrigger)
+        if (fn != null && Cce.NonNull(fn.Func).NeverTrigger)
         {
           parent.Triggers = new Trigger(fn.Func.tok, false, new List<Expr> {node}, parent.Triggers);
         }

--- a/Source/Core/AST/AbsyType.cs
+++ b/Source/Core/AST/AbsyType.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Boogie
     [Pure]
     public static bool IsIdempotent(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ unifier)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(unifier));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(unifier));
       return unifier.Values.All(val => val.FreeVariables.All(var => !unifier.ContainsKey(var)));
     }
 
@@ -248,7 +248,7 @@ namespace Microsoft.Boogie
 
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // Type.AsVariable should never be called
       }
     }
@@ -266,7 +266,7 @@ namespace Microsoft.Boogie
 
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // Type.AsCtor should never be called
       }
     }
@@ -284,7 +284,7 @@ namespace Microsoft.Boogie
 
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // Type.AsMap should never be called
       }
     }
@@ -295,7 +295,7 @@ namespace Microsoft.Boogie
       {
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // Type.MapArity should never be called
       }
     }
@@ -313,7 +313,7 @@ namespace Microsoft.Boogie
 
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // Type.AsUnresolved should never be called
       }
     }
@@ -329,7 +329,7 @@ namespace Microsoft.Boogie
       {
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // Type.FloatExponent should never be called
       }
     }
@@ -340,7 +340,7 @@ namespace Microsoft.Boogie
       {
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // Type.FloatSignificand should never be called
       }
     }
@@ -356,7 +356,7 @@ namespace Microsoft.Boogie
       {
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // Type.BvBits should never be called
       }
     }
@@ -436,9 +436,9 @@ namespace Microsoft.Boogie
       Contract.Requires(tc != null);
       Contract.Requires(formalArgs.Count == actualArgs.Count);
       Contract.Requires((formalOuts == null) == (actualOuts == null));
-      Contract.Requires(formalOuts == null || formalOuts.Count == cce.NonNull(actualOuts).Count);
+      Contract.Requires(formalOuts == null || formalOuts.Count == Cce.NonNull(actualOuts).Count);
       Contract.Requires(tc == null || opName != null); //Redundant
-      Contract.Ensures(cce.NonNullDictionaryAndValues(Contract.Result<IDictionary<TypeVariable, Type>>()));
+      Contract.Ensures(Cce.NonNullDictionaryAndValues(Contract.Result<IDictionary<TypeVariable, Type>>()));
 
       // requires "actualArgs" and "actualOuts" to have been type checked
 
@@ -453,7 +453,7 @@ namespace Microsoft.Boogie
       for (int i = 0; i < formalArgs.Count; i++)
       {
         Type formal = formalArgs[i].Substitute(subst);
-        Type actual = cce.NonNull(cce.NonNull(actualArgs[i]).Type);
+        Type actual = Cce.NonNull(Cce.NonNull(actualArgs[i]).Type);
         // if the type variables to be matched occur in the actual
         // argument types, something has gone very wrong
         Contract.Assert(
@@ -463,7 +463,7 @@ namespace Microsoft.Boogie
         {
           Contract.Assume(tc != null); // caller expected no errors
           Contract.Assert(opName != null); // follows from precondition
-          tc.Error(cce.NonNull(actualArgs[i]),
+          tc.Error(Cce.NonNull(actualArgs[i]),
             "invalid type for argument {0} in {1}: {2} (expected: {3})",
             i, opName, actual, formalArgs[i]);
         }
@@ -474,7 +474,7 @@ namespace Microsoft.Boogie
         for (int i = 0; i < formalOuts.Count; ++i)
         {
           Type formal = formalOuts[i].Substitute(subst);
-          Type actual = cce.NonNull(cce.NonNull(actualOuts)[i].Type);
+          Type actual = Cce.NonNull(Cce.NonNull(actualOuts)[i].Type);
           // if the type variables to be matched occur in the actual
           // argument types, something has gone very wrong
           Contract.Assert(Contract.ForAll(0, typeParams.Count, var => !actual.FreeVariables.Contains(typeParams[var])));
@@ -515,7 +515,7 @@ namespace Microsoft.Boogie
       Contract.Requires(actualIns != null);
       Contract.Requires(typeCheckingSubject != null);
       Contract.Requires(opName != null);
-      Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out actualTypeParams)));
+      Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out actualTypeParams)));
       actualTypeParams = new List<Type /*!*/>();
 
       if (formalIns.Count != actualIns.Count)
@@ -540,7 +540,7 @@ namespace Microsoft.Boogie
       IDictionary<TypeVariable /*!*/, Type /*!*/> subst =
         MatchArgumentTypes(typeParams, formalIns, actualIns,
           actualOuts != null ? formalOuts : null, actualOuts, opName, tc);
-      Contract.Assert(cce.NonNullDictionaryAndValues(subst));
+      Contract.Assert(Cce.NonNullDictionaryAndValues(subst));
       foreach (TypeVariable /*!*/ var in typeParams)
       {
         Contract.Assert(var != null);
@@ -596,7 +596,7 @@ namespace Microsoft.Boogie
       IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/
         subst =
           InferTypeParameters(typeParams, formalArgs, actualArgs);
-      Contract.Assert(cce.NonNullDictionaryAndValues(subst));
+      Contract.Assert(Cce.NonNullDictionaryAndValues(subst));
 
       Type /*!*/
         res = formalResult.Substitute(subst);
@@ -622,7 +622,7 @@ namespace Microsoft.Boogie
       Contract.Requires(formalArgs != null);
       Contract.Requires(actualArgs != null);
       Contract.Requires(formalArgs.Count == actualArgs.Count);
-      Contract.Ensures(cce.NonNullDictionaryAndValues(Contract.Result<IDictionary<TypeVariable, Type>>()));
+      Contract.Ensures(Cce.NonNullDictionaryAndValues(Contract.Result<IDictionary<TypeVariable, Type>>()));
 
 
       List<Type> proxies = new List<Type>();
@@ -779,7 +779,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
         throw new NotImplementedException();
       }
     }
@@ -795,7 +795,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable, TypeVariable> varMap)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(varMap));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
 
       throw new NotImplementedException();
@@ -827,7 +827,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(that != null);
       Contract.Requires(unifiableVariables != null);
-      Contract.Requires(cce.NonNullDictionaryAndValues(unifier));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(unifier));
       Contract.Requires(Contract.ForAll(unifier.Keys, key => unifiableVariables.Contains(key)));
       Contract.Requires(IsIdempotent(unifier));
       throw new NotImplementedException();
@@ -835,7 +835,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable, Type> subst)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(subst));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
 
       throw new NotImplementedException();
@@ -926,7 +926,7 @@ namespace Microsoft.Boogie
       Debug.Assert(false, "bad type " + T);
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       } // make compiler happy
     }
 
@@ -1027,7 +1027,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
         return new List<TypeProxy /*!*/>();
       }
     }
@@ -1210,7 +1210,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
         return new List<TypeProxy /*!*/>();
       }
     }
@@ -1374,7 +1374,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
         return new List<TypeProxy /*!*/>();
       }
     }
@@ -1496,7 +1496,7 @@ namespace Microsoft.Boogie
       //Contract.Requires(that != null);
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       } // UnresolvedTypeIdentifier.Unify should never be called
     }
 
@@ -1508,7 +1508,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<Type>() != null);
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       } // UnresolvedTypeIdentifier.Substitute should never be called
     }
 
@@ -1520,7 +1520,7 @@ namespace Microsoft.Boogie
       //Contract.Requires(boundVariables != null);
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       } // UnresolvedTypeIdentifier.GetHashCode should never be called
     }
 
@@ -1711,7 +1711,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
         return new List<TypeProxy /*!*/>();
       }
     }
@@ -1877,7 +1877,7 @@ namespace Microsoft.Boogie
       // the type that "this" is instantiated with
       Type /*!*/ newSubst)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(oldSolution));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(oldSolution));
       Contract.Requires(newSubst != null);
       Contract.Requires(!oldSolution.ContainsKey(this));
 
@@ -1976,7 +1976,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
         return new List<TypeProxy /*!*/>();
       }
     }
@@ -2266,7 +2266,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
         Type p = ProxyFor;
         if (p != null)
         {
@@ -2542,7 +2542,7 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(constraints, true));
+      Contract.Invariant(Cce.NonNullElements(constraints, true));
     }
 
     class BvTypeConstraint
@@ -2605,7 +2605,7 @@ namespace Microsoft.Boogie
     private BvTypeProxy(IToken token, string name, int minBits, List<BvTypeConstraint /*!*/> constraints)
       : base(token, name, "")
     {
-      Contract.Requires(cce.NonNullElements(constraints, true));
+      Contract.Requires(Cce.NonNullElements(constraints, true));
       Contract.Requires(name != null);
       Contract.Requires(token != null);
       this.MinBits = minBits;
@@ -2893,7 +2893,7 @@ namespace Microsoft.Boogie
 
       public Constraint Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
       {
-        Contract.Requires(cce.NonNullDictionaryAndValues(varMap));
+        Contract.Requires(Cce.NonNullDictionaryAndValues(varMap));
         List<Type> /*!*/
           args = new List<Type>();
         foreach (Type /*!*/ t in Arguments)
@@ -2913,7 +2913,7 @@ namespace Microsoft.Boogie
         IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ result)
       {
         Contract.Requires(unifiableVariables != null);
-        Contract.Requires(cce.NonNullDictionaryAndValues(result));
+        Contract.Requires(Cce.NonNullDictionaryAndValues(result));
         Contract.Requires(that != null);
         Contract.Requires(Arguments.Count == that.Arguments.Count);
         Dictionary<TypeVariable /*!*/, Type /*!*/> /*!*/
@@ -3200,7 +3200,7 @@ namespace Microsoft.Boogie
         {
           {
             Contract.Assert(false);
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
           } // what to do now?
         }
       }
@@ -3428,7 +3428,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeProxy>>()));
         return ExpandedType.FreeProxies;
       }
     }
@@ -3926,7 +3926,7 @@ namespace Microsoft.Boogie
           new Dictionary<TypeVariable /*!*/, TypeVariable /*!*/>();
       foreach (KeyValuePair<TypeVariable /*!*/, TypeVariable /*!*/> p in varMap)
       {
-        Contract.Assert(cce.NonNullElements(p));
+        Contract.Assert(Cce.NonNullElements(p));
         if (!TypeParameters.Contains(p.Key))
         {
           newVarMap.Add(p);
@@ -4109,7 +4109,7 @@ namespace Microsoft.Boogie
         // ... and in the resulting unifier of type variables
         foreach (KeyValuePair<TypeVariable /*!*/, Type /*!*/> pair in result)
         {
-          Contract.Assert(cce.NonNullElements(pair));
+          Contract.Assert(Cce.NonNullElements(pair));
           freeVars = pair.Value.FreeVariables;
           foreach (TypeVariable fr in freshies)
           {
@@ -4129,7 +4129,7 @@ namespace Microsoft.Boogie
     [Pure]
     private bool collisionsPossible(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(subst));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(subst));
       // PR: could be written more efficiently
       return TypeParameters.Any(param =>
         subst.ContainsKey(param) || subst.Values.Any(val => val.FreeVariables.Contains(param)));
@@ -4403,7 +4403,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeVariable>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeVariable>>()));
         throw new NotImplementedException();
       }
     }
@@ -4431,7 +4431,7 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void TypeParamsInvariantMethod()
     {
-      Contract.Invariant(cce.NonNullElements(TypeParams));
+      Contract.Invariant(Cce.NonNullElements(TypeParams));
     }
 
     private readonly IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/
@@ -4440,14 +4440,14 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void InstantiationsInvariantMethod()
     {
-      Contract.Invariant(cce.NonNullDictionaryAndValues(Instantiations));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(Instantiations));
     }
 
     public SimpleTypeParamInstantiation(List<TypeVariable /*!*/> /*!*/ typeParams,
       IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ instantiations)
     {
-      Contract.Requires(cce.NonNullElements(typeParams));
-      Contract.Requires(cce.NonNullDictionaryAndValues(instantiations));
+      Contract.Requires(Cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(instantiations));
       this.TypeParams = typeParams;
       this.Instantiations = instantiations;
     }
@@ -4455,7 +4455,7 @@ namespace Microsoft.Boogie
     public static TypeParamInstantiation /*!*/
       From(List<TypeVariable> typeParams, List<Type /*!*/> /*!*/ actualTypeParams)
     {
-      Contract.Requires(cce.NonNullElements(actualTypeParams));
+      Contract.Requires(Cce.NonNullElements(actualTypeParams));
       Contract.Requires(typeParams != null);
       Contract.Requires(typeParams.Count == actualTypeParams.Count);
       Contract.Ensures(Contract.Result<TypeParamInstantiation>() != null);
@@ -4487,7 +4487,7 @@ namespace Microsoft.Boogie
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeVariable>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeVariable>>()));
         return TypeParams;
       }
     }
@@ -4523,7 +4523,7 @@ namespace Microsoft.Boogie
     {
       Contract.Invariant(Proxy != null);
       Contract.Invariant(ArgumentsResult != null);
-      Contract.Invariant(Instantiations == null || cce.NonNullDictionaryAndValues(Instantiations));
+      Contract.Invariant(Instantiations == null || Cce.NonNullDictionaryAndValues(Instantiations));
     }
 
 

--- a/Source/Core/AST/AbsyType.cs
+++ b/Source/Core/AST/AbsyType.cs
@@ -881,7 +881,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       // BasicTypes are immutable anyway, we do not clone
       return this;
@@ -963,7 +963,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(unifiableVariables != null);
       //Contract.Requires(that != null);
-      //Contract.Requires(cce.NonNullElements(unifier));
+      //Contract.Requires(Cce.NonNullElements(unifier));
       // an idempotent substitution that describes the
       // unification result up to a certain point
 
@@ -982,7 +982,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       return this;
     }
@@ -1107,7 +1107,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       // FloatTypes are immutable anyway, we do not clone
       return this;
@@ -1157,7 +1157,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(that != null);
       //Contract.Requires(unifiableVariables != null);
-      //Contract.Requires(cce.NonNullElements(unifier));
+      //Contract.Requires(Cce.NonNullElements(unifier));
       that = that.Expanded;
       if (that is TypeProxy || that is TypeVariable)
       {
@@ -1266,7 +1266,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       // BvTypes are immutable anyway, we do not clone
       return this;
@@ -1319,7 +1319,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(that != null);
       //Contract.Requires(unifiableVariables != null);
-      //Contract.Requires(cce.NonNullElements(unifier));
+      //Contract.Requires(Cce.NonNullElements(unifier));
       that = that.Expanded;
       if (that is TypeProxy || that is TypeVariable)
       {
@@ -1335,7 +1335,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       return this;
     }
@@ -1444,7 +1444,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       List<Type> /*!*/
         newArgs = new List<Type>();
@@ -1492,7 +1492,7 @@ namespace Microsoft.Boogie
       IDictionary<TypeVariable /*!*/, Type /*!*/> result)
     {
       //Contract.Requires(unifiableVariables != null);
-      //Contract.Requires(cce.NonNullElements(result));
+      //Contract.Requires(Cce.NonNullElements(result));
       //Contract.Requires(that != null);
       {
         Contract.Assert(false);
@@ -1504,7 +1504,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       {
         Contract.Assert(false);
@@ -1779,7 +1779,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       // if this variable is mapped to some new variable, we take the new one
       // otherwise, return this
@@ -1834,7 +1834,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(that != null);
       //Contract.Requires(unifiableVariables != null);
-      //Contract.Requires(cce.NonNullElements(unifier));
+      //Contract.Requires(Cce.NonNullElements(unifier));
       that = that.Expanded;
       if (that is TypeProxy && !(that is ConstrainedProxy))
       {
@@ -1915,7 +1915,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       if (subst.TryGetValue(this, out var res))
       {
@@ -2093,7 +2093,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       Type p = ProxyFor;
       if (p != null)
@@ -2154,7 +2154,7 @@ namespace Microsoft.Boogie
       List<TypeVariable> /*!*/ unifiableVariables,
       IDictionary<TypeVariable /*!*/, Type /*!*/> result)
     {
-      //Contract.Requires(cce.NonNullElements(result));
+      //Contract.Requires(Cce.NonNullElements(result));
       //Contract.Requires(unifiableVariables != null);
       //Contract.Requires(that != null);
       Type p = ProxyFor;
@@ -2179,7 +2179,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       Type p = ProxyFor;
       if (p != null)
@@ -2639,7 +2639,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       Type p = ProxyFor;
       if (p != null)
@@ -2666,7 +2666,7 @@ namespace Microsoft.Boogie
       List<TypeVariable> unifiableVariables,
       IDictionary<TypeVariable, Type> result)
     {
-      //Contract.Requires(cce.NonNullElements(result));
+      //Contract.Requires(Cce.NonNullElements(result));
       //Contract.Requires(unifiableVariables != null);
       //Contract.Requires(that != null);
       Type p = ProxyFor;
@@ -2797,7 +2797,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       if (this.ProxyFor == null)
       {
@@ -3032,7 +3032,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       Type p = ProxyFor;
       if (p != null)
@@ -3085,7 +3085,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(that != null);
       //Contract.Requires(unifiableVariables != null);
-      //Contract.Requires(cce.NonNullElements(result));
+      //Contract.Requires(Cce.NonNullElements(result));
       Type p = ProxyFor;
       if (p != null)
       {
@@ -3163,7 +3163,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       if (this.ProxyFor == null)
       {
@@ -3290,7 +3290,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       List<Type> /*!*/
         newArgs = new List<Type>();
@@ -3352,7 +3352,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(that != null);
       //Contract.Requires(unifiableVariables != null);
-      //Contract.Requires(cce.NonNullElements(result));
+      //Contract.Requires(Cce.NonNullElements(result));
       return ExpandedType.Unify(that, unifiableVariables, result);
     }
 
@@ -3360,7 +3360,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       if (subst.Count == 0)
       {
@@ -3614,7 +3614,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       List<Type> /*!*/
         newArgs = new List<Type>();
@@ -3726,7 +3726,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       if (subst.Count == 0)
       {
@@ -3919,7 +3919,7 @@ namespace Microsoft.Boogie
 
     public override Type Clone(IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/ varMap)
     {
-      //Contract.Requires(cce.NonNullElements(varMap));
+      //Contract.Requires(Cce.NonNullElements(varMap));
       Contract.Ensures(Contract.Result<Type>() != null);
       IDictionary<TypeVariable /*!*/, TypeVariable /*!*/> /*!*/
         newVarMap =
@@ -4137,7 +4137,7 @@ namespace Microsoft.Boogie
 
     public override Type Substitute(IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ subst)
     {
-      //Contract.Requires(cce.NonNullElements(subst));
+      //Contract.Requires(Cce.NonNullElements(subst));
       Contract.Ensures(Contract.Result<Type>() != null);
       if (subst.Count == 0)
       {

--- a/Source/Core/AST/CallCmd.cs
+++ b/Source/Core/AST/CallCmd.cs
@@ -624,7 +624,7 @@ public class CallCmd : CallCommonality
     {
       if (Ins[i] != null)
       {
-        formalInTypes.Add(cce.NonNull(Proc.InParams[i]).TypedIdent.Type);
+        formalInTypes.Add(Cce.NonNull(Proc.InParams[i]).TypedIdent.Type);
         actualIns.Add(Ins[i]);
       }
     }
@@ -633,7 +633,7 @@ public class CallCmd : CallCommonality
     {
       if (Outs[i] != null)
       {
-        formalOutTypes.Add(cce.NonNull(Proc.OutParams[i]).TypedIdent.Type);
+        formalOutTypes.Add(Cce.NonNull(Proc.OutParams[i]).TypedIdent.Type);
         actualOuts.Add(Outs[i]);
       }
     }
@@ -646,7 +646,7 @@ public class CallCmd : CallCommonality
       this.tok,
       "call to " + callee,
       tc);
-    Contract.Assert(cce.NonNullElements(actualTypeParams));
+    Contract.Assert(Cce.NonNullElements(actualTypeParams));
     TypeParameters = SimpleTypeParamInstantiation.From(Proc.TypeParameters,
       actualTypeParams);
 
@@ -690,7 +690,7 @@ public class CallCmd : CallCommonality
 
   private IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ TypeParamSubstitution()
   {
-    Contract.Ensures(cce.NonNullDictionaryAndValues(Contract.Result<IDictionary<TypeVariable, Type>>()));
+    Contract.Ensures(Cce.NonNullDictionaryAndValues(Contract.Result<IDictionary<TypeVariable, Type>>()));
     Contract.Assume(TypeParameters != null);
     IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/
       res = new Dictionary<TypeVariable /*!*/, Type /*!*/>();
@@ -742,7 +742,7 @@ public class CallCmd : CallCommonality
     for (int i = 0; i < this.Proc.InParams.Count; ++i)
     {
       Variable /*!*/
-        param = cce.NonNull(this.Proc.InParams[i]);
+        param = Cce.NonNull(this.Proc.InParams[i]);
       bool isWildcard = this.Ins[i] == null;
 
       Type /*!*/
@@ -755,7 +755,7 @@ public class CallCmd : CallCommonality
       {
         // during type checking, we have ensured that the type of the actual
         // parameter Ins[i] is correct, so we can use it here
-        actualType = cce.NonNull(cce.NonNull(Ins[i]).Type);
+        actualType = Cce.NonNull(Cce.NonNull(Ins[i]).Type);
       }
 
       Variable cin = CreateTemporaryVariable(tempVars, param, actualType,
@@ -783,11 +783,11 @@ public class CallCmd : CallCommonality
     for (int i = 0, n = this.Ins.Count; i < n; i++)
     {
       IdentifierExpr /*!*/
-        cin_exp = new IdentifierExpr(cce.NonNull(cins[i]).tok, cce.NonNull(cins[i]));
+        cin_exp = new IdentifierExpr(Cce.NonNull(cins[i]).tok, Cce.NonNull(cins[i]));
       Contract.Assert(cin_exp != null);
       if (this.Ins[i] != null)
       {
-        AssignCmd assign = Cmd.SimpleAssign(Token.NoToken, cin_exp, cce.NonNull(this.Ins[i]));
+        AssignCmd assign = Cmd.SimpleAssign(Token.NoToken, cin_exp, Cce.NonNull(this.Ins[i]));
         newBlockBody.Add(assign);
       }
       else
@@ -810,7 +810,7 @@ public class CallCmd : CallCommonality
     for (int i = 0; i < this.Proc.Requires.Count; i++)
     {
       Requires /*!*/
-        req = cce.NonNull(this.Proc.Requires[i]);
+        req = Cce.NonNull(this.Proc.Requires[i]);
       if (!req.Free && !IsFree)
       {
         if (hasWildcard)
@@ -828,7 +828,7 @@ public class CallCmd : CallCommonality
         else
         {
           Requires /*!*/
-            reqCopy = (Requires /*!*/) cce.NonNull(req.Clone());
+            reqCopy = (Requires /*!*/) Cce.NonNull(req.Clone());
           reqCopy.Condition = Substituter.Apply(s, req.Condition);
           AssertCmd /*!*/
             a = new AssertRequiresCmd(this, reqCopy);
@@ -837,7 +837,7 @@ public class CallCmd : CallCommonality
           if (Attributes != null)
           {
             // Inherit attributes of call.
-            var attrCopy = (QKeyValue) cce.NonNull(Attributes.Clone());
+            var attrCopy = (QKeyValue) Cce.NonNull(Attributes.Clone());
             attrCopy = Substituter.Apply(s, attrCopy);
             a.Attributes = attrCopy;
           }
@@ -885,7 +885,7 @@ public class CallCmd : CallCommonality
       if (Attributes != null)
       {
         // Inherit attributes of call.
-        var attrCopy = (QKeyValue) cce.NonNull(Attributes.Clone());
+        var attrCopy = (QKeyValue) Cce.NonNull(Attributes.Clone());
         attrCopy = Substituter.Apply(s, attrCopy);
         a.Attributes = attrCopy;
       }
@@ -904,11 +904,11 @@ public class CallCmd : CallCommonality
       for (int i = 0; i < this.Proc.Requires.Count; i++)
       {
         Requires /*!*/
-          req = cce.NonNull(this.Proc.Requires[i]);
+          req = Cce.NonNull(this.Proc.Requires[i]);
         if (!req.Free)
         {
           Requires /*!*/
-            reqCopy = (Requires /*!*/) cce.NonNull(req.Clone());
+            reqCopy = (Requires /*!*/) Cce.NonNull(req.Clone());
           reqCopy.Condition = Substituter.Apply(s, req.Condition);
           AssumeCmd /*!*/
             a = new AssumeCmd(tok, reqCopy.Condition);
@@ -951,7 +951,7 @@ public class CallCmd : CallCommonality
     for (int i = 0; i < this.Proc.OutParams.Count; ++i)
     {
       Variable /*!*/
-        param = cce.NonNull(this.Proc.OutParams[i]);
+        param = Cce.NonNull(this.Proc.OutParams[i]);
       bool isWildcard = this.Outs[i] == null;
 
       Type /*!*/
@@ -964,7 +964,7 @@ public class CallCmd : CallCommonality
       {
         // during type checking, we have ensured that the type of the actual
         // out parameter Outs[i] is correct, so we can use it here
-        actualType = cce.NonNull(cce.NonNull(Outs[i]).Type);
+        actualType = Cce.NonNull(Cce.NonNull(Outs[i]).Type);
       }
 
       Variable cout = CreateTemporaryVariable(tempVars, param, actualType,
@@ -986,7 +986,7 @@ public class CallCmd : CallCommonality
       Expr w = param.TypedIdent.WhereExpr;
       if (w != null)
       {
-        IdentifierExpr ie = (IdentifierExpr /*!*/) cce.NonNull(substMap[param]);
+        IdentifierExpr ie = (IdentifierExpr /*!*/) Cce.NonNull(substMap[param]);
         Contract.Assert(ie.Decl != null);
         ie.Decl.TypedIdent.WhereExpr = Substituter.Apply(Substituter.SubstitutionFromDictionary(substMap), w);
       }
@@ -1044,11 +1044,11 @@ public class CallCmd : CallCommonality
       if (this.Outs[i] != null)
       {
         Variable /*!*/
-          param_i = cce.NonNull(this.Proc.OutParams[i]);
+          param_i = Cce.NonNull(this.Proc.OutParams[i]);
         Expr /*!*/
-          cout_exp = new IdentifierExpr(cce.NonNull(couts[i]).tok, cce.NonNull(couts[i]));
+          cout_exp = new IdentifierExpr(Cce.NonNull(couts[i]).tok, Cce.NonNull(couts[i]));
         Contract.Assert(cout_exp != null);
-        AssignCmd assign = Cmd.SimpleAssign(param_i.tok, cce.NonNull(this.Outs[i]), cout_exp);
+        AssignCmd assign = Cmd.SimpleAssign(param_i.tok, Cce.NonNull(this.Outs[i]), cout_exp);
         if (callId is not null) {
           Attributes = new QKeyValue(param_i.tok, "id", new List<object>(){ $"{callId}$out{i}" }, Attributes);
         }

--- a/Source/Core/AST/Expression/AbsyExpr.cs
+++ b/Source/Core/AST/Expression/AbsyExpr.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Boogie
       // The reason for mentioning the method here at all is to give TypeCheck a postcondition for all expressions.
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 
@@ -289,14 +289,14 @@ namespace Microsoft.Boogie
           UnaryOperator op = (UnaryOperator) nary.Fun;
           if (op.Op == UnaryOperator.Opcode.Not)
           {
-            return cce.NonNull(nary.Args[0]);
+            return Cce.NonNull(nary.Args[0]);
           }
         }
         else if (nary.Fun is BinaryOperator)
         {
           BinaryOperator op = (BinaryOperator) nary.Fun;
-          Expr arg0 = cce.NonNull(nary.Args[0]);
-          Expr arg1 = cce.NonNull(nary.Args[1]);
+          Expr arg0 = Cce.NonNull(nary.Args[0]);
+          Expr arg1 = Cce.NonNull(nary.Args[1]);
           if (op.Op == BinaryOperator.Opcode.Eq)
           {
             return Neq(arg0, arg1);
@@ -508,7 +508,7 @@ namespace Microsoft.Boogie
     public static NAryExpr Select(Expr map, List<Expr /*!*/> /*!*/ args)
     {
       Contract.Requires(map != null);
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<NAryExpr>() != null);
       return Select(map, args.ToArray());
     }
@@ -545,7 +545,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(rhs != null);
       Contract.Requires(map != null);
-      Contract.Requires(cce.NonNullElements(indexes));
+      Contract.Requires(Cce.NonNullElements(indexes));
       Contract.Ensures(Contract.Result<NAryExpr>() != null);
       Expr[] /*!*/
         allArgs = new Expr[indexes.Count + 1];
@@ -886,11 +886,11 @@ namespace Microsoft.Boogie
       }
       else if (Type.IsString)
       {
-        stream.Write("\"" + cce.NonNull(this.Val.ToString()) + "\"");
+        stream.Write("\"" + Cce.NonNull(this.Val.ToString()) + "\"");
       }
       else
       {
-        stream.Write(cce.NonNull(this.Val.ToString()));
+        stream.Write(Cce.NonNull(this.Val.ToString()));
       }
     }
 
@@ -951,7 +951,7 @@ namespace Microsoft.Boogie
         {
           {
             Contract.Assert(false);
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
           } // like, where did this value come from?!
         }
       }
@@ -983,7 +983,7 @@ namespace Microsoft.Boogie
       get
       {
         Contract.Assert(isBigNum);
-        return (BigNum) cce.NonNull(Val);
+        return (BigNum) Cce.NonNull(Val);
       }
     }
 
@@ -1002,7 +1002,7 @@ namespace Microsoft.Boogie
       get
       {
         Contract.Assert(isBigDec);
-        return (BigDec) cce.NonNull(Val);
+        return (BigDec) Cce.NonNull(Val);
       }
     }
 
@@ -1011,7 +1011,7 @@ namespace Microsoft.Boogie
       get
       {
         Contract.Assert(isBigFloat);
-        return (BigFloat) cce.NonNull(Val);
+        return (BigFloat) Cce.NonNull(Val);
       }
     }
 
@@ -1025,7 +1025,7 @@ namespace Microsoft.Boogie
       get
       {
         Contract.Assert(isBool);
-        return (bool) cce.NonNull(Val);
+        return (bool) Cce.NonNull(Val);
       }
     }
 
@@ -1039,7 +1039,7 @@ namespace Microsoft.Boogie
       get
       {
         Contract.Assert(isBvConst);
-        return (BvConst) cce.NonNull(Val);
+        return (BvConst) Cce.NonNull(Val);
       }
     }
 
@@ -1053,7 +1053,7 @@ namespace Microsoft.Boogie
       get
       {
         Contract.Assert(isRoundingMode);
-        return (RoundingMode) cce.NonNull(Val);
+        return (RoundingMode) Cce.NonNull(Val);
       }
     }
 
@@ -1067,7 +1067,7 @@ namespace Microsoft.Boogie
       get
       {
         Contract.Assert(isString);
-        return (String) cce.NonNull(Val);
+        return (String) Cce.NonNull(Val);
       }
     }
 
@@ -1104,7 +1104,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<string>() != null);
       if (Value > BigNum.FromInt(10000))
       {
-        string val = cce.NonNull(Value.ToString("x"));
+        string val = Cce.NonNull(Value.ToString("x"));
         int pos = val.Length % 4;
         string res = "0x" + val.Substring(0, pos);
         Contract.Assert(res != null);
@@ -1233,7 +1233,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(tok != null);
       Contract.Requires(d != null);
-      _Name = cce.NonNull(d.Name);
+      _Name = Cce.NonNull(d.Name);
       _Decl = d;
       Type = d.TypedIdent.Type;
       if (immutable)
@@ -1340,7 +1340,7 @@ namespace Microsoft.Boogie
             Name, Type, Decl.TypedIdent.Type);
           {
             Contract.Assert(false);
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
           }
         }
 
@@ -1430,7 +1430,7 @@ namespace Microsoft.Boogie
       }
 
       private static IList /*!*/
-        emptyArgs = ArrayList.ReadOnly(cce.NonNull((IList /*!*/) new ArrayList()));
+        emptyArgs = ArrayList.ReadOnly(Cce.NonNull((IList /*!*/) new ArrayList()));
 
       public IList /*!*/ Arguments
       {
@@ -1904,7 +1904,7 @@ namespace Microsoft.Boogie
       }
 
       stream.Write(FunctionName);
-      cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
+      Cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
       if (parensNeeded)
       {
         stream.Write(")");
@@ -1935,7 +1935,7 @@ namespace Microsoft.Boogie
 
       Contract.Assume(args.Count == 1);
       tpInstantiation = SimpleTypeParamInstantiation.EMPTY;
-      Type arg0type = cce.NonNull(cce.NonNull(args[0]).Type);
+      Type arg0type = Cce.NonNull(Cce.NonNull(args[0]).Type);
       switch (this.op)
       {
         case Opcode.Neg:
@@ -1965,7 +1965,7 @@ namespace Microsoft.Boogie
       System.Diagnostics.Debug.Fail("unknown unary operator: " + op.ToString());
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
       BAD_TYPE:
       tc.Error(this.tok, "invalid argument type ({1}) to unary operator {0}",
@@ -1980,13 +1980,13 @@ namespace Microsoft.Boogie
       switch (this.op)
       {
         case Opcode.Neg:
-          return cce.NonNull(cce.NonNull(args[0]).Type);
+          return Cce.NonNull(Cce.NonNull(args[0]).Type);
         case Opcode.Not:
           return Type.Bool;
         default:
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // unexpected unary operator
       }
     }
@@ -2236,10 +2236,10 @@ namespace Microsoft.Boogie
         stream.Write("(");
       }
 
-      cce.NonNull(args[0]).Emit(stream, opBindingStrength, fragileLeftContext);
+      Cce.NonNull(args[0]).Emit(stream, opBindingStrength, fragileLeftContext);
       stream.sep();
       stream.Write(" {0} ", FunctionName);
-      cce.NonNull(args[1]).Emit(stream, opBindingStrength, fragileRightContext);
+      Cce.NonNull(args[1]).Emit(stream, opBindingStrength, fragileRightContext);
       if (parensNeeded)
       {
         stream.Write(")");
@@ -2306,10 +2306,10 @@ namespace Microsoft.Boogie
       // the default; the only binary operator with a type parameter is equality, but right
       // we don't store this parameter because it does not appear necessary
       tpInstantiation = SimpleTypeParamInstantiation.EMPTY;
-      Expr arg0 = cce.NonNull(args[0]);
-      Expr arg1 = cce.NonNull(args[1]);
-      Type arg0type = cce.NonNull(arg0.Type);
-      Type arg1type = cce.NonNull(arg1.Type);
+      Expr arg0 = Cce.NonNull(args[0]);
+      Expr arg1 = Cce.NonNull(args[1]);
+      Type arg0type = Cce.NonNull(arg0.Type);
+      Type arg1type = Cce.NonNull(arg1.Type);
       switch (this.op)
       {
         case Opcode.Add:
@@ -2430,7 +2430,7 @@ namespace Microsoft.Boogie
       System.Diagnostics.Debug.Fail("unknown binary operator: " + op.ToString());
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
       BAD_TYPE:
       tc.Error(this.tok, "invalid argument types ({1} and {2}) to binary operator {0}", this.FunctionName, arg0type,
@@ -2447,7 +2447,7 @@ namespace Microsoft.Boogie
         case Opcode.Add:
         case Opcode.Sub:
         case Opcode.Mul:
-          return cce.NonNull(args[0]).ShallowType;
+          return Cce.NonNull(args[0]).ShallowType;
 
         case Opcode.Div:
         case Opcode.Mod:
@@ -2472,7 +2472,7 @@ namespace Microsoft.Boogie
         default:
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         } // unexpected binary operator
       }
     }
@@ -2487,8 +2487,8 @@ namespace Microsoft.Boogie
         return;
       }
 
-      Expr arg0 = cce.NonNull(expr.Args[0]);
-      Expr arg1 = cce.NonNull(expr.Args[1]);
+      Expr arg0 = Cce.NonNull(expr.Args[0]);
+      Expr arg1 = Cce.NonNull(expr.Args[1]);
       switch (op)
       {
         case Opcode.Eq:
@@ -2782,7 +2782,7 @@ namespace Microsoft.Boogie
         stream.Write("(");
       }
 
-      cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
+      Cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
       stream.Write("{0} ", FunctionName);
       Type.Emit(stream, 0);
 
@@ -2817,10 +2817,10 @@ namespace Microsoft.Boogie
       Contract.Assume(args.Count == 1);
       tpInstantiation = SimpleTypeParamInstantiation.EMPTY;
 
-      if (!this.Type.Unify(cce.NonNull(cce.NonNull(args[0]).Type)))
+      if (!this.Type.Unify(Cce.NonNull(Cce.NonNull(args[0]).Type)))
       {
         tc.Error(this.tok, "{0} cannot be coerced to {1}",
-          cce.NonNull(args[0]).Type, this.Type);
+          Cce.NonNull(args[0]).Type, this.Type);
       }
 
       return this.Type;
@@ -2940,9 +2940,9 @@ namespace Microsoft.Boogie
 
       tpInstantiation = SimpleTypeParamInstantiation.EMPTY;
 
-      if (!cce.NonNull(cce.NonNull(args[0]).Type).Unify(argType))
+      if (!Cce.NonNull(Cce.NonNull(args[0]).Type).Unify(argType))
       {
-        tc.Error(this.tok, "argument type {0} does not match expected type {1}", cce.NonNull(args[0]).Type,
+        tc.Error(this.tok, "argument type {0} does not match expected type {1}", Cce.NonNull(args[0]).Type,
           this.argType);
       }
 
@@ -3037,7 +3037,7 @@ namespace Microsoft.Boogie
         stream.Write("(");
       }
 
-      cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
+      Cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
       stream.Write("[");
 
       string sep = "";
@@ -3046,13 +3046,13 @@ namespace Microsoft.Boogie
       {
         stream.Write(sep);
         sep = ", ";
-        cce.NonNull(args[i]).Emit(stream);
+        Cce.NonNull(args[i]).Emit(stream);
       }
 
       if (withRhs)
       {
         stream.Write(" := ");
-        cce.NonNull(args.Last()).Emit(stream);
+        Cce.NonNull(args.Last()).Emit(stream);
       }
 
       stream.Write("]");
@@ -3144,7 +3144,7 @@ namespace Microsoft.Boogie
         actualArgs.Add(args[i]);
       }
 
-      return Typecheck(cce.NonNull(cce.NonNull(args[0]).Type), cce.NonNull(args[0]),
+      return Typecheck(Cce.NonNull(Cce.NonNull(args[0]).Type), Cce.NonNull(args[0]),
         actualArgs, out tpInstantiation, tc, this.tok, "map select");
     }
 
@@ -3155,7 +3155,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(args != null);
       Contract.Ensures(Contract.Result<Type>() != null);
-      Expr a0 = cce.NonNull(args[0]);
+      Expr a0 = Cce.NonNull(args[0]);
       Type a0Type = a0.ShallowType;
       if (a0Type == null || !a0Type.IsMap)
       {
@@ -3167,7 +3167,7 @@ namespace Microsoft.Boogie
       List<Type> actualArgTypes = new List<Type>();
       for (int i = 1; i < args.Count; ++i)
       {
-        actualArgTypes.Add(cce.NonNull(args[i]).ShallowType);
+        actualArgTypes.Add(Cce.NonNull(args[i]).ShallowType);
       }
 
       return Type.InferValueType(mapType.TypeParameters, mapType.Arguments, mapType.Result, actualArgTypes);
@@ -3271,7 +3271,7 @@ namespace Microsoft.Boogie
       }
 
       Type resultType =
-        MapSelect.Typecheck(cce.NonNull(cce.NonNull(args[0]).Type), cce.NonNull(args[0]),
+        MapSelect.Typecheck(Cce.NonNull(Cce.NonNull(args[0]).Type), Cce.NonNull(args[0]),
           selectArgs, out tpInstantiation, tc, typeCheckingSubject, opName);
 
       // check the the rhs has the right type
@@ -3281,16 +3281,16 @@ namespace Microsoft.Boogie
         return null;
       }
 
-      Type rhsType = cce.NonNull(cce.NonNull(args.Last()).Type);
+      Type rhsType = Cce.NonNull(Cce.NonNull(args.Last()).Type);
       if (!resultType.Unify(rhsType))
       {
-        tc.Error(cce.NonNull(args.Last()).tok,
+        tc.Error(Cce.NonNull(args.Last()).tok,
           "right-hand side in {0} with wrong type: {1} (expected: {2})",
           opName, rhsType, resultType);
         return null;
       }
 
-      return cce.NonNull(args[0]).Type;
+      return Cce.NonNull(args[0]).Type;
     }
 
     public Type Typecheck(IList<Expr> /*!*/ args,
@@ -3312,7 +3312,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(args != null);
       Contract.Ensures(Contract.Result<Type>() != null);
-      return cce.NonNull(args[0]).ShallowType;
+      return Cce.NonNull(args[0]).ShallowType;
     }
 
     public T Dispatch<T>(IAppliableVisitor<T> visitor)
@@ -3390,13 +3390,13 @@ namespace Microsoft.Boogie
       Contract.Assert(args.Count == 3);
       stream.push();
       stream.Write("(if ");
-      cce.NonNull(args[0]).Emit(stream, 0x00, false);
+      Cce.NonNull(args[0]).Emit(stream, 0x00, false);
       stream.sep();
       stream.Write(" then ");
-      cce.NonNull(args[1]).Emit(stream, 0x00, false);
+      Cce.NonNull(args[1]).Emit(stream, 0x00, false);
       stream.sep();
       stream.Write(" else ");
-      cce.NonNull(args[2]).Emit(stream, 0x00, false);
+      Cce.NonNull(args[2]).Emit(stream, 0x00, false);
       stream.Write(")");
       stream.pop();
     }
@@ -3423,15 +3423,15 @@ namespace Microsoft.Boogie
       // the default; the only binary operator with a type parameter is equality, but right
       // we don't store this parameter because it does not appear necessary
       tpInstantiation = SimpleTypeParamInstantiation.EMPTY;
-      Expr arg0 = cce.NonNull(args[0]);
-      Expr arg1 = cce.NonNull(args[1]);
-      Expr arg2 = cce.NonNull(args[2]);
+      Expr arg0 = Cce.NonNull(args[0]);
+      Expr arg1 = Cce.NonNull(args[1]);
+      Expr arg2 = Cce.NonNull(args[2]);
 
-      if (!cce.NonNull(arg0.Type).Unify(Type.Bool))
+      if (!Cce.NonNull(arg0.Type).Unify(Type.Bool))
       {
         tc.Error(this.tok, "the first argument to if-then-else should be bool, not {0}", arg0.Type);
       }
-      else if (!cce.NonNull(arg1.Type).Unify(cce.NonNull(arg2.Type)))
+      else if (!Cce.NonNull(arg1.Type).Unify(Cce.NonNull(arg2.Type)))
       {
         tc.Error(this.tok, "branches of if-then-else have incompatible types {0} and {1}", arg1.Type, arg2.Type);
       }
@@ -3450,7 +3450,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(args != null);
       Contract.Ensures(Contract.Result<Type>() != null);
-      return cce.NonNull(args[1]).ShallowType;
+      return Cce.NonNull(args[1]).ShallowType;
     }
 
     public T Dispatch<T>(IAppliableVisitor<T> visitor)
@@ -3531,7 +3531,7 @@ namespace Microsoft.Boogie
       {
         stream.Write("(");
       }
-      cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
+      Cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
       stream.Write("->{0}", FieldName);
       if (parensNeeded)
       {
@@ -3550,7 +3550,7 @@ namespace Microsoft.Boogie
     public Type Typecheck(IList<Expr> args, out TypeParamInstantiation tpInstantiation, TypecheckingContext tc)
     {
       Contract.Assert(args.Count == 1);
-      return Typecheck(cce.NonNull(args[0]).Type, tc, out tpInstantiation);
+      return Typecheck(Cce.NonNull(args[0]).Type, tc, out tpInstantiation);
     }
     
     public Type Typecheck(Type type, TypecheckingContext tc, out TypeParamInstantiation tpInstantiation)
@@ -3701,9 +3701,9 @@ namespace Microsoft.Boogie
       {
         stream.Write("(");
       }
-      cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
+      Cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
       stream.Write("->({0} := ", fieldAccess.FieldName);
-      cce.NonNull(args[1]).Emit(stream, opBindingStrength, false);
+      Cce.NonNull(args[1]).Emit(stream, opBindingStrength, false);
       stream.Write(")");
       if (parensNeeded)
       {
@@ -3722,7 +3722,7 @@ namespace Microsoft.Boogie
     public Type Typecheck(IList<Expr> args, out TypeParamInstantiation tpInstantiation, TypecheckingContext tc)
     {
       Contract.Assert(args.Count == 2);
-      return Typecheck(cce.NonNull(args[0]).Type, cce.NonNull(args[1]).Type, tc, out tpInstantiation);
+      return Typecheck(Cce.NonNull(args[0]).Type, Cce.NonNull(args[1]).Type, tc, out tpInstantiation);
     }
     
     public Type Typecheck(Type datatype, Type fieldType, TypecheckingContext tc, out TypeParamInstantiation tpInstantiation)
@@ -3813,7 +3813,7 @@ namespace Microsoft.Boogie
       {
         stream.Write("(");
       }
-      cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
+      Cce.NonNull(args[0]).Emit(stream, opBindingStrength, false);
       stream.Write(" is {0}", ConstructorName);
       if (parensNeeded)
       {
@@ -3832,7 +3832,7 @@ namespace Microsoft.Boogie
     public Type Typecheck(IList<Expr> args, out TypeParamInstantiation tpInstantiation, TypecheckingContext tc)
     {
       Contract.Assert(args.Count == 1);
-      return Typecheck(cce.NonNull(args[0]).Type, tc, out tpInstantiation);
+      return Typecheck(Cce.NonNull(args[0]).Type, tc, out tpInstantiation);
     }
     
     public Type Typecheck(Type type, TypecheckingContext tc, out TypeParamInstantiation tpInstantiation)
@@ -3883,14 +3883,14 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(LocVars != null);
-      Contract.Invariant(cce.NonNullElements(Blocks));
+      Contract.Invariant(Cce.NonNullElements(Blocks));
     }
 
     public CodeExpr(List<Variable> /*!*/ localVariables, List<Block /*!*/> /*!*/ blocks, bool immutable = false)
       : base(Token.NoToken, immutable)
     {
       Contract.Requires(localVariables != null);
-      Contract.Requires(cce.NonNullElements(blocks));
+      Contract.Requires(Cce.NonNullElements(blocks));
       Contract.Requires(0 < blocks.Count);
       LocVars = localVariables;
       Blocks = blocks;

--- a/Source/Core/AST/Expression/FunctionCall.cs
+++ b/Source/Core/AST/Expression/FunctionCall.cs
@@ -153,7 +153,7 @@ public class FunctionCall : IAppliable
         null,
         // we need some token to report a possibly wrong number of
         // arguments
-        actuals.Count > 0 ? cce.NonNull(actuals[0]).tok : Token.NoToken,
+        actuals.Count > 0 ? Cce.NonNull(actuals[0]).tok : Token.NoToken,
         "application of " + name.Name,
         tc);
 

--- a/Source/Core/AST/Program.cs
+++ b/Source/Core/AST/Program.cs
@@ -12,8 +12,8 @@ public class Program : Absy
   [ContractInvariantMethod]
   void ObjectInvariant()
   {
-    Contract.Invariant(cce.NonNullElements(this.topLevelDeclarations));
-    Contract.Invariant(cce.NonNullElements(this.globalVariablesCache, true));
+    Contract.Invariant(Cce.NonNullElements(this.topLevelDeclarations));
+    Contract.Invariant(Cce.NonNullElements(this.globalVariablesCache, true));
   }
 
   public Dictionary<object, List<object>> DeclarationDependencies { get; set; }
@@ -178,7 +178,7 @@ public class Program : Absy
   {
     get
     {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<Declaration>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<Declaration>>()));
       return topLevelDeclarations.AsReadOnly();
     }
 
@@ -209,7 +209,7 @@ public class Program : Absy
   public void AddTopLevelDeclarations(IEnumerable<Declaration> decls)
   {
     Contract.Requires(!TopLevelDeclarationsAreFrozen);
-    Contract.Requires(cce.NonNullElements(decls));
+    Contract.Requires(Cce.NonNullElements(decls));
 
     topLevelDeclarations.AddRange(decls);
     this.globalVariablesCache = null;
@@ -390,7 +390,7 @@ public class Program : Absy
   {
     get
     {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<GlobalVariable>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<GlobalVariable>>()));
 
       if (globalVariablesCache == null)
       {
@@ -434,15 +434,15 @@ public class Program : Absy
     {
       if (impl.Blocks != null && impl.Blocks.Count > 0)
       {
-        cce.BeginExpose(impl);
+        Cce.BeginExpose(impl);
         {
           Block start = impl.Blocks[0];
           Contract.Assume(start != null);
-          Contract.Assume(cce.IsConsistent(start));
+          Contract.Assume(Cce.IsConsistent(start));
           impl.Blocks = LoopUnroll.UnrollLoops(start, n, uc);
           impl.FreshenCaptureStates();
         }
-        cce.EndExpose();
+        Cce.EndExpose();
       }
     }
   }
@@ -510,7 +510,7 @@ public class Program : Absy
       }
     }
 
-    g.AddSource(cce.NonNull(blocks[0])); // there is always at least one node in the graph
+    g.AddSource(Cce.NonNull(blocks[0])); // there is always at least one node in the graph
     foreach (Block b in blocks)
     {
       if (b.TransferCmd is GotoCmd gtc)
@@ -525,7 +525,7 @@ public class Program : Absy
   public static Graph<Block /*!*/> /*!*/ GraphFromImpl(Implementation impl, bool forward = true)
   {
     Contract.Requires(impl != null);
-    Contract.Ensures(cce.NonNullElements(Contract.Result<Graph<Block>>().Nodes));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<Graph<Block>>().Nodes));
     Contract.Ensures(Contract.Result<Graph<Block>>() != null);
 
     return GraphFromBlocks(impl.Blocks, forward);

--- a/Source/Core/AlphaEquality.cs
+++ b/Source/Core/AlphaEquality.cs
@@ -157,12 +157,12 @@ namespace Microsoft.Boogie
 
         public override bool IsMutable
         {
-          get { throw new cce.UnreachableException(); }
+          get { throw new Cce.UnreachableException(); }
         }
 
         public override void Register(ResolutionContext rc)
         {
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
       }
     }

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -44,7 +44,7 @@ public static Program ParseLibrary(string libraryName)
 ///</summary>
 public static int Parse(string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(filename != null);
-  Contract.Requires(cce.NonNullElements(defines,true));
+  Contract.Requires(Cce.NonNullElements(defines,true));
 
   if (filename == "stdin.bpl") {
     return Parse(Console.In, filename, defines, out program, useBaseName);
@@ -65,7 +65,7 @@ public static int Parse(string s, string/*!*/ filename, out /*maybe null*/ Progr
   Contract.Requires(s != null);
   Contract.Requires(filename != null);
 
-  byte[]/*!*/ buffer = cce.NonNull(UTF8Encoding.Default.GetBytes(s));
+  byte[]/*!*/ buffer = Cce.NonNull(UTF8Encoding.Default.GetBytes(s));
   MemoryStream ms = new MemoryStream(buffer,false);
   Errors errors = new Errors();
   Scanner scanner = new Scanner(ms, errors, filename, useBaseName);
@@ -116,9 +116,9 @@ private class BvBounds : Expr {
   }
   public override void Emit(TokenTextWriter/*!*/ stream,
                             int contextBindingStrength, bool fragileContext) {
-    Contract.Assert(false);throw new cce.UnreachableException();
+    Contract.Assert(false);throw new Cce.UnreachableException();
   }
-  public override void ComputeFreeVariables(GSet<object>/*!*/ freeVars) { Contract.Assert(false);throw new cce.UnreachableException(); }
+  public override void ComputeFreeVariables(GSet<object>/*!*/ freeVars) { Contract.Assert(false);throw new Cce.UnreachableException(); }
 
   public override int ContentHash => throw new NotSupportedException("Not supported since this type is translated away");
 
@@ -501,7 +501,7 @@ Function<.out List<Declaration>/*!*/ ds.>
     if (!allUnnamed) {
       Bpl.Type prevType = null;
       for (int i = arguments.Count; 0 <= --i; ) {
-        TypedIdent/*!*/ curr = cce.NonNull(arguments[i]).TypedIdent;
+        TypedIdent/*!*/ curr = Cce.NonNull(arguments[i]).TypedIdent;
         if (curr.HasName) {
           // the argument was given as both an identifier and a type
           prevType = curr.Type;
@@ -578,7 +578,7 @@ Axiom<out Axiom/*!*/ m>
 
 /*------------------------------------------------------------------------*/
 UserDefinedTypes<.out List<Declaration/*!*/>/*!*/ ts.>
-= (. Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out ts))); Declaration/*!*/ decl; QKeyValue kv = null; ts = new List<Declaration/*!*/> (); .)
+= (. Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out ts))); Declaration/*!*/ decl; QKeyValue kv = null; ts = new List<Declaration/*!*/> (); .)
   "type"
   { Attribute<ref kv> }
   UserDefinedType<out decl, kv>          (.  ts.Add(decl);  .)
@@ -1028,7 +1028,7 @@ TransferCmd<out TransferCmd/*!*/ tc>
   .
 
 StructuredCmd<out StructuredCmd/*!*/ ec>
-= (. Contract.Ensures(Contract.ValueAtReturn(out ec) != null); ec = dummyStructuredCmd;  Contract.Assume(cce.IsPeerConsistent(ec));
+= (. Contract.Ensures(Contract.ValueAtReturn(out ec) != null); ec = dummyStructuredCmd;  Contract.Assume(Cce.IsPeerConsistent(ec));
      IfCmd/*!*/ ifcmd;  WhileCmd/*!*/ wcmd;  BreakCmd/*!*/ bcmd;
   .)
   ( IfCmd<out ifcmd>    (. ec = ifcmd; .)
@@ -1065,7 +1065,7 @@ WhileCmd<out WhileCmd wcmd>
      QKeyValue kv = null;
   .)
   "while"             (. x = t; .)
-  Guard<out guard>    (. Contract.Assume(guard == null || cce.Owner.None(guard)); .)
+  Guard<out guard>    (. Contract.Assume(guard == null || Cce.Owner.None(guard)); .)
   {                   (. isFree = false; z = la/*lookahead token*/; .)
     [ "free"          (. isFree = true;  .) ]
     "invariant"
@@ -1216,7 +1216,7 @@ LabelOrAssign<out Cmd c, out IToken label>
   .
 
 MapAssignIndex<.out IToken/*!*/ x, out List<Expr/*!*/>/*!*/ indexes.>
-= (.Contract.Ensures(Contract.ValueAtReturn(out x) != null); Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out indexes))); indexes = new List<Expr/*!*/> ();
+= (.Contract.Ensures(Contract.ValueAtReturn(out x) != null); Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out indexes))); indexes = new List<Expr/*!*/> ();
      Expr/*!*/ e;
   .)
   "["                        (. x = t; .)
@@ -1654,7 +1654,7 @@ AtomExpression<out Expr/*!*/ e>
   .
 
 CodeExpression<.out List<Variable>/*!*/ locals, out List<Block/*!*/>/*!*/ blocks.>
-= (. Contract.Ensures(Contract.ValueAtReturn(out locals) != null); Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out blocks))); locals = new List<Variable>(); Block/*!*/ b;
+= (. Contract.Ensures(Contract.ValueAtReturn(out locals) != null); Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out blocks))); locals = new List<Variable>(); Block/*!*/ b;
      blocks = new List<Block/*!*/>();
   .)
   "|{"

--- a/Source/Core/DeadVarElim.cs
+++ b/Source/Core/DeadVarElim.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullDictionaryAndValues(modSets));
-      Contract.Invariant(Contract.ForAll(modSets.Values, v => cce.NonNullElements(v)));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(modSets));
+      Contract.Invariant(Contract.ForAll(modSets.Values, v => Cce.NonNullElements(v)));
     }
 
     public ModSetCollector(CoreOptions options)
@@ -234,7 +234,7 @@ namespace Microsoft.Boogie
     private void ProcessVariable(Variable var)
     {
       Procedure /*!*/
-        localProc = cce.NonNull(enclosingProc);
+        localProc = Cce.NonNull(enclosingProc);
       if (var == null)
       {
         return;
@@ -315,8 +315,8 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(_usedVars));
-      Contract.Invariant(cce.NonNullElements(_oldVarsUsed));
+      Contract.Invariant(Cce.NonNullElements(_usedVars));
+      Contract.Invariant(Cce.NonNullElements(_oldVarsUsed));
     }
 
     int insideOldExpr;
@@ -383,7 +383,7 @@ namespace Microsoft.Boogie
     private static HashSet<Block /*!*/> /*!*/ ComputeMultiPredecessorBlocks(Implementation /*!*/ impl)
     {
       Contract.Requires(impl != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<HashSet<Block>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<HashSet<Block>>()));
       HashSet<Block /*!*/> visitedBlocks = new HashSet<Block /*!*/>();
       HashSet<Block /*!*/> multiPredBlocks = new HashSet<Block /*!*/>();
       Stack<Block /*!*/> dfsStack = new Stack<Block /*!*/>();
@@ -435,7 +435,7 @@ namespace Microsoft.Boogie
       //Console.WriteLine("Initial number of blocks = {0}", impl.Blocks.Count);
 
       HashSet<Block /*!*/> multiPredBlocks = ComputeMultiPredecessorBlocks(impl);
-      Contract.Assert(cce.NonNullElements(multiPredBlocks));
+      Contract.Assert(Cce.NonNullElements(multiPredBlocks));
       HashSet<Block /*!*/> visitedBlocks = new HashSet<Block /*!*/>();
       HashSet<Block /*!*/> removedBlocks = new HashSet<Block /*!*/>();
       Stack<Block /*!*/> dfsStack = new Stack<Block /*!*/>();
@@ -471,7 +471,7 @@ namespace Microsoft.Boogie
         if (gotoCmd.labelTargets.Count == 1)
         {
           Block /*!*/
-            succ = cce.NonNull(gotoCmd.labelTargets[0]);
+            succ = Cce.NonNull(gotoCmd.labelTargets[0]);
           if (!multiPredBlocks.Contains(succ))
           {
             foreach (Cmd /*!*/ cmd in succ.Cmds)
@@ -599,11 +599,11 @@ namespace Microsoft.Boogie
           if (cmds[i] is CallCmd)
           {
             Procedure /*!*/
-              proc = cce.NonNull(cce.NonNull((CallCmd /*!*/) cmds[i]).Proc);
+              proc = Cce.NonNull(Cce.NonNull((CallCmd /*!*/) cmds[i]).Proc);
             if (InterProcGenKill.HasSummary(proc.Name))
             {
               liveVarsAfter =
-                InterProcGenKill.PropagateLiveVarsAcrossCall(options, cce.NonNull((CallCmd /*!*/) cmds[i]), liveVarsAfter);
+                InterProcGenKill.PropagateLiveVarsAcrossCall(options, Cce.NonNull((CallCmd /*!*/) cmds[i]), liveVarsAfter);
               continue;
             }
           }
@@ -619,11 +619,11 @@ namespace Microsoft.Boogie
     public void Propagate(Cmd cmd, HashSet<Variable /*!*/> /*!*/ liveSet)
     {
       Contract.Requires(cmd != null);
-      Contract.Requires(cce.NonNullElements(liveSet));
+      Contract.Requires(Cce.NonNullElements(liveSet));
       if (cmd is AssignCmd)
       {
         AssignCmd /*!*/
-          assignCmd = (AssignCmd) cce.NonNull(cmd);
+          assignCmd = (AssignCmd) Cce.NonNull(cmd);
         // I must first iterate over all the targets and remove the live ones.
         // After the removals are done, I must add the variables referred on 
         // the right side of the removed targets
@@ -679,7 +679,7 @@ namespace Microsoft.Boogie
       {
         Contract.Assert((cmd is AssertCmd || cmd is AssumeCmd));
         PredicateCmd /*!*/
-          predicateCmd = (PredicateCmd) cce.NonNull(cmd);
+          predicateCmd = (PredicateCmd) Cce.NonNull(cmd);
         if (predicateCmd.Expr is LiteralExpr)
         {
           LiteralExpr le = (LiteralExpr) predicateCmd.Expr;
@@ -708,15 +708,15 @@ namespace Microsoft.Boogie
       else if (cmd is SugaredCmd)
       {
         SugaredCmd /*!*/
-          sugCmd = (SugaredCmd) cce.NonNull(cmd);
+          sugCmd = (SugaredCmd) Cce.NonNull(cmd);
         Propagate(sugCmd.GetDesugaring(options), liveSet);
       }
       else if (cmd is StateCmd)
       {
         StateCmd /*!*/
-          stCmd = (StateCmd) cce.NonNull(cmd);
+          stCmd = (StateCmd) Cce.NonNull(cmd);
         List<Cmd> /*!*/
-          cmds = cce.NonNull(stCmd.Cmds);
+          cmds = Cce.NonNull(stCmd.Cmds);
         int len = cmds.Count;
         for (int i = len - 1; i >= 0; i--)
         {
@@ -733,7 +733,7 @@ namespace Microsoft.Boogie
       {
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
       }
     }
@@ -765,8 +765,8 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(gen));
-      Contract.Invariant(cce.NonNullElements(kill));
+      Contract.Invariant(Cce.NonNullElements(gen));
+      Contract.Invariant(Cce.NonNullElements(kill));
       Contract.Invariant(oneWeight != null);
       Contract.Invariant(zeroWeight != null);
     }
@@ -789,8 +789,8 @@ namespace Microsoft.Boogie
 
     public GenKillWeight(HashSet<Variable /*!*/> gen, HashSet<Variable /*!*/> kill)
     {
-      Contract.Requires(cce.NonNullElements(gen));
-      Contract.Requires(cce.NonNullElements(kill));
+      Contract.Requires(Cce.NonNullElements(gen));
+      Contract.Requires(Cce.NonNullElements(kill));
       Contract.Assert(gen != null);
       Contract.Assert(kill != null);
       this.gen = gen;
@@ -910,14 +910,14 @@ namespace Microsoft.Boogie
 
     public HashSet<Variable /*!*/> /*!*/ getLiveVars()
     {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
       return gen;
     }
 
     public HashSet<Variable /*!*/> /*!*/ getLiveVars(HashSet<Variable /*!*/> /*!*/ lv)
     {
-      Contract.Requires(cce.NonNullElements(lv));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
+      Contract.Requires(Cce.NonNullElements(lv));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
       HashSet<Variable> temp = new HashSet<Variable>(lv);
       temp.ExceptWith(kill);
       temp.UnionWith(gen);
@@ -975,18 +975,18 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(graph.Nodes));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(procsCalled));
-      Contract.Invariant(cce.NonNullElements(nodes));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(succEdges));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(predEdges));
+      Contract.Invariant(Cce.NonNullElements(graph.Nodes));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(procsCalled));
+      Contract.Invariant(Cce.NonNullElements(nodes));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(succEdges));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(predEdges));
       Contract.Invariant(priority != null);
-      Contract.Invariant(cce.NonNullElements(srcNodes));
-      Contract.Invariant(cce.NonNullElements(exitNodes));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(weightBefore));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(weightAfter));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(liveVarsAfter));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(liveVarsBefore));
+      Contract.Invariant(Cce.NonNullElements(srcNodes));
+      Contract.Invariant(Cce.NonNullElements(exitNodes));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(weightBefore));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(weightAfter));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(liveVarsAfter));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(liveVarsBefore));
       Contract.Invariant(summary != null);
       Contract.Invariant(impl != null);
     }
@@ -1054,7 +1054,7 @@ namespace Microsoft.Boogie
           if (c is CallCmd)
           {
             CallCmd /*!*/
-              cc = cce.NonNull((CallCmd /*!*/) c);
+              cc = Cce.NonNull((CallCmd /*!*/) c);
             Contract.Assert(cc.Proc != null);
             string /*!*/
               procName = cc.Proc.Name;
@@ -1182,18 +1182,18 @@ namespace Microsoft.Boogie
       Contract.Invariant(workList != null);
       Contract.Invariant(mainImpl != null);
       Contract.Invariant(program != null);
-      Contract.Invariant(cce.NonNullDictionaryAndValues(procICFG));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(name2Proc));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(callers) &&
-                         Contract.ForAll(callers.Values, v => cce.NonNullElements(v)));
-      Contract.Invariant(cce.NonNullElements(callGraph.Nodes));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(procICFG));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(name2Proc));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(callers) &&
+                         Contract.ForAll(callers.Values, v => Cce.NonNullElements(v)));
+      Contract.Invariant(Cce.NonNullElements(callGraph.Nodes));
       Contract.Invariant(procPriority != null);
-      Contract.Invariant(cce.NonNullDictionaryAndValues(varsLiveAtEntry));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(varsLiveAtExit) &&
-                         Contract.ForAll(varsLiveAtExit.Values, v => cce.NonNullElements(v)));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(varsLiveSummary));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(weightCacheAfterCall));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(weightCacheBeforeCall));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(varsLiveAtEntry));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(varsLiveAtExit) &&
+                         Contract.ForAll(varsLiveAtExit.Values, v => Cce.NonNullElements(v)));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(varsLiveSummary));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(weightCacheAfterCall));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(weightCacheBeforeCall));
     }
 
 
@@ -1225,13 +1225,13 @@ namespace Microsoft.Boogie
         if (decl is Implementation)
         {
           Implementation /*!*/
-            imp = (Implementation /*!*/) cce.NonNull(decl);
+            imp = (Implementation /*!*/) Cce.NonNull(decl);
           name2Impl[imp.Name] = imp;
         }
         else if (decl is Procedure)
         {
           Procedure /*!*/
-            proc = cce.NonNull(decl as Procedure);
+            proc = Cce.NonNull(decl as Procedure);
           name2Proc[proc.Name] = proc;
         }
       }
@@ -1314,7 +1314,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(prog != null);
       Contract.Requires(impl != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
       if (varsLiveAtExit.ContainsKey(impl.Name))
       {
         return varsLiveAtExit[impl.Name];
@@ -1342,7 +1342,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(prog != null);
       Contract.Requires(impl != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
       if (varsLiveAtEntry.ContainsKey(impl.Name))
       {
         return varsLiveAtEntry[impl.Name];
@@ -1376,10 +1376,10 @@ namespace Microsoft.Boogie
       PropagateLiveVarsAcrossCall(CoreOptions options, CallCmd cmd, HashSet<Variable /*!*/> /*!*/ lvAfter)
     {
       Contract.Requires(cmd != null);
-      Contract.Requires(cce.NonNullElements(lvAfter));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
+      Contract.Requires(Cce.NonNullElements(lvAfter));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<HashSet<Variable>>()));
       Procedure /*!*/
-        proc = cce.NonNull(cmd.Proc);
+        proc = Cce.NonNull(cmd.Proc);
       if (varsLiveSummary.ContainsKey(proc.Name))
       {
         GenKillWeight /*!*/
@@ -1457,7 +1457,7 @@ namespace Microsoft.Boogie
       public override bool Equals(object other)
       {
         WorkItem /*!*/
-          wi = (WorkItem /*!*/) cce.NonNull(other);
+          wi = (WorkItem /*!*/) Cce.NonNull(other);
         return (wi.cfg == cfg && wi.block == block);
       }
 
@@ -1508,9 +1508,9 @@ namespace Microsoft.Boogie
       void ObjectInvariant()
       {
         Contract.Invariant(priorities != null);
-        Contract.Invariant(cce.NonNullElements(labels));
-        Contract.Invariant(cce.NonNullDictionaryAndValues(workList) &&
-                           Contract.ForAll(workList.Values, v => cce.NonNullElements(v)));
+        Contract.Invariant(Cce.NonNullElements(labels));
+        Contract.Invariant(Cce.NonNullDictionaryAndValues(workList) &&
+                           Contract.ForAll(workList.Values, v => Cce.NonNullElements(v)));
       }
 
 
@@ -1552,7 +1552,7 @@ namespace Microsoft.Boogie
       {
         Contract.Ensures(Contract.Result<WorkItem>() != null);
         // Get minimum priority
-        int p = cce.NonNull(priorities.Keys)[0];
+        int p = Cce.NonNull(priorities.Keys)[0];
         priorities[p] = priorities[p] - 1;
         if (priorities[p] == 0)
         {
@@ -1594,7 +1594,7 @@ namespace Microsoft.Boogie
 
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 
@@ -1715,7 +1715,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
       Contract.Assert(block != null);
       HashSet<Variable /*!*/> /*!*/
         lv = cfg.liveVarsAfter[block];
-      Contract.Assert(cce.NonNullElements(lv));
+      Contract.Assert(Cce.NonNullElements(lv));
       // Propagate backwards in the block
       HashSet<Variable /*!*/> /*!*/
         prop = new HashSet<Variable /*!*/>();
@@ -1728,7 +1728,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
         if (cmd is CallCmd)
         {
           string /*!*/
-            procName = cce.NonNull(cce.NonNull((CallCmd) cmd).Proc).Name;
+            procName = Cce.NonNull(Cce.NonNull((CallCmd) cmd).Proc).Name;
           Contract.Assert(procName != null);
           if (procICFG.ContainsKey(procName))
           {
@@ -1764,7 +1764,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
 
             // Continue with intra propagation
             GenKillWeight /*!*/
-              summary = GetWeightCall(cce.NonNull((CallCmd /*!*/) cmd));
+              summary = GetWeightCall(Cce.NonNull((CallCmd /*!*/) cmd));
             prop = summary.getLiveVars(prop);
           }
           else
@@ -1785,11 +1785,11 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
         Contract.Assert(b != null);
         HashSet<Variable /*!*/> /*!*/
           prev = cfg.liveVarsAfter[b];
-        Contract.Assert(cce.NonNullElements(prev));
+        Contract.Assert(Cce.NonNullElements(prev));
         HashSet<Variable /*!*/> /*!*/
           curr = new HashSet<Variable>(prev);
         curr.UnionWith(cfg.liveVarsBefore[block]);
-        Contract.Assert(cce.NonNullElements(curr));
+        Contract.Assert(Cce.NonNullElements(curr));
         if (curr.Count != prev.Count)
         {
           cfg.liveVarsAfter[b] = curr;
@@ -1810,9 +1810,9 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
         Cmd /*!*/
           c = wi.block.Cmds[i];
         Contract.Assert(c != null);
-        if (c is CallCmd && procICFG.ContainsKey(cce.NonNull(cce.NonNull((CallCmd) c).Proc).Name))
+        if (c is CallCmd && procICFG.ContainsKey(Cce.NonNull(Cce.NonNull((CallCmd) c).Proc).Name))
         {
-          w = GenKillWeight.extend(GetWeightCall(cce.NonNull((CallCmd) c)), w);
+          w = GenKillWeight.extend(GetWeightCall(Cce.NonNull((CallCmd) c)), w);
         }
         else
         {
@@ -1961,7 +1961,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
       else if (cmd is HavocCmd)
       {
         HavocCmd /*!*/
-          havocCmd = (HavocCmd) cce.NonNull(cmd);
+          havocCmd = (HavocCmd) Cce.NonNull(cmd);
         foreach (IdentifierExpr /*!*/ expr in havocCmd.Vars)
         {
           Contract.Assert(expr != null);
@@ -1977,14 +1977,14 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
       {
         Contract.Assert((cmd is AssertCmd || cmd is AssumeCmd));
         PredicateCmd /*!*/
-          predicateCmd = (PredicateCmd) cce.NonNull(cmd);
+          predicateCmd = (PredicateCmd) Cce.NonNull(cmd);
         if (predicateCmd.Expr is LiteralExpr && prog != null && impl != null)
         {
           LiteralExpr le = (LiteralExpr) predicateCmd.Expr;
           if (le.IsFalse)
           {
             var globals = prog.GlobalVariables;
-            Contract.Assert(cce.NonNullElements(globals));
+            Contract.Assert(Cce.NonNullElements(globals));
             foreach (Variable /*!*/ v in globals)
             {
               Contract.Assert(v != null);
@@ -2056,7 +2056,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
       {
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
       }
 
@@ -2087,7 +2087,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
 
       Contract.Assert(cmd is CallCmd);
       CallCmd /*!*/
-        ccmd = cce.NonNull((CallCmd) cmd);
+        ccmd = Cce.NonNull((CallCmd) cmd);
 
       foreach (IdentifierExpr /*!*/ ie in ccmd.Outs)
       {
@@ -2099,7 +2099,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
       }
 
       // Variables in ensures are considered as "read"
-      foreach (Ensures /*!*/ re in cce.NonNull(ccmd.Proc).Ensures)
+      foreach (Ensures /*!*/ re in Cce.NonNull(ccmd.Proc).Ensures)
       {
         Contract.Assert(re != null);
         VariableCollector /*!*/
@@ -2137,7 +2137,7 @@ b.liveVarsBefore = procICFG[mainImpl.Name].liveVarsAfter[b];
       HashSet<Variable /*!*/> /*!*/
         kill = new HashSet<Variable /*!*/>();
       CallCmd /*!*/
-        ccmd = cce.NonNull((CallCmd /*!*/) cmd);
+        ccmd = Cce.NonNull((CallCmd /*!*/) cmd);
 
       foreach (Expr /*!*/ expr in ccmd.Ins)
       {

--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Boogie
 
     public override List<Block /*!*/> /*!*/ VisitBlockList(List<Block /*!*/> /*!*/ blocks)
     {
-      //Contract.Requires(cce.NonNullElements(blocks));
+      //Contract.Requires(Cce.NonNullElements(blocks));
       Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
       return base.VisitBlockList(new List<Block /*!*/>(blocks));
     }
@@ -218,7 +218,7 @@ namespace Microsoft.Boogie
 
     public override List<Declaration /*!*/> /*!*/ VisitDeclarationList(List<Declaration /*!*/> /*!*/ declarationList)
     {
-      //Contract.Requires(cce.NonNullElements(declarationList));
+      //Contract.Requires(Cce.NonNullElements(declarationList));
       Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Declaration>>()));
 
       // For Implementation.Proc to resolve correctly to duplicated Procedures

--- a/Source/Core/Duplicator.cs
+++ b/Source/Core/Duplicator.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Boogie
         if (g != null)
         {
           List<Block> targets = new List<Block>();
-          foreach (Block t in cce.NonNull(g.labelTargets))
+          foreach (Block t in Cce.NonNull(g.labelTargets))
           {
             Block nt = subst[t];
             targets.Add(nt);
@@ -145,7 +145,7 @@ namespace Microsoft.Boogie
     public override List<Block /*!*/> /*!*/ VisitBlockList(List<Block /*!*/> /*!*/ blocks)
     {
       //Contract.Requires(cce.NonNullElements(blocks));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Block>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
       return base.VisitBlockList(new List<Block /*!*/>(blocks));
     }
 
@@ -219,7 +219,7 @@ namespace Microsoft.Boogie
     public override List<Declaration /*!*/> /*!*/ VisitDeclarationList(List<Declaration /*!*/> /*!*/ declarationList)
     {
       //Contract.Requires(cce.NonNullElements(declarationList));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Declaration>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Declaration>>()));
 
       // For Implementation.Proc to resolve correctly to duplicated Procedures
       // we need to visit the procedures first
@@ -230,7 +230,7 @@ namespace Microsoft.Boogie
           continue;
         }
 
-        declarationList[i] = cce.NonNull((Declaration) this.Visit(declarationList[i]));
+        declarationList[i] = Cce.NonNull((Declaration) this.Visit(declarationList[i]));
       }
 
       // Now visit everything else
@@ -241,7 +241,7 @@ namespace Microsoft.Boogie
           continue;
         }
 
-        declarationList[i] = cce.NonNull((Declaration) this.Visit(declarationList[i]));
+        declarationList[i] = Cce.NonNull((Declaration) this.Visit(declarationList[i]));
       }
 
       return declarationList;
@@ -1026,12 +1026,12 @@ namespace Microsoft.Boogie
 
         if (insideOldExpr)
         {
-          e = forold(cce.NonNull(node.Decl));
+          e = forold(Cce.NonNull(node.Decl));
         }
 
         if (e == null)
         {
-          e = always(cce.NonNull(node.Decl));
+          e = always(Cce.NonNull(node.Decl));
         }
 
         return e == null ? base.VisitIdentifierExpr(node) : e;
@@ -1044,7 +1044,7 @@ namespace Microsoft.Boogie
         bool previouslyInOld = insideOldExpr;
         insideOldExpr = true;
         Expr /*!*/
-          e = (Expr /*!*/) cce.NonNull(this.Visit(node.Expr));
+          e = (Expr /*!*/) Cce.NonNull(this.Visit(node.Expr));
         insideOldExpr = previouslyInOld;
         return new OldExpr(node.tok, e);
       }
@@ -1139,12 +1139,12 @@ namespace Microsoft.Boogie
 
         if (insideOldExpr)
         {
-          e = forold(cce.NonNull(node.Decl));
+          e = forold(Cce.NonNull(node.Decl));
         }
 
         if (e == null)
         {
-          e = always(cce.NonNull(node.Decl));
+          e = always(Cce.NonNull(node.Decl));
         }
 
         return e == null ? base.VisitIdentifierExpr(node) : e;
@@ -1157,7 +1157,7 @@ namespace Microsoft.Boogie
         bool previouslyInOld = insideOldExpr;
         insideOldExpr = true;
         Expr /*!*/
-          e = (Expr /*!*/) cce.NonNull(this.Visit(node.Expr));
+          e = (Expr /*!*/) Cce.NonNull(this.Visit(node.Expr));
         insideOldExpr = previouslyInOld;
         return e;
       }

--- a/Source/Core/Helpers.cs
+++ b/Source/Core/Helpers.cs
@@ -119,13 +119,13 @@ namespace Microsoft.Boogie
           else if (fun is MapSelect && eSeq.Count <= 3)
           {
             // only maps with up to two arguments are supported right now (here)
-            if (cce.NonNull(eSeq[0]).ToString() == "$Heap")
+            if (Cce.NonNull(eSeq[0]).ToString() == "$Heap")
             {
               //print Index0.Index1, unless Index1 is "$elements", then just print Index0
-              string s0 = PrettyPrintBplExpr(cce.NonNull(eSeq[1]));
+              string s0 = PrettyPrintBplExpr(Cce.NonNull(eSeq[1]));
               if (eSeq.Count > 2)
               {
-                string s1 = PrettyPrintBplExpr(cce.NonNull(eSeq[2]));
+                string s1 = PrettyPrintBplExpr(Cce.NonNull(eSeq[2]));
                 if (s1 == "$elements")
                 {
                   return s0;
@@ -265,7 +265,7 @@ namespace Microsoft.Boogie
     private static readonly ConcurrentDictionary<string, int> UsedLogNames = new();
     public static (string fileName, bool reused) GetLogFilename(string descriptiveName, string filename, bool allowReuse)
     {
-      filename = SubstituteAtPROC(descriptiveName, cce.NonNull(filename));
+      filename = SubstituteAtPROC(descriptiveName, Cce.NonNull(filename));
 
       var reused = false;
       var index = UsedLogNames.AddOrUpdate(filename, 0, (_, i) => {

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Boogie
 
       bool inlined = false;
       List<Block> newBlocks = DoInlineBlocks(impl.Blocks, ref inlined);
-      Contract.Assert(cce.NonNullElements(newBlocks));
+      Contract.Assert(Cce.NonNullElements(newBlocks));
 
       if (!inlined)
       {
@@ -271,7 +271,7 @@ namespace Microsoft.Boogie
     void CheckRecursion(Implementation impl, Stack<Procedure /*!*/> /*!*/ callStack)
     {
       Contract.Requires(impl != null);
-      Contract.Requires(cce.NonNullElements(callStack));
+      Contract.Requires(Cce.NonNullElements(callStack));
       foreach (Procedure /*!*/ p in callStack)
       {
         Contract.Assert(p != null);
@@ -294,7 +294,7 @@ namespace Microsoft.Boogie
       List<Block> newBlocks, int lblCount)
     {
       Contract.Assume(impl != null);
-      Contract.Assert(cce.NonNull(impl.OriginalBlocks).Count > 0);
+      Contract.Assert(Cce.NonNull(impl.OriginalBlocks).Count > 0);
 
       // do inline now
       int nextlblCount = lblCount + 1;
@@ -313,7 +313,7 @@ namespace Microsoft.Boogie
 
       List<Block /*!*/> /*!*/
         inlinedBlocks = CreateInlinedBlocks(callCmd, impl, nextBlockLabel);
-      Contract.Assert(cce.NonNullElements(inlinedBlocks));
+      Contract.Assert(Cce.NonNullElements(inlinedBlocks));
 
       EndInline();
 
@@ -355,15 +355,15 @@ namespace Microsoft.Boogie
 
     public virtual List<Block /*!*/> /*!*/ DoInlineBlocks(List<Block /*!*/> /*!*/ blocks, ref bool inlinedSomething)
     {
-      Contract.Requires(cce.NonNullElements(blocks));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Block>>()));
+      Contract.Requires(Cce.NonNullElements(blocks));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
       List<Block /*!*/> /*!*/
         newBlocks = new List<Block /*!*/>();
 
       foreach (Block block in blocks)
       {
         TransferCmd /*!*/
-          transferCmd = cce.NonNull(block.TransferCmd);
+          transferCmd = Cce.NonNull(block.TransferCmd);
         List<Cmd> cmds = block.Cmds;
         List<Cmd> newCmds = new List<Cmd>();
         int lblCount = 0;
@@ -475,7 +475,7 @@ namespace Microsoft.Boogie
       Dictionary<Variable, Expr> substMap = new Dictionary<Variable, Expr>();
       Procedure proc = impl.Proc;
 
-      foreach (Variable /*!*/ locVar in cce.NonNull(impl.OriginalLocVars))
+      foreach (Variable /*!*/ locVar in Cce.NonNull(impl.OriginalLocVars))
       {
         Contract.Assert(locVar != null);
         LocalVariable localVar = new LocalVariable(Token.NoToken,
@@ -489,7 +489,7 @@ namespace Microsoft.Boogie
 
       for (int i = 0; i < impl.InParams.Count; i++)
       {
-        Variable inVar = cce.NonNull(impl.InParams[i]);
+        Variable inVar = Cce.NonNull(impl.InParams[i]);
         LocalVariable localVar = new LocalVariable(Token.NoToken,
           new TypedIdent(Token.NoToken, GetProcVarName(proc.Name, inVar.Name), inVar.TypedIdent.Type,
             inVar.TypedIdent.WhereExpr));
@@ -502,7 +502,7 @@ namespace Microsoft.Boogie
         IdentifierExpr ie = new IdentifierExpr(Token.NoToken, localVar);
         substMap.Add(inVar, ie);
         // also add a substitution from the corresponding formal occurring in the PROCEDURE declaration
-        Variable procInVar = cce.NonNull(proc.InParams[i]);
+        Variable procInVar = Cce.NonNull(proc.InParams[i]);
         if (procInVar != inVar)
         {
           substMap.Add(procInVar, ie);
@@ -511,7 +511,7 @@ namespace Microsoft.Boogie
 
       for (int i = 0; i < impl.OutParams.Count; i++)
       {
-        Variable outVar = cce.NonNull(impl.OutParams[i]);
+        Variable outVar = Cce.NonNull(impl.OutParams[i]);
         LocalVariable localVar = new LocalVariable(Token.NoToken,
           new TypedIdent(Token.NoToken, GetProcVarName(proc.Name, outVar.Name), outVar.TypedIdent.Type,
             outVar.TypedIdent.WhereExpr));
@@ -524,7 +524,7 @@ namespace Microsoft.Boogie
         IdentifierExpr ie = new IdentifierExpr(Token.NoToken, localVar);
         substMap.Add(outVar, ie);
         // also add a substitution from the corresponding formal occurring in the PROCEDURE declaration
-        Variable procOutVar = cce.NonNull(proc.OutParams[i]);
+        Variable procOutVar = Cce.NonNull(proc.OutParams[i]);
         if (procOutVar != outVar)
         {
           substMap.Add(procOutVar, ie);
@@ -537,7 +537,7 @@ namespace Microsoft.Boogie
       {
         Contract.Assert(mie != null);
         Variable /*!*/
-          mVar = cce.NonNull(mie.Decl);
+          mVar = Cce.NonNull(mie.Decl);
         LocalVariable localVar = new LocalVariable(Token.NoToken,
           new TypedIdent(Token.NoToken, GetProcVarName(proc.Name, mVar.Name), mVar.TypedIdent.Type));
         newLocalVars.Add(localVar);
@@ -565,7 +565,7 @@ namespace Microsoft.Boogie
     private Cmd InlinedRequires(CallCmd callCmd, Requires req)
     {
       Requires /*!*/
-        reqCopy = (Requires /*!*/) cce.NonNull(req.Clone());
+        reqCopy = (Requires /*!*/) Cce.NonNull(req.Clone());
       if (req.Free)
       {
         reqCopy.Condition = Expr.True;
@@ -594,7 +594,7 @@ namespace Microsoft.Boogie
       else
       {
         Ensures /*!*/
-          ensCopy = (Ensures /*!*/) cce.NonNull(ens.Clone());
+          ensCopy = (Ensures /*!*/) Cce.NonNull(ens.Clone());
         ensCopy.Condition = codeCopier.CopyExpr(ens.Condition);
         return new AssertEnsuresCmd(ensCopy);
       }
@@ -627,9 +627,9 @@ namespace Microsoft.Boogie
       Contract.Requires(codeCopier.substMap != null);
       Contract.Requires(codeCopier.oldSubstMap != null);
 
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Block>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
       List<Block /*!*/> /*!*/
-        implBlocks = cce.NonNull(impl.OriginalBlocks);
+        implBlocks = Cce.NonNull(impl.OriginalBlocks);
       Contract.Assert(implBlocks.Count > 0);
 
       Procedure proc = impl.Proc;
@@ -645,8 +645,8 @@ namespace Microsoft.Boogie
       for (int i = 0; i < impl.InParams.Count; ++i)
       {
         Cmd cmd = Cmd.SimpleAssign(impl.tok,
-          (IdentifierExpr) codeCopier.Subst(cce.NonNull(impl.InParams[i])),
-          cce.NonNull(callCmd.Ins[i]));
+          (IdentifierExpr) codeCopier.Subst(Cce.NonNull(impl.InParams[i])),
+          Cce.NonNull(callCmd.Ins[i]));
         inCmds.Add(cmd);
       }
 
@@ -654,11 +654,11 @@ namespace Microsoft.Boogie
       for (int i = 0; i < proc.Requires.Count; i++)
       {
         Requires /*!*/
-          req = cce.NonNull(proc.Requires[i]);
+          req = Cce.NonNull(proc.Requires[i]);
         inCmds.Add(InlinedRequires(callCmd, req));
       }
 
-      List<Variable> locVars = cce.NonNull(impl.OriginalLocVars);
+      List<Variable> locVars = Cce.NonNull(impl.OriginalLocVars);
 
       // havoc locals and out parameters in case procedure is invoked in a loop
       List<IdentifierExpr> havocVars = new List<IdentifierExpr>();
@@ -682,8 +682,8 @@ namespace Microsoft.Boogie
       {
         Contract.Assert(mie != null);
         Variable /*!*/
-          mvar = cce.NonNull(mie.Decl);
-        AssignCmd assign = Cmd.SimpleAssign(impl.tok, (IdentifierExpr) cce.NonNull(codeCopier.OldSubst(mvar)), mie);
+          mvar = Cce.NonNull(mie.Decl);
+        AssignCmd assign = Cmd.SimpleAssign(impl.tok, (IdentifierExpr) Cce.NonNull(codeCopier.OldSubst(mvar)), mie);
         inCmds.Add(assign);
       }
 
@@ -703,7 +703,7 @@ namespace Microsoft.Boogie
         }
 
         TransferCmd transferCmd =
-          CreateInlinedTransferCmd(cce.NonNull(block.TransferCmd), GetInlinedProcLabel(proc.Name));
+          CreateInlinedTransferCmd(Cce.NonNull(block.TransferCmd), GetInlinedProcLabel(proc.Name));
         intBlock = new Block(block.tok, GetInlinedProcLabel(proc.Name) + "$" + block.Label, copyCmds, transferCmd);
         inlinedBlocks.Add(intBlock);
       }
@@ -715,7 +715,7 @@ namespace Microsoft.Boogie
       for (int i = 0; i < proc.Ensures.Count; i++)
       {
         Ensures /*!*/
-          ens = cce.NonNull(proc.Ensures[i]);
+          ens = Cce.NonNull(proc.Ensures[i]);
         outCmds.Add(InlinedEnsures(callCmd, ens));
       }
 
@@ -723,8 +723,8 @@ namespace Microsoft.Boogie
       for (int i = 0; i < impl.OutParams.Count; ++i)
       {
         Expr /*!*/
-          cout_exp = (IdentifierExpr) cce.NonNull(codeCopier.Subst(cce.NonNull(impl.OutParams[i])));
-        Cmd cmd = Cmd.SimpleAssign(impl.tok, cce.NonNull(callCmd.Outs[i]), cout_exp);
+          cout_exp = (IdentifierExpr) Cce.NonNull(codeCopier.Subst(Cce.NonNull(impl.OutParams[i])));
+        Cmd cmd = Cmd.SimpleAssign(impl.tok, Cce.NonNull(callCmd.Outs[i]), cout_exp);
         outCmds.Add(cmd);
       }
 
@@ -747,7 +747,7 @@ namespace Microsoft.Boogie
       {
         List<String> gotoSeq = gotoCmd.labelNames;
         List<String> newGotoSeq = new List<String>();
-        foreach (string /*!*/ blockLabel in cce.NonNull(gotoSeq))
+        foreach (string /*!*/ blockLabel in Cce.NonNull(gotoSeq))
         {
           Contract.Assert(blockLabel != null);
           newGotoSeq.Add(procLabel + "$" + blockLabel);

--- a/Source/Core/LambdaHelper.cs
+++ b/Source/Core/LambdaHelper.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Boogie
         string lam_str = sw.ToString();
 
         IToken tok = lambda.tok;
-        Formal res = new Formal(tok, new TypedIdent(tok, TypedIdent.NoName, cce.NonNull(lambda.Type)), false);
+        Formal res = new Formal(tok, new TypedIdent(tok, TypedIdent.NoName, Cce.NonNull(lambda.Type)), false);
 
         if (liftedLambdas.TryGetValue(lambda, out var fcall))
         {

--- a/Source/Core/LoopUnroll.cs
+++ b/Source/Core/LoopUnroll.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Boogie
       Contract.Requires(start != null);
 
       Contract.Requires(0 <= unrollMaxDepth);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Block>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
       Dictionary<Block, GraphNode /*!*/> gd = new Dictionary<Block, GraphNode /*!*/>();
       HashSet<Block> beingVisited = new HashSet<Block>();
       GraphNode gStart = GraphNode.ComputeGraphInfo(null, start, gd, beingVisited);
@@ -88,9 +88,9 @@ namespace Microsoft.Boogie
       {
         Contract.Invariant(Block != null);
         Contract.Invariant(Body != null);
-        Contract.Invariant(cce.NonNullElements(ForwardEdges));
-        Contract.Invariant(cce.NonNullElements(BackEdges));
-        Contract.Invariant(cce.NonNullElements(Predecessors));
+        Contract.Invariant(Cce.NonNullElements(ForwardEdges));
+        Contract.Invariant(Cce.NonNullElements(BackEdges));
+        Contract.Invariant(Cce.NonNullElements(Predecessors));
         Contract.Invariant(isCutPoint == (BackEdges.Count != 0));
       }
 
@@ -143,7 +143,7 @@ namespace Microsoft.Boogie
       {
         Contract.Requires(beingVisited != null);
         Contract.Requires(b != null);
-        Contract.Requires(cce.NonNullDictionaryAndValues(gd));
+        Contract.Requires(Cce.NonNullDictionaryAndValues(gd));
         Contract.Ensures(Contract.Result<GraphNode>() != null);
         if (gd.TryGetValue(b, out var g))
         {
@@ -220,8 +220,8 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(head != null);
-      Contract.Invariant(cce.NonNullElements(newBlockSeqGlobal));
-      Contract.Invariant(newBlocks != null && cce.NonNullElements(newBlocks.Values));
+      Contract.Invariant(Cce.NonNullElements(newBlockSeqGlobal));
+      Contract.Invariant(newBlocks != null && Cce.NonNullElements(newBlocks.Values));
     }
 
 
@@ -230,9 +230,9 @@ namespace Microsoft.Boogie
       Dictionary<GraphNode /*!*/, SCC<GraphNode /*!*/>> /*!*/ scc, List<Block /*!*/> /*!*/ newBlockSeqGlobal)
       : base()
     {
-      Contract.Requires(cce.NonNullElements(newBlockSeqGlobal));
-      Contract.Requires(cce.NonNullDictionaryAndValues(scc) &&
-                        Contract.ForAll(scc.Values, v => cce.NonNullElements(v)));
+      Contract.Requires(Cce.NonNullElements(newBlockSeqGlobal));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(scc) &&
+                        Contract.ForAll(scc.Values, v => Cce.NonNullElements(v)));
       Contract.Requires(0 <= unrollMaxDepth);
       this.newBlockSeqGlobal = newBlockSeqGlobal;
       this.c = unrollMaxDepth;
@@ -248,8 +248,8 @@ namespace Microsoft.Boogie
       Dictionary<GraphNode /*!*/, SCC<GraphNode /*!*/>> scc, List<Block /*!*/> /*!*/ newBlockSeqGlobal, LoopUnroll head)
     {
       Contract.Requires(head != null);
-      Contract.Requires(cce.NonNullDictionaryAndValues(scc));
-      Contract.Requires(cce.NonNullElements(newBlockSeqGlobal));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(scc));
+      Contract.Requires(Cce.NonNullElements(newBlockSeqGlobal));
       Contract.Requires(0 <= unrollMaxDepth);
       this.newBlockSeqGlobal = newBlockSeqGlobal;
       this.c = unrollMaxDepth;

--- a/Source/Core/MaxHolesLambdaLifter.cs
+++ b/Source/Core/MaxHolesLambdaLifter.cs
@@ -374,7 +374,7 @@ namespace Core
 
       // the resulting lifted function applied to free variables
       IToken tok = _lambda.tok;
-      Formal res = new Formal(tok, new TypedIdent(tok, TypedIdent.NoName, cce.NonNull(_lambda.Type)), false);
+      Formal res = new Formal(tok, new TypedIdent(tok, TypedIdent.NoName, Cce.NonNull(_lambda.Type)), false);
 
       var liftedLambda = (LambdaExpr) LambdaLiftingMaxHolesFiller.Fill(
         (from kvp in _templates where !kvp.Value.ContainsBoundVariables() select kvp.Key).ToList(),
@@ -490,7 +490,7 @@ namespace Core
       else
       {
         // After OldFinder pass, old expressions should only occur around free variables
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
 
       return node;

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -1159,7 +1159,7 @@ namespace Microsoft.Boogie
         }
         else
         {
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
       }
 
@@ -1223,7 +1223,7 @@ namespace Microsoft.Boogie
           mapType.TypeParameters.ForEach(x => boundTypeVariables.Remove(x));
           return returnVal;
         }
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
   }
@@ -1563,7 +1563,7 @@ namespace Microsoft.Boogie
       {
         return polymorphicMapInfos[mapType].Instances;
       }
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public PolymorphicMapInfo RegisterPolymorphicMapType(Type type)

--- a/Source/Core/OOLongUtil.cs
+++ b/Source/Core/OOLongUtil.cs
@@ -92,16 +92,16 @@ namespace Boogie.Util
 
     public override void Close()
     {
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         reader.Close();
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     public override int Read()
     {
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       try
       {
         while (readAhead == null)
@@ -129,7 +129,7 @@ namespace Boogie.Util
       }
       finally
       {
-        cce.EndExpose();
+        Cce.EndExpose();
       }
     }
 
@@ -155,12 +155,12 @@ namespace Boogie.Util
       string res;
       if (readAhead != null)
       {
-        cce.BeginExpose(this);
+        Cce.BeginExpose(this);
         {
           res = readAhead.Substring(readAheadConsumed);
           readAhead = null;
         }
-        cce.EndExpose();
+        Cce.EndExpose();
       }
       else
       {
@@ -181,7 +181,7 @@ namespace Boogie.Util
     void ObjectInvariant()
     {
       Contract.Invariant(readState != null);
-      Contract.Invariant(cce.NonNullElements(defines));
+      Contract.Invariant(Cce.NonNullElements(defines));
       Contract.Invariant(0 <= ignoreCutoff && ignoreCutoff <= readState.Count);
     }
 
@@ -190,7 +190,7 @@ namespace Boogie.Util
       : base(reader)
     {
       Contract.Requires(reader != null);
-      Contract.Requires(cce.NonNullElements(defines));
+      Contract.Requires(Cce.NonNullElements(defines));
       this.defines = defines;
     }
 

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -75,7 +75,7 @@ public static Program ParseLibrary(string libraryName)
 ///</summary>
 public static int Parse(string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(filename != null);
-  Contract.Requires(Cce.NonNullElements(defines,true));
+  Contract.Requires(cce.NonNullElements(defines,true));
 
   if (filename == "stdin.bpl") {
     return Parse(Console.In, filename, defines, out program, useBaseName);
@@ -96,7 +96,7 @@ public static int Parse(string s, string/*!*/ filename, out /*maybe null*/ Progr
   Contract.Requires(s != null);
   Contract.Requires(filename != null);
 
-  byte[]/*!*/ buffer = Cce.NonNull(UTF8Encoding.Default.GetBytes(s));
+  byte[]/*!*/ buffer = cce.NonNull(UTF8Encoding.Default.GetBytes(s));
   MemoryStream ms = new MemoryStream(buffer,false);
   Errors errors = new Errors();
   Scanner scanner = new Scanner(ms, errors, filename, useBaseName);
@@ -147,9 +147,9 @@ private class BvBounds : Expr {
   }
   public override void Emit(TokenTextWriter/*!*/ stream,
                             int contextBindingStrength, bool fragileContext) {
-    Contract.Assert(false);throw new Cce.UnreachableException();
+    Contract.Assert(false);throw new cce.UnreachableException();
   }
-  public override void ComputeFreeVariables(GSet<object>/*!*/ freeVars) { Contract.Assert(false);throw new Cce.UnreachableException(); }
+  public override void ComputeFreeVariables(GSet<object>/*!*/ freeVars) { Contract.Assert(false);throw new cce.UnreachableException(); }
 
   public override int ContentHash => throw new NotSupportedException("Not supported since this type is translated away");
 
@@ -471,7 +471,7 @@ private class BvBounds : Expr {
 		if (!allUnnamed) {
 		 Bpl.Type prevType = null;
 		 for (int i = arguments.Count; 0 <= --i; ) {
-		   TypedIdent/*!*/ curr = Cce.NonNull(arguments[i]).TypedIdent;
+		   TypedIdent/*!*/ curr = cce.NonNull(arguments[i]).TypedIdent;
 		   if (curr.HasName) {
 		     // the argument was given as both an identifier and a type
 		     prevType = curr.Type;
@@ -530,7 +530,7 @@ private class BvBounds : Expr {
 	}
 
 	void UserDefinedTypes(out List<Declaration/*!*/>/*!*/ ts) {
-		Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out ts))); Declaration/*!*/ decl; QKeyValue kv = null; ts = new List<Declaration/*!*/> (); 
+		Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out ts))); Declaration/*!*/ decl; QKeyValue kv = null; ts = new List<Declaration/*!*/> (); 
 		Expect(32);
 		while (la.kind == 26) {
 			Attribute(ref kv);
@@ -1496,7 +1496,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	}
 
 	void StructuredCmd(out StructuredCmd/*!*/ ec) {
-		Contract.Ensures(Contract.ValueAtReturn(out ec) != null); ec = dummyStructuredCmd;  Contract.Assume(Cce.IsPeerConsistent(ec));
+		Contract.Ensures(Contract.ValueAtReturn(out ec) != null); ec = dummyStructuredCmd;  Contract.Assume(cce.IsPeerConsistent(ec));
 		IfCmd/*!*/ ifcmd;  WhileCmd/*!*/ wcmd;  BreakCmd/*!*/ bcmd;
 		
 		if (la.kind == 55) {
@@ -1569,7 +1569,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		Expect(57);
 		x = t; 
 		Guard(out guard);
-		Contract.Assume(guard == null || Cce.Owner.None(guard)); 
+		Contract.Assume(guard == null || cce.Owner.None(guard)); 
 		while (la.kind == 35 || la.kind == 51) {
 			isFree = false; z = la/*lookahead token*/; 
 			if (la.kind == 51) {
@@ -1724,7 +1724,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	}
 
 	void MapAssignIndex(out IToken/*!*/ x, out List<Expr/*!*/>/*!*/ indexes) {
-		Contract.Ensures(Contract.ValueAtReturn(out x) != null); Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out indexes))); indexes = new List<Expr/*!*/> ();
+		Contract.Ensures(Contract.ValueAtReturn(out x) != null); Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out indexes))); indexes = new List<Expr/*!*/> ();
 		Expr/*!*/ e;
 		
 		Expect(19);
@@ -2514,7 +2514,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 	}
 
 	void CodeExpression(out List<Variable>/*!*/ locals, out List<Block/*!*/>/*!*/ blocks) {
-		Contract.Ensures(Contract.ValueAtReturn(out locals) != null); Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out blocks))); locals = new List<Variable>(); Block/*!*/ b;
+		Contract.Ensures(Contract.ValueAtReturn(out locals) != null); Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out blocks))); locals = new List<Variable>(); Block/*!*/ b;
 		blocks = new List<Block/*!*/>();
 		
 		Expect(112);

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -75,7 +75,7 @@ public static Program ParseLibrary(string libraryName)
 ///</summary>
 public static int Parse(string/*!*/ filename, List<string/*!*/> defines, out /*maybe null*/ Program program, bool useBaseName=false) /* throws System.IO.IOException */ {
   Contract.Requires(filename != null);
-  Contract.Requires(cce.NonNullElements(defines,true));
+  Contract.Requires(Cce.NonNullElements(defines,true));
 
   if (filename == "stdin.bpl") {
     return Parse(Console.In, filename, defines, out program, useBaseName);
@@ -96,7 +96,7 @@ public static int Parse(string s, string/*!*/ filename, out /*maybe null*/ Progr
   Contract.Requires(s != null);
   Contract.Requires(filename != null);
 
-  byte[]/*!*/ buffer = cce.NonNull(UTF8Encoding.Default.GetBytes(s));
+  byte[]/*!*/ buffer = Cce.NonNull(UTF8Encoding.Default.GetBytes(s));
   MemoryStream ms = new MemoryStream(buffer,false);
   Errors errors = new Errors();
   Scanner scanner = new Scanner(ms, errors, filename, useBaseName);
@@ -147,9 +147,9 @@ private class BvBounds : Expr {
   }
   public override void Emit(TokenTextWriter/*!*/ stream,
                             int contextBindingStrength, bool fragileContext) {
-    Contract.Assert(false);throw new cce.UnreachableException();
+    Contract.Assert(false);throw new Cce.UnreachableException();
   }
-  public override void ComputeFreeVariables(GSet<object>/*!*/ freeVars) { Contract.Assert(false);throw new cce.UnreachableException(); }
+  public override void ComputeFreeVariables(GSet<object>/*!*/ freeVars) { Contract.Assert(false);throw new Cce.UnreachableException(); }
 
   public override int ContentHash => throw new NotSupportedException("Not supported since this type is translated away");
 
@@ -471,7 +471,7 @@ private class BvBounds : Expr {
 		if (!allUnnamed) {
 		 Bpl.Type prevType = null;
 		 for (int i = arguments.Count; 0 <= --i; ) {
-		   TypedIdent/*!*/ curr = cce.NonNull(arguments[i]).TypedIdent;
+		   TypedIdent/*!*/ curr = Cce.NonNull(arguments[i]).TypedIdent;
 		   if (curr.HasName) {
 		     // the argument was given as both an identifier and a type
 		     prevType = curr.Type;
@@ -530,7 +530,7 @@ private class BvBounds : Expr {
 	}
 
 	void UserDefinedTypes(out List<Declaration/*!*/>/*!*/ ts) {
-		Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out ts))); Declaration/*!*/ decl; QKeyValue kv = null; ts = new List<Declaration/*!*/> (); 
+		Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out ts))); Declaration/*!*/ decl; QKeyValue kv = null; ts = new List<Declaration/*!*/> (); 
 		Expect(32);
 		while (la.kind == 26) {
 			Attribute(ref kv);
@@ -1496,7 +1496,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	}
 
 	void StructuredCmd(out StructuredCmd/*!*/ ec) {
-		Contract.Ensures(Contract.ValueAtReturn(out ec) != null); ec = dummyStructuredCmd;  Contract.Assume(cce.IsPeerConsistent(ec));
+		Contract.Ensures(Contract.ValueAtReturn(out ec) != null); ec = dummyStructuredCmd;  Contract.Assume(Cce.IsPeerConsistent(ec));
 		IfCmd/*!*/ ifcmd;  WhileCmd/*!*/ wcmd;  BreakCmd/*!*/ bcmd;
 		
 		if (la.kind == 55) {
@@ -1569,7 +1569,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 		Expect(57);
 		x = t; 
 		Guard(out guard);
-		Contract.Assume(guard == null || cce.Owner.None(guard)); 
+		Contract.Assume(guard == null || Cce.Owner.None(guard)); 
 		while (la.kind == 35 || la.kind == 51) {
 			isFree = false; z = la/*lookahead token*/; 
 			if (la.kind == 51) {
@@ -1724,7 +1724,7 @@ out List<Variable>/*!*/ ins, out List<Variable>/*!*/ outs, out QKeyValue kv) {
 	}
 
 	void MapAssignIndex(out IToken/*!*/ x, out List<Expr/*!*/>/*!*/ indexes) {
-		Contract.Ensures(Contract.ValueAtReturn(out x) != null); Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out indexes))); indexes = new List<Expr/*!*/> ();
+		Contract.Ensures(Contract.ValueAtReturn(out x) != null); Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out indexes))); indexes = new List<Expr/*!*/> ();
 		Expr/*!*/ e;
 		
 		Expect(19);
@@ -2514,7 +2514,7 @@ out QKeyValue kv, out Trigger trig, out Expr/*!*/ body) {
 	}
 
 	void CodeExpression(out List<Variable>/*!*/ locals, out List<Block/*!*/>/*!*/ blocks) {
-		Contract.Ensures(Contract.ValueAtReturn(out locals) != null); Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out blocks))); locals = new List<Variable>(); Block/*!*/ b;
+		Contract.Ensures(Contract.ValueAtReturn(out locals) != null); Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out blocks))); locals = new List<Variable>(); Block/*!*/ b;
 		blocks = new List<Block/*!*/>();
 		
 		Expect(112);

--- a/Source/Core/ParserHelper.cs
+++ b/Source/Core/ParserHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Boogie
     private static bool IfdefConditionSaysToInclude(string arg, List<string /*!*/> /*!*/ defines)
     {
       Contract.Requires(arg != null);
-      Contract.Requires(cce.NonNullElements(defines));
+      Contract.Requires(Cce.NonNullElements(defines));
       bool sense = true;
       while (arg.StartsWith("!"))
       {
@@ -37,7 +37,7 @@ namespace Microsoft.Boogie
     public static string Fill(Stream stream, List<string /*!*/> /*!*/ defines)
     {
       Contract.Requires(stream != null);
-      Contract.Requires(cce.NonNullElements(defines));
+      Contract.Requires(Cce.NonNullElements(defines));
       Contract.Ensures(Contract.Result<string>() != null);
       StreamReader /*!*/
         reader = new StreamReader(stream);
@@ -47,7 +47,7 @@ namespace Microsoft.Boogie
     public static string Fill(TextReader reader, List<string /*!*/> /*!*/ defines)
     {
       Contract.Requires(reader != null);
-      Contract.Requires(cce.NonNullElements(defines));
+      Contract.Requires(Cce.NonNullElements(defines));
       Contract.Ensures(Contract.Result<string>() != null);
       StringBuilder sb = new StringBuilder();
       List<ReadState> /*!*/

--- a/Source/Core/ResolutionContext.cs
+++ b/Source/Core/ResolutionContext.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Boogie
     void ObjectInvariant()
     {
       Contract.Invariant(types != null);
-      Contract.Invariant(cce.NonNullElements(typeBinders));
+      Contract.Invariant(Cce.NonNullElements(typeBinders));
       Contract.Invariant(varContext != null);
       Contract.Invariant(functions != null);
       Contract.Invariant(procedures != null);
@@ -382,7 +382,7 @@ namespace Microsoft.Boogie
     public void AddVariable(Variable var)
     {
       Contract.Requires(var != null);
-      var previous = FindVariable(cce.NonNull(var.Name), true);
+      var previous = FindVariable(Cce.NonNull(var.Name), true);
       if (previous == null)
       {
         varContext.VarSymbols.Add(var.Name, var);
@@ -711,11 +711,11 @@ namespace Microsoft.Boogie
       {
         Contract.Assert(value != stateMode);
         Contract.Assert(stateMode == State.Single || value == State.Single);
-        cce.BeginExpose(this);
+        Cce.BeginExpose(this);
         {
           stateMode = value;
         }
-        cce.EndExpose();
+        Cce.EndExpose();
       }
     }
 
@@ -732,11 +732,11 @@ namespace Microsoft.Boogie
       set
       {
         Contract.Assert(triggerMode != value);
-        cce.BeginExpose(this);
+        Cce.BeginExpose(this);
         {
           triggerMode = value;
         }
-        cce.EndExpose();
+        Cce.EndExpose();
       }
     }
 

--- a/Source/Core/StandardVisitor.cs
+++ b/Source/Core/StandardVisitor.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Boogie
       {
         for (int i = 0, n = list.Count; i < n; i++)
         {
-          list[i] = (Expr) this.Visit(cce.NonNull(list[i]));
+          list[i] = (Expr) this.Visit(Cce.NonNull(list[i]));
         }
       }
 
@@ -102,8 +102,8 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<Cmd>() != null);
       for (int i = 0; i < node.Lhss.Count; ++i)
       {
-        node.SetLhs(i, cce.NonNull((AssignLhs) this.Visit(node.Lhss[i])));
-        node.SetRhs(i, cce.NonNull((Expr /*!*/) this.VisitExpr(node.Rhss[i])));
+        node.SetLhs(i, Cce.NonNull((AssignLhs) this.Visit(node.Lhss[i])));
+        node.SetRhs(i, Cce.NonNull((Expr /*!*/) this.VisitExpr(node.Rhss[i])));
       }
       VisitAttributes(node);
       return node;
@@ -191,7 +191,7 @@ namespace Microsoft.Boogie
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Block>() != null);
       node.Cmds = this.VisitCmdSeq(node.Cmds);
-      node.TransferCmd = (TransferCmd) this.Visit(cce.NonNull(node.TransferCmd));
+      node.TransferCmd = (TransferCmd) this.Visit(Cce.NonNull(node.TransferCmd));
       return node;
     }
 
@@ -212,7 +212,7 @@ namespace Microsoft.Boogie
       {
         for (int i = 0, n = blockSeq.Count; i < n; i++)
         {
-          blockSeq[i] = this.VisitBlock(cce.NonNull(blockSeq[i]));
+          blockSeq[i] = this.VisitBlock(Cce.NonNull(blockSeq[i]));
         }
       }
 
@@ -247,7 +247,7 @@ namespace Microsoft.Boogie
       {
         if (node.Ins[i] != null)
         {
-          node.Ins[i] = this.VisitExpr(cce.NonNull(node.Ins[i]));
+          node.Ins[i] = this.VisitExpr(Cce.NonNull(node.Ins[i]));
         }
       }
 
@@ -255,7 +255,7 @@ namespace Microsoft.Boogie
       {
         if (node.Outs[i] != null)
         {
-          node.Outs[i] = (IdentifierExpr) this.VisitIdentifierExpr(cce.NonNull(node.Outs[i]));
+          node.Outs[i] = (IdentifierExpr) this.VisitIdentifierExpr(Cce.NonNull(node.Outs[i]));
         }
       }
       VisitAttributes(node);
@@ -295,7 +295,7 @@ namespace Microsoft.Boogie
         for (int i = 0, n = cmdSeq.Count; i < n; i++)
         {
           cmdSeq[i] = (Cmd) this.Visit(
-            cce.NonNull(cmdSeq[i])); // call general Visit so subtypes of Cmd get visited by their particular visitor
+            Cce.NonNull(cmdSeq[i])); // call general Visit so subtypes of Cmd get visited by their particular visitor
         }
       }
 
@@ -332,7 +332,7 @@ namespace Microsoft.Boogie
       {
         for (int i = 0; i < node.Arguments.Count; ++i)
         {
-          node.Arguments[i] = cce.NonNull((Type /*!*/) this.Visit(node.Arguments[i]));
+          node.Arguments[i] = Cce.NonNull((Type /*!*/) this.Visit(node.Arguments[i]));
         }
       }
 
@@ -352,7 +352,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<List<Declaration>>() != null);
       for (int i = 0, n = declarationList.Count; i < n; i++)
       {
-        declarationList[i] = cce.NonNull((Declaration /*!*/) this.Visit(declarationList[i]));
+        declarationList[i] = Cce.NonNull((Declaration /*!*/) this.Visit(declarationList[i]));
       }
 
       return declarationList;
@@ -397,7 +397,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<IList<Expr>>() != null);
       for (int i = 0, n = exprSeq.Count; i < n; i++)
       {
-        exprSeq[i] = this.VisitExpr(cce.NonNull(exprSeq[i]));
+        exprSeq[i] = this.VisitExpr(Cce.NonNull(exprSeq[i]));
       }
 
       return exprSeq;
@@ -538,7 +538,7 @@ namespace Microsoft.Boogie
       {
         for (int i = 0, n = identifierExprSeq.Count; i < n; i++)
         {
-          identifierExprSeq[i] = (IdentifierExpr) this.VisitIdentifierExpr(cce.NonNull(identifierExprSeq[i]));
+          identifierExprSeq[i] = (IdentifierExpr) this.VisitIdentifierExpr(Cce.NonNull(identifierExprSeq[i]));
         }
       }
 
@@ -575,10 +575,10 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<AssignLhs>() != null);
-      node.Map = cce.NonNull((AssignLhs) this.Visit(node.Map));
+      node.Map = Cce.NonNull((AssignLhs) this.Visit(node.Map));
       for (int i = 0; i < node.Indexes.Count; ++i)
       {
-        node.Indexes[i] = cce.NonNull((Expr) this.VisitExpr(node.Indexes[i]));
+        node.Indexes[i] = Cce.NonNull((Expr) this.VisitExpr(node.Indexes[i]));
       }
 
       return node;
@@ -588,7 +588,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<AssignLhs>() != null);
-      node.Datatype = cce.NonNull((AssignLhs) this.Visit(node.Datatype));
+      node.Datatype = Cce.NonNull((AssignLhs) this.Visit(node.Datatype));
       return node;
     }
     
@@ -605,11 +605,11 @@ namespace Microsoft.Boogie
       {
         for (int i = 0; i < node.Arguments.Count; ++i)
         {
-          node.Arguments[i] = cce.NonNull((Type /*!*/) this.Visit(node.Arguments[i]));
+          node.Arguments[i] = Cce.NonNull((Type /*!*/) this.Visit(node.Arguments[i]));
         }
       }
 
-      node.Result = cce.NonNull((Type /*!*/) this.Visit(node.Result));
+      node.Result = Cce.NonNull((Type /*!*/) this.Visit(node.Result));
       return node;
     }
 
@@ -761,7 +761,7 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<QuantifierExpr>() != null);
-      node = cce.NonNull((QuantifierExpr) this.VisitBinderExpr(node));
+      node = Cce.NonNull((QuantifierExpr) this.VisitBinderExpr(node));
       if (node.Triggers != null)
       {
         node.Triggers = this.VisitTrigger(node.Triggers);
@@ -783,7 +783,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<List<RE>>() != null);
       for (int i = 0, n = reSeq.Count; i < n; i++)
       {
-        reSeq[i] = (RE) this.VisitRE(cce.NonNull(reSeq[i]));
+        reSeq[i] = (RE) this.VisitRE(Cce.NonNull(reSeq[i]));
       }
 
       return reSeq;
@@ -884,12 +884,12 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Type>() != null);
-      node.ExpandedType = cce.NonNull((Type /*!*/) this.Visit(node.ExpandedType));
+      node.ExpandedType = Cce.NonNull((Type /*!*/) this.Visit(node.ExpandedType));
       lock (node.Arguments)
       {
         for (int i = 0; i < node.Arguments.Count; ++i)
         {
-          node.Arguments[i] = cce.NonNull((Type /*!*/) this.Visit(node.Arguments[i]));
+          node.Arguments[i] = Cce.NonNull((Type /*!*/) this.Visit(node.Arguments[i]));
         }
       }
 
@@ -918,7 +918,7 @@ namespace Microsoft.Boogie
       // specific type, we visit the instantiation
       if (node.ProxyFor != null)
       {
-        return cce.NonNull((Type /*!*/) this.Visit(node.ProxyFor));
+        return Cce.NonNull((Type /*!*/) this.Visit(node.ProxyFor));
       }
 
       return this.VisitType(node);
@@ -947,7 +947,7 @@ namespace Microsoft.Boogie
       {
         for (int i = 0, n = variableSeq.Count; i < n; i++)
         {
-          variableSeq[i] = this.VisitVariable(cce.NonNull(variableSeq[i]));
+          variableSeq[i] = this.VisitVariable(Cce.NonNull(variableSeq[i]));
         }
       }
 
@@ -1117,7 +1117,7 @@ namespace Microsoft.Boogie
     {
       Contract.Ensures(Contract.Result<Block>() == node);
       this.VisitCmdSeq(node.Cmds);
-      this.Visit(cce.NonNull(node.TransferCmd));
+      this.Visit(Cce.NonNull(node.TransferCmd));
       return node;
     }
 
@@ -1134,7 +1134,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<List<Block>>() == blockSeq);
       for (int i = 0, n = blockSeq.Count; i < n; i++)
       {
-        this.VisitBlock(cce.NonNull(blockSeq[i]));
+        this.VisitBlock(Cce.NonNull(blockSeq[i]));
       }
 
       return blockSeq;
@@ -1198,7 +1198,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<List<Cmd>>() == cmdSeq);
       for (int i = 0, n = cmdSeq.Count; i < n; i++)
       {
-        this.Visit(cce.NonNull(
+        this.Visit(Cce.NonNull(
           cmdSeq[i])); // call general Visit so subtypes of Cmd get visited by their particular visitor
       }
 
@@ -1284,7 +1284,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<IList<Expr>>() == exprSeq);
       for (int i = 0, n = exprSeq.Count; i < n; i++)
       {
-        this.VisitExpr(cce.NonNull(exprSeq[i]));
+        this.VisitExpr(Cce.NonNull(exprSeq[i]));
       }
 
       return exprSeq;
@@ -1405,7 +1405,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<List<IdentifierExpr>>() == identifierExprSeq);
       for (int i = 0, n = identifierExprSeq.Count; i < n; i++)
       {
-        this.VisitIdentifierExpr(cce.NonNull(identifierExprSeq[i]));
+        this.VisitIdentifierExpr(Cce.NonNull(identifierExprSeq[i]));
       }
 
       return identifierExprSeq;
@@ -1558,7 +1558,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<List<RE>>() == reSeq);
       for (int i = 0, n = reSeq.Count; i < n; i++)
       {
-        this.VisitRE(cce.NonNull(reSeq[i]));
+        this.VisitRE(Cce.NonNull(reSeq[i]));
       }
 
       return reSeq;
@@ -1642,7 +1642,7 @@ namespace Microsoft.Boogie
     public override Type VisitTypeSynonymAnnotation(TypeSynonymAnnotation node)
     {
       Contract.Ensures(Contract.Result<Type>() == node);
-      node.ExpandedType = cce.NonNull((Type /*!*/) this.Visit(node.ExpandedType));
+      node.ExpandedType = Cce.NonNull((Type /*!*/) this.Visit(node.ExpandedType));
       for (int i = 0; i < node.Arguments.Count; ++i)
       {
         this.Visit(node.Arguments[i]);
@@ -1694,7 +1694,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(Contract.Result<List<Variable>>() == variableSeq);
       for (int i = 0, n = variableSeq.Count; i < n; i++)
       {
-        this.VisitVariable(cce.NonNull(variableSeq[i]));
+        this.VisitVariable(Cce.NonNull(variableSeq[i]));
       }
 
       return variableSeq;

--- a/Source/Core/TypeAmbiguitySeeker.cs
+++ b/Source/Core/TypeAmbiguitySeeker.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Expr>() != null);
-      CheckTypeParams(node, cce.NonNull(node.TypeParameters));
+      CheckTypeParams(node, Cce.NonNull(node.TypeParameters));
       return base.VisitNAryExpr(node);
     }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Boogie
     {
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<AssignLhs>() != null);
-      CheckTypeParams(node, cce.NonNull(node.TypeParameters));
+      CheckTypeParams(node, Cce.NonNull(node.TypeParameters));
       return base.VisitMapAssignLhs(node);
     }
   }

--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -202,12 +202,12 @@ namespace Microsoft.Boogie
     public void WriteError(string message, Cci.Node offendingNode, List<Block> trace) {
       Contract.Requires(offendingNode != null);
       Contract.Requires(message != null);
-      Contract.Requires(IsOpen && cce.Owner.Different(this, offendingNode));
-      Contract.Requires(trace == null || cce.Owner.Different(this, trace));
+      Contract.Requires(IsOpen && Cce.Owner.Different(this, offendingNode));
+      Contract.Requires(trace == null || Cce.Owner.Different(this, trace));
       //modifies this.*, offendingNode.*, trace.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteStartElement("error");
         wr.WriteAttributeString("message", message);
@@ -216,7 +216,7 @@ namespace Microsoft.Boogie
           wr.WriteStartElement("trace");
           {
             foreach (object bo in trace) {
-              cce.LoopInvariant(wr != null);
+              Cce.LoopInvariant(wr != null);
               Contract.Assume(bo is Block);
               Block b = (Block)bo;
               wr.WriteStartElement("traceNode");
@@ -231,7 +231,7 @@ namespace Microsoft.Boogie
         }
         wr.WriteEndElement();
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 #endif
 
@@ -252,7 +252,7 @@ namespace Microsoft.Boogie
     [Inside]
     private void WriteTokenAttributes(Cci.Node node) {
       Contract.Requires(node != null);
-      Contract.Requires(wr != null && cce.IsPeerConsistent(wr));
+      Contract.Requires(wr != null && Cce.IsPeerConsistent(wr));
       //modifies this.0, wr.*;
       Contract.Assert(wr != null);
       if (node.SourceContext.Document != null) {

--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Boogie
         Close();
       }
 
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       XmlWriterSettings settings = new XmlWriterSettings();
       settings.Indent = true;
       wr = XmlWriter.Create(filename, settings);
@@ -51,7 +51,7 @@ namespace Microsoft.Boogie
       wr.WriteStartElement("boogie");
       wr.WriteAttributeString("version", options.VersionNumber);
       wr.WriteAttributeString("commandLine", Environment.CommandLine);
-      cce.EndExpose();
+      Cce.EndExpose();
       return null; // success
     }
 
@@ -60,13 +60,13 @@ namespace Microsoft.Boogie
       //modifies this.*;
       if (wr != null)
       {
-        cce.BeginExpose(this);
+        Cce.BeginExpose(this);
         {
           wr.WriteEndDocument();
           wr.Close();
           wr = null;
         }
-        cce.EndExpose();
+        Cce.EndExpose();
       }
     }
 
@@ -79,11 +79,11 @@ namespace Microsoft.Boogie
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       wr.WriteStartElement("method");
       wr.WriteAttributeString("name", methodName);
       wr.WriteAttributeString("startTime", startTime.ToString(DateTimeFormatString));
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     public void WriteEndMethod(string outcome, DateTime endTime, TimeSpan elapsed, int? resourceCount)
@@ -93,7 +93,7 @@ namespace Microsoft.Boogie
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteStartElement("conclusion");
         wr.WriteAttributeString("endTime", endTime.ToString(DateTimeFormatString));
@@ -108,7 +108,7 @@ namespace Microsoft.Boogie
         wr.WriteEndElement(); // outcome
         wr.WriteEndElement(); // method
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     public void WriteSplit(int splitNum, int iteration, IEnumerable<AssertCmd> asserts, DateTime startTime,
@@ -121,7 +121,7 @@ namespace Microsoft.Boogie
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
 
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteStartElement("assertionBatch");
         wr.WriteAttributeString("number", splitNum.ToString());
@@ -149,18 +149,18 @@ namespace Microsoft.Boogie
 
         wr.WriteEndElement(); // assertionBatch
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
     
     public void WriteError(string message, IToken errorToken, IToken relatedToken, List<Block> trace)
     {
       Contract.Requires(errorToken != null);
       Contract.Requires(message != null);
-      Contract.Requires(IsOpen && (trace == null || cce.Owner.Different(this, trace)));
+      Contract.Requires(IsOpen && (trace == null || Cce.Owner.Different(this, trace)));
       //modifies this.*, errorToken.*, relatedToken.*, trace.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteStartElement("error");
         wr.WriteAttributeString("message", message);
@@ -178,7 +178,7 @@ namespace Microsoft.Boogie
           {
             foreach (object bo in trace)
             {
-              cce.LoopInvariant(wr != null);
+              Cce.LoopInvariant(wr != null);
               Contract.Assume(bo is Block);
               Block b = (Block) bo;
               wr.WriteStartElement("traceNode");
@@ -195,7 +195,7 @@ namespace Microsoft.Boogie
 
         wr.WriteEndElement();
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
 #if CCI
@@ -238,7 +238,7 @@ namespace Microsoft.Boogie
     [Inside]
     private void WriteTokenAttributes(IToken tok)
     {
-      Contract.Requires(wr != null && cce.IsPeerConsistent(wr));
+      Contract.Requires(wr != null && Cce.IsPeerConsistent(wr));
       //modifies this.0, wr.*;
       if (tok != null && tok.filename != null)
       {
@@ -270,12 +270,12 @@ namespace Microsoft.Boogie
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteStartElement("inference");
         wr.WriteAttributeString("name", inferenceName);
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     public void WriteEndInference()
@@ -284,11 +284,11 @@ namespace Microsoft.Boogie
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteEndElement(); // inference
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     public void WriteContractParaAssignment(string varName, string val)
@@ -298,14 +298,14 @@ namespace Microsoft.Boogie
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteStartElement("assignment");
         wr.WriteAttributeString("name", varName);
         wr.WriteAttributeString("value", val);
         wr.WriteEndElement();
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     public void WriteStartFile(string filename)
@@ -315,12 +315,12 @@ namespace Microsoft.Boogie
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteStartElement("file");
         wr.WriteAttributeString("name", filename);
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     public void WriteEndFile()
@@ -329,11 +329,11 @@ namespace Microsoft.Boogie
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteEndElement();
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
 
     public void WriteFileFragment(string fragment)
@@ -343,13 +343,13 @@ namespace Microsoft.Boogie
       //modifies this.*;
       Contract.Ensures(IsOpen);
       Contract.Assert(wr != null);
-      cce.BeginExpose(this);
+      Cce.BeginExpose(this);
       {
         wr.WriteStartElement("fileFragment");
         wr.WriteAttributeString("name", fragment);
         wr.WriteEndElement();
       }
-      cce.EndExpose();
+      Cce.EndExpose();
     }
   }
 
@@ -366,7 +366,7 @@ namespace Microsoft.Boogie
       if (sink != null)
       {
         sink.WriteStartFile(filename); // invoke this method while "sink" is still peer consistent
-        cce.Owner.AssignSame(this, sink);
+        Cce.Owner.AssignSame(this, sink);
         this.sink = sink;
       }
     }

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,8 +2,8 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>3.2.0</Version>
-    <TargetFramework>net6.0</TargetFramework>
+    <Version>3.2.1</Version>
+    <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>
     <RepositoryUrl>https://github.com/boogie-org/boogie</RepositoryUrl>

--- a/Source/ExecutionEngine/CommandLineOptionEngine.cs
+++ b/Source/ExecutionEngine/CommandLineOptionEngine.cs
@@ -17,7 +17,7 @@ public class CommandLineOptionEngine
     Contract.Invariant(ToolName != null);
     Contract.Invariant(DescriptiveToolName != null);
     Contract.Invariant(this._environment != null);
-    Contract.Invariant(cce.NonNullElements(this._files));
+    Contract.Invariant(Cce.NonNullElements(this._files));
     Contract.Invariant(this._fileTimestamp != null);
   }
 
@@ -43,7 +43,7 @@ public class CommandLineOptionEngine
   {
     get
     {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<IList<string>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<IList<string>>()));
       Contract.Ensures(Contract.Result<IList<string>>().IsReadOnly);
       return this._files.AsReadOnly();
     }
@@ -67,7 +67,7 @@ public class CommandLineOptionEngine
     get
     {
       Contract.Ensures(Contract.Result<string>() != null);
-      return cce.NonNull(cce
+      return Cce.NonNull(Cce
         .NonNull(System.Diagnostics.FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly()
           .Location)).FileVersion);
     }
@@ -92,7 +92,7 @@ public class CommandLineOptionEngine
   }
 
   private string /*!*/
-    _fileTimestamp = cce.NonNull(DateTime.Now.ToString("o")).Replace(':', '.');
+    _fileTimestamp = Cce.NonNull(DateTime.Now.ToString("o")).Replace(':', '.');
 
   public string FileTimestamp
   {
@@ -188,16 +188,16 @@ public class CommandLineOptionEngine
   /// </summary>
   public virtual bool Parse(string[] /*!*/ args)
   {
-    Contract.Requires(cce.NonNullElements(args));
+    Contract.Requires(Cce.NonNullElements(args));
 
     // save the command line options for the log files
     Environment += "Command Line Options: " + string.Join(" ", args);
-    args = cce.NonNull((string[]) args.Clone()); // the operations performed may mutate the array, so make a copy
+    args = Cce.NonNull((string[]) args.Clone()); // the operations performed may mutate the array, so make a copy
     var ps = InitializeCommandLineParseState(args);
 
     while (ps.i < args.Length)
     {
-      cce.LoopInvariant(ps.args == args);
+      Cce.LoopInvariant(ps.args == args);
       string arg = args[ps.i];
       Contract.Assert(arg != null);
       ps.s = arg.Trim();

--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Boogie
       Contract.Invariant(0 <= EnhancedErrorMessages && EnhancedErrorMessages < 2);
       Contract.Invariant(0 <= Ai.StepsBeforeWidening && Ai.StepsBeforeWidening <= 9);
       Contract.Invariant(-1 <= this.bracketIdsInVC && this.bracketIdsInVC <= 1);
-      Contract.Invariant(cce.NonNullElements(this.ProverOptions));
+      Contract.Invariant(Cce.NonNullElements(this.ProverOptions));
     }
 
     public int LoopUnrollCount { get; set; } = -1; // -1 means don't unroll loops
@@ -566,8 +566,8 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant5()
     {
-      Contract.Invariant(cce.NonNullElements(this.ProcsToCheck, true));
-      Contract.Invariant(cce.NonNullElements(this.ProcsToIgnore, true));
+      Contract.Invariant(Cce.NonNullElements(this.ProcsToCheck, true));
+      Contract.Invariant(Cce.NonNullElements(this.ProcsToIgnore, true));
       Contract.Invariant(Ai != null);
     }
 
@@ -617,7 +617,7 @@ namespace Microsoft.Boogie
           if (ps.ConfirmArgumentCount(1))
           {
             UseAbstractInterpretation = true;
-            foreach (char c in cce.NonNull(args[ps.i]))
+            foreach (char c in Cce.NonNull(args[ps.i]))
             {
               switch (c)
               {
@@ -668,7 +668,7 @@ namespace Microsoft.Boogie
         case "lib":
           if (ps.ConfirmArgumentCount(1))
           {
-            this.Libraries.Add(cce.NonNull(args[ps.i]));
+            this.Libraries.Add(Cce.NonNull(args[ps.i]));
           }
 
           return true;
@@ -676,7 +676,7 @@ namespace Microsoft.Boogie
         case "proc":
           if (ps.ConfirmArgumentCount(1))
           {
-            this.ProcsToCheck.Add(cce.NonNull(args[ps.i]));
+            this.ProcsToCheck.Add(Cce.NonNull(args[ps.i]));
           }
 
           return true;
@@ -684,7 +684,7 @@ namespace Microsoft.Boogie
         case "noProc":
           if (ps.ConfirmArgumentCount(1))
           {
-            this.ProcsToIgnore.Add(cce.NonNull(args[ps.i]));
+            this.ProcsToIgnore.Add(Cce.NonNull(args[ps.i]));
           }
 
           return true;
@@ -774,7 +774,7 @@ namespace Microsoft.Boogie
         case "logPrefix":
           if (ps.ConfirmArgumentCount(1))
           {
-            string s = cce.NonNull(args[ps.i]);
+            string s = Cce.NonNull(args[ps.i]);
             LogPrefix += s.Replace('/', '-').Replace('\\', '-');
           }
 
@@ -803,7 +803,7 @@ namespace Microsoft.Boogie
               default:
               {
                 Contract.Assert(false);
-                throw new cce.UnreachableException();
+                throw new Cce.UnreachableException();
               } // postcondition of GetIntArgument guarantees that we don't get here
             }
           }
@@ -830,7 +830,7 @@ namespace Microsoft.Boogie
               default:
               {
                 Contract.Assert(false);
-                throw new cce.UnreachableException();
+                throw new Cce.UnreachableException();
               } // postcondition of GetIntArgument guarantees that we don't get here
             }
           }
@@ -923,7 +923,7 @@ namespace Microsoft.Boogie
               default:
               {
                 Contract.Assert(false);
-                throw new cce.UnreachableException();
+                throw new Cce.UnreachableException();
               } // postcondition of GetIntArgument guarantees that we don't get here
             }
           }
@@ -1042,7 +1042,7 @@ namespace Microsoft.Boogie
         case "proverDll":
           if (ps.ConfirmArgumentCount(1))
           {
-            ProverDllName = cce.NonNull(args[ps.i]);
+            ProverDllName = Cce.NonNull(args[ps.i]);
             TheProverFactory = ProverFactory.Load(ProverDllName);
           }
 
@@ -1052,7 +1052,7 @@ namespace Microsoft.Boogie
         case "proverOpt":
           if (ps.ConfirmArgumentCount(1))
           {
-            ProverOptions.Add(cce.NonNull(args[ps.i]));
+            ProverOptions.Add(Cce.NonNull(args[ps.i]));
           }
 
           return true;
@@ -1100,14 +1100,14 @@ namespace Microsoft.Boogie
         case "recursionBound":
           if (ps.ConfirmArgumentCount(1))
           {
-            RecursionBound = Int32.Parse(cce.NonNull(args[ps.i]));
+            RecursionBound = Int32.Parse(Cce.NonNull(args[ps.i]));
           }
 
           return true;
         case "enableUnSatCoreExtraction":
           if (ps.ConfirmArgumentCount(1))
           {
-            EnableUnSatCoreExtract = Int32.Parse(cce.NonNull(args[ps.i]));
+            EnableUnSatCoreExtract = Int32.Parse(Cce.NonNull(args[ps.i]));
           }
 
           return true;
@@ -1461,7 +1461,7 @@ namespace Microsoft.Boogie
       int i = 0;
       for (int n = argList.Length; i < n;)
       {
-        cce.LoopInvariant(0 <= i);
+        Cce.LoopInvariant(0 <= i);
         int separatorIndex = this.GetArgumentSeparatorIndex(argList, i);
         if (separatorIndex > i)
         {

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Boogie
 
     public async Task<bool> ProcessFiles(TextWriter output, IList<string> fileNames, bool lookForSnapshots = true,
       string programId = null) {
-      Contract.Requires(cce.NonNullElements(fileNames));
+      Contract.Requires(Cce.NonNullElements(fileNames));
 
       if (Options.VerifySeparately && 1 < fileNames.Count) {
         var success = true;
@@ -284,7 +284,7 @@ namespace Microsoft.Boogie
     /// </summary>
     public Program ParseBoogieProgram(IList<string> fileNames, bool suppressTraceOutput)
     {
-      Contract.Requires(cce.NonNullElements(fileNames));
+      Contract.Requires(Cce.NonNullElements(fileNames));
 
       Program program = new Program();
       bool okay = true;
@@ -471,7 +471,7 @@ namespace Microsoft.Boogie
       }
 
       // Inline
-      var TopLevelDeclarations = cce.NonNull(program.TopLevelDeclarations);
+      var TopLevelDeclarations = Cce.NonNull(program.TopLevelDeclarations);
 
       if (Options.ProcedureInlining != CoreOptions.Inlining.None)
       {
@@ -626,7 +626,7 @@ namespace Microsoft.Boogie
     private Implementation[] GetPrioritizedImplementations(Program program)
     {
       var impls = program.Implementations.Where(
-        impl => impl != null && Options.UserWantsToCheckRoutine(cce.NonNull(impl.VerboseName)) &&
+        impl => impl != null && Options.UserWantsToCheckRoutine(Cce.NonNull(impl.VerboseName)) &&
                 !impl.IsSkipVerification(Options)).ToArray();
 
       // operate on a stable copy, in case it gets updated while we're running
@@ -689,7 +689,7 @@ namespace Microsoft.Boogie
               .OrderBy(s => s)));
       }
 
-      cce.NonNull(Options.TheProverFactory).Close();
+      Cce.NonNull(Options.TheProverFactory).Close();
 
       return outcome;
 
@@ -1221,7 +1221,7 @@ namespace Microsoft.Boogie
       {
         default:
           Contract.Assert(false); // unexpected outcome
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         case VcOutcome.ReachedBound:
           traceOutput = "verified";
           break;
@@ -1261,7 +1261,7 @@ namespace Microsoft.Boogie
       {
         default:
           Contract.Assert(false); // unexpected outcome
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         case VcOutcome.ReachedBound:
           Interlocked.Increment(ref stats.VerifiedCount);
 
@@ -1305,7 +1305,7 @@ namespace Microsoft.Boogie
       {
         default:
           Contract.Assert(false); // unexpected outcome
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         case VcOutcome.ReachedBound:
           Interlocked.Increment(ref stats.CachedVerifiedCount);
 

--- a/Source/Graph/Graph.cs
+++ b/Source/Graph/Graph.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Boogie.GraphUtil
 
     public Graph(HashSet<Tuple<Node /*!*/, Node /*!*/>> edges)
     {
-      Contract.Requires(cce.NonNullElements(edges) && Contract.ForAll(edges, p => p.Item1 != null && p.Item2 != null));
+      Contract.Requires(Cce.NonNullElements(edges) && Contract.ForAll(edges, p => p.Item1 != null && p.Item2 != null));
       this.edges = edges;
 
       // original A#
@@ -537,7 +537,7 @@ namespace Microsoft.Boogie.GraphUtil
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<Tuple<Node, Node>>>())
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<Tuple<Node, Node>>>())
                          && Contract.ForAll(Contract.Result<IEnumerable<Tuple<Node, Node>>>(), n =>
                            n.Item1 != null && n.Item2 != null));
         return edges;
@@ -1451,7 +1451,7 @@ namespace Microsoft.Boogie.GraphUtil
 
     private ICollection<Node> /*!*/ nodes
     {
-      get { return cce.NonNull(nodesMap.Keys); }
+      get { return Cce.NonNull(nodesMap.Keys); }
     }
 
     [Pure]
@@ -1578,7 +1578,7 @@ namespace Microsoft.Boogie.GraphUtil
       Contract.Ensures(Contract.Result<IEnumerator<SCC<Node>>>() != null);
 
       Contract.Assume(Computed);
-      Contract.Assert(cce.NonNullElements((IEnumerable<SCC<Node> /*!*/>) sccs)); //REVIEW
+      Contract.Assert(Cce.NonNullElements((IEnumerable<SCC<Node> /*!*/>) sccs)); //REVIEW
       return ((IEnumerable<SCC<Node> /*!*/>) sccs).GetEnumerator();
     }
 
@@ -1588,7 +1588,7 @@ namespace Microsoft.Boogie.GraphUtil
     [ContractInvariantMethod]
     void sccsInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(sccs));
+      Contract.Invariant(Cce.NonNullElements(sccs));
     }
 
 
@@ -1598,7 +1598,7 @@ namespace Microsoft.Boogie.GraphUtil
       Contract.Ensures(Computed);
       // Compute post times on graph with edges reversed
       this.dfsNext = this.preds;
-      foreach (Node /*!*/ n in cce.NonNull(graph.Keys))
+      foreach (Node /*!*/ n in Cce.NonNull(graph.Keys))
       {
         Contract.Assert(n != null);
         if (!seen.ContainsKey(n))
@@ -1646,7 +1646,7 @@ namespace Microsoft.Boogie.GraphUtil
     void ObjectInvariant()
     {
       Contract.Invariant(seen != null);
-      Contract.Invariant(cce.NonNullElements(postOrder));
+      Contract.Invariant(Cce.NonNullElements(postOrder));
     }
 
 

--- a/Source/Provers/SMTLib/ProverContext.cs
+++ b/Source/Provers/SMTLib/ProverContext.cs
@@ -136,8 +136,8 @@ namespace Microsoft.Boogie
       Contract.Invariant(gen != null);
       Contract.Invariant(genOptions != null);
       Contract.Invariant(translator != null);
-      Contract.Invariant(cce.NonNullElements(distincts));
-      Contract.Invariant(cce.NonNullElements(axiomConjuncts));
+      Contract.Invariant(Cce.NonNullElements(distincts));
+      Contract.Invariant(Cce.NonNullElements(axiomConjuncts));
     }
 
     public VCExprTranslator /*?*/
@@ -191,7 +191,7 @@ namespace Microsoft.Boogie
       }
       else
       {
-        exprTranslator = (VCExprTranslator) cce.NonNull(ctxt.exprTranslator.Clone());
+        exprTranslator = (VCExprTranslator) Cce.NonNull(ctxt.exprTranslator.Clone());
       }
     }
 

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -27,7 +27,7 @@ public abstract class ProverInterface
   {
     Contract.Requires(prog != null);
 
-    ProverOptions options = cce.NonNull(libOptions.TheProverFactory).BlankProverOptions(libOptions);
+    ProverOptions options = Cce.NonNull(libOptions.TheProverFactory).BlankProverOptions(libOptions);
 
     if (logFilePath != null)
     {
@@ -125,7 +125,7 @@ public abstract class ProverInterface
 
     public virtual void OnModel(IList<string> labels, Model model, SolverOutcome proverOutcome)
     {
-      Contract.Requires(cce.NonNullElements(labels));
+      Contract.Requires(Cce.NonNullElements(labels));
     }
 
     public virtual void OnResourceExceeded(string message,
@@ -149,7 +149,7 @@ public abstract class ProverInterface
           break;
         default:
           Contract.Assume(false);
-          throw new cce.UnreachableException(); // unexpected case
+          throw new Cce.UnreachableException(); // unexpected case
       }
     }
 

--- a/Source/Provers/SMTLib/ProverUtil.cs
+++ b/Source/Provers/SMTLib/ProverUtil.cs
@@ -100,7 +100,7 @@ The generic options may or may not be used by the prover plugin.
 
     public virtual void Parse(IEnumerable<string /*!*/> /*!*/ opts)
     {
-      Contract.Requires(cce.NonNullElements(opts));
+      Contract.Requires(Cce.NonNullElements(opts));
       StringBuilder sb = new StringBuilder(stringRepr);
       Contract.Assert(sb != null);
       foreach (string /*!*/ opt in opts)
@@ -129,7 +129,7 @@ The generic options may or may not be used by the prover plugin.
     static string CodebaseString()
     {
       Contract.Ensures(Contract.Result<string>() != null);
-      return Path.GetDirectoryName(cce.NonNull(System.Reflection.Assembly.GetExecutingAssembly().Location));
+      return Path.GetDirectoryName(Cce.NonNull(System.Reflection.Assembly.GetExecutingAssembly().Location));
     }
 
     public string ExecutablePath()
@@ -205,7 +205,7 @@ The generic options may or may not be used by the prover plugin.
       string tmp = null;
       if (ParseString(opt, name, ref tmp))
       {
-        switch (cce.NonNull(tmp).ToLower())
+        switch (Cce.NonNull(tmp).ToLower())
         {
           case "1":
           case "true":
@@ -232,7 +232,7 @@ The generic options may or may not be used by the prover plugin.
       string tmp = null;
       if (ParseString(opt, name, ref tmp))
       {
-        if (int.TryParse(cce.NonNull(tmp), out var t2))
+        if (int.TryParse(Cce.NonNull(tmp), out var t2))
         {
           field = t2;
           return true;
@@ -253,7 +253,7 @@ The generic options may or may not be used by the prover plugin.
       string tmp = null;
       if (ParseString(opt, name, ref tmp))
       {
-        if (uint.TryParse(cce.NonNull(tmp), out var t2))
+        if (uint.TryParse(Cce.NonNull(tmp), out var t2))
         {
           field = t2;
           return true;
@@ -317,7 +317,7 @@ The generic options may or may not be used by the prover plugin.
     {
       Contract.Requires(proverName != null);
       Contract.Ensures(Contract.Result<ProverFactory>() != null);
-      Contract.Ensures(cce.IsNew(Contract.Result<ProverFactory>()) && cce.Owner.New(Contract.Result<ProverFactory>()));
+      Contract.Ensures(Cce.IsNew(Contract.Result<ProverFactory>()) && Cce.Owner.New(Contract.Result<ProverFactory>()));
       string /*!*/
         path;
       if (proverName.IndexOf("/") >= 0 || proverName.IndexOf("\\") >= 0)
@@ -326,16 +326,16 @@ The generic options may or may not be used by the prover plugin.
       }
       else
       {
-        string codebase = cce.NonNull(System.IO.Path.GetDirectoryName(
-          cce.NonNull(System.Reflection.Assembly.GetExecutingAssembly().Location)));
+        string codebase = Cce.NonNull(System.IO.Path.GetDirectoryName(
+          Cce.NonNull(System.Reflection.Assembly.GetExecutingAssembly().Location)));
         path = System.IO.Path.Combine(codebase, "Boogie.Provers." + proverName + ".dll");
       }
 
-      Assembly asm = cce.NonNull(Assembly.LoadFrom(path));
-      string name = cce.NonNull(asm.GetName().Name);
+      Assembly asm = Cce.NonNull(Assembly.LoadFrom(path));
+      string name = Cce.NonNull(asm.GetName().Name);
       System.Type factoryType =
-        cce.NonNull(asm.GetType("Microsoft.Boogie." + name.Replace("Boogie.Provers.", "") + ".Factory"));
-      return cce.NonNull((ProverFactory /*!*/) Activator.CreateInstance(factoryType));
+        Cce.NonNull(asm.GetType("Microsoft.Boogie." + name.Replace("Boogie.Provers.", "") + ".Factory"));
+      return Cce.NonNull((ProverFactory /*!*/) Activator.CreateInstance(factoryType));
     }
   }
 

--- a/Source/Provers/SMTLib/SMTLibLineariser.cs
+++ b/Source/Provers/SMTLib/SMTLibLineariser.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Boogie.SMTLib
       SMTLibExprLineariser lin = new SMTLibExprLineariser(sw, namer, libOptions, opts, namedAssumes, optReqs);
       Contract.Assert(lin != null);
       lin.Linearise(e, LineariserOptions.Default);
-      return cce.NonNull(sw.ToString());
+      return Cce.NonNull(sw.ToString());
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////
@@ -316,7 +316,7 @@ namespace Microsoft.Boogie.SMTLib
       else
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
 
       return true;
@@ -622,7 +622,7 @@ namespace Microsoft.Boogie.SMTLib
       ///////////////////////////////////////////////////////////////////////////////////
       private void WriteApplication(string opName, VCExprNAry /*!>!*/ call, LineariserOptions options)
       {
-        Contract.Requires(cce.NonNullElements(call.Arguments));
+        Contract.Requires(Cce.NonNullElements(call.Arguments));
         Contract.Requires(options != null);
         Contract.Assert(opName != null);
 

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Boogie.SMTLib
       Contract.Invariant(ctx != null);
       Contract.Invariant(Namer != null);
       Contract.Invariant(DeclCollector != null);
-      Contract.Invariant(cce.NonNullElements(Axioms));
-      Contract.Invariant(cce.NonNullElements(TypeDecls));
+      Contract.Invariant(Cce.NonNullElements(Axioms));
+      Contract.Invariant(Cce.NonNullElements(TypeDecls));
       Contract.Invariant(backgroundPredicates != null);
     }
 
@@ -1632,8 +1632,8 @@ namespace Microsoft.Boogie.SMTLib
       Contract.Ensures(Contract.Result<object>() != null);
 
       return this.SpawnProver(libOptions, options,
-        cce.NonNull((SMTLibProverContext) ctxt).ExprGen,
-        cce.NonNull((SMTLibProverContext) ctxt));
+        Cce.NonNull((SMTLibProverContext) ctxt).ExprGen,
+        Cce.NonNull((SMTLibProverContext) ctxt));
     }
 
     public override ProverContext NewProverContext(ProverOptions options)

--- a/Source/Provers/SMTLib/SMTLibSolverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibSolverOptions.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Boogie.SMTLib
           break;
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
 
       if (ProverName == null) {

--- a/Source/Provers/SMTLib/TypeDeclCollector.cs
+++ b/Source/Provers/SMTLib/TypeDeclCollector.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Boogie.SMTLib
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<string>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<string>>()));
 
         List<string> /*!>!*/
           res = new List<string /*!*/>();
@@ -138,7 +138,7 @@ namespace Microsoft.Boogie.SMTLib
 
     public List<string /*!>!*/> GetNewDeclarations()
     {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<string>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<string>>()));
       List<string> /*!>!*/
         res = new List<string /*!*/>();
       res.AddRange(IncDecls);

--- a/Source/VCExpr/BigLiteralAbstracter.cs
+++ b/Source/VCExpr/BigLiteralAbstracter.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Boogie.VCExprAST
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(IncAxioms));
+      Contract.Invariant(Cce.NonNullElements(IncAxioms));
     }
 
     private void AddAxiom(VCExpr /*!*/ axiom)

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Boogie.VCExprAST
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(SubExpressions));
+      Contract.Invariant(Cce.NonNullElements(SubExpressions));
       Contract.Invariant(Gen != null);
     }
 
@@ -80,12 +80,12 @@ namespace Microsoft.Boogie.VCExprAST
     public List<VCExpr /*!*/> /*!*/ Translate(IList<Expr> exprs)
     {
       Contract.Requires(exprs != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExpr>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExpr>>()));
       List<VCExpr /*!*/> /*!*/
         res = new List<VCExpr /*!*/>();
       foreach (Expr e in exprs)
       {
-        res.Add(Translate(cce.NonNull(e)));
+        res.Add(Translate(Cce.NonNull(e)));
       }
 
       return res;
@@ -153,7 +153,7 @@ namespace Microsoft.Boogie.VCExprAST
       [ContractInvariantMethod]
       void ObjectInvariant()
       {
-        Contract.Invariant(Mapping != null && Contract.ForAll(Mapping, i => cce.NonNullDictionaryAndValues(i)));
+        Contract.Invariant(Mapping != null && Contract.ForAll(Mapping, i => Cce.NonNullDictionaryAndValues(i)));
       }
 
 
@@ -174,7 +174,7 @@ namespace Microsoft.Boogie.VCExprAST
             new List<Dictionary<VarKind /*!*/, VCExprVar /*!*/> /*!*/>();
         foreach (Dictionary<VarKind /*!*/, VCExprVar /*!*/> /*!*/ d in vm.Mapping)
         {
-          Contract.Assert(cce.NonNullDictionaryAndValues(d));
+          Contract.Assert(Cce.NonNullDictionaryAndValues(d));
           mapping.Add(new Dictionary<VarKind /*!*/, VCExprVar /*!*/>(d));
         }
 
@@ -310,7 +310,7 @@ namespace Microsoft.Boogie.VCExprAST
       {
         // only bound variables and formals are declared explicitly
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 
@@ -328,7 +328,7 @@ namespace Microsoft.Boogie.VCExprAST
       Formal fml = boogieVar as Formal;
       if (fml != null && Formals.TryGetValue(fml, out var res))
       {
-        return cce.NonNull(res);
+        return Cce.NonNull(res);
       }
 
       // global variables, local variables, incarnations, etc. are
@@ -347,7 +347,7 @@ namespace Microsoft.Boogie.VCExprAST
         UnboundVariables.Bind(boogieVar, res);
       }
 
-      return cce.NonNull(res);
+      return Cce.NonNull(res);
     }
 
     /// <summary>
@@ -364,12 +364,12 @@ namespace Microsoft.Boogie.VCExprAST
       Formal fml = boogieVar as Formal;
       if (fml != null && Formals.TryGetValue(fml, out var res))
       {
-        return cce.NonNull(res);
+        return Cce.NonNull(res);
       }
 
       if (UnboundVariables.TryGetValue(boogieVar, out res))
       {
-        return cce.NonNull(res);
+        return Cce.NonNull(res);
       }
 
       return null; // not present
@@ -440,7 +440,7 @@ namespace Microsoft.Boogie.VCExprAST
       {
         System.Diagnostics.Debug.Assert(false, "unknown kind of literal " + node.tok.ToString());
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 
@@ -466,7 +466,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Expr>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////
@@ -520,7 +520,7 @@ namespace Microsoft.Boogie.VCExprAST
           isPositiveContext = !isPositiveContext;
         }
 
-        vcs.Add(Translate(cce.NonNull(node.Args)[i]));
+        vcs.Add(Translate(Cce.NonNull(node.Args)[i]));
         if (i == 0 && flipContextForArg0)
         {
           isPositiveContext = !isPositiveContext;
@@ -531,11 +531,11 @@ namespace Microsoft.Boogie.VCExprAST
       {
         System.Console.WriteLine("*** type is null for {0}", node);
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
 
       return IAppTranslator.Translate(node.Fun, node.Type, vcs,
-        ToList(cce.NonNull(node.TypeParameters)));
+        ToList(Cce.NonNull(node.TypeParameters)));
     }
 
 
@@ -552,7 +552,7 @@ namespace Microsoft.Boogie.VCExprAST
     private List<Type /*!*/> /*!*/ ToList(TypeParamInstantiation insts)
     {
       Contract.Requires(insts != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Type>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Type>>()));
       if (insts.FormalTypeParams.Count == 0)
       {
         return EMPTY_TYPE_LIST;
@@ -637,7 +637,7 @@ namespace Microsoft.Boogie.VCExprAST
         else
         {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
 
         return Gen.Quantify(quan, typeParams, boundVars, triggers, info, body);
@@ -650,7 +650,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     private List<VCTrigger /*!*/> /*!*/ TranslateTriggers(Trigger node)
     {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCTrigger>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCTrigger>>()));
       List<VCTrigger /*!*/> /*!*/
         res = new List<VCTrigger /*!*/>();
       Trigger curTrigger = node;
@@ -765,7 +765,7 @@ namespace Microsoft.Boogie.VCExprAST
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       VCExpr /*!*/
         bv = Translate(node.Bitvector);
-      return Gen.BvExtract(bv, cce.NonNull(node.Bitvector.Type).BvBits, node.Start, node.End);
+      return Gen.BvExtract(bv, Cce.NonNull(node.Bitvector.Type).BvBits, node.Start, node.End);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////
@@ -797,21 +797,21 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitAssignCmd(AssignCmd node)
     {
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitUnpackCmd(UnpackCmd node)
     {
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
     
     public override Cmd VisitAssumeCmd(AssumeCmd node)
@@ -819,7 +819,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override AtomicRE VisitAtomicRE(AtomicRE node)
@@ -827,7 +827,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<AtomicRE>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Axiom VisitAxiom(Axiom node)
@@ -835,7 +835,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Axiom>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Type VisitBasicType(BasicType node)
@@ -843,7 +843,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Type>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Type VisitBvType(BvType node)
@@ -851,7 +851,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Type>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Block VisitBlock(Block node)
@@ -859,7 +859,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Block>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public CodeExprConverter codeExprConverter = null;
@@ -886,15 +886,15 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(blockSeq != null);
       Contract.Ensures(Contract.Result<List<Block>>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override List<Block /*!*/> /*!*/ VisitBlockList(List<Block /*!*/> /*!*/ blocks)
     {
       //Contract.Requires(cce.NonNullElements(blocks));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Block>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override BoundVariable VisitBoundVariable(BoundVariable node)
@@ -902,7 +902,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<BoundVariable>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitCallCmd(CallCmd node)
@@ -910,7 +910,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitParCallCmd(ParCallCmd node)
@@ -918,7 +918,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override List<Cmd> VisitCmdSeq(List<Cmd> cmdSeq)
@@ -926,7 +926,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(cmdSeq != null);
       Contract.Ensures(Contract.Result<List<Cmd>>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Choice VisitChoice(Choice node)
@@ -934,7 +934,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Choice>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitCommentCmd(CommentCmd node)
@@ -942,7 +942,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Constant VisitConstant(Constant node)
@@ -950,7 +950,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Constant>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override CtorType VisitCtorType(CtorType node)
@@ -958,7 +958,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<CtorType>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Declaration VisitDeclaration(Declaration node)
@@ -966,15 +966,15 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Declaration>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override List<Declaration /*!*/> /*!*/ VisitDeclarationList(List<Declaration /*!*/> /*!*/ declarationList)
     {
       //Contract.Requires(cce.NonNullElements(declarationList));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Declaration>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Declaration>>()));
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override DeclWithFormals VisitDeclWithFormals(DeclWithFormals node)
@@ -982,7 +982,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<DeclWithFormals>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Requires VisitRequires(Requires @requires)
@@ -990,7 +990,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(@requires != null);
       Contract.Ensures(Contract.Result<Requires>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override List<Requires> VisitRequiresSeq(List<Requires> requiresSeq)
@@ -998,7 +998,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(requiresSeq != null);
       Contract.Ensures(Contract.Result<List<Requires>>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Ensures VisitEnsures(Ensures @ensures)
@@ -1006,7 +1006,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(@ensures != null);
       Contract.Ensures(Contract.Result<Ensures>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override List<Ensures> VisitEnsuresSeq(List<Ensures> ensuresSeq)
@@ -1014,7 +1014,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(ensuresSeq != null);
       Contract.Ensures(Contract.Result<List<Ensures>>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Formal VisitFormal(Formal node)
@@ -1022,7 +1022,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Formal>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Function VisitFunction(Function node)
@@ -1030,7 +1030,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Function>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override GlobalVariable VisitGlobalVariable(GlobalVariable node)
@@ -1038,7 +1038,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<GlobalVariable>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override GotoCmd VisitGotoCmd(GotoCmd node)
@@ -1046,7 +1046,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<GotoCmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitHavocCmd(HavocCmd node)
@@ -1054,7 +1054,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Implementation VisitImplementation(Implementation node)
@@ -1062,7 +1062,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Implementation>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override LocalVariable VisitLocalVariable(LocalVariable node)
@@ -1070,7 +1070,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<LocalVariable>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override AssignLhs VisitMapAssignLhs(MapAssignLhs node)
@@ -1078,7 +1078,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<AssignLhs>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Type VisitMapType(MapType node)
@@ -1086,7 +1086,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<MapType>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Procedure VisitProcedure(Procedure node)
@@ -1094,7 +1094,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Procedure>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Program VisitProgram(Program node)
@@ -1102,7 +1102,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Program>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitRE(RE node)
@@ -1110,7 +1110,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override List<RE> VisitRESeq(List<RE> reSeq)
@@ -1118,7 +1118,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(reSeq != null);
       Contract.Ensures(Contract.Result<List<RE>>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override ReturnCmd VisitReturnCmd(ReturnCmd node)
@@ -1126,7 +1126,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<ReturnCmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override ReturnExprCmd VisitReturnExprCmd(ReturnExprCmd node)
@@ -1134,7 +1134,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<ReturnExprCmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Sequential VisitSequential(Sequential node)
@@ -1142,7 +1142,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Sequential>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override AssignLhs VisitSimpleAssignLhs(SimpleAssignLhs node)
@@ -1150,7 +1150,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<AssignLhs>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitStateCmd(StateCmd node)
@@ -1158,7 +1158,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override TransferCmd VisitTransferCmd(TransferCmd node)
@@ -1166,7 +1166,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<TransferCmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Trigger VisitTrigger(Trigger node)
@@ -1174,7 +1174,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Trigger>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Type VisitType(Type node)
@@ -1182,7 +1182,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Type>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override TypedIdent VisitTypedIdent(TypedIdent node)
@@ -1190,7 +1190,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<TypedIdent>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Type VisitTypeSynonymAnnotation(TypeSynonymAnnotation node)
@@ -1198,7 +1198,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Type>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Type VisitTypeVariable(TypeVariable node)
@@ -1206,7 +1206,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Type>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Variable VisitVariable(Variable node)
@@ -1214,7 +1214,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Variable>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override List<Variable> VisitVariableSeq(List<Variable> variableSeq)
@@ -1222,7 +1222,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(variableSeq != null);
       Contract.Ensures(Contract.Result<List<Variable>>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitAssertEnsuresCmd(AssertEnsuresCmd node)
@@ -1230,7 +1230,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public override Cmd VisitAssertRequiresCmd(AssertRequiresCmd node)
@@ -1238,7 +1238,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<Cmd>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
   }
 
@@ -1303,8 +1303,8 @@ namespace Microsoft.Boogie.VCExprAST
     {
       Contract.Requires(ty != null);
       Contract.Requires(app != null);
-      Contract.Requires(cce.NonNullElements(typeArgs));
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(typeArgs));
+      Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
       List<VCExpr /*!*/> /*!*/
@@ -1331,8 +1331,8 @@ namespace Microsoft.Boogie.VCExprAST
       Contract.Assert(this.args.Count == 1);
       if (unaryOperator.Op == UnaryOperator.Opcode.Neg)
       {
-        VCExpr e = cce.NonNull(this.args[0]);
-        if (cce.NonNull(e.Type).IsInt)
+        VCExpr e = Cce.NonNull(this.args[0]);
+        if (Cce.NonNull(e.Type).IsInt)
         {
           return Gen.Function(VCExpressionGenerator.SubIOp, Gen.Integer(BigNum.ZERO), e);
         }
@@ -1436,7 +1436,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     public VCExpr Visit(FieldUpdate fieldUpdate)
     {
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
     
     public VCExpr Visit(IsConstructor isConstructor)
@@ -1450,10 +1450,10 @@ namespace Microsoft.Boogie.VCExprAST
     private VCExpr TranslateBinaryOperator(BinaryOperator app, List<VCExpr /*!*/> /*!*/ args)
     {
       Contract.Requires(app != null);
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       Contract.Assert(args.Count == 2);
-      Type t = cce.NonNull(cce.NonNull(args[0]).Type);
+      Type t = Cce.NonNull(Cce.NonNull(args[0]).Type);
 
       switch (app.Op)
       {
@@ -1509,14 +1509,14 @@ namespace Microsoft.Boogie.VCExprAST
             return Gen.Function(Gen.BinaryFloatOp(t.FloatSignificand, t.FloatExponent, "/"), args);
           }
 
-          VCExpr arg0 = cce.NonNull(args[0]);
-          VCExpr arg1 = cce.NonNull(args[1]);
-          if (cce.NonNull(arg0.Type).IsInt)
+          VCExpr arg0 = Cce.NonNull(args[0]);
+          VCExpr arg1 = Cce.NonNull(args[1]);
+          if (Cce.NonNull(arg0.Type).IsInt)
           {
             arg0 = Gen.Function(VCExpressionGenerator.ToRealOp, arg0);
           }
 
-          if (cce.NonNull(arg1.Type).IsInt)
+          if (Cce.NonNull(arg1.Type).IsInt)
           {
             arg1 = Gen.Function(VCExpressionGenerator.ToRealOp, arg1);
           }
@@ -1576,7 +1576,7 @@ namespace Microsoft.Boogie.VCExprAST
           return Gen.Function(VCExpressionGenerator.OrOp, args);
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException(); // unexpected binary operator
+          throw new Cce.UnreachableException(); // unexpected binary operator
       }
     }
 
@@ -1585,8 +1585,8 @@ namespace Microsoft.Boogie.VCExprAST
     private VCExpr /*!*/
       TranslateFunctionCall(FunctionCall app, List<VCExpr /*!*/> /*!*/ args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      Contract.Requires(cce.NonNullElements(args));
-      Contract.Requires(cce.NonNullElements(typeArgs));
+      Contract.Requires(Cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(typeArgs));
       Contract.Requires(app != null);
       Contract.Requires((app.Func != null));
       Contract.Ensures(Contract.Result<VCExpr>() != null); // resolution must have happened
@@ -1605,8 +1605,8 @@ namespace Microsoft.Boogie.VCExprAST
     private VCExpr ApplyExpansion(FunctionCall app, List<VCExpr /*!*/> /*!*/ args, List<Type /*!*/> /*!*/ typeArgs)
     {
       Contract.Requires(app != null);
-      Contract.Requires(cce.NonNullElements(args));
-      Contract.Requires(cce.NonNullElements(typeArgs));
+      Contract.Requires(Cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(typeArgs));
       Contract.Assert(app.Func != null); // resolution must have happened
 
       lock (app.Func)

--- a/Source/VCExpr/Boogie2VCExpr.cs
+++ b/Source/VCExpr/Boogie2VCExpr.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Boogie.VCExprAST
         Contract.Requires(boogieVar != null);
         foreach (Dictionary<VarKind /*!*/, VCExprVar /*!*/> /*!*/ d in Mapping)
         {
-          //Contract.Assert(cce.NonNullElements(d));
+          //Contract.Assert(Cce.NonNullElements(d));
           if (d.TryGetValue(boogieVar, out var res))
           {
             Contract.Assert(res != null);
@@ -891,7 +891,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override List<Block /*!*/> /*!*/ VisitBlockList(List<Block /*!*/> /*!*/ blocks)
     {
-      //Contract.Requires(cce.NonNullElements(blocks));
+      //Contract.Requires(Cce.NonNullElements(blocks));
       Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
       Contract.Assert(false);
       throw new Cce.UnreachableException();
@@ -971,7 +971,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override List<Declaration /*!*/> /*!*/ VisitDeclarationList(List<Declaration /*!*/> /*!*/ declarationList)
     {
-      //Contract.Requires(cce.NonNullElements(declarationList));
+      //Contract.Requires(Cce.NonNullElements(declarationList));
       Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Declaration>>()));
       Contract.Assert(false);
       throw new Cce.UnreachableException();
@@ -1338,7 +1338,7 @@ namespace Microsoft.Boogie.VCExprAST
         }
         else
         {
-          // if (cce.NonNull(e.Type).IsReal) {
+          // if (Cce.NonNull(e.Type).IsReal) {
           return Gen.Function(VCExpressionGenerator.SubROp, Gen.Real(BigDec.ZERO), e);
         }
 

--- a/Source/VCExpr/Clustering.cs
+++ b/Source/VCExpr/Clustering.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Boogie.Clustering
     void ObjectInvariant()
     {
       Contract.Invariant(Gen != null);
-      Contract.Invariant(cce.NonNullDictionaryAndValues(GlobalVariables));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(SubtermClusters));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(GlobalVariables));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(SubtermClusters));
     }
 
 
@@ -40,7 +40,7 @@ namespace Microsoft.Boogie.Clustering
       foreach (KeyValuePair<VCExprOp /*!*/, TermClustersSameHead /*!*/> pair
         in SubtermClusters)
       {
-        Contract.Assert(cce.NonNullElements(pair));
+        Contract.Assert(Cce.NonNullElements(pair));
         pair.Value.UnifyClusters();
       }
     }
@@ -84,7 +84,7 @@ namespace Microsoft.Boogie.Clustering
           SubtermClusters.Add(op, clusters);
         }
 
-        cce.NonNull(clusters).AddExpr(node);
+        Cce.NonNull(clusters).AddExpr(node);
       }
 
       return res;
@@ -110,7 +110,7 @@ namespace Microsoft.Boogie.Clustering
       foreach (KeyValuePair<VCExprOp /*!*/, TermClustersSameHead /*!*/> pair
         in SubtermClusters)
       {
-        Contract.Assert(cce.NonNullElements(pair));
+        Contract.Assert(Cce.NonNullElements(pair));
         res = res + pair.Value + "\n";
       }
 
@@ -129,7 +129,7 @@ namespace Microsoft.Boogie.Clustering
     {
       Contract.Invariant(Op != null);
       Contract.Invariant(Gen != null);
-      Contract.Invariant(cce.NonNullDictionaryAndValues(GlobalVariables));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(GlobalVariables));
     }
 
     // variables that are global and treated like constants
@@ -145,7 +145,7 @@ namespace Microsoft.Boogie.Clustering
     public TermClustersSameHead(VCExprOp op, IDictionary<VCExprVar /*!*/, VCExprVar /*!*/> /*!*/ globalVars,
       VCExpressionGenerator /*!*/ gen)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(globalVars));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(globalVars));
       Contract.Requires(gen != null);
       Contract.Requires(op != null);
       Op = op;
@@ -251,7 +251,7 @@ namespace Microsoft.Boogie.Clustering
       void ObjectInvariant()
       {
         Contract.Invariant(Gen != null);
-        Contract.Invariant(cce.NonNullDictionaryAndValues(GlobalVariables));
+        Contract.Invariant(Cce.NonNullDictionaryAndValues(GlobalVariables));
         Contract.Invariant(Clusters != null);
         Contract.Invariant(RemainingClusters != null);
         Contract.Invariant(Distances != null);
@@ -269,7 +269,7 @@ namespace Microsoft.Boogie.Clustering
           VCExpressionGenerator gen)
         {
           Contract.Requires(gen != null);
-          Contract.Requires(cce.NonNullDictionaryAndValues(globalVars));
+          Contract.Requires(Cce.NonNullDictionaryAndValues(globalVars));
           AntiUnificationVisitor /*!*/
             visitor = new AntiUnificationVisitor(gen);
           Generator = (VCExprNAry) visitor.AntiUnify(a.Generator, b.Generator);
@@ -284,7 +284,7 @@ namespace Microsoft.Boogie.Clustering
       {
         Contract.Requires(gen != null);
         Contract.Requires(clusters != null);
-        Contract.Requires(cce.NonNullDictionaryAndValues(globalVars));
+        Contract.Requires(Cce.NonNullDictionaryAndValues(globalVars));
         List<Cluster> c = new List<Cluster>();
         c.AddRange(clusters);
         Clusters = c;
@@ -438,7 +438,7 @@ namespace Microsoft.Boogie.Clustering
     void ObjectInvariant()
     {
       Contract.Invariant(Gen != null);
-      Contract.Invariant(cce.NonNullDictionaryAndValues(Representation));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(Representation));
     }
 
 
@@ -503,11 +503,11 @@ namespace Microsoft.Boogie.Clustering
 
     public bool RepresentationIsRenaming(IDictionary<VCExprVar /*!*/, VCExprVar /*!*/> /*!*/ globalVars)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(globalVars));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(globalVars));
       if (!Representation.Any(pair =>
         pair.Key.Expr0 is VCExprVar && pair.Key.Expr1 is VCExprVar &&
-        !globalVars.ContainsKey(cce.NonNull((VCExprVar) pair.Key.Expr0)) &&
-        !globalVars.ContainsKey(cce.NonNull((VCExprVar /*!*/) pair.Key.Expr1))))
+        !globalVars.ContainsKey(Cce.NonNull((VCExprVar) pair.Key.Expr0)) &&
+        !globalVars.ContainsKey(Cce.NonNull((VCExprVar /*!*/) pair.Key.Expr1))))
       {
         return false;
       }
@@ -522,7 +522,7 @@ namespace Microsoft.Boogie.Clustering
     public void RepresentationSize(IDictionary<VCExprVar /*!*/, VCExprVar /*!*/> /*!*/ globalVars, out int expr0Size,
       out int expr1Size)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(globalVars));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(globalVars));
       ReprSizeComputingVisitor /*!*/
         size0Visitor = new ReprSizeComputingVisitor();
       ReprSizeComputingVisitor /*!*/
@@ -564,7 +564,7 @@ namespace Microsoft.Boogie.Clustering
         Representation.Add(pair, repr);
       }
 
-      return cce.NonNull(repr);
+      return Cce.NonNull(repr);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -626,7 +626,7 @@ namespace Microsoft.Boogie.Clustering
       //Contract.Requires(node != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException(); // not handled here      
+      throw new Cce.UnreachableException(); // not handled here      
     }
   }
 
@@ -642,7 +642,7 @@ namespace Microsoft.Boogie.Clustering
     public void ComputeSize(VCExpr expr, IDictionary<VCExprVar /*!*/, VCExprVar /*!*/> /*!*/ globalVars)
     {
       Contract.Requires(expr != null);
-      Contract.Requires(cce.NonNullDictionaryAndValues(globalVars));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(globalVars));
       Traverse(expr, globalVars);
     }
 

--- a/Source/VCExpr/Clustering.cs
+++ b/Source/VCExpr/Clustering.cs
@@ -649,7 +649,7 @@ namespace Microsoft.Boogie.Clustering
     protected override bool StandardResult(VCExpr node, IDictionary<VCExprVar /*!*/, VCExprVar /*!*/> /*!*/ globalVars)
     {
       //Contract.Requires(node != null);
-      //Contract.Requires(cce.NonNullElements(globalVars));
+      //Contract.Requires(Cce.NonNullElements(globalVars));
       VCExprVar nodeAsVar = node as VCExprVar;
       if (nodeAsVar == null || globalVars.ContainsKey(nodeAsVar))
       {

--- a/Source/VCExpr/LetBindingSorter.cs
+++ b/Source/VCExpr/LetBindingSorter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Boogie.VCExprAST
     private List<VCExprVar /*!*/> /*!*/ FreeVarsIn(VCExpr expr)
     {
       Contract.Requires(expr != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
       FreeVarCollector.Collect(expr);
       List<VCExprVar /*!*/> /*!*/
         freeVars = new List<VCExprVar /*!*/>(FreeVarCollector.FreeTermVars);
@@ -57,7 +57,7 @@ namespace Microsoft.Boogie.VCExprAST
       // generate the occurrence edges
       foreach (KeyValuePair<VCExprVar /*!*/, Binding /*!*/> pair in boundVars)
       {
-        Contract.Assert(cce.NonNullElements(pair));
+        Contract.Assert(Cce.NonNullElements(pair));
         Binding /*!*/
           b = pair.Value;
         Contract.Assert(b != null);
@@ -66,7 +66,7 @@ namespace Microsoft.Boogie.VCExprAST
           Contract.Assert(v != null);
           if (boundVars.TryGetValue(v, out var b2))
           {
-            cce.NonNull(b2).Occurrences.Add(b);
+            Cce.NonNull(b2).Occurrences.Add(b);
             b.InvOccurrencesNum = b.InvOccurrencesNum + 1;
           }
         }
@@ -76,7 +76,7 @@ namespace Microsoft.Boogie.VCExprAST
       Stack<Binding /*!*/> rootBindings = new Stack<Binding /*!*/>();
       foreach (KeyValuePair<VCExprVar /*!*/, Binding /*!*/> pair in boundVars)
       {
-        Contract.Assert(cce.NonNullElements(pair));
+        Contract.Assert(Cce.NonNullElements(pair));
         if (pair.Value.InvOccurrencesNum == 0)
         {
           rootBindings.Push(pair.Value);
@@ -171,7 +171,7 @@ namespace Microsoft.Boogie.VCExprAST
       {
         Contract.Invariant(V != null);
         Contract.Invariant(E != null);
-        Contract.Invariant(cce.NonNullElements(FreeVars));
+        Contract.Invariant(Cce.NonNullElements(FreeVars));
         Contract.Invariant(Occurrences != null);
       }
 
@@ -190,7 +190,7 @@ namespace Microsoft.Boogie.VCExprAST
       {
         Contract.Requires(e != null);
         Contract.Requires(v != null);
-        Contract.Requires(cce.NonNullElements(freeVars));
+        Contract.Requires(Cce.NonNullElements(freeVars));
         this.V = v;
         this.E = e;
         this.FreeVars = freeVars;

--- a/Source/VCExpr/MutatingVCExprVisitor.cs
+++ b/Source/VCExpr/MutatingVCExprVisitor.cs
@@ -31,8 +31,8 @@ public abstract class MutatingVCExprVisitor<Arg>
 
   public List<VCExpr /*!*/> /*!*/ MutateSeq(IEnumerable<VCExpr /*!*/> /*!*/ exprs, Arg arg)
   {
-    Contract.Requires(cce.NonNullElements(exprs));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExpr>>()));
+    Contract.Requires(Cce.NonNullElements(exprs));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExpr>>()));
     List<VCExpr /*!*/> /*!*/
       res = new List<VCExpr /*!*/>();
     foreach (VCExpr /*!*/ expr in exprs)
@@ -46,8 +46,8 @@ public abstract class MutatingVCExprVisitor<Arg>
 
   private List<VCExpr /*!*/> /*!*/ MutateList(List<VCExpr /*!*/> /*!*/ exprs, Arg arg)
   {
-    Contract.Requires(cce.NonNullElements(exprs));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExpr>>()));
+    Contract.Requires(Cce.NonNullElements(exprs));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExpr>>()));
     bool changed = false;
     List<VCExpr /*!*/> /*!*/
       res = new List<VCExpr /*!*/>();
@@ -104,8 +104,8 @@ public abstract class MutatingVCExprVisitor<Arg>
   [ContractInvariantMethod]
   void ObjectInvarianta()
   {
-    Contract.Invariant(cce.NonNullElements(NAryExprResultStack));
-    Contract.Invariant(cce.NonNullElements(NAryExprTodoStack));
+    Contract.Invariant(Cce.NonNullElements(NAryExprResultStack));
+    Contract.Invariant(Cce.NonNullElements(NAryExprTodoStack));
   }
 
 
@@ -198,7 +198,7 @@ public abstract class MutatingVCExprVisitor<Arg>
     bool changed,
     Arg arg)
   {
-    Contract.Requires(cce.NonNullElements(newSubExprs));
+    Contract.Requires(Cce.NonNullElements(newSubExprs));
     Contract.Ensures(Contract.Result<VCExpr>() != null);
 
     if (changed)
@@ -223,8 +223,8 @@ public abstract class MutatingVCExprVisitor<Arg>
 
   protected List<VCTrigger /*!*/> /*!*/ MutateTriggers(List<VCTrigger /*!*/> /*!*/ triggers, Arg arg)
   {
-    Contract.Requires(cce.NonNullElements(triggers));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCTrigger>>()));
+    Contract.Requires(Cce.NonNullElements(triggers));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCTrigger>>()));
     List<VCTrigger /*!*/> /*!*/
       newTriggers = new List<VCTrigger /*!*/>();
     bool changed = false;
@@ -275,10 +275,10 @@ public abstract class MutatingVCExprVisitor<Arg>
     // visit the trigger expressions as well
     List<VCTrigger /*!*/> /*!*/
       triggers = node.Triggers;
-    Contract.Assert(cce.NonNullElements(triggers));
+    Contract.Assert(Cce.NonNullElements(triggers));
     List<VCTrigger /*!*/> /*!*/
       newTriggers = MutateTriggers(triggers, arg);
-    Contract.Assert(cce.NonNullElements(newTriggers));
+    Contract.Assert(Cce.NonNullElements(newTriggers));
     if (!Object.ReferenceEquals(triggers, newTriggers))
     {
       changed = true;

--- a/Source/VCExpr/OpTypeEraserPremisses.cs
+++ b/Source/VCExpr/OpTypeEraserPremisses.cs
@@ -31,8 +31,8 @@ public class OpTypeEraserPremisses : OpTypeEraser
   {
     Contract.Requires(bindings != null);
     Contract.Requires(newFun != null);
-    Contract.Requires(cce.NonNullElements(typeArgs /*!*/));
-    Contract.Requires(cce.NonNullElements(oldArgs));
+    Contract.Requires(Cce.NonNullElements(typeArgs /*!*/));
+    Contract.Requires(Cce.NonNullElements(oldArgs));
     Contract.Ensures(Contract.Result<VCExpr>() != null);
     // UGLY: the code for tracking polarities should be factored out
     int oldPolarity = Eraser.Polarity;
@@ -53,7 +53,7 @@ public class OpTypeEraserPremisses : OpTypeEraser
     {
       Contract.Assert(arg != null);
       Type /*!*/
-        newType = cce.NonNull(newFun.InParams[newArgs.Count]).TypedIdent.Type;
+        newType = Cce.NonNull(newFun.InParams[newArgs.Count]).TypedIdent.Type;
       newArgs.Add(AxBuilder.Cast(Eraser.Mutate(arg, bindings), newType));
     }
 
@@ -132,8 +132,8 @@ public class OpTypeEraserPremisses : OpTypeEraser
   {
     Contract.Requires(allTypeParams != null);
     Contract.Requires(node != null);
-    Contract.Requires(cce.NonNullElements(explicitTypeParams));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<Type>>()));
+    Contract.Requires(Cce.NonNullElements(explicitTypeParams));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Type>>()));
     List<Type /*!*/> /*!*/
       res = new List<Type /*!*/>(explicitTypeParams.Count);
     foreach (TypeVariable /*!*/ var in explicitTypeParams)

--- a/Source/VCExpr/ScopedNamer.cs
+++ b/Source/VCExpr/ScopedNamer.cs
@@ -60,19 +60,19 @@ namespace Microsoft.Boogie.VCExprAST
     [ContractInvariantMethod]
     private void GlobalNamesInvariantMethod()
     {
-      Contract.Invariant(cce.NonNullDictionaryAndValues(GlobalNames));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(GlobalNames));
     }
 
     [ContractInvariantMethod]
     private void LocalNamesInvariantMethod()
     {
-      Contract.Invariant(Contract.ForAll(LocalNames, i => i != null && cce.NonNullDictionaryAndValues(i)));
+      Contract.Invariant(Contract.ForAll(LocalNames, i => i != null && Cce.NonNullDictionaryAndValues(i)));
     }
 
     [ContractInvariantMethod]
     private void UsedNamesInvariantMethod()
     {
-      Contract.Invariant(cce.NonNull(UsedNames));
+      Contract.Invariant(Cce.NonNull(UsedNames));
     }
 
     [ContractInvariantMethod]
@@ -84,7 +84,7 @@ namespace Microsoft.Boogie.VCExprAST
     [ContractInvariantMethod]
     private void GlobalPlusLocalNamesInvariantMethod()
     {
-      Contract.Invariant(cce.NonNullDictionaryAndValues(GlobalPlusLocalNames));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(GlobalPlusLocalNames));
     }
 
     public void PushScope()

--- a/Source/VCExpr/TypeErasure/HelperFuns.cs
+++ b/Source/VCExpr/TypeErasure/HelperFuns.cs
@@ -10,7 +10,7 @@ public class HelperFuns
   {
     Contract.Requires(types != null);
     Contract.Requires(name != null);
-    Contract.Requires(cce.NonNullElements(typeParams));
+    Contract.Requires(Cce.NonNullElements(typeParams));
     Contract.Requires(types.Length > 0);
     Contract.Requires(Contract.ForAll(0, types.Length, i => types[i] != null));
     Contract.Ensures(Contract.Result<Function>() != null);
@@ -19,13 +19,13 @@ public class HelperFuns
     for (int i = 0; i < types.Length - 1; ++i)
     {
       args.Add(new Formal(Token.NoToken,
-        new TypedIdent(Token.NoToken, "arg" + i, cce.NonNull(types[i])),
+        new TypedIdent(Token.NoToken, "arg" + i, Cce.NonNull(types[i])),
         true));
     }
 
     Formal result = new Formal(Token.NoToken,
       new TypedIdent(Token.NoToken, "res",
-        cce.NonNull(types)[types.Length - 1]),
+        Cce.NonNull(types)[types.Length - 1]),
       false);
     return new Function(Token.NoToken, name, new List<TypeVariable>(typeParams), args, result);
   }
@@ -58,7 +58,7 @@ public class HelperFuns
   {
     Contract.Requires(gen != null);
     Contract.Requires(fun != null);
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
     List<VCExprVar /*!*/> /*!*/
       arguments = new List<VCExprVar /*!*/>(fun.InParams.Count);
     foreach (Formal /*!*/ f in fun.InParams)
@@ -74,15 +74,15 @@ public class HelperFuns
 
   public static List<T /*!*/> /*!*/ ToList<T>(params T[] args) where T : class
   {
-    Contract.Requires(cce.NonNullElements(args));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<T>>()));
+    Contract.Requires(Cce.NonNullElements(args));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<T>>()));
     return new List<T>(args);
   }
 
   public static List<VCExpr /*!*/> /*!*/ ToVCExprList(List<VCExprVar /*!*/> /*!*/ list)
   {
-    Contract.Requires(cce.NonNullElements(list));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExpr>>()));
+    Contract.Requires(Cce.NonNullElements(list));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExpr>>()));
     return new List<VCExpr>(list);
   }
 
@@ -91,7 +91,7 @@ public class HelperFuns
     Contract.Requires(gen != null);
     Contract.Requires(type != null);
     Contract.Requires(baseName != null);
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
     List<VCExprVar /*!*/> /*!*/
       res = new List<VCExprVar /*!*/>(num);
     for (int i = 0; i < num; ++i)
@@ -107,8 +107,8 @@ public class HelperFuns
   {
     Contract.Requires(gen != null);
     Contract.Requires(baseName != null);
-    Contract.Requires(cce.NonNullElements(types));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
+    Contract.Requires(Cce.NonNullElements(types));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
     List<VCExprVar /*!*/> /*!*/
       res = new List<VCExprVar /*!*/>(types.Count);
     for (int i = 0; i < types.Count; ++i)

--- a/Source/VCExpr/TypeErasure/MapTypeAbstractionBuilder.cs
+++ b/Source/VCExpr/TypeErasure/MapTypeAbstractionBuilder.cs
@@ -57,7 +57,7 @@ internal abstract class MapTypeAbstractionBuilder
   [ContractInvariantMethod]
   void AbstractionVariablesInvariantMethod()
   {
-    Contract.Invariant(cce.NonNullElements(AbstractionVariables));
+    Contract.Invariant(Cce.NonNullElements(AbstractionVariables));
   }
 
   private TypeVariable AbstractionVariable(int num)

--- a/Source/VCExpr/TypeErasure/OpTypeEraser.cs
+++ b/Source/VCExpr/TypeErasure/OpTypeEraser.cs
@@ -43,14 +43,14 @@ public abstract class OpTypeEraser : StandardVCExprOpVisitor<VCExpr /*!*/, Varia
     Contract.Ensures(Contract.Result<VCExpr>() != null);
     System.Diagnostics.Debug.Fail("Don't know how to erase types in this expression: " + node);
     Contract.Assert(false);
-    throw new cce.UnreachableException(); // to please the compiler
+    throw new Cce.UnreachableException(); // to please the compiler
   }
 
   private List<VCExpr /*!*/> /*!*/ MutateSeq(VCExprNAry node, VariableBindings bindings, int newPolarity)
   {
     Contract.Requires((bindings != null));
     Contract.Requires((node != null));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExpr>>()));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExpr>>()));
     int oldPolarity = Eraser.Polarity;
     Eraser.Polarity = newPolarity;
     List<VCExpr /*!*/> /*!*/

--- a/Source/VCExpr/TypeErasure/TypeAxiomBuilder.cs
+++ b/Source/VCExpr/TypeErasure/TypeAxiomBuilder.cs
@@ -32,7 +32,7 @@ public abstract class TypeAxiomBuilder : ICloneable
   [ContractInvariantMethod]
   void AllTypeAxiomsInvariantMethod()
   {
-    Contract.Invariant(cce.NonNullElements(AllTypeAxioms));
+    Contract.Invariant(Cce.NonNullElements(AllTypeAxioms));
   }
 
   // list in which type axioms are incrementally collected
@@ -42,7 +42,7 @@ public abstract class TypeAxiomBuilder : ICloneable
   [ContractInvariantMethod]
   void IncTypeAxiomsInvariantMethod()
   {
-    Contract.Invariant(cce.NonNullElements(IncTypeAxioms));
+    Contract.Invariant(Cce.NonNullElements(IncTypeAxioms));
   }
 
   internal void AddTypeAxiom(VCExpr axiom)
@@ -109,7 +109,7 @@ public abstract class TypeAxiomBuilder : ICloneable
     Contract.Ensures(Contract.Result<VCExpr>() != null);
     List<VCExprVar /*!*/> /*!*/
       quantifiedVars = HelperFuns.GenVarsForInParams(fun, Gen);
-    Contract.Assert(cce.NonNullElements(quantifiedVars));
+    Contract.Assert(Cce.NonNullElements(quantifiedVars));
 
     VCExpr /*!*/
       funApp = Gen.Function(fun, HelperFuns.ToVCExprList(quantifiedVars));
@@ -122,7 +122,7 @@ public abstract class TypeAxiomBuilder : ICloneable
 
     List<VCTrigger /*!*/> /*!*/
       triggers = HelperFuns.ToList(Gen.Trigger(true, HelperFuns.ToList(funApp)));
-    Contract.Assert(cce.NonNullElements(triggers));
+    Contract.Assert(Cce.NonNullElements(triggers));
     return Gen.Forall(quantifiedVars, triggers, "typeInv:" + invFun.Name, 1, eq);
   }
 
@@ -165,7 +165,7 @@ public abstract class TypeAxiomBuilder : ICloneable
   [ContractInvariantMethod]
   void BasicTypeReprsInvariantMethod()
   {
-    Contract.Invariant(cce.NonNullDictionaryAndValues(BasicTypeReprs));
+    Contract.Invariant(Cce.NonNullDictionaryAndValues(BasicTypeReprs));
   }
 
   private VCExpr GetBasicTypeRepr(Type type)
@@ -180,7 +180,7 @@ public abstract class TypeAxiomBuilder : ICloneable
       BasicTypeReprs.Add(type, res);
     }
 
-    return cce.NonNull(res);
+    return Cce.NonNull(res);
   }
 
   private readonly IDictionary<TypeCtorDecl /*!*/, TypeCtorRepr /*!*/> /*!*/
@@ -240,7 +240,7 @@ public abstract class TypeAxiomBuilder : ICloneable
   [ContractInvariantMethod]
   void TypeVariableMappingInvariantMethod()
   {
-    Contract.Invariant(cce.NonNullDictionaryAndValues(TypeVariableMapping));
+    Contract.Invariant(Cce.NonNullDictionaryAndValues(TypeVariableMapping));
   }
 
   public VCExprVar Typed2Untyped(TypeVariable var)
@@ -253,7 +253,7 @@ public abstract class TypeAxiomBuilder : ICloneable
       TypeVariableMapping.Add(var, res);
     }
 
-    return cce.NonNull(res);
+    return Cce.NonNull(res);
   }
 
 
@@ -267,7 +267,7 @@ public abstract class TypeAxiomBuilder : ICloneable
   [ContractInvariantMethod]
   void Typed2UntypedVariablesInvariantMethod()
   {
-    Contract.Invariant(cce.NonNullDictionaryAndValues(Typed2UntypedVariables));
+    Contract.Invariant(Cce.NonNullDictionaryAndValues(Typed2UntypedVariables));
   }
 
   // This method must only be used for free (unbound) variables
@@ -283,7 +283,7 @@ public abstract class TypeAxiomBuilder : ICloneable
       AddVarTypeAxiom(res, var.Type);
     }
 
-    return cce.NonNull(res);
+    return Cce.NonNull(res);
   }
 
   /// <summary>
@@ -314,7 +314,7 @@ public abstract class TypeAxiomBuilder : ICloneable
   public VCExpr Type2Term(Type type, IDictionary<TypeVariable /*!*/, VCExpr /*!*/> /*!*/ varMapping)
   {
     Contract.Requires(type != null);
-    Contract.Requires(cce.NonNullDictionaryAndValues(varMapping));
+    Contract.Requires(Cce.NonNullDictionaryAndValues(varMapping));
     Contract.Ensures(Contract.Result<VCExpr>() != null);
     //
     if (type.IsBasic || type.IsBv || type.IsFloat)
@@ -350,7 +350,7 @@ public abstract class TypeAxiomBuilder : ICloneable
         res = Typed2Untyped(type.AsVariable);
       }
 
-      return cce.NonNull(res);
+      return Cce.NonNull(res);
       //
     }
     else if (type.IsMap)
@@ -363,7 +363,7 @@ public abstract class TypeAxiomBuilder : ICloneable
     {
       System.Diagnostics.Debug.Fail("Don't know how to handle this type: " + type);
       Contract.Assert(false);
-      throw new cce.UnreachableException(); // please the compiler
+      throw new Cce.UnreachableException(); // please the compiler
     }
   }
 

--- a/Source/VCExpr/TypeErasure/TypeEraser.cs
+++ b/Source/VCExpr/TypeErasure/TypeEraser.cs
@@ -103,7 +103,7 @@ public abstract class TypeEraser : MutatingVCExprVisitor<VariableBindings /*!*/>
       return AxBuilder.Typed2Untyped(node);
     }
 
-    return cce.NonNull(res);
+    return Cce.NonNull(res);
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -121,8 +121,8 @@ public abstract class TypeEraser : MutatingVCExprVisitor<VariableBindings /*!*/>
     VariableBindings /*!*/ bindings)
   {
     Contract.Requires(bindings != null);
-    Contract.Requires(cce.NonNullElements(oldBoundVars));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
+    Contract.Requires(Cce.NonNullElements(oldBoundVars));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
 
     List<VCExprVar /*!*/> /*!*/
       newBoundVars = new List<VCExprVar /*!*/>(oldBoundVars.Count);
@@ -155,10 +155,10 @@ public abstract class TypeEraser : MutatingVCExprVisitor<VariableBindings /*!*/>
   {
     Contract.Requires(node != null);
     Contract.Requires(newNode != null);
-    Contract.Requires(cce.NonNullElements(occurringVars));
+    Contract.Requires(Cce.NonNullElements(occurringVars));
     Contract.Requires(oldBindings != null);
     Contract.Ensures(Contract.ValueAtReturn(out newBindings) != null);
-    Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out newBoundVars)));
+    Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out newBoundVars)));
     List<VCExprVar /*!*/> castVariables =
       VariableCastCollector.FindCastVariables(node, newNode, AxBuilder);
     if (castVariables.Count == 0)

--- a/Source/VCExpr/TypeErasure/TypeEraser.cs
+++ b/Source/VCExpr/TypeErasure/TypeEraser.cs
@@ -82,7 +82,7 @@ public abstract class TypeEraser : MutatingVCExprVisitor<VariableBindings /*!*/>
     List<VCExpr /*!*/> /*!*/ newSubExprs, bool changed, VariableBindings /*!*/ bindings)
   {
     //Contract.Requires(originalNode != null);
-    //Contract.Requires(cce.NonNullElements(newSubExprs));
+    //Contract.Requires(Cce.NonNullElements(newSubExprs));
     //Contract.Requires(bindings != null);
     Contract.Assume(originalNode.Op == VCExpressionGenerator.AndOp ||
                     originalNode.Op == VCExpressionGenerator.OrOp);

--- a/Source/VCExpr/TypeErasure/TypeEraserPremisses.cs
+++ b/Source/VCExpr/TypeErasure/TypeEraserPremisses.cs
@@ -86,7 +86,7 @@ public class TypeEraserPremisses : TypeEraser
     List<VCExprVar /*!*/> /*!*/
       newBoundVars =
         BoundVarsAfterErasure(occurringVars, bindings);
-    Contract.Assert(cce.NonNullElements(newBoundVars));
+    Contract.Assert(Cce.NonNullElements(newBoundVars));
     VCExpr /*!*/
       newNode = HandleQuantifier(node, occurringVars,
         newBoundVars, bindings);
@@ -114,11 +114,11 @@ public class TypeEraserPremisses : TypeEraser
     List<VCExprLetBinding /*!*/> /*!*/ typeVarBindings,
     out List<VCTrigger /*!*/> /*!*/ triggers)
   {
-    Contract.Requires(cce.NonNullElements(oldBoundVars));
-    Contract.Requires(cce.NonNullElements(newBoundVars));
-    Contract.Requires(cce.NonNullDictionaryAndValues(typeVarTranslation));
-    Contract.Requires(cce.NonNullElements(typeVarBindings));
-    Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out triggers)));
+    Contract.Requires(Cce.NonNullElements(oldBoundVars));
+    Contract.Requires(Cce.NonNullElements(newBoundVars));
+    Contract.Requires(Cce.NonNullDictionaryAndValues(typeVarTranslation));
+    Contract.Requires(Cce.NonNullElements(typeVarBindings));
+    Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out triggers)));
     Contract.Ensures(Contract.Result<VCExpr>() != null);
 
     // build a substitution of the type variables that it can be checked
@@ -200,8 +200,8 @@ public class TypeEraserPremisses : TypeEraser
   {
     Contract.Requires(bindings != null);
     Contract.Requires(node != null);
-    Contract.Requires(cce.NonNullElements(occurringVars /*!*/));
-    Contract.Requires(cce.NonNullElements(newBoundVars));
+    Contract.Requires(Cce.NonNullElements(occurringVars /*!*/));
+    Contract.Requires(Cce.NonNullElements(newBoundVars));
     Contract.Ensures(Contract.Result<VCExpr>() != null);
     List<VCExprLetBinding /*!*/> /*!*/
       typeVarBindings =
@@ -246,11 +246,11 @@ public class TypeEraserPremisses : TypeEraser
           bindings.TypeVariableBindings,
           typeVarBindings, out var furtherTriggers);
 
-    Contract.Assert(cce.NonNullElements(furtherTriggers));
+    Contract.Assert(Cce.NonNullElements(furtherTriggers));
     Contract.Assert(typePremisses != null);
     List<VCTrigger /*!*/> /*!*/
       newTriggers = new List<VCTrigger>(MutateTriggers(node.Triggers, bindings));
-    Contract.Assert(cce.NonNullElements(newTriggers));
+    Contract.Assert(Cce.NonNullElements(newTriggers));
     newTriggers.AddRange(furtherTriggers);
     newTriggers = AddLets2Triggers(newTriggers, typeVarBindings);
 
@@ -291,9 +291,9 @@ public class TypeEraserPremisses : TypeEraser
   private List<VCTrigger /*!*/> /*!*/ AddLets2Triggers(List<VCTrigger /*!*/> /*!*/ triggers /*!*/,
     List<VCExprLetBinding /*!*/> /*!*/ typeVarBindings)
   {
-    Contract.Requires(cce.NonNullElements(triggers /*!*/));
-    Contract.Requires(cce.NonNullElements(typeVarBindings));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCTrigger>>()));
+    Contract.Requires(Cce.NonNullElements(triggers /*!*/));
+    Contract.Requires(Cce.NonNullElements(typeVarBindings));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCTrigger>>()));
     List<VCTrigger /*!*/> /*!*/
       triggersWithLets = new List<VCTrigger /*!*/>(triggers.Count);
 
@@ -308,7 +308,7 @@ public class TypeEraserPremisses : TypeEraser
       {
         Contract.Assert(e != null);
         HashSet<VCExprVar> freeVars = FreeVariableCollector.FreeTermVariables(e);
-        Contract.Assert(freeVars != null && cce.NonNullElements(freeVars));
+        Contract.Assert(freeVars != null && Cce.NonNullElements(freeVars));
         if (typeVarBindings.Any(b => freeVars.Contains(b.V)))
         {
           exprsWithLets.Add(Gen.Let(typeVarBindings, e));

--- a/Source/VCExpr/TypeErasure/TypeErasure.cs
+++ b/Source/VCExpr/TypeErasure/TypeErasure.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Boogie.TypeErasure
     void ObjectInvariant()
     {
       Contract.Invariant(Ctor != null);
-      Contract.Invariant(cce.NonNullElements(Dtors));
+      Contract.Invariant(Cce.NonNullElements(Dtors));
     }
 
 
     public TypeCtorRepr(Function ctor, List<Function /*!*/> /*!*/ dtors)
     {
       Contract.Requires(ctor != null);
-      Contract.Requires(cce.NonNullElements(dtors));
+      Contract.Requires(Cce.NonNullElements(dtors));
       Contract.Requires(ctor.InParams.Count == dtors.Count);
       this.Ctor = ctor;
       this.Dtors = dtors;
@@ -146,7 +146,7 @@ namespace Microsoft.Boogie.TypeErasure
     {
       Contract.Requires((castFromU != null));
       Contract.Requires((castToU != null));
-      Contract.Ensures((cce.NonNullElements(Contract.ValueAtReturn(out triggers))));
+      Contract.Ensures((Cce.NonNullElements(Contract.ValueAtReturn(out triggers))));
       Contract.Ensures(Contract.ValueAtReturn(out var) != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       var = Gen.Variable("x", U);
@@ -245,11 +245,11 @@ namespace Microsoft.Boogie.TypeErasure
       }
 
       Type /*!*/
-        inType = cce.NonNull(fun.InParams[0]).TypedIdent.Type;
+        inType = Cce.NonNull(fun.InParams[0]).TypedIdent.Type;
       if (inType.Equals(U))
       {
         Type /*!*/
-          outType = cce.NonNull(fun.OutParams[0]).TypedIdent.Type;
+          outType = Cce.NonNull(fun.OutParams[0]).TypedIdent.Type;
         if (!TypeCasts.ContainsKey(outType))
         {
           return false;
@@ -265,7 +265,7 @@ namespace Microsoft.Boogie.TypeErasure
         }
 
         Type /*!*/
-          outType = cce.NonNull(fun.OutParams[0]).TypedIdent.Type;
+          outType = Cce.NonNull(fun.OutParams[0]).TypedIdent.Type;
         if (!outType.Equals(U))
         {
           return false;
@@ -330,8 +330,8 @@ namespace Microsoft.Boogie.TypeErasure
     public List<VCExpr /*!*/> /*!*/ CastSeq(List<VCExpr /*!*/> /*!*/ exprs, Type toType)
     {
       Contract.Requires(toType != null);
-      Contract.Requires(cce.NonNullElements(exprs));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExpr>>()));
+      Contract.Requires(Cce.NonNullElements(exprs));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExpr>>()));
       List<VCExpr /*!*/> /*!*/
         res = new List<VCExpr /*!*/>(exprs.Count);
       foreach (VCExpr /*!*/ expr in exprs)

--- a/Source/VCExpr/TypeErasure/TypeErasureArguments.cs
+++ b/Source/VCExpr/TypeErasure/TypeErasureArguments.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Boogie.TypeErasure
     [ContractInvariantMethod]
     void Typed2UntypedFunctionsInvariantMethod()
     {
-      Contract.Invariant(cce.NonNullDictionaryAndValues(Typed2UntypedFunctions));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(Typed2UntypedFunctions));
     }
 
     public Function Typed2Untyped(Function fun)
@@ -117,8 +117,8 @@ namespace Microsoft.Boogie.TypeErasure
 
         // if all of the parameters are int or bool, the function does
         // not have to be changed
-        if (fun.InParams.All(param => UnchangedType(cce.NonNull(param).TypedIdent.Type)) &&
-            UnchangedType(cce.NonNull(fun.OutParams[0]).TypedIdent.Type))
+        if (fun.InParams.All(param => UnchangedType(Cce.NonNull(param).TypedIdent.Type)) &&
+            UnchangedType(Cce.NonNull(fun.OutParams[0]).TypedIdent.Type))
         {
           res = fun;
         }
@@ -143,7 +143,7 @@ namespace Microsoft.Boogie.TypeErasure
             i = i + 1;
           }
 
-          types[types.Length - 1] = TypeAfterErasure(cce.NonNull(fun.OutParams[0]).TypedIdent.Type);
+          types[types.Length - 1] = TypeAfterErasure(Cce.NonNull(fun.OutParams[0]).TypedIdent.Type);
 
           res = HelperFuns.BoogieFunction(fun.Name, types);
           res.Attributes = fun.Attributes;
@@ -152,7 +152,7 @@ namespace Microsoft.Boogie.TypeErasure
         Typed2UntypedFunctions.Add(fun, res);
       }
 
-      return cce.NonNull(res);
+      return Cce.NonNull(res);
     }
   }
 
@@ -243,8 +243,8 @@ namespace Microsoft.Boogie.TypeErasure
       i++;
       // Fill in the map type which is the output of the store function
       storeTypes[i] = AxBuilder.U;
-      Contract.Assert(cce.NonNullElements<Type>(selectTypes));
-      Contract.Assert(cce.NonNullElements<Type>(storeTypes));
+      Contract.Assert(Cce.NonNullElements<Type>(selectTypes));
+      Contract.Assert(Cce.NonNullElements<Type>(storeTypes));
 
       select = HelperFuns.BoogieFunction(baseName + "Select", selectTypes);
       store = HelperFuns.BoogieFunction(baseName + "Store", storeTypes);
@@ -262,8 +262,8 @@ namespace Microsoft.Boogie.TypeErasure
     {
       Contract.Requires(map != null);
       Contract.Requires(select != null);
-      Contract.Requires(cce.NonNullElements(indexes));
-      Contract.Requires(cce.NonNullElements(types));
+      Contract.Requires(Cce.NonNullElements(indexes));
+      Contract.Requires(Cce.NonNullElements(types));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       List<VCExpr /*!*/> /*!*/
         selectArgs = new List<VCExpr /*!*/>();
@@ -279,8 +279,8 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Requires(val != null);
       Contract.Requires(map != null);
       Contract.Requires(store != null);
-      Contract.Requires(cce.NonNullElements(indexes));
-      Contract.Requires(cce.NonNullElements(types));
+      Contract.Requires(Cce.NonNullElements(indexes));
+      Contract.Requires(Cce.NonNullElements(types));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       List<VCExpr /*!*/> /*!*/
         storeArgs = new List<VCExpr /*!*/>();
@@ -311,7 +311,7 @@ namespace Microsoft.Boogie.TypeErasure
       List<Type /*!*/> indexTypes = new List<Type /*!*/>();
       for (int i = mapTypeParamNum + mapAbstractionVarNum + 1; i < select.InParams.Count; i++)
       {
-        indexTypes.Add(cce.NonNull(select.InParams[i]).TypedIdent.Type);
+        indexTypes.Add(Cce.NonNull(select.InParams[i]).TypedIdent.Type);
       }
 
       Contract.Assert(arity == indexTypes.Count);
@@ -323,7 +323,7 @@ namespace Microsoft.Boogie.TypeErasure
         m = Gen.Variable("m", AxBuilder.U);
       Contract.Assert(m != null);
       VCExprVar /*!*/
-        val = Gen.Variable("val", cce.NonNull(select.OutParams[0]).TypedIdent.Type);
+        val = Gen.Variable("val", Cce.NonNull(select.OutParams[0]).TypedIdent.Type);
       Contract.Assert(val != null);
 
       VCExpr /*!*/
@@ -381,7 +381,7 @@ namespace Microsoft.Boogie.TypeErasure
       List<Type /*!*/> indexTypes = new List<Type /*!*/>();
       for (int i = mapTypeParamNum + mapAbstractionVarNum + 1; i < select.InParams.Count; i++)
       {
-        indexTypes.Add(cce.NonNull(select.InParams[i]).TypedIdent.Type);
+        indexTypes.Add(Cce.NonNull(select.InParams[i]).TypedIdent.Type);
       }
 
       Contract.Assert(arity == indexTypes.Count);
@@ -395,7 +395,7 @@ namespace Microsoft.Boogie.TypeErasure
         m = Gen.Variable("m", AxBuilder.U);
       Contract.Assert(m != null);
       VCExprVar /*!*/
-        val = Gen.Variable("val", cce.NonNull(select.OutParams[0]).TypedIdent.Type);
+        val = Gen.Variable("val", Cce.NonNull(select.OutParams[0]).TypedIdent.Type);
       Contract.Assert(val != null);
 
       VCExpr /*!*/
@@ -541,8 +541,8 @@ namespace Microsoft.Boogie.TypeErasure
       List<VCExprVar /*!*/> /*!*/ newBoundVars, VariableBindings bindings)
     {
       Contract.Requires(bindings != null);
-      Contract.Requires(cce.NonNullElements(typeParams));
-      Contract.Requires(cce.NonNullElements(newBoundVars));
+      Contract.Requires(Cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullElements(newBoundVars));
       foreach (TypeVariable /*!*/ tvar in typeParams)
       {
         Contract.Assert(tvar != null);
@@ -559,11 +559,11 @@ namespace Microsoft.Boogie.TypeErasure
     {
       Contract.Requires(bindings != null);
       Contract.Requires(node != null);
-      Contract.Requires(cce.NonNullElements(newBoundVars));
+      Contract.Requires(Cce.NonNullElements(newBoundVars));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       List<VCTrigger /*!*/> /*!*/
         newTriggers = MutateTriggers(node.Triggers, bindings);
-      Contract.Assert(cce.NonNullElements(newTriggers));
+      Contract.Assert(Cce.NonNullElements(newTriggers));
       VCExpr /*!*/
         newBody = Mutate(node.Body, bindings);
       Contract.Assert(newBody != null);
@@ -608,7 +608,7 @@ namespace Microsoft.Boogie.TypeErasure
       VariableBindings bindings)
     {
       Contract.Requires(bindings != null);
-      Contract.Requires(cce.NonNullElements(oldArgs));
+      Contract.Requires(Cce.NonNullElements(oldArgs));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       // UGLY: the code for tracking polarities should be factored out
       int oldPolarity = Eraser.Polarity;
@@ -632,7 +632,7 @@ namespace Microsoft.Boogie.TypeErasure
       {
         Contract.Assert(arg != null);
         newArgs.Add(AxBuilder.Cast(Eraser.Mutate(arg, bindings),
-          cce.NonNull(newFun.InParams[i]).TypedIdent.Type));
+          Cce.NonNull(newFun.InParams[i]).TypedIdent.Type));
         i = i + 1;
       }
 
@@ -831,14 +831,14 @@ namespace Microsoft.Boogie.TypeErasure
       void ObjectInvariant()
       {
         Contract.Invariant(Op != null);
-        Contract.Invariant(cce.NonNullElements(Types));
+        Contract.Invariant(Cce.NonNullElements(Types));
       }
 
 
       public OpTypesPair(VCExprOp op, List<Type /*!*/> /*!*/ types)
       {
         Contract.Requires(op != null);
-        Contract.Requires(cce.NonNullElements(types));
+        Contract.Requires(Cce.NonNullElements(types));
         this.Op = op;
         this.Types = types;
         this.HashCode = HFNS.PolyHash(op.GetHashCode(), 17, types);

--- a/Source/VCExpr/TypeErasure/TypeErasurePremisses.cs
+++ b/Source/VCExpr/TypeErasure/TypeErasurePremisses.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Boogie.TypeErasure
     void ObjectInvariant()
     {
       Contract.Invariant(Fun != null);
-      Contract.Invariant(cce.NonNullElements(ImplicitTypeParams));
-      Contract.Invariant(cce.NonNullElements(ExplicitTypeParams));
+      Contract.Invariant(Cce.NonNullElements(ImplicitTypeParams));
+      Contract.Invariant(Cce.NonNullElements(ExplicitTypeParams));
     }
 
 
@@ -48,8 +48,8 @@ namespace Microsoft.Boogie.TypeErasure
       List<TypeVariable /*!*/> /*!*/ explicitTypeParams)
     {
       Contract.Requires(fun != null);
-      Contract.Requires(cce.NonNullElements(implicitTypeParams));
-      Contract.Requires(cce.NonNullElements(explicitTypeParams));
+      Contract.Requires(Cce.NonNullElements(implicitTypeParams));
+      Contract.Requires(Cce.NonNullElements(explicitTypeParams));
       Fun = fun;
       ImplicitTypeParams = implicitTypeParams;
       ExplicitTypeParams = explicitTypeParams;
@@ -115,12 +115,12 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       VCExpr /*!*/
         eq = GenReverseCastEq(castToU, castFromU, out var var, out var triggers);
-      Contract.Assert(cce.NonNullElements(triggers));
+      Contract.Assert(Cce.NonNullElements(triggers));
       Contract.Assert(var != null);
       Contract.Assert(eq != null);
       VCExpr /*!*/
         premiss;
-      premiss = GenVarTypeAxiom(var, cce.NonNull(castFromU.OutParams[0]).TypedIdent.Type,
+      premiss = GenVarTypeAxiom(var, Cce.NonNull(castFromU.OutParams[0]).TypedIdent.Type,
         // we don't have any bindings available
         new Dictionary<TypeVariable /*!*/, VCExpr /*!*/>());
       VCExpr /*!*/
@@ -135,7 +135,7 @@ namespace Microsoft.Boogie.TypeErasure
       //Contract.Requires(castToU != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       Type /*!*/
-        fromType = cce.NonNull(castToU.InParams[0]).TypedIdent.Type;
+        fromType = Cce.NonNull(castToU.InParams[0]).TypedIdent.Type;
       return GenFunctionAxiom(castToU, new List<TypeVariable /*!*/>(), new List<TypeVariable /*!*/>(),
         HelperFuns.ToList(fromType), fromType);
     }
@@ -201,10 +201,10 @@ namespace Microsoft.Boogie.TypeErasure
         bool addTypeVarsToBindings)
     {
       Contract.Requires(typeParams != null);
-      Contract.Requires(cce.NonNullElements(oldBoundVars));
+      Contract.Requires(Cce.NonNullElements(oldBoundVars));
       Contract.Requires(bindings != null);
 
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprLetBinding>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprLetBinding>>()));
 
       // type variables are replaced with ordinary variables that are bound using a
       // let-expression
@@ -244,7 +244,7 @@ namespace Microsoft.Boogie.TypeErasure
       VCExpr /*!*/ typePremisses, bool universal,
       VCExpr /*!*/ body)
     {
-      Contract.Requires(cce.NonNullElements(typeVarBindings));
+      Contract.Requires(Cce.NonNullElements(typeVarBindings));
       Contract.Requires(typePremisses != null);
       Contract.Requires(body != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
@@ -274,11 +274,11 @@ namespace Microsoft.Boogie.TypeErasure
         List<VCExprVar /*!*/> /*!*/ concreteTypeSources,
         VariableBindings /*!*/ bindings)
     {
-      Contract.Requires(cce.NonNullElements(vars));
-      Contract.Requires(cce.NonNullElements(types));
-      Contract.Requires(cce.NonNullElements(concreteTypeSources));
+      Contract.Requires(Cce.NonNullElements(vars));
+      Contract.Requires(Cce.NonNullElements(types));
+      Contract.Requires(Cce.NonNullElements(concreteTypeSources));
       Contract.Requires(bindings != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprLetBinding>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprLetBinding>>()));
 
       List<VCExprLetBinding /*!*/> /*!*/
         typeParamBindings = new List<VCExprLetBinding /*!*/>();
@@ -301,10 +301,10 @@ namespace Microsoft.Boogie.TypeErasure
       List<VCExprVar /*!*/> /*!*/ concreteTypeSources)
     {
       Contract.Requires(var != null);
-      Contract.Requires(cce.NonNullElements(types));
-      Contract.Requires(cce.NonNullElements(concreteTypeSources));
+      Contract.Requires(Cce.NonNullElements(types));
+      Contract.Requires(Cce.NonNullElements(concreteTypeSources));
       List<VCExpr /*!*/> allExtractors = TypeVarExtractors(var, types, concreteTypeSources);
-      Contract.Assert(cce.NonNullElements(allExtractors));
+      Contract.Assert(Cce.NonNullElements(allExtractors));
       if (allExtractors.Count == 0)
       {
         return null;
@@ -329,10 +329,10 @@ namespace Microsoft.Boogie.TypeErasure
       List<VCExprVar /*!*/> /*!*/ concreteTypeSources)
     {
       Contract.Requires(var != null);
-      Contract.Requires(cce.NonNullElements(types));
-      Contract.Requires(cce.NonNullElements(concreteTypeSources));
+      Contract.Requires(Cce.NonNullElements(types));
+      Contract.Requires(Cce.NonNullElements(concreteTypeSources));
       Contract.Requires((types.Count == concreteTypeSources.Count));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExpr>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExpr>>()));
       List<VCExpr /*!*/> /*!*/
         res = new List<VCExpr /*!*/>();
       for (int i = 0; i < types.Count; ++i)
@@ -349,7 +349,7 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Requires(innerTerm != null);
       Contract.Requires(completeType != null);
       Contract.Requires(var != null);
-      Contract.Requires(cce.NonNullElements(extractors));
+      Contract.Requires(Cce.NonNullElements(extractors));
       if (completeType.IsVariable)
       {
         if (var.Equals(completeType))
@@ -409,10 +409,10 @@ namespace Microsoft.Boogie.TypeErasure
       out List<TypeVariable /*!*/> /*!*/ implicitParams,
       out List<TypeVariable /*!*/> /*!*/ explicitParams)
     {
-      Contract.Requires(cce.NonNullElements(valueArgumentTypes));
+      Contract.Requires(Cce.NonNullElements(valueArgumentTypes));
       Contract.Requires(allTypeParams != null);
-      Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out implicitParams)));
-      Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out explicitParams)));
+      Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out implicitParams)));
+      Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out explicitParams)));
       List<TypeVariable> /*!*/
         varsInInParamTypes = new List<TypeVariable>();
       foreach (Type /*!*/ t in valueArgumentTypes)
@@ -450,8 +450,8 @@ namespace Microsoft.Boogie.TypeErasure
 
         // if all of the parameters are int or bool, the function does
         // not have to be changed
-        if (fun.InParams.All(param => UnchangedType(cce.NonNull(param).TypedIdent.Type)) &&
-            UnchangedType(cce.NonNull(fun.OutParams[0]).TypedIdent.Type) &&
+        if (fun.InParams.All(param => UnchangedType(Cce.NonNull(param).TypedIdent.Type)) &&
+            UnchangedType(Cce.NonNull(fun.OutParams[0]).TypedIdent.Type) &&
             fun.TypeParameters.Count == 0)
         {
           res = new UntypedFunction(fun, new List<TypeVariable /*!*/>(), new List<TypeVariable /*!*/>());
@@ -479,10 +479,10 @@ namespace Microsoft.Boogie.TypeErasure
 
           for (int j = 0; j < fun.InParams.Count; ++i, ++j)
           {
-            types[i] = TypeAfterErasure(cce.NonNull(fun.InParams[j]).TypedIdent.Type);
+            types[i] = TypeAfterErasure(Cce.NonNull(fun.InParams[j]).TypedIdent.Type);
           }
 
-          types[types.Length - 1] = TypeAfterErasure(cce.NonNull(fun.OutParams[0]).TypedIdent.Type);
+          types[types.Length - 1] = TypeAfterErasure(Cce.NonNull(fun.OutParams[0]).TypedIdent.Type);
 
           Function /*!*/
             untypedFun = HelperFuns.BoogieFunction(fun.Name, types);
@@ -514,7 +514,7 @@ namespace Microsoft.Boogie.TypeErasure
 
       return GenFunctionAxiom(fun.Fun, fun.ImplicitTypeParams, fun.ExplicitTypeParams,
         originalInTypes,
-        cce.NonNull(originalFun.OutParams[0]).TypedIdent.Type);
+        Cce.NonNull(originalFun.OutParams[0]).TypedIdent.Type);
     }
 
     internal VCExpr /*!*/ GenFunctionAxiom(Function /*!*/ fun,
@@ -523,10 +523,10 @@ namespace Microsoft.Boogie.TypeErasure
       List<Type /*!*/> /*!*/ originalInTypes,
       Type /*!*/ originalResultType)
     {
-      Contract.Requires(cce.NonNullElements(implicitTypeParams));
+      Contract.Requires(Cce.NonNullElements(implicitTypeParams));
       Contract.Requires(fun != null);
-      Contract.Requires(cce.NonNullElements(explicitTypeParams));
-      Contract.Requires(cce.NonNullElements(originalInTypes));
+      Contract.Requires(Cce.NonNullElements(explicitTypeParams));
+      Contract.Requires(Cce.NonNullElements(originalInTypes));
       Contract.Requires(originalResultType != null);
       Contract.Requires(originalInTypes.Count + explicitTypeParams.Count == fun.InParams.Count);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
@@ -574,7 +574,7 @@ namespace Microsoft.Boogie.TypeErasure
 
       List<VCExprLetBinding /*!*/> typeVarBindings =
         GenTypeParamBindings(implicitTypeParams, typedInputVars, bindings, true);
-      Contract.Assert(cce.NonNullElements(typeVarBindings));
+      Contract.Assert(Cce.NonNullElements(typeVarBindings));
       List<VCExpr> boundVarExprs = HelperFuns.ToVCExprList(boundVars);
 
       VCExpr /*!*/
@@ -597,7 +597,7 @@ namespace Microsoft.Boogie.TypeErasure
       if (boundVars.Count > 0)
       {
         List<VCTrigger /*!*/> triggers = HelperFuns.ToList(Gen.Trigger(true, HelperFuns.ToList(funApp)));
-        Contract.Assert(cce.NonNullElements(triggers));
+        Contract.Assert(Cce.NonNullElements(triggers));
         return Gen.Forall(boundVars, triggers, "funType:" + fun.Name, 1, conclusionWithPremisses);
       }
       else
@@ -622,7 +622,7 @@ namespace Microsoft.Boogie.TypeErasure
     {
       Contract.Requires(var != null);
       Contract.Requires(originalType != null);
-      Contract.Requires(cce.NonNullDictionaryAndValues(varMapping));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(varMapping));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
       if (!var.Type.Equals(originalType))
@@ -699,7 +699,7 @@ namespace Microsoft.Boogie.TypeErasure
         explicitSelectTypeParamsCache.Add(type, res);
       }
 
-      return cce.NonNull(res);
+      return Cce.NonNull(res);
     }
 
     private IDictionary<MapType /*!*/, List<int> /*!*/> /*!*/
@@ -709,7 +709,7 @@ namespace Microsoft.Boogie.TypeErasure
     [ContractInvariantMethod]
     void ObjectInvarant()
     {
-      Contract.Invariant(cce.NonNullDictionaryAndValues(explicitSelectTypeParamsCache));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(explicitSelectTypeParamsCache));
     }
 
 
@@ -753,8 +753,8 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Requires(abstractedType != null);
       Contract.Requires(synonymDecl != null);
       Contract.Ensures(Contract.ValueAtReturn(out mapTypeSynonym) != null);
-      Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out typeParams)));
-      Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out originalIndexTypes)));
+      Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out typeParams)));
+      Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out originalIndexTypes)));
       typeParams = new List<TypeVariable /*!*/>();
       typeParams.AddRange(abstractedType.TypeParameters);
       typeParams.AddRange(abstractedType.FreeVariables);
@@ -781,13 +781,13 @@ namespace Microsoft.Boogie.TypeErasure
       string /*!*/ name,
       out List<TypeVariable /*!*/> /*!*/ implicitTypeParams, out List<TypeVariable /*!*/> /*!*/ explicitTypeParams)
     {
-      Contract.Requires(cce.NonNullElements(originalTypeParams));
-      Contract.Requires(cce.NonNullElements(originalInTypes));
+      Contract.Requires(Cce.NonNullElements(originalTypeParams));
+      Contract.Requires(Cce.NonNullElements(originalInTypes));
       Contract.Requires(originalResult != null);
       Contract.Requires(name != null);
       Contract.Ensures(Contract.Result<Function>() != null);
-      Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out implicitTypeParams)));
-      Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out explicitTypeParams)));
+      Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out implicitTypeParams)));
+      Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out explicitTypeParams)));
 
       // select and store are basically handled like normal functions: the type
       // parameters are split into the implicit parameters, and into the parameters
@@ -842,9 +842,9 @@ namespace Microsoft.Boogie.TypeErasure
       List<VCExprVar /*!*/> /*!*/ indexes)
     {
       Contract.Requires(select != null);
-      Contract.Requires(cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullElements(typeParams));
       Contract.Requires(map != null);
-      Contract.Requires(cce.NonNullElements(indexes));
+      Contract.Requires(Cce.NonNullElements(indexes));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
       List<VCExpr /*!*/> /*!*/
@@ -860,7 +860,7 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Requires(val != null);
       Contract.Requires(map != null);
       Contract.Requires(store != null);
-      Contract.Requires(cce.NonNullElements(indexes));
+      Contract.Requires(Cce.NonNullElements(indexes));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       List<VCExpr /*!*/> /*!*/
         storeArgs = new List<VCExpr /*!*/>(indexes.Count + 2);
@@ -884,9 +884,9 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Requires(mapResult != null);
       Contract.Requires(store != null);
       Contract.Requires(select != null);
-      Contract.Requires(cce.NonNullElements(implicitTypeParamsSelect));
-      Contract.Requires(cce.NonNullElements(originalInTypes));
-      Contract.Requires(cce.NonNullElements(explicitTypeParamsSelect));
+      Contract.Requires(Cce.NonNullElements(implicitTypeParamsSelect));
+      Contract.Requires(Cce.NonNullElements(originalInTypes));
+      Contract.Requires(Cce.NonNullElements(explicitTypeParamsSelect));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       int arity = store.InParams.Count - 2;
       List<VCExprVar /*!*/> inParams = new List<VCExprVar /*!*/>();
@@ -906,14 +906,14 @@ namespace Microsoft.Boogie.TypeErasure
       for (int i = 1; i < store.InParams.Count - 1; i++)
       {
         origIndexTypes.Add(originalInTypes[i]);
-        indexTypes.Add(cce.NonNull(store.InParams[i]).TypedIdent.Type);
+        indexTypes.Add(Cce.NonNull(store.InParams[i]).TypedIdent.Type);
       }
 
       Contract.Assert(arity == indexTypes.Count);
       List<VCExprVar /*!*/> typedArgs = HelperFuns.VarVector("arg", origIndexTypes, Gen);
-      Contract.Assert(cce.NonNullElements(typedArgs));
+      Contract.Assert(Cce.NonNullElements(typedArgs));
       List<VCExprVar /*!*/> indexes = HelperFuns.VarVector("x", indexTypes, Gen);
-      Contract.Assert(cce.NonNullElements(indexes));
+      Contract.Assert(Cce.NonNullElements(indexes));
       Contract.Assert(typedArgs.Count == indexes.Count);
       inParams.AddRange(typedArgs);
       quantifiedVars.AddRange(indexes);
@@ -924,7 +924,7 @@ namespace Microsoft.Boogie.TypeErasure
 
       // bound variable:  val
       VCExprVar typedVal = Gen.Variable("val", mapResult);
-      VCExprVar val = Gen.Variable("val", cce.NonNull(select.OutParams[0]).TypedIdent.Type);
+      VCExprVar val = Gen.Variable("val", Cce.NonNull(select.OutParams[0]).TypedIdent.Type);
       quantifiedVars.Add(val);
       bindings.VCExprVarBindings.Add(typedVal, val);
 
@@ -957,12 +957,12 @@ namespace Microsoft.Boogie.TypeErasure
       // in inParams here.
       List<VCExprLetBinding /*!*/> letBindings_Implicit =
         AxBuilderPremisses.GenTypeParamBindings(implicitTypeParamsSelect, inParams, bindings, false);
-      Contract.Assert(cce.NonNullElements(letBindings_Implicit));
+      Contract.Assert(Cce.NonNullElements(letBindings_Implicit));
       // The explicit ones, by definition, can only be phrased in terms of the result, so we pass
       // in List(typedVal) here.
       List<VCExprLetBinding /*!*/> letBindings_Explicit =
         AxBuilderPremisses.GenTypeParamBindings(explicitTypeParamsSelect, HelperFuns.ToList(typedVal), bindings, false);
-      Contract.Assert(cce.NonNullElements(letBindings_Explicit));
+      Contract.Assert(Cce.NonNullElements(letBindings_Explicit));
 
       // generate:  select(store(m, indices, val)) == val
       VCExpr /*!*/
@@ -975,7 +975,7 @@ namespace Microsoft.Boogie.TypeErasure
           AxBuilderPremisses.Type2Term(mapResult, bindings.TypeVariableBindings));
       Contract.Assert(ante != null);
       VCExpr body;
-      if (!AxBuilder.U.Equals(cce.NonNull(select.OutParams[0]).TypedIdent.Type))
+      if (!AxBuilder.U.Equals(Cce.NonNull(select.OutParams[0]).TypedIdent.Type))
       {
         body = Gen.Let(letBindings_Explicit, eq);
       }
@@ -993,29 +993,29 @@ namespace Microsoft.Boogie.TypeErasure
       Contract.Requires(mapResult != null);
       Contract.Requires(store != null);
       Contract.Requires(select != null);
-      Contract.Requires(cce.NonNullElements(explicitSelectParams));
+      Contract.Requires(Cce.NonNullElements(explicitSelectParams));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       int arity = store.InParams.Count - 2;
 
       List<Type /*!*/> indexTypes = new List<Type /*!*/>();
       for (int i = 1; i < store.InParams.Count - 1; i++)
       {
-        indexTypes.Add(cce.NonNull(store.InParams[i]).TypedIdent.Type);
+        indexTypes.Add(Cce.NonNull(store.InParams[i]).TypedIdent.Type);
       }
 
       Contract.Assert(indexTypes.Count == arity);
 
       List<VCExprVar /*!*/> /*!*/
         indexes0 = HelperFuns.VarVector("x", indexTypes, Gen);
-      Contract.Assert(cce.NonNullElements(indexes0));
+      Contract.Assert(Cce.NonNullElements(indexes0));
       List<VCExprVar /*!*/> /*!*/
         indexes1 = HelperFuns.VarVector("y", indexTypes, Gen);
-      Contract.Assert(cce.NonNullElements(indexes1));
+      Contract.Assert(Cce.NonNullElements(indexes1));
       VCExprVar /*!*/
         m = Gen.Variable("m", AxBuilder.U);
       Contract.Assert(m != null);
       VCExprVar /*!*/
-        val = Gen.Variable("val", cce.NonNull(select.OutParams[0]).TypedIdent.Type);
+        val = Gen.Variable("val", Cce.NonNull(select.OutParams[0]).TypedIdent.Type);
       Contract.Assert(val != null);
 
       // extract the explicit type parameters from the actual result type ...
@@ -1031,7 +1031,7 @@ namespace Microsoft.Boogie.TypeErasure
           AxBuilderPremisses.GenTypeParamBindings(explicitSelectParams,
             HelperFuns.ToList(typedVal),
             bindings, true);
-      Contract.Assert(cce.NonNullElements(letBindings));
+      Contract.Assert(Cce.NonNullElements(letBindings));
 
       // ... and quantify the introduced term variables for type
       // parameters universally
@@ -1073,7 +1073,7 @@ namespace Microsoft.Boogie.TypeErasure
 
       List<VCTrigger /*!*/> /*!*/
         triggers = new List<VCTrigger /*!*/>();
-      Contract.Assert(cce.NonNullElements(triggers));
+      Contract.Assert(Cce.NonNullElements(triggers));
 
       VCExpr /*!*/
         axiom = VCExpressionGenerator.True;

--- a/Source/VCExpr/TypeErasure/VariableBindings.cs
+++ b/Source/VCExpr/TypeErasure/VariableBindings.cs
@@ -15,16 +15,16 @@ public class VariableBindings
   [ContractInvariantMethod]
   void ObjectInvariant()
   {
-    Contract.Invariant(cce.NonNullDictionaryAndValues(VCExprVarBindings));
-    Contract.Invariant(cce.NonNullDictionaryAndValues(TypeVariableBindings));
+    Contract.Invariant(Cce.NonNullDictionaryAndValues(VCExprVarBindings));
+    Contract.Invariant(Cce.NonNullDictionaryAndValues(TypeVariableBindings));
   }
 
 
   public VariableBindings(IDictionary<VCExprVar /*!*/, VCExprVar /*!*/> /*!*/ vcExprVarBindings,
     IDictionary<TypeVariable /*!*/, VCExpr /*!*/> /*!*/ typeVariableBindings)
   {
-    Contract.Requires(cce.NonNullDictionaryAndValues(vcExprVarBindings));
-    Contract.Requires(cce.NonNullDictionaryAndValues(typeVariableBindings));
+    Contract.Requires(Cce.NonNullDictionaryAndValues(vcExprVarBindings));
+    Contract.Requires(Cce.NonNullDictionaryAndValues(typeVariableBindings));
     this.VCExprVarBindings = vcExprVarBindings;
     this.TypeVariableBindings = typeVariableBindings;
   }
@@ -43,7 +43,7 @@ public class VariableBindings
         new Dictionary<VCExprVar /*!*/, VCExprVar /*!*/>();
     foreach (KeyValuePair<VCExprVar /*!*/, VCExprVar /*!*/> pair in VCExprVarBindings)
     {
-      Contract.Assert(cce.NonNullElements(pair));
+      Contract.Assert(Cce.NonNullElements(pair));
       newVCExprVarBindings.Add(pair);
     }
 
@@ -52,7 +52,7 @@ public class VariableBindings
         new Dictionary<TypeVariable /*!*/, VCExpr /*!*/>();
     foreach (KeyValuePair<TypeVariable /*!*/, VCExpr /*!*/> pair in TypeVariableBindings)
     {
-      Contract.Assert(cce.NonNullElements(pair));
+      Contract.Assert(Cce.NonNullElements(pair));
       newTypeVariableBindings.Add(pair);
     }
 

--- a/Source/VCExpr/TypeErasure/VariableCastCollector.cs
+++ b/Source/VCExpr/TypeErasure/VariableCastCollector.cs
@@ -23,7 +23,7 @@ internal class VariableCastCollector : TraversingVCExprVisitor<bool, bool>
     Contract.Requires((axBuilder != null));
     Contract.Requires((newNode != null));
     Contract.Requires((oldNode != null));
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
     VariableCastCollector /*!*/
       collector = new VariableCastCollector(axBuilder);
     Contract.Assert(collector != null);
@@ -79,7 +79,7 @@ internal class VariableCastCollector : TraversingVCExprVisitor<bool, bool>
   [ContractInvariantMethod]
   void ObjectInvariant()
   {
-    Contract.Invariant(cce.NonNullElements(varsInCasts));
+    Contract.Invariant(Cce.NonNullElements(varsInCasts));
     Contract.Invariant(varsOutsideCasts != null && Contract.ForAll(varsOutsideCasts, voc => voc.Key != null));
     Contract.Invariant(AxBuilder != null);
   }

--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -921,8 +921,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       return OpType;
     }
@@ -1097,8 +1097,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       MapType /*!*/
         mapType = args[0].Type.AsMap;
@@ -1174,8 +1174,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       return args[0].Type;
     }
@@ -1235,8 +1235,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       return args[1].Type;
     }
@@ -1355,8 +1355,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type /*!*/ InferType(List<VCExpr /*!*/> /*!*/ args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires((cce.NonNullElements(args)));
-      //Contract.Requires((cce.NonNullElements(typeArgs)));
+      //Contract.Requires((Cce.NonNullElements(args)));
+      //Contract.Requires((Cce.NonNullElements(typeArgs)));
       Contract.Ensures(Contract.Result<Type>() != null);
       return Type;
     }
@@ -1393,8 +1393,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       switch (op)
       {
@@ -1502,8 +1502,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       return Type.GetBvType(Bits);
     }
@@ -1565,8 +1565,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       return Type.GetBvType(End - Start);
     }
@@ -1632,8 +1632,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       return Type.GetBvType(args[0].Type.BvBits + args[1].Type.BvBits);
     }
@@ -1706,8 +1706,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     public override Type InferType(List<VCExpr> args, List<Type /*!*/> /*!*/ typeArgs)
     {
-      //Contract.Requires(cce.NonNullElements(typeArgs));
-      //Contract.Requires(cce.NonNullElements(args));
+      //Contract.Requires(Cce.NonNullElements(typeArgs));
+      //Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Type>() != null);
       Contract.Assert(TypeParamArity == Func.TypeParameters.Count);
       if (TypeParamArity == 0)

--- a/Source/VCExpr/VCExprAST.cs
+++ b/Source/VCExpr/VCExprAST.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Boogie.VCExprAST
         {
           if (ib.MoveNext())
           {
-            if (!cce.NonNull(ia.Current).Equals(ib.Current))
+            if (!Cce.NonNull(ia.Current).Equals(ib.Current))
             {
               return false;
             }
@@ -48,7 +48,7 @@ namespace Microsoft.Boogie.VCExprAST
       int res = init;
       foreach (object x in a)
       {
-        res = res * factor + (cce.NonNull(x)).GetHashCode();
+        res = res * factor + (Cce.NonNull(x)).GetHashCode();
       }
 
       return res;
@@ -77,7 +77,7 @@ namespace Microsoft.Boogie.VCExprAST
         res = new List<Type>();
       for (int i = startIndex; i < exprs.Length; ++i)
       {
-        res.Add(cce.NonNull(exprs[i]).Type);
+        res.Add(Cce.NonNull(exprs[i]).Type);
       }
 
       return res;
@@ -90,7 +90,7 @@ namespace Microsoft.Boogie.VCExprAST
         res = new List<T>(args.Length);
       foreach (T t in args)
       {
-        res.Add(cce.NonNull(t));
+        res.Add(Cce.NonNull(t));
       }
 
       return res;
@@ -143,7 +143,7 @@ namespace Microsoft.Boogie.VCExprAST
       StringWriter sw = new StringWriter();
       VCExprPrinter printer = new VCExprPrinter(PrintOptions.Default);
       printer.Print(this, sw);
-      return cce.NonNull(sw.ToString());
+      return Cce.NonNull(sw.ToString());
     }
   }
 
@@ -396,8 +396,8 @@ namespace Microsoft.Boogie.VCExprAST
     void ObjectInvariant()
     {
       Contract.Invariant(Op != null);
-      Contract.Invariant(cce.NonNullElements(EMPTY_TYPE_LIST));
-      Contract.Invariant(cce.NonNullElements(EMPTY_VCEXPR_LIST));
+      Contract.Invariant(Cce.NonNullElements(EMPTY_TYPE_LIST));
+      Contract.Invariant(Cce.NonNullElements(EMPTY_VCEXPR_LIST));
     }
 
     public int Arity
@@ -469,7 +469,7 @@ namespace Microsoft.Boogie.VCExprAST
           }
           else
           {
-            if (!cce.NonNull(enum0.Current).Equals(enum1.Current))
+            if (!Cce.NonNull(enum0.Current).Equals(enum1.Current))
             {
               return false;
             }
@@ -555,7 +555,7 @@ namespace Microsoft.Boogie.VCExprAST
         Contract.Ensures(Contract.Result<VCExpr>() != null);
 
         Contract.Assert(false);
-        throw new cce.UnreachableException(); // no arguments
+        throw new Cce.UnreachableException(); // no arguments
       }
     }
 
@@ -564,7 +564,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<Type>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Type>>()));
         return EMPTY_TYPE_LIST;
       }
     }
@@ -618,7 +618,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<Type>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Type>>()));
         return EMPTY_TYPE_LIST;
       }
     }
@@ -627,7 +627,7 @@ namespace Microsoft.Boogie.VCExprAST
       : base(op)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
       Contract.Requires(op.Arity == 1 && op.TypeParamArity == 0 && arguments.Count == 1);
 
       this.Argument = arguments[0];
@@ -688,7 +688,7 @@ namespace Microsoft.Boogie.VCExprAST
           default:
           {
             Contract.Assert(false);
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
           }
         }
       }
@@ -699,7 +699,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<Type>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Type>>()));
         return EMPTY_TYPE_LIST;
       }
     }
@@ -708,7 +708,7 @@ namespace Microsoft.Boogie.VCExprAST
       : base(op)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
       Contract.Requires(op.Arity == 2 && op.TypeParamArity == 0 && arguments.Count == 2);
 
       this.Argument0 = arguments[0];
@@ -743,8 +743,8 @@ namespace Microsoft.Boogie.VCExprAST
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(arguments));
-      Contract.Invariant(cce.NonNullElements(TypeArgumentsAttr));
+      Contract.Invariant(Cce.NonNullElements(arguments));
+      Contract.Invariant(Cce.NonNullElements(TypeArgumentsAttr));
       Contract.Invariant(ExprType != null);
     }
 
@@ -768,7 +768,7 @@ namespace Microsoft.Boogie.VCExprAST
         Contract.Ensures(Contract.Result<VCExpr>() != null);
 
         Contract.Assume(index >= 0 && index < Arity);
-        return cce.NonNull(arguments)[index];
+        return Cce.NonNull(arguments)[index];
       }
     }
 
@@ -777,7 +777,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<Type>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Type>>()));
         return TypeArgumentsAttr;
       }
     }
@@ -786,7 +786,7 @@ namespace Microsoft.Boogie.VCExprAST
       : base(op)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
       this.arguments = arguments;
       this.TypeArgumentsAttr = EMPTY_TYPE_LIST;
       this.ExprType = op.InferType(arguments, TypeArgumentsAttr);
@@ -796,8 +796,8 @@ namespace Microsoft.Boogie.VCExprAST
       : base(op)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(typeArguments));
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(typeArguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
       Contract.Requires(arguments.Count > 2 || typeArguments.Count > 0);
       Contract.Requires(op.Arity == arguments.Count);
       Contract.Requires(op.TypeParamArity == typeArguments.Count);
@@ -874,13 +874,13 @@ namespace Microsoft.Boogie.VCExprAST
             return visitor.VisitToRealOp(expr, arg);
           default:
             Contract.Assert(false);
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
         }
       }
       else
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
   }
@@ -890,8 +890,8 @@ namespace Microsoft.Boogie.VCExprAST
   {
     public override Type InferType(List<VCExpr> args, List<Type> typeArgs)
     {
-      Contract.Requires(cce.NonNullElements(args));
-      Contract.Requires(cce.NonNullElements(typeArgs));
+      Contract.Requires(Cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(typeArgs));
       Contract.Ensures(Contract.Result<Type>() != null);
 
       throw new NotImplementedException();
@@ -1412,7 +1412,7 @@ namespace Microsoft.Boogie.VCExprAST
           return Type.Bool;
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
 
@@ -1478,7 +1478,7 @@ namespace Microsoft.Boogie.VCExprAST
           return visitor.VisitNeqOp(expr, arg);
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
   }
@@ -1712,7 +1712,7 @@ namespace Microsoft.Boogie.VCExprAST
       Contract.Assert(TypeParamArity == Func.TypeParameters.Count);
       if (TypeParamArity == 0)
       {
-        return cce.NonNull(Func.OutParams[0]).TypedIdent.Type;
+        return Cce.NonNull(Func.OutParams[0]).TypedIdent.Type;
       }
 
       IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/
@@ -1722,7 +1722,7 @@ namespace Microsoft.Boogie.VCExprAST
         subst.Add(Func.TypeParameters[i], typeArgs[i]);
       }
 
-      return cce.NonNull(Func.OutParams[0]).TypedIdent.Type.Substitute(subst);
+      return Cce.NonNull(Func.OutParams[0]).TypedIdent.Type.Substitute(subst);
     }
 
     [Pure]
@@ -1826,7 +1826,7 @@ namespace Microsoft.Boogie.VCExprAST
         VCExprVarKind.Soft => "soft$$",
         VCExprVarKind.Try => "try$$",
         VCExprVarKind.Normal => "",
-        _ => throw new cce.UnreachableException()
+        _ => throw new Cce.UnreachableException()
       };
     }
 
@@ -1866,8 +1866,8 @@ namespace Microsoft.Boogie.VCExprAST
     void ObjectInvariant()
     {
       Contract.Invariant(Body != null);
-      Contract.Invariant(cce.NonNullElements(TypeParameters));
-      Contract.Invariant(cce.NonNullElements(BoundVars));
+      Contract.Invariant(Cce.NonNullElements(TypeParameters));
+      Contract.Invariant(Cce.NonNullElements(BoundVars));
     }
 
 
@@ -1884,8 +1884,8 @@ namespace Microsoft.Boogie.VCExprAST
     internal VCExprBinder(List<TypeVariable /*!*/> /*!*/ typeParams, List<VCExprVar /*!*/> /*!*/ boundVars, VCExpr body)
     {
       Contract.Requires(body != null);
-      Contract.Requires(cce.NonNullElements(boundVars));
-      Contract.Requires(cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullElements(boundVars));
+      Contract.Requires(Cce.NonNullElements(typeParams));
       Contract.Requires(boundVars.Count + typeParams.Count > 0); // only nontrivial binders ...
       this.TypeParameters = typeParams;
       this.BoundVars = boundVars;
@@ -1936,7 +1936,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     public VCTrigger(bool pos, List<VCExpr> exprs)
     {
-      Contract.Requires(cce.NonNullElements(exprs));
+      Contract.Requires(Cce.NonNullElements(exprs));
       this.Pos = pos;
       this.Exprs = exprs;
     }
@@ -2002,7 +2002,7 @@ namespace Microsoft.Boogie.VCExprAST
     void ObjectInvariant()
     {
       Contract.Invariant(Info != null);
-      Contract.Invariant(cce.NonNullElements(Triggers));
+      Contract.Invariant(Cce.NonNullElements(Triggers));
     }
 
     public readonly List<VCTrigger /*!*/> /*!*/
@@ -2049,9 +2049,9 @@ namespace Microsoft.Boogie.VCExprAST
     {
       Contract.Requires(body != null);
       Contract.Requires(info != null);
-      Contract.Requires(cce.NonNullElements(triggers));
-      Contract.Requires(cce.NonNullElements(boundVars));
-      Contract.Requires(cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullElements(triggers));
+      Contract.Requires(Cce.NonNullElements(boundVars));
+      Contract.Requires(Cce.NonNullElements(typeParams));
 
       this.Quan = kind;
       this.Triggers = triggers;
@@ -2124,7 +2124,7 @@ namespace Microsoft.Boogie.VCExprAST
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(Bindings));
+      Contract.Invariant(Cce.NonNullElements(Bindings));
     }
 
 
@@ -2173,7 +2173,7 @@ namespace Microsoft.Boogie.VCExprAST
     [Escapes(true, false)]
     public IEnumerator<VCExprLetBinding /*!*/> /*!*/ GetEnumerator()
     {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerator<VCExprLetBinding>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerator<VCExprLetBinding>>()));
       return Bindings.GetEnumerator();
     }
 
@@ -2188,8 +2188,8 @@ namespace Microsoft.Boogie.VCExprAST
 
     private static List<VCExprVar /*!*/> /*!*/ toSeq(List<VCExprLetBinding /*!*/> /*!*/ bindings)
     {
-      Contract.Requires(cce.NonNullElements(bindings));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
+      Contract.Requires(Cce.NonNullElements(bindings));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<VCExprVar>>()));
       List<VCExprVar> res = new List<VCExprVar>();
       foreach (VCExprLetBinding /*!*/ b in bindings)
       {
@@ -2202,7 +2202,7 @@ namespace Microsoft.Boogie.VCExprAST
     internal VCExprLet(List<VCExprLetBinding /*!*/> /*!*/ bindings, VCExpr /*!*/ body)
       : base(new List<TypeVariable /*!*/>(), toSeq(bindings), body)
     {
-      Contract.Requires(cce.NonNullElements(bindings));
+      Contract.Requires(Cce.NonNullElements(bindings));
       Contract.Requires(body != null);
       this.Bindings = bindings;
     }

--- a/Source/VCExpr/VCExprASTPrinter.cs
+++ b/Source/VCExpr/VCExprASTPrinter.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Boogie.VCExprAST
       else
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
 
       return true;
@@ -92,7 +92,7 @@ namespace Microsoft.Boogie.VCExprAST
           if (naryExpr == null || !naryExpr.Op.Equals(op))
           {
             wr.Write(" ");
-            Print(cce.NonNull((VCExpr /*!*/) enumerator.Current), wr);
+            Print(Cce.NonNull((VCExpr /*!*/) enumerator.Current), wr);
           }
         }
 
@@ -270,7 +270,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(wr != null);
       //Contract.Requires(node != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public bool VisitOrOp(VCExprNAry node, TextWriter wr)
@@ -278,7 +278,7 @@ namespace Microsoft.Boogie.VCExprAST
       //Contract.Requires(wr != null);
       //Contract.Requires(node != null);
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     public bool VisitImpliesOp(VCExprNAry node, TextWriter wr)

--- a/Source/VCExpr/VCExprASTVisitors.cs
+++ b/Source/VCExpr/VCExprASTVisitors.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Boogie.VCExprAST
         IEnumerator enumerator = new VCExprNAryMultiUniformOpEnumerator(node, ops);
         while (enumerator.MoveNext())
         {
-          VCExpr expr = cce.NonNull((VCExpr) enumerator.Current);
+          VCExpr expr = Cce.NonNull((VCExpr) enumerator.Current);
           VCExprNAry naryExpr = expr as VCExprNAry;
           if (naryExpr == null || !ops.Contains(naryExpr.Op))
           {
@@ -508,7 +508,7 @@ namespace Microsoft.Boogie.VCExprAST
     void ObjectInvariant()
     {
       Contract.Invariant(CompleteExpr != null);
-      Contract.Invariant(cce.NonNullElements(ExprTodo));
+      Contract.Invariant(Cce.NonNullElements(ExprTodo));
     }
 
     public VCExprNAryEnumerator(VCExprNAry completeExpr)
@@ -554,7 +554,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     public object Current
     {
-      get { return cce.NonNull(CurrentExpr); }
+      get { return Cce.NonNull(CurrentExpr); }
     }
 
     public void Reset()
@@ -752,7 +752,7 @@ namespace Microsoft.Boogie.VCExprAST
     void ObjectInvariant()
     {
       Contract.Invariant(FreeTermVars != null && Contract.ForAll(FreeTermVars, entry => entry != null));
-      Contract.Invariant(cce.NonNullElements(FreeTypeVars));
+      Contract.Invariant(Cce.NonNullElements(FreeTypeVars));
     }
 
 
@@ -776,7 +776,7 @@ namespace Microsoft.Boogie.VCExprAST
     public static List<TypeVariable> FreeTypeVariables(VCExpr node)
     {
       Contract.Requires(node != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<TypeVariable>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<TypeVariable>>()));
       FreeVariableCollector collector = new FreeVariableCollector();
       collector.Traverse(node, true);
       return collector.FreeTypeVars;
@@ -804,7 +804,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     private void CollectTypeVariables(IEnumerable<VCExprVar /*!*/> /*!*/ boundVars)
     {
-      Contract.Requires(cce.NonNullElements(boundVars));
+      Contract.Requires(Cce.NonNullElements(boundVars));
       foreach (VCExprVar /*!*/ var in boundVars)
       {
         Contract.Assert(var != null);
@@ -814,7 +814,7 @@ namespace Microsoft.Boogie.VCExprAST
 
     private void AddTypeVariables(IEnumerable<TypeVariable /*!*/> /*!*/ typeVars)
     {
-      Contract.Requires(cce.NonNullElements(typeVars));
+      Contract.Requires(Cce.NonNullElements(typeVars));
       foreach (TypeVariable /*!*/ tvar in typeVars)
       {
         Contract.Assert(tvar != null);
@@ -885,7 +885,7 @@ namespace Microsoft.Boogie.VCExprAST
     [ContractInvariantMethod]
     void TermSubstsInvariantMethod()
     {
-      Contract.Invariant(TermSubsts != null && Contract.ForAll(TermSubsts, i => cce.NonNullDictionaryAndValues(i)));
+      Contract.Invariant(TermSubsts != null && Contract.ForAll(TermSubsts, i => Cce.NonNullDictionaryAndValues(i)));
     }
 
     private readonly List<IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/> /*!*/
@@ -894,14 +894,14 @@ namespace Microsoft.Boogie.VCExprAST
     [ContractInvariantMethod]
     void TypeSubstsInvariantMethod()
     {
-      Contract.Invariant(TermSubsts != null && Contract.ForAll(TypeSubsts, i => cce.NonNullDictionaryAndValues(i)));
+      Contract.Invariant(TermSubsts != null && Contract.ForAll(TypeSubsts, i => Cce.NonNullDictionaryAndValues(i)));
     }
 
     public VCExprSubstitution(IDictionary<VCExprVar /*!*/, VCExpr /*!*/> /*!*/ termSubst,
       IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ typeSubst)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(termSubst));
-      Contract.Requires(cce.NonNullDictionaryAndValues(typeSubst));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(termSubst));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(typeSubst));
       List<IDictionary<VCExprVar /*!*/, VCExpr /*!*/> /*!*/> /*!*/
         termSubsts =
           new List<IDictionary<VCExprVar /*!*/, VCExpr /*!*/> /*!*/>();
@@ -946,7 +946,7 @@ namespace Microsoft.Boogie.VCExprAST
 
         return null;
       }
-      set { TermSubsts[TermSubsts.Count - 1][var] = cce.NonNull(value); }
+      set { TermSubsts[TermSubsts.Count - 1][var] = Cce.NonNull(value); }
     }
 
     public Type this[TypeVariable /*!*/ var]
@@ -964,7 +964,7 @@ namespace Microsoft.Boogie.VCExprAST
 
         return null;
       }
-      set { TypeSubsts[TypeSubsts.Count - 1][var] = cce.NonNull(value); }
+      set { TypeSubsts[TypeSubsts.Count - 1][var] = Cce.NonNull(value); }
     }
 
     public bool ContainsKey(VCExprVar var)
@@ -993,14 +993,14 @@ namespace Microsoft.Boogie.VCExprAST
     {
       get
       {
-        Contract.Ensures(cce.NonNullDictionaryAndValues(Contract.Result<IDictionary<TypeVariable, Type>>()));
+        Contract.Ensures(Cce.NonNullDictionaryAndValues(Contract.Result<IDictionary<TypeVariable, Type>>()));
         IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/
           res = new Dictionary<TypeVariable /*!*/, Type /*!*/>();
         foreach (IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ dict in TypeSubsts)
         {
           foreach (KeyValuePair<TypeVariable /*!*/, Type /*!*/> pair in dict)
           {
-            Contract.Assert(cce.NonNullElements(pair));
+            Contract.Assert(Cce.NonNullElements(pair));
             // later ones overwrite earlier ones
             res[pair.Key] = pair.Value;
           }
@@ -1015,7 +1015,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<VCExprVar>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<VCExprVar>>()));
         HashSet<VCExprVar /*!*/> /*!*/
           domain = new HashSet<VCExprVar /*!*/>();
         foreach (IDictionary<VCExprVar /*!*/, VCExpr /*!*/> /*!*/ dict in TermSubsts)
@@ -1040,7 +1040,7 @@ namespace Microsoft.Boogie.VCExprAST
     {
       get
       {
-        Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<TypeVariable>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<TypeVariable>>()));
         HashSet<TypeVariable /*!*/> /*!*/
           domain = new HashSet<TypeVariable /*!*/>();
         foreach (IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/ dict in TypeSubsts)
@@ -1070,12 +1070,12 @@ namespace Microsoft.Boogie.VCExprAST
           coll = new FreeVariableCollector();
         foreach (VCExprVar /*!*/ var in TermDomain)
         {
-          coll.Collect(cce.NonNull(this)[var]);
+          coll.Collect(Cce.NonNull(this)[var]);
         }
 
         foreach (TypeVariable /*!*/ var in TypeDomain)
         {
-          coll.Collect(cce.NonNull(this)[var]);
+          coll.Collect(Cce.NonNull(this)[var]);
         }
 
         return coll;
@@ -1118,8 +1118,8 @@ namespace Microsoft.Boogie.VCExprAST
     private bool CollisionPossible(IEnumerable<TypeVariable /*!*/> /*!*/ typeParams,
       IEnumerable<VCExprVar /*!*/> /*!*/ boundVars, VCExprSubstitution /*!*/ substitution)
     {
-      Contract.Requires(cce.NonNullElements(typeParams));
-      Contract.Requires(cce.NonNullElements(boundVars));
+      Contract.Requires(Cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullElements(boundVars));
       Contract.Requires(substitution != null);
       // variables can be shadowed by a binder
       if (typeParams.Any(var => substitution.ContainsKey(var)) ||
@@ -1201,7 +1201,7 @@ namespace Microsoft.Boogie.VCExprAST
       {
         List<TypeVariable /*!*/> /*!*/
           typeParams = node.TypeParameters;
-        Contract.Assert(cce.NonNullElements(typeParams));
+        Contract.Assert(Cce.NonNullElements(typeParams));
         bool refreshAllVariables = refreshBoundVariables ||
                                    CollisionPossible(node.TypeParameters, node.BoundVars, substitution);
         if (refreshAllVariables)
@@ -1223,7 +1223,7 @@ namespace Microsoft.Boogie.VCExprAST
 
         List<VCExprVar /*!*/> /*!*/
           boundVars = node.BoundVars;
-        Contract.Assert(cce.NonNullElements(boundVars));
+        Contract.Assert(Cce.NonNullElements(boundVars));
         if (refreshAllVariables || !substitution.TypeSubstIsEmpty)
         {
           // collisions are possible, or we also substitute type variables. in this case
@@ -1232,7 +1232,7 @@ namespace Microsoft.Boogie.VCExprAST
           boundVars = new List<VCExprVar /*!*/>();
           IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/
             typeSubst = substitution.ToTypeSubst;
-          Contract.Assert(cce.NonNullDictionaryAndValues(typeSubst));
+          Contract.Assert(Cce.NonNullDictionaryAndValues(typeSubst));
           foreach (VCExprVar /*!*/ var in node.BoundVars)
           {
             Contract.Assert(var != null);
@@ -1308,7 +1308,7 @@ namespace Microsoft.Boogie.VCExprAST
 
         List<VCExprVar /*!*/> /*!*/
           newBoundVars = node.BoundVars;
-        Contract.Assert(cce.NonNullElements(newBoundVars));
+        Contract.Assert(Cce.NonNullElements(newBoundVars));
         if (refreshAllVariables)
         {
           // collisions are possible, or we also substitute type variables. in this case
@@ -1317,7 +1317,7 @@ namespace Microsoft.Boogie.VCExprAST
           newBoundVars = new List<VCExprVar /*!*/>();
           IDictionary<TypeVariable /*!*/, Type /*!*/> /*!*/
             typeSubst = substitution.ToTypeSubst;
-          Contract.Assert(cce.NonNullDictionaryAndValues(typeSubst));
+          Contract.Assert(Cce.NonNullDictionaryAndValues(typeSubst));
           foreach (VCExprVar /*!*/ var in node.BoundVars)
           {
             Contract.Assert(var != null);

--- a/Source/VCExpr/VCExprASTVisitors.cs
+++ b/Source/VCExpr/VCExprASTVisitors.cs
@@ -1148,7 +1148,7 @@ namespace Microsoft.Boogie.VCExprAST
       List<VCExpr /*!*/> /*!*/ newSubExprs, bool changed, VCExprSubstitution /*!*/ substitution)
     {
       //Contract.Requires(originalNode != null);
-      //Contract.Requires(cce.NonNullElements(newSubExprs));
+      //Contract.Requires(Cce.NonNullElements(newSubExprs));
       //Contract.Requires(substitution != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 

--- a/Source/VCExpr/VCExpressionGenerator.cs
+++ b/Source/VCExpr/VCExpressionGenerator.cs
@@ -81,8 +81,8 @@ namespace Microsoft.Boogie
       List<Type /*!*/> /*!*/ typeArguments)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(arguments));
-      Contract.Requires(cce.NonNullElements(typeArguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(typeArguments));
       if (typeArguments.Count > 0)
       {
         return new VCExprMultiAry(op, arguments, typeArguments);
@@ -104,7 +104,7 @@ namespace Microsoft.Boogie
     public VCExpr /*!*/ Function(VCExprOp /*!*/ op, List<VCExpr /*!*/> /*!*/ arguments)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
       return Function(op, arguments, VCExprNAry.EMPTY_TYPE_LIST);
@@ -113,7 +113,7 @@ namespace Microsoft.Boogie
     public VCExpr /*!*/ Function(VCExprOp /*!*/ op, params VCExpr[] /*!*/ arguments)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
 
       return Function(op,
         HelperFuns.ToNonNullList(arguments),
@@ -123,8 +123,8 @@ namespace Microsoft.Boogie
     public VCExpr /*!*/ Function(VCExprOp /*!*/ op, VCExpr[] /*!*/ arguments, Type[] /*!*/ typeArguments)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(arguments));
-      Contract.Requires(cce.NonNullElements(typeArguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(typeArguments));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
 
@@ -136,7 +136,7 @@ namespace Microsoft.Boogie
     public VCExpr /*!*/ Function(Function /*!*/ op, List<VCExpr /*!*/> /*!*/ arguments)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
       return Function(BoogieFunctionOp(op), arguments, VCExprNAry.EMPTY_TYPE_LIST);
@@ -144,7 +144,7 @@ namespace Microsoft.Boogie
 
     public VCExpr /*!*/ Function(Function /*!*/ op, params VCExpr[] /*!*/ arguments)
     {
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
       Contract.Requires(op != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
@@ -157,7 +157,7 @@ namespace Microsoft.Boogie
     public VCExpr /*!*/ NAry(VCExprOp /*!*/ op, List<VCExpr /*!*/> /*!*/ args)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
       return NAry(op, args.ToArray());
@@ -166,7 +166,7 @@ namespace Microsoft.Boogie
     public VCExpr /*!*/ NAry(VCExprOp /*!*/ op, params VCExpr[] /*!*/ args)
     {
       Contract.Requires(op != null);
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
       Contract.Requires(op == AndOp || op == OrOp);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
@@ -176,7 +176,7 @@ namespace Microsoft.Boogie
         e = and ? True : False;
       foreach (VCExpr a in args)
       {
-        e = and ? AndSimp(e, cce.NonNull(a)) : OrSimp(e, cce.NonNull(a));
+        e = and ? AndSimp(e, Cce.NonNull(a)) : OrSimp(e, Cce.NonNull(a));
       }
 
       return e;
@@ -251,7 +251,7 @@ namespace Microsoft.Boogie
       Contract.Requires(e1 != null);
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
-      VCExprOp op = cce.NonNull(cce.NonNull(e0).Type).IsInt ? AddIOp : AddROp;
+      VCExprOp op = Cce.NonNull(Cce.NonNull(e0).Type).IsInt ? AddIOp : AddROp;
       return Function(op, e0, e1);
     }
 
@@ -273,7 +273,7 @@ namespace Microsoft.Boogie
 
     public VCExpr /*!*/ Distinct(List<VCExpr /*!*/> /*!*/ args)
     {
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
 
       if (args.Count <= 1)
@@ -582,7 +582,7 @@ namespace Microsoft.Boogie
     public VCExpr Let(List<VCExprLetBinding> bindings, VCExpr body)
     {
       Contract.Requires(body != null);
-      Contract.Requires(cce.NonNullElements(bindings));
+      Contract.Requires(Cce.NonNullElements(bindings));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       if (bindings.Count == 0)
       {
@@ -596,7 +596,7 @@ namespace Microsoft.Boogie
     public VCExpr Let(VCExpr body, params VCExprLetBinding[] bindings)
     {
       Contract.Requires(body != null);
-      Contract.Requires((cce.NonNullElements(bindings)));
+      Contract.Requires((Cce.NonNullElements(bindings)));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       return Let(HelperFuns.ToNonNullList(bindings), body);
     }
@@ -616,7 +616,7 @@ namespace Microsoft.Boogie
     // Turn let-bindings let v = E in ... into implications E ==> v
     public VCExpr AsImplications(List<VCExprLetBinding> bindings)
     {
-      Contract.Requires(cce.NonNullElements(bindings));
+      Contract.Requires(Cce.NonNullElements(bindings));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       VCExpr /*!*/
         antecedents = True;
@@ -632,7 +632,7 @@ namespace Microsoft.Boogie
     // Turn let-bindings let v = E in ... into equations v == E
     public VCExpr AsEquations(List<VCExprLetBinding> bindings)
     {
-      Contract.Requires(cce.NonNullElements(bindings));
+      Contract.Requires(Cce.NonNullElements(bindings));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       VCExpr /*!*/
         antecedents = True;
@@ -685,9 +685,9 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(body != null);
       Contract.Requires(info != null);
-      Contract.Requires(cce.NonNullElements(triggers));
-      Contract.Requires(cce.NonNullElements(vars));
-      Contract.Requires(cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullElements(triggers));
+      Contract.Requires(Cce.NonNullElements(vars));
+      Contract.Requires(Cce.NonNullElements(typeParams));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       return new VCExprQuantifier(quan, typeParams, vars, triggers, info, body);
     }
@@ -697,9 +697,9 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(body != null);
       Contract.Requires(info != null);
-      Contract.Requires(cce.NonNullElements(triggers));
-      Contract.Requires(cce.NonNullElements(vars));
-      Contract.Requires(cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullElements(triggers));
+      Contract.Requires(Cce.NonNullElements(vars));
+      Contract.Requires(Cce.NonNullElements(typeParams));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       return Quantify(Quantifier.ALL, typeParams, vars, triggers, info, body);
     }
@@ -709,8 +709,8 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(body != null);
       Contract.Requires(qid != null);
-      Contract.Requires(cce.NonNullElements(triggers));
-      Contract.Requires(cce.NonNullElements(vars));
+      Contract.Requires(Cce.NonNullElements(triggers));
+      Contract.Requires(Cce.NonNullElements(vars));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       return Quantify(Quantifier.ALL, new List<TypeVariable /*!*/>(), vars,
         triggers, new VCQuantifierInfo(qid, -1, weight), body);
@@ -719,8 +719,8 @@ namespace Microsoft.Boogie
     public VCExpr Forall(List<VCExprVar /*!*/> /*!*/ vars, List<VCTrigger /*!*/> /*!*/ triggers, VCExpr body)
     {
       Contract.Requires(body != null);
-      Contract.Requires(cce.NonNullElements(triggers));
-      Contract.Requires(cce.NonNullElements(vars));
+      Contract.Requires(Cce.NonNullElements(triggers));
+      Contract.Requires(Cce.NonNullElements(vars));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       return Quantify(Quantifier.ALL, new List<TypeVariable /*!*/>(), vars,
         triggers, new VCQuantifierInfo(null, -1), body);
@@ -740,9 +740,9 @@ namespace Microsoft.Boogie
     {
       Contract.Requires(body != null);
       Contract.Requires(info != null);
-      Contract.Requires(cce.NonNullElements(triggers));
-      Contract.Requires(cce.NonNullElements(vars));
-      Contract.Requires(cce.NonNullElements(typeParams));
+      Contract.Requires(Cce.NonNullElements(triggers));
+      Contract.Requires(Cce.NonNullElements(vars));
+      Contract.Requires(Cce.NonNullElements(typeParams));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       return Quantify(Quantifier.EX, typeParams, vars, triggers, info, body);
     }
@@ -750,8 +750,8 @@ namespace Microsoft.Boogie
     public VCExpr Exists(List<VCExprVar /*!*/> /*!*/ vars, List<VCTrigger /*!*/> /*!*/ triggers, VCExpr body)
     {
       Contract.Requires(body != null);
-      Contract.Requires(cce.NonNullElements(triggers));
-      Contract.Requires(cce.NonNullElements(vars));
+      Contract.Requires(Cce.NonNullElements(triggers));
+      Contract.Requires(Cce.NonNullElements(vars));
       Contract.Ensures(Contract.Result<VCExpr>() != null);
       return Quantify(Quantifier.EX, new List<TypeVariable /*!*/>(), vars,
         triggers, new VCQuantifierInfo(null, -1), body);
@@ -768,7 +768,7 @@ namespace Microsoft.Boogie
 
     public VCTrigger Trigger(bool pos, List<VCExpr> exprs)
     {
-      Contract.Requires(cce.NonNullElements(exprs));
+      Contract.Requires(Cce.NonNullElements(exprs));
       Contract.Ensures(Contract.Result<VCTrigger>() != null);
       return new VCTrigger(pos, exprs);
     }

--- a/Source/VCGeneration/BlockStats.cs
+++ b/Source/VCGeneration/BlockStats.cs
@@ -22,8 +22,8 @@ class BlockStats
   [ContractInvariantMethod]
   void ObjectInvariant()
   {
-    Contract.Invariant(cce.NonNullElements(virtualSuccessors));
-    Contract.Invariant(cce.NonNullElements(virtualPredecessors));
+    Contract.Invariant(Cce.NonNullElements(virtualSuccessors));
+    Contract.Invariant(Cce.NonNullElements(virtualPredecessors));
     Contract.Invariant(block != null);
   }
 

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Boogie
     {
       Pool = pool;
 
-      SolverOptions = cce.NonNull(Pool.Options.TheProverFactory).BlankProverOptions(pool.Options);
+      SolverOptions = Cce.NonNull(Pool.Options.TheProverFactory).BlankProverOptions(pool.Options);
 
       if (logFilePath != null)
       {
@@ -267,7 +267,7 @@ namespace Microsoft.Boogie
 
     private async Task Check(string descriptiveName, VCExpr vc, CancellationToken cancellationToken) {
       try {
-        outcome = await thmProver.Check(descriptiveName, vc, cce.NonNull(handler), Options.ErrorLimit,
+        outcome = await thmProver.Check(descriptiveName, vc, Cce.NonNull(handler), Options.ErrorLimit,
           cancellationToken);
       }
       catch (OperationCanceledException) {

--- a/Source/VCGeneration/ConditionGeneration.cs
+++ b/Source/VCGeneration/ConditionGeneration.cs
@@ -66,7 +66,7 @@ namespace VC
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullDictionaryAndValues(incarnationOriginMap));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(incarnationOriginMap));
       Contract.Invariant(program != null);
     }
 
@@ -296,7 +296,7 @@ namespace VC
         if (!ens.Free)
         {
           Expr e = Substituter.Apply(formalProcImplSubst, ens.Condition);
-          Ensures ensCopy = (Ensures) cce.NonNull(ens.Clone());
+          Ensures ensCopy = (Ensures) Cce.NonNull(ens.Clone());
           ensCopy.Condition = e;
           AssertEnsuresCmd c = new AssertEnsuresCmd(ensCopy);
           c.ErrorDataEnhanced = ensCopy.ErrorDataEnhanced;
@@ -398,7 +398,7 @@ namespace VC
         {
           Expr e = Substituter.Apply(formalProcImplSubst, ens.Condition);
           Contract.Assert(e != null);
-          Ensures ensCopy = cce.NonNull((Ensures) ens.Clone());
+          Ensures ensCopy = Cce.NonNull((Ensures) ens.Clone());
           ensCopy.Condition = e;
           Cmd c = new AssertEnsuresCmd(ensCopy);
           ((AssertEnsuresCmd) c).ErrorDataEnhanced = ensCopy.ErrorDataEnhanced;
@@ -462,14 +462,14 @@ namespace VC
       Contract.Assert(impl.OutParams.Count == impl.Proc.OutParams.Count);
       for (int i = 0; i < impl.OutParams.Count; i++)
       {
-        Variable f = cce.NonNull(impl.Proc.OutParams[i]);
+        Variable f = Cce.NonNull(impl.Proc.OutParams[i]);
         if (f.TypedIdent.WhereExpr != null)
         {
           Expr e = Substituter.Apply(formalProcImplSubst, f.TypedIdent.WhereExpr);
           Cmd c = new AssumeCmd(f.tok, e);
           whereClauses.Add(c);
 
-          Variable fi = cce.NonNull(impl.OutParams[i]);
+          Variable fi = Cce.NonNull(impl.OutParams[i]);
           Contract.Assume(fi.TypedIdent.WhereExpr == null);
           fi.TypedIdent.WhereExpr = e;
 
@@ -722,7 +722,7 @@ namespace VC
 
           #region Create an identifier expression for the last incarnation in pred
 
-          Dictionary<Variable, Expr> predMap = (Dictionary<Variable, Expr>) cce.NonNull(block2Incarnation[pred]);
+          Dictionary<Variable, Expr> predMap = (Dictionary<Variable, Expr>) Cce.NonNull(block2Incarnation[pred]);
 
           Expr pred_incarnation_exp;
           Expr o = predMap.ContainsKey(v) ? predMap[v] : null;
@@ -954,7 +954,7 @@ namespace VC
       foreach (IdentifierExpr ie in modifies)
       {
         Contract.Assert(ie != null);
-        if (!oldFrameMap.ContainsKey(cce.NonNull(ie.Decl)))
+        if (!oldFrameMap.ContainsKey(Cce.NonNull(ie.Decl)))
         {
           oldFrameMap.Add(ie.Decl, ie);
         }
@@ -1117,7 +1117,7 @@ namespace VC
           var ac = (AssertCmd) pc;
           ac.OrigExpr = ac.Expr;
           Contract.Assert(ac.IncarnationMap == null);
-          ac.IncarnationMap = (Dictionary<Variable, Expr>) cce.NonNull(new Dictionary<Variable, Expr>(incarnationMap));
+          ac.IncarnationMap = (Dictionary<Variable, Expr>) Cce.NonNull(new Dictionary<Variable, Expr>(incarnationMap));
 
           var subsumption = Wlp.Subsumption(Options, ac);
           if (relevantDoomedAssumpVars.Any())
@@ -1243,8 +1243,8 @@ namespace VC
         for (int i = 0; i < assign.Lhss.Count; ++i)
         {
           IdentifierExpr lhsIdExpr =
-            cce.NonNull((SimpleAssignLhs) assign.Lhss[i]).AssignedVariable;
-          Variable lhs = cce.NonNull(lhsIdExpr.Decl);
+            Cce.NonNull((SimpleAssignLhs) assign.Lhss[i]).AssignedVariable;
+          Variable lhs = Cce.NonNull(lhsIdExpr.Decl);
           Contract.Assert(lhs != null);
           Expr rhs = assign.Rhss[i];
           Contract.Assert(rhs != null);
@@ -1257,9 +1257,9 @@ namespace VC
           else if (rhs is IdentifierExpr)
           {
             IdentifierExpr ie = (IdentifierExpr) rhs;
-            if (incarnationMap.ContainsKey(cce.NonNull(ie.Decl)))
+            if (incarnationMap.ContainsKey(Cce.NonNull(ie.Decl)))
             {
-              newIncarnationMappings[lhs] = cce.NonNull((Expr) incarnationMap[ie.Decl]);
+              newIncarnationMappings[lhs] = Cce.NonNull((Expr) incarnationMap[ie.Decl]);
             }
             else
             {
@@ -1380,7 +1380,7 @@ namespace VC
           Contract.Assert(ie != null);
           if (!(ie.Decl is Incarnation))
           {
-            Variable x = cce.NonNull(ie.Decl);
+            Variable x = Cce.NonNull(ie.Decl);
             Variable x_prime = CreateIncarnation(x, c);
             incarnationMap[x] = new IdentifierExpr(x_prime.tok, x_prime);
           }
@@ -1393,7 +1393,7 @@ namespace VC
           Contract.Assert(ie != null);
           if (!(ie.Decl is Incarnation))
           {
-            Variable x = cce.NonNull(ie.Decl);
+            Variable x = Cce.NonNull(ie.Decl);
             Expr w = x.TypedIdent.WhereExpr;
             if (w != null)
             {
@@ -1514,7 +1514,7 @@ namespace VC
       Contract.Requires(succ != null);
       Contract.Ensures(Contract.Result<Block>() != null);
 
-      Block pred = cce.NonNull(succ.Predecessors[predIndex]);
+      Block pred = Cce.NonNull(succ.Predecessors[predIndex]);
 
       string newBlockLabel = pred.Label + "_@2_" + succ.Label;
 
@@ -1540,7 +1540,7 @@ namespace VC
 
       #region Change the edge "pred->succ" to "pred->newBlock"
 
-      GotoCmd gtc = (GotoCmd) cce.NonNull(pred.TransferCmd);
+      GotoCmd gtc = (GotoCmd) Cce.NonNull(pred.TransferCmd);
       Contract.Assume(gtc.labelTargets != null);
       Contract.Assume(gtc.labelNames != null);
       for (int i = 0, n = gtc.labelTargets.Count; i < n; i++)
@@ -1576,7 +1576,7 @@ namespace VC
           // b is a join point (i.e., it has more than one predecessor)
           for (int i = 0; i < nPreds; i++)
           {
-            GotoCmd gotocmd = (GotoCmd) (cce.NonNull(b.Predecessors[i]).TransferCmd);
+            GotoCmd gotocmd = (GotoCmd) (Cce.NonNull(b.Predecessors[i]).TransferCmd);
             if (gotocmd.labelNames != null && gotocmd.labelNames.Count > 1)
             {
               tweens.Add(CreateBlockBetween(i, b));

--- a/Source/VCGeneration/Counterexample.cs
+++ b/Source/VCGeneration/Counterexample.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Boogie
     [ContractInvariantMethod]
     void ObjectInvariant()
     {
-      Contract.Invariant(cce.NonNullElements(args));
+      Contract.Invariant(Cce.NonNullElements(args));
     }
 
     public CalleeCounterexampleInfo(Counterexample cex, List<object /*!>!*/> x)
     {
-      Contract.Requires(cce.NonNullElements(x));
+      Contract.Requires(Cce.NonNullElements(x));
       counterexample = cex;
       args = x;
     }
@@ -72,7 +72,7 @@ namespace Microsoft.Boogie
     {
       Contract.Invariant(Trace != null);
       Contract.Invariant(Context != null);
-      Contract.Invariant(cce.NonNullDictionaryAndValues(calleeCounterexamples));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(calleeCounterexamples));
     }
 
     public ProofRun ProofRun { get; }
@@ -125,7 +125,7 @@ namespace Microsoft.Boogie
 
     public void AddCalleeCounterexample(Dictionary<TraceLocation, CalleeCounterexampleInfo> cs)
     {
-      Contract.Requires(cce.NonNullDictionaryAndValues(cs));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(cs));
       foreach (TraceLocation loc in cs.Keys)
       {
         AddCalleeCounterexample(loc, cs[loc]);
@@ -761,7 +761,7 @@ namespace Microsoft.Boogie
           break;
         default:
           Contract.Assume(false);
-          throw new cce.UnreachableException(); // unexpected case
+          throw new Cce.UnreachableException(); // unexpected case
       }
     }
 

--- a/Source/VCGeneration/LoopExtractor.cs
+++ b/Source/VCGeneration/LoopExtractor.cs
@@ -87,7 +87,7 @@ public class LoopExtractor {
     Dictionary<string, Dictionary<string, Block>> fullMap)
   {
     Contract.Requires(impl != null);
-    Contract.Requires(cce.NonNullElements(loopImpls));
+    Contract.Requires(Cce.NonNullElements(loopImpls));
     // Enumerate the headers
     // for each header h:
     //   create implementation p_h with
@@ -438,13 +438,13 @@ public class LoopExtractor {
         blocks = new List<Block /*!*/>();
       Block exit = new Block(Token.NoToken, "exit", new List<Cmd>(), new ReturnCmd(Token.NoToken));
       GotoCmd cmd = new GotoCmd(Token.NoToken,
-        new List<String> {cce.NonNull(blockMap[header]).Label, exit.Label},
+        new List<String> {Cce.NonNull(blockMap[header]).Label, exit.Label},
         new List<Block> {blockMap[header], exit});
 
       if (detLoopExtract) //cutting the non-determinism
       {
         cmd = new GotoCmd(Token.NoToken,
-          new List<String> {cce.NonNull(blockMap[header]).Label},
+          new List<String> {Cce.NonNull(blockMap[header]).Label},
           new List<Block> {blockMap[header]});
       }
 
@@ -463,7 +463,7 @@ public class LoopExtractor {
       {
         Contract.Assert(block != null);
         Block /*!*/
-          newBlock = cce.NonNull(blockMap[block]);
+          newBlock = Cce.NonNull(blockMap[block]);
         GotoCmd gotoCmd = block.TransferCmd as GotoCmd;
         if (gotoCmd == null)
         {

--- a/Source/VCGeneration/ManualSplitFinder.cs
+++ b/Source/VCGeneration/ManualSplitFinder.cs
@@ -14,7 +14,7 @@ public static class ManualSplitFinder {
 
   private static List<ManualSplit /*!*/> FindManualSplits(ManualSplit initialSplit) {
     Contract.Requires(initialSplit.Implementation != null);
-    Contract.Ensures(Contract.Result<List<Split>>() == null || cce.NonNullElements(Contract.Result<List<Split>>()));
+    Contract.Ensures(Contract.Result<List<Split>>() == null || Cce.NonNullElements(Contract.Result<List<Split>>()));
 
     var splitOnEveryAssert = initialSplit.Options.VcsSplitOnEveryAssert;
     initialSplit.Run.Implementation.CheckBooleanAttribute("vcs_split_on_every_assert", ref splitOnEveryAssert);

--- a/Source/VCGeneration/SmokeTester.cs
+++ b/Source/VCGeneration/SmokeTester.cs
@@ -19,8 +19,8 @@ public class SmokeTester
     Contract.Invariant(parent != null);
     Contract.Invariant(run != null);
     Contract.Invariant(initial != null);
-    Contract.Invariant(cce.NonNullDictionaryAndValues(copies));
-    Contract.Invariant(cce.NonNull(visited));
+    Contract.Invariant(Cce.NonNullDictionaryAndValues(copies));
+    Contract.Invariant(Cce.NonNull(visited));
     Contract.Invariant(callback != null);
   }
 
@@ -83,14 +83,14 @@ public class SmokeTester
 
     if (copies.TryGetValue(b, out var fake_res))
     {
-      return cce.NonNull(fake_res);
+      return Cce.NonNull(fake_res);
     }
 
     Block res = new Block(b.tok, b.Label, new List<Cmd>(b.Cmds), null);
     copies[b] = res;
     if (b.TransferCmd is GotoCmd)
     {
-      foreach (Block ch in cce.NonNull((GotoCmd) b.TransferCmd).labelTargets)
+      foreach (Block ch in Cce.NonNull((GotoCmd) b.TransferCmd).labelTargets)
       {
         Contract.Assert(ch != null);
         CloneBlock(ch);
@@ -115,7 +115,7 @@ public class SmokeTester
     if (copies.TryGetValue(b, out var fake_res))
     {
       // fake_res should be Block! but the compiler fails
-      return cce.NonNull(fake_res);
+      return Cce.NonNull(fake_res);
     }
 
     Block res;
@@ -147,7 +147,7 @@ public class SmokeTester
 
   List<Block> GetCopiedBlocks()
   {
-    Contract.Ensures(cce.NonNullElements(Contract.Result<List<Block>>()));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Block>>()));
 
     // the order of nodes in res is random (except for the first one, being the entry)
     List<Block> res = new List<Block>();
@@ -167,12 +167,12 @@ public class SmokeTester
       {
         GotoCmd copy = new GotoCmd(go.tok, new List<String>(), new List<Block>());
         kv.Value.TransferCmd = copy;
-        foreach (Block b in cce.NonNull(go.labelTargets))
+        foreach (Block b in Cce.NonNull(go.labelTargets))
         {
           Contract.Assert(b != null);
           if (copies.TryGetValue(b, out var c))
           {
-            copy.AddTarget(cce.NonNull(c));
+            copy.AddTarget(Cce.NonNull(c));
           }
         }
       }
@@ -183,7 +183,7 @@ public class SmokeTester
       else
       {
         Contract.Assume(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 
@@ -208,7 +208,7 @@ public class SmokeTester
     else if (call != null &&
              call.Fun is UnaryOperator &&
              ((UnaryOperator) call.Fun).Op == UnaryOperator.Opcode.Not &&
-             BooleanEval(cce.NonNull(call.Args[0]), ref val))
+             BooleanEval(Cce.NonNull(call.Args[0]), ref val))
     {
       val = !val;
       return true;
@@ -218,7 +218,7 @@ public class SmokeTester
              call.Fun is BinaryOperator &&
              ((BinaryOperator) call.Fun).Op == BinaryOperator.Opcode.Neq &&
              call.Args[0] is LiteralExpr &&
-             cce.NonNull(call.Args[0]).Equals(call.Args[1]))
+             Cce.NonNull(call.Args[0]).Equals(call.Args[1]))
     {
       val = false;
       return true;
@@ -306,7 +306,7 @@ public class SmokeTester
           Emit();
         }
       }
-      await checker.BeginCheck(cce.NonNull(Implementation.Name + "_smoke" + id++), vc, new ErrorHandler(Options, absyIds, callback),
+      await checker.BeginCheck(Cce.NonNull(Implementation.Name + "_smoke" + id++), vc, new ErrorHandler(Options, absyIds, callback),
         Options.SmokeTimeout, Options.ResourceLimit, CancellationToken.None);
 
       await checker.ProverTask;
@@ -403,7 +403,7 @@ public class SmokeTester
       }
       else if (call != null)
       {
-        foreach (Ensures e in (cce.NonNull(call.Proc)).Ensures)
+        foreach (Ensures e in (Cce.NonNull(call.Proc)).Ensures)
         {
           Contract.Assert(e != null);
           if (IsFalse(e.Condition))
@@ -428,7 +428,7 @@ public class SmokeTester
 
     Contract.Assume(!(go != null && go.labelTargets == null && go.labelNames != null && go.labelNames.Count > 0));
 
-    if (ret != null || (go != null && cce.NonNull(go.labelTargets).Count == 0))
+    if (ret != null || (go != null && Cce.NonNull(go.labelTargets).Count == 0))
     {
       // we end in return, so there will be no more places to check
       await CheckUnreachable(traceWriter, cur, seq);
@@ -438,7 +438,7 @@ public class SmokeTester
       bool needToCheck = true;
       // if all of our children have more than one parent, then
       // we're in the right place to check
-      foreach (Block target in cce.NonNull(go.labelTargets))
+      foreach (Block target in Cce.NonNull(go.labelTargets))
       {
         Contract.Assert(target != null);
         if (target.Predecessors.Count == 1)
@@ -487,7 +487,7 @@ public class SmokeTester
       Contract.Ensures(Contract.Result<Absy>() != null);
 
       int id = int.Parse(label);
-      return cce.NonNull((Absy) absyIds.GetValue(id));
+      return Cce.NonNull((Absy) absyIds.GetValue(id));
     }
 
     public override void OnProverWarning(string msg)

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -71,7 +71,7 @@ namespace VC
         Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
         VerificationConditionGenerator /*!*/ par, ImplementationRun run, int? randomSeed = null)
       {
-        Contract.Requires(cce.NonNullElements(blocks));
+        Contract.Requires(Cce.NonNullElements(blocks));
         Contract.Requires(gotoCmdOrigins != null);
         Contract.Requires(par != null);
         this.Blocks = blocks;
@@ -205,7 +205,7 @@ namespace VC
           stats[b] = s;
         }
 
-        return cce.NonNull(s);
+        return Cce.NonNull(s);
       }
 
       double AssertionCost(PredicateCmd c)
@@ -266,7 +266,7 @@ namespace VC
       HashSet<Block /*!*/> /*!*/ ComputeReachableNodes(Block /*!*/ b)
       {
         Contract.Requires(b != null);
-        Contract.Ensures(cce.NonNull(Contract.Result<HashSet<Block /*!*/>>()));
+        Contract.Ensures(Cce.NonNull(Contract.Result<HashSet<Block /*!*/>>()));
         BlockStats s = GetBlockStats(b);
         if (s.reachableBlocks != null)
         {
@@ -327,7 +327,7 @@ namespace VC
                 Options.OutputWriter.WriteLine("non-big {0} accessed from {1}", ch, b);
                 DumpDot(-1);
                 Contract.Assert(false);
-                throw new cce.UnreachableException();
+                throw new Cce.UnreachableException();
               }
 
               chs.virtualPredecessors.Add(b);
@@ -351,7 +351,7 @@ namespace VC
             continue;
           }
 
-          List<Block> targ = cce.NonNull(gt.labelTargets);
+          List<Block> targ = Cce.NonNull(gt.labelTargets);
           if (targ.Count < 2)
           {
             continue;
@@ -362,14 +362,14 @@ namespace VC
           splitBlock = b;
 
           assumizedBranches.Clear();
-          assumizedBranches.Add(cce.NonNull(targ[0]));
+          assumizedBranches.Add(Cce.NonNull(targ[0]));
           left0 = DoComputeScore(true);
           right0 = DoComputeScore(false);
 
           assumizedBranches.Clear();
           for (int idx = 1; idx < targ.Count; idx++)
           {
-            assumizedBranches.Add(cce.NonNull(targ[idx]));
+            assumizedBranches.Add(Cce.NonNull(targ[idx]));
           }
 
           left1 = DoComputeScore(true);
@@ -382,7 +382,7 @@ namespace VC
           {
             currentScore = otherScore;
             assumizedBranches.Clear();
-            assumizedBranches.Add(cce.NonNull(targ[0]));
+            assumizedBranches.Add(Cce.NonNull(targ[0]));
           }
 
           if (currentScore < score)
@@ -489,7 +489,7 @@ namespace VC
           foreach (Block b in allowSmall ? Blocks : bigBlocks)
           {
             Contract.Assert(b != null);
-            if (ComputeReachableNodes(b).Contains(cce.NonNull(splitBlock)))
+            if (ComputeReachableNodes(b).Contains(Cce.NonNull(splitBlock)))
             {
               keepAtAll.Add(b);
             }
@@ -595,7 +595,7 @@ namespace VC
             else
             {
               Contract.Assert(false);
-              throw new cce.UnreachableException();
+              throw new Cce.UnreachableException();
             }
 
             if (swap)
@@ -617,7 +617,7 @@ namespace VC
 
         if (copies.TryGetValue(b, out var res))
         {
-          return cce.NonNull(res);
+          return Cce.NonNull(res);
         }
 
         res = new Block(b.tok, b.Label, SliceCmds(b), b.TransferCmd);
@@ -628,7 +628,7 @@ namespace VC
           GotoCmd newGoto = new GotoCmd(gt.tok, new List<String>(), new List<Block>());
           res.TransferCmd = newGoto;
           int pos = 0;
-          foreach (Block ch in cce.NonNull(gt.labelTargets))
+          foreach (Block ch in Cce.NonNull(gt.labelTargets))
           {
             Contract.Assert(ch != null);
             Contract.Assert(doingSlice ||
@@ -663,7 +663,7 @@ namespace VC
             continue;
           }
 
-          newBlocks.Add(cce.NonNull(tmp));
+          newBlocks.Add(Cce.NonNull(tmp));
           if (GotoCmdOrigins.TryGetValue(block.TransferCmd, out var origin))
           {
             newGotoCmdOrigins[tmp.TransferCmd] = origin;
@@ -742,7 +742,7 @@ namespace VC
             if (command is AssertCmd assertCmd)
             {
               var counterexample = VerificationConditionGenerator.AssertCmdToCounterexample(Options, assertCmd,
-                cce.NonNull(block.TransferCmd), trace, null, null, null, context, this);
+                Cce.NonNull(block.TransferCmd), trace, null, null, null, context, this);
               Counterexamples.Add(counterexample);
               return counterexample;
             }
@@ -750,13 +750,13 @@ namespace VC
         }
 
         Contract.Assume(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
 
       public static List<Split /*!*/> /*!*/ DoSplit(Split initial, double splitThreshold, int maxSplits)
       {
         Contract.Requires(initial != null);
-        Contract.Ensures(cce.NonNullElements(Contract.Result<List<Split>>()));
+        Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Split>>()));
 
         var run = initial.Run;
         var result = new List<Split> { initial };
@@ -799,7 +799,7 @@ namespace VC
               if (g != null)
               {
                 run.OutputWriter.Write("    exits: ");
-                foreach (Block b in cce.NonNull(g.labelTargets))
+                foreach (Block b in Cce.NonNull(g.labelTargets))
                 {
                   Contract.Assert(b != null);
                   run.OutputWriter.Write("{0} ", b.Label);
@@ -848,7 +848,7 @@ namespace VC
               s0.DumpDot(-2);
               s1.DumpDot(-3);
               Contract.Assert(false);
-              throw new cce.UnreachableException();
+              throw new Cce.UnreachableException();
             }
           }
 
@@ -875,7 +875,7 @@ namespace VC
       public VerificationRunResult ReadOutcome(int iteration, Checker checker, VerifierCallback callback)
       {
         Contract.EnsuresOnThrow<UnexpectedProverOutputException>(true);
-        SolverOutcome outcome = cce.NonNull(checker).ReadOutcome();
+        SolverOutcome outcome = Cce.NonNull(checker).ReadOutcome();
 
         if (Options.Trace && SplitIndex >= 0)
         {
@@ -972,7 +972,7 @@ namespace VC
       {
         get
         {
-          string description = cce.NonNull(Implementation.Name);
+          string description = Cce.NonNull(Implementation.Name);
           if (SplitIndex >= 0)
           {
             description += "_split" + SplitIndex;
@@ -985,7 +985,7 @@ namespace VC
       private void SoundnessCheck(HashSet<List<Block> /*!*/> /*!*/ cache, Block /*!*/ orig,
         List<Block /*!*/> /*!*/ copies)
       {
-        Contract.Requires(cce.NonNull(cache));
+        Contract.Requires(Cce.NonNull(cache));
         Contract.Requires(orig != null);
         Contract.Requires(copies != null);
         {

--- a/Source/VCGeneration/SplitAndVerifyWorker.cs
+++ b/Source/VCGeneration/SplitAndVerifyWorker.cs
@@ -219,7 +219,7 @@ namespace VC
           return true;
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
 
@@ -261,7 +261,7 @@ namespace VC
           return currentVcOutcome;
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
 

--- a/Source/VCGeneration/VerificationConditionGenerator.cs
+++ b/Source/VCGeneration/VerificationConditionGenerator.cs
@@ -67,7 +67,7 @@ namespace VC
           break;
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException(); // unexpected case
+          throw new Cce.UnreachableException(); // unexpected case
       }
 
       var assume = new AssumeCmd(assrt.tok, expr);
@@ -169,9 +169,9 @@ namespace VC
 
       VCExpr vc;
       int assertionCount;
-      if (cce.NonNull(CheckerPool.Options.TheProverFactory).SupportsDags)
+      if (Cce.NonNull(CheckerPool.Options.TheProverFactory).SupportsDags)
       {
-        vc = DagVC(cce.NonNull(impl.Blocks[0]), controlFlowVariableExpr, absyIds,
+        vc = DagVC(Cce.NonNull(impl.Blocks[0]), controlFlowVariableExpr, absyIds,
           new Dictionary<Block, VCExpr>(), proverContext, out assertionCount);
       }
       else
@@ -481,7 +481,7 @@ namespace VC
       {
         Contract.Invariant(gotoCmdOrigins != null);
         Contract.Invariant(absyIds != null);
-        Contract.Invariant(cce.NonNullElements(blocks));
+        Contract.Invariant(Cce.NonNullElements(blocks));
         Contract.Invariant(callback != null);
         Contract.Invariant(context != null);
         Contract.Invariant(program != null);
@@ -509,7 +509,7 @@ namespace VC
       {
         Contract.Requires(gotoCmdOrigins != null);
         Contract.Requires(absyIds != null);
-        Contract.Requires(cce.NonNullElements(blocks));
+        Contract.Requires(Cce.NonNullElements(blocks));
         Contract.Requires(callback != null);
         Contract.Requires(context != null);
         Contract.Requires(program != null);
@@ -552,7 +552,7 @@ namespace VC
         }
 
         List<Block> trace = new List<Block>();
-        Block entryBlock = cce.NonNull(this.blocks[0]);
+        Block entryBlock = Cce.NonNull(this.blocks[0]);
         Contract.Assert(traceNodes.Contains(entryBlock));
         trace.Add(entryBlock);
 
@@ -594,7 +594,7 @@ namespace VC
         Contract.Ensures(Contract.Result<Absy>() != null);
 
         int id = int.Parse(label);
-        return cce.NonNull(absyIds.GetValue(id));
+        return Cce.NonNull(absyIds.GetValue(id));
       }
 
       public override void OnResourceExceeded(string msg, IEnumerable<Tuple<AssertCmd, TransferCmd>> assertCmds = null)
@@ -718,11 +718,11 @@ namespace VC
 
       #region Cut the backedges, push assert/assume statements from loop header into predecessors, change them all into assume statements at top of loop, introduce havoc statements
 
-      foreach (Block header in cce.NonNull(g.Headers))
+      foreach (Block header in Cce.NonNull(g.Headers))
       {
         Contract.Assert(header != null);
         IDictionary<Block, object> backEdgeNodes = new Dictionary<Block, object>();
-        foreach (Block b in cce.NonNull(g.BackEdgeNodes(header)))
+        foreach (Block b in Cce.NonNull(g.BackEdgeNodes(header)))
         {
           Contract.Assert(b != null);
           backEdgeNodes.Add(b, null);
@@ -829,10 +829,10 @@ namespace VC
 
         for (int predIndex = 0, n = header.Predecessors.Count; predIndex < n; predIndex++)
         {
-          Block pred = cce.NonNull(header.Predecessors[predIndex]);
+          Block pred = Cce.NonNull(header.Predecessors[predIndex]);
 
           // Create a block between header and pred for the predicate commands if pred has more than one successor
-          GotoCmd gotocmd = cce.NonNull((GotoCmd)pred.TransferCmd);
+          GotoCmd gotocmd = Cce.NonNull((GotoCmd)pred.TransferCmd);
           Contract.Assert(gotocmd.labelNames !=
                           null); // if "pred" is really a predecessor, it may be a GotoCmd with at least one label
           if (gotocmd.labelNames.Count > 1)
@@ -865,7 +865,7 @@ namespace VC
 
         #region Cut the back edge
 
-        foreach (Block backEdgeNode in cce.NonNull(backEdgeNodes.Keys))
+        foreach (Block backEdgeNode in Cce.NonNull(backEdgeNodes.Keys))
         {
           Contract.Assert(backEdgeNode != null);
           Debug.Assert(backEdgeNode.TransferCmd is GotoCmd,
@@ -962,7 +962,7 @@ namespace VC
     public static List<Variable> VarsAssignedInLoop(Graph<Block> g, Block header)
     {
       List<Variable> varsToHavoc = new List<Variable>();
-      foreach (Block backEdgeNode in cce.NonNull(g.BackEdgeNodes(header)))
+      foreach (Block backEdgeNode in Cce.NonNull(g.BackEdgeNodes(header)))
       {
         Contract.Assert(backEdgeNode != null);
         foreach (Block b in g.NaturalLoops(header, backEdgeNode))
@@ -982,7 +982,7 @@ namespace VC
     public static IEnumerable<Variable> VarsReferencedInLoop(Graph<Block> g, Block header)
     {
       HashSet<Variable> referencedVars = new HashSet<Variable>();
-      foreach (Block backEdgeNode in cce.NonNull(g.BackEdgeNodes(header)))
+      foreach (Block backEdgeNode in Cce.NonNull(g.BackEdgeNodes(header)))
       {
         Contract.Assert(backEdgeNode != null);
         foreach (Block b in g.NaturalLoops(header, backEdgeNode))
@@ -1033,7 +1033,7 @@ namespace VC
 
         #endregion
 
-        foreach (Block header in cce.NonNull(g.Headers))
+        foreach (Block header in Cce.NonNull(g.Headers))
         {
           Contract.Assert(header != null);
 
@@ -1102,7 +1102,7 @@ namespace VC
           #region redirect into the new loop copies and remove the original loop (but don't redirect back-edges)
 
           IDictionary<Block, object> backEdgeNodes = new Dictionary<Block, object>();
-          foreach (Block b in cce.NonNull(g.BackEdgeNodes(header)))
+          foreach (Block b in Cce.NonNull(g.BackEdgeNodes(header)))
           {
             Contract.Assert(b != null);
             backEdgeNodes.Add(b, null);
@@ -1110,7 +1110,7 @@ namespace VC
 
           for (int predIndex = 0, n = header.Predecessors.Count(); predIndex < n; predIndex++)
           {
-            Block pred = cce.NonNull(header.Predecessors[predIndex]);
+            Block pred = Cce.NonNull(header.Predecessors[predIndex]);
             if (!backEdgeNodes.ContainsKey(pred))
             {
               GotoCmd gc = pred.TransferCmd as GotoCmd;
@@ -1149,7 +1149,7 @@ namespace VC
 
       #region create copies of all blocks in the loop
 
-      foreach (Block backEdgeNode in cce.NonNull(g.BackEdgeNodes(header)))
+      foreach (Block backEdgeNode in Cce.NonNull(g.BackEdgeNodes(header)))
       {
         Contract.Assert(backEdgeNode != null);
         foreach (Block b in g.NaturalLoops(header, backEdgeNode))
@@ -1895,7 +1895,7 @@ namespace VC
       Contract.Requires(traceNodes != null);
       Contract.Requires(trace != null);
       Contract.Requires(context != null);
-      Contract.Requires(cce.NonNullDictionaryAndValues(calleeCounterexamples));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(calleeCounterexamples));
       // After translation, all potential errors come from asserts.
 
       List<object> augmentedTrace = new List<object>();
@@ -1903,10 +1903,10 @@ namespace VC
       {
         List<Cmd> cmds = b.Cmds;
         Contract.Assert(cmds != null);
-        TransferCmd transferCmd = cce.NonNull(b.TransferCmd);
+        TransferCmd transferCmd = Cce.NonNull(b.TransferCmd);
         for (int i = 0; i < cmds.Count; i++)
         {
-          Cmd cmd = cce.NonNull(cmds[i]);
+          Cmd cmd = Cce.NonNull(cmds[i]);
 
           // update augmentedTrace
           if (errModel != null && debugInfos != null && debugInfos.ContainsKey(cmd))
@@ -1933,7 +1933,7 @@ namespace VC
         }
 
         Block foundBlock = null;
-        foreach (Block bb in cce.NonNull(gotoCmd.labelTargets))
+        foreach (Block bb in Cce.NonNull(gotoCmd.labelTargets))
         {
           Contract.Assert(bb != null);
           if (traceNodes.Contains(bb))
@@ -2231,7 +2231,7 @@ namespace VC
       GotoCmd gotocmd = block.TransferCmd as GotoCmd;
       if (gotocmd != null)
       {
-        foreach (Block successor in cce.NonNull(gotocmd.labelTargets))
+        foreach (Block successor in Cce.NonNull(gotocmd.labelTargets))
         {
           Contract.Assert(successor != null);
           VCExpr c = DagVC(successor, controlFlowVariableExpr, absyIds, blockEquations, proverCtxt, out var ac);

--- a/Source/VCGeneration/VerificationResultCollector.cs
+++ b/Source/VCGeneration/VerificationResultCollector.cs
@@ -16,8 +16,8 @@ public class VerificationResultCollector : VerifierCallback
   [ContractInvariantMethod]
   void ObjectInvariant()
   {
-    Contract.Invariant(cce.NonNullElements(examples));
-    Contract.Invariant(cce.NonNullElements(vcResults));
+    Contract.Invariant(Cce.NonNullElements(examples));
+    Contract.Invariant(Cce.NonNullElements(vcResults));
   }
 
   public readonly ConcurrentQueue<Counterexample> examples = new();

--- a/Source/VCGeneration/Wlp.cs
+++ b/Source/VCGeneration/Wlp.cs
@@ -62,19 +62,19 @@ namespace VC
 
       for (int i = b.Cmds.Count; --i >= 0;)
       {
-        res = Cmd(b, cce.NonNull(b.Cmds[i]), res, ctxt);
+        res = Cmd(b, Cce.NonNull(b.Cmds[i]), res, ctxt);
       }
 
       ctxt.absyIds.GetId(b);
 
       try
       {
-        cce.BeginExpose(ctxt);
+        Cce.BeginExpose(ctxt);
         return res;
       }
       finally
       {
-        cce.EndExpose();
+        Cce.EndExpose();
       }
     }
 
@@ -231,7 +231,7 @@ namespace VC
       {
         ctxt.Options.OutputWriter.WriteLine(cmd.ToString());
         Contract.Assert(false);
-        throw new cce.UnreachableException(); // unexpected command
+        throw new Cce.UnreachableException(); // unexpected command
       }
     }
 
@@ -293,10 +293,10 @@ namespace VC
         }
         else
         {
-          VCExpr currentWLP = RegExpr(cce.NonNull(ch.rs[0]), N, ctxt);
+          VCExpr currentWLP = RegExpr(Cce.NonNull(ch.rs[0]), N, ctxt);
           for (int i = 1, n = ch.rs.Count; i < n; i++)
           {
-            currentWLP = ctxt.Ctxt.ExprGen.And(currentWLP, RegExpr(cce.NonNull(ch.rs[i]), N, ctxt));
+            currentWLP = ctxt.Ctxt.ExprGen.And(currentWLP, RegExpr(Cce.NonNull(ch.rs[i]), N, ctxt));
           }
 
           res = currentWLP;
@@ -307,7 +307,7 @@ namespace VC
       else
       {
         Contract.Assert(false);
-        throw new cce.UnreachableException(); // unexpected RE subtype
+        throw new Cce.UnreachableException(); // unexpected RE subtype
       }
     }
   }

--- a/Test/lean-auto/test.sh
+++ b/Test/lean-auto/test.sh
@@ -5,5 +5,5 @@ set -e
 boogie_file=$1
 base=`basename $boogie_file .bpl`
 lean_file="$base.lean"
-dotnet ../../Source/BoogieDriver/bin/Debug/net6.0/BoogieDriver.dll /printLean:$lean_file $boogie_file
+dotnet ../../Source/BoogieDriver/bin/Debug/net8.0/BoogieDriver.dll /printLean:$lean_file $boogie_file
 lake env lean $lean_file

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -78,7 +78,7 @@ repositoryRoot = up(up(os.path.abspath(__file__)))
 lit_config.note('Repository root is {}'.format(repositoryRoot))
 
 configuration = lit_config.params.get('configuration', 'Debug')
-framework = lit_config.params.get('framework', 'net6.0')
+framework = lit_config.params.get('framework', 'net8.0')
 
 boogieBinary = 'Source/BoogieDriver/bin/{}/{}/BoogieDriver.dll'.format(configuration, framework)
 runtime = 'dotnet'


### PR DESCRIPTION
### Changes
- Use large stack threads when preprocessing Boogie programs, to prevent stack overflow
- Use dotnet 8