### PR TITLE
Relaxing side condition check

### DIFF
--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Boogie
         var block = BlockHelper.Block($"{lc.domain.permissionType}_{lc.checkName}", cmds);
         checkerBlocks.Add(block);
       }
-      
+
       // Create init blocks
       var blocks = new List<Block>(linearityChecks.Count + 1);
       if (checkerBlocks.Count != 0)
@@ -509,7 +509,7 @@ namespace Microsoft.Boogie
         blocks.Add(
           BlockHelper.Block(
             "init",
-            new List<Cmd>() { CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs) },
+            new List<Cmd>() { CmdHelper.AssumeCmd(Expr.Not(GetExitCondition(action))), CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs) },
             checkerBlocks));
       }
       else

--- a/Source/Concurrency/InductiveSequentialization.cs
+++ b/Source/Concurrency/InductiveSequentialization.cs
@@ -459,6 +459,10 @@ namespace Microsoft.Boogie
     protected List<Declaration> GenerateSideConditionChecker(Action action)
     {
       var ltc = civlTypeChecker.linearTypeChecker;
+      if (ltc.LinearDomains.Count() == 0)
+      {
+        return new List<Declaration>();
+      }
       var inputs = action.Impl.InParams;
       var outputs = action.Impl.OutParams;
     
@@ -502,23 +506,13 @@ namespace Microsoft.Boogie
         checkerBlocks.Add(block);
       }
 
-      // Create init blocks
-      var blocks = new List<Block>(linearityChecks.Count + 1);
-      if (checkerBlocks.Count != 0)
+      var blocks = new List<Block>(linearityChecks.Count + 1)
       {
-        blocks.Add(
-          BlockHelper.Block(
-            "init",
-            new List<Cmd>() { CmdHelper.AssumeCmd(Expr.Not(GetExitCondition(action))), CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs) },
-            checkerBlocks));
-      }
-      else
-      {
-        blocks.Add(
-          BlockHelper.Block(
-            "init",
-            new List<Cmd>() { CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs) }));
-      }
+        BlockHelper.Block(
+          "init",
+          new List<Cmd>() { CmdHelper.AssumeCmd(Expr.Not(GetExitCondition(action))), CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs) },
+          checkerBlocks)
+      };
       blocks.AddRange(checkerBlocks);
       CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, blocks, ResolutionContext.State.Two);
 

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -276,15 +276,18 @@ function {:inline} One_Collector<T>(a: One T): [T]bool
 
 datatype Fraction<T, K> { Fraction(val: T, id: K, ids: Set K) }
 
+function {:inline} AllPieces<T,K>(t: T, ids: Set K): Set (Fraction T K) {
+  Set((lambda piece: Fraction T K :: piece->val == t && Set_Contains(ids, piece->id) && piece->ids == ids))
+}
+
 pure procedure {:inline 1} One_To_Fractions<T,K>({:linear_in} one_t: One T, ids: Set K) returns ({:linear} pieces: Set (Fraction T K))
 {
-  pieces := Set((lambda piece: Fraction T K :: piece->val == one_t->val && Set_Contains(ids, piece->id) && piece->ids == ids));
+  pieces := AllPieces(one_t->val, ids);
 }
 
 pure procedure {:inline 1} Fractions_To_One<T,K>({:linear_out} one_t: One T, ids: Set K, {:linear_in} pieces: Set (Fraction T K))
 {
-  assert (forall piece: Fraction T K:: Set_Contains(pieces, piece) ==> piece->val == one_t->val && piece->ids == ids);
-  assert pieces == Set((lambda piece: Fraction T K :: piece->val == one_t->val && Set_Contains(ids, piece->id) && piece->ids == ids));
+  assert pieces == AllPieces(one_t->val, ids);
 }
 
 /// singleton map

--- a/Test/civl/regression-tests/is2-attributes.bpl.expect
+++ b/Test/civl/regression-tests/is2-attributes.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 9 verified, 0 errors
+Boogie program verifier finished with 8 verified, 0 errors


### PR DESCRIPTION
We don’t need the entire body of the action to obey the side condition (permissions are only put into globals). So, we relax it by only checking it when the exit condition does not hold.