### PR TITLE
Split Set_Size and axioms into a separate embedded resource (or poor man's module)

### DIFF
--- a/Source/Core/Core.csproj
+++ b/Source/Core/Core.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <EmbeddedResource Include="base.bpl" />
     <EmbeddedResource Include="node.bpl" />
+    <EmbeddedResource Include="set_size.bpl" />
   </ItemGroup>
 
 </Project>

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -155,28 +155,6 @@ function {:builtin "seq.extract"} Seq_Extract<T>(a: Seq T, pos: int, length: int
 /// finite sets
 datatype Set<T> { Set(val: [T]bool) }
 
-function Set_Size<T>(a: Set T) : int;
-
-axiom (forall<T> a: Set T :: a == Set_Empty() || 0 < Set_Size(a));
-
-axiom (forall<T> :: Set_Size(Set_Empty(): Set T) == 0);
-
-axiom (forall<T> a: Set T, t: T :: {Set_Add(a, t)} Set_Size(Set_Add(a, t)) == if Set_Contains(a, t) then Set_Size(a) else Set_Size(a) + 1);
-
-axiom (forall<T> a: Set T, t: T :: {Set_Remove(a, t)} Set_Size(Set_Remove(a, t)) == if Set_Contains(a, t) then Set_Size(a) - 1 else Set_Size(a));
-
-axiom (forall<T> a: Set T, b: Set T ::
-        {Set_Difference(a, b)} {Set_Intersection(a, b)} {Set_Union(a, b)}
-        Set_Size(a) == Set_Size(Set_Difference(a, b)) + Set_Size(Set_Intersection(a, b)));
-
-axiom (forall<T> a: Set T, b: Set T ::
-        {Set_Union(a, b)} {Set_Intersection(a, b)}
-        Set_Size(Set_Union(a, b)) + Set_Size(Set_Intersection(a, b)) == Set_Size(a) + Set_Size(b));
-
-pure procedure Lemma_SubsetSize<T>(a: Set T, b: Set T);
-requires Set_IsSubset(a, b);
-ensures a == b || Set_Size(a) < Set_Size(b);
-
 function {:inline} Set_Empty<T>(): Set T
 {
   Set(MapConst(false))

--- a/Source/Core/set_size.bpl
+++ b/Source/Core/set_size.bpl
@@ -1,0 +1,21 @@
+function Set_Size<T>(a: Set T) : int;
+
+axiom (forall<T> a: Set T :: a == Set_Empty() || 0 < Set_Size(a));
+
+axiom (forall<T> :: Set_Size(Set_Empty(): Set T) == 0);
+
+axiom (forall<T> a: Set T, t: T :: {Set_Add(a, t)} Set_Size(Set_Add(a, t)) == if Set_Contains(a, t) then Set_Size(a) else Set_Size(a) + 1);
+
+axiom (forall<T> a: Set T, t: T :: {Set_Remove(a, t)} Set_Size(Set_Remove(a, t)) == if Set_Contains(a, t) then Set_Size(a) - 1 else Set_Size(a));
+
+axiom (forall<T> a: Set T, b: Set T ::
+        {Set_Difference(a, b)} {Set_Intersection(a, b)} {Set_Union(a, b)}
+        Set_Size(a) == Set_Size(Set_Difference(a, b)) + Set_Size(Set_Intersection(a, b)));
+
+axiom (forall<T> a: Set T, b: Set T ::
+        {Set_Union(a, b)} {Set_Intersection(a, b)}
+        Set_Size(Set_Union(a, b)) + Set_Size(Set_Intersection(a, b)) == Set_Size(a) + Set_Size(b));
+
+pure procedure Lemma_SubsetSize<T>(a: Set T, b: Set T);
+requires Set_IsSubset(a, b);
+ensures a == b || Set_Size(a) < Set_Size(b);

--- a/Test/civl/large-samples/GC.bpl
+++ b/Test/civl/large-samples/GC.bpl
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //
 
-// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %parallel-boogie -lib:set_size "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Tid(i, ps) represents a linear thread id for thread number i, where i > 0 and ps = {Left(i), Right(i)}.

--- a/Test/civl/samples/bluetooth.bpl
+++ b/Test/civl/samples/bluetooth.bpl
@@ -1,4 +1,4 @@
-// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %parallel-boogie -lib:set_size "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 /*

--- a/Test/civl/samples/cav2020-3.bpl
+++ b/Test/civl/samples/cav2020-3.bpl
@@ -1,4 +1,4 @@
-// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %parallel-boogie -lib:set_size "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 datatype Perm { Left(i: int), Right(i: int) }

--- a/Test/civl/samples/reserve.bpl
+++ b/Test/civl/samples/reserve.bpl
@@ -1,4 +1,4 @@
-// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %parallel-boogie -lib:set_size "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 /*

--- a/Test/datatypes/set.bpl
+++ b/Test/datatypes/set.bpl
@@ -1,4 +1,4 @@
-// RUN: %parallel-boogie /lib:base "%s" > "%t"
+// RUN: %parallel-boogie /lib:base /lib:set_size "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 procedure Test1() {


### PR DESCRIPTION
Civl employs a simple-minded "module" system to isolate definitions. Currently, there are two modules: 
- base.bpl includes a lot of basic Civl types (One, Set, Map, and all the permission transfer operations).
- node.bpl includes list reachability (employed in Treiber stack, for example)

base.bpl contains the definition of a function ```Set_Size``` to represent the cardinality of a finite set. Since there is no support in SMT, I added some axioms. I discovered that these axioms were creating a lot of problems for the distributed snapshot example, even though ```Set_Size``` is not being used in that example.

This PR splits out Set_Size into a separate module.