### PR TITLE
Fix reveal analysis when focus blocks are used

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>3.2.1</Version>
+    <Version>3.2.2</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/VCGeneration/Prune/Prune.cs
+++ b/Source/VCGeneration/Prune/Prune.cs
@@ -100,7 +100,15 @@ namespace Microsoft.Boogie
 
     private static Graph<Cmd> GetControlFlowGraph(List<Block> blocks)
     {
-      // The blocks created by splitting have unset block.Predecessors fields 
+      /*
+       * Generally the blocks created by splitting have unset block.Predecessors fields
+       * However, when {:focus} is used, the field is already set
+       * To ensure it's correct. We're recomputing it here.
+       */
+      foreach(var block in blocks)
+      {
+        block.Predecessors.Clear();
+      }
       Implementation.ComputePredecessorsForBlocks(blocks);
       var graph = new Graph<Cmd>();
       foreach (var block in blocks) {

--- a/Source/VCGeneration/Prune/RevealedAnalysis.cs
+++ b/Source/VCGeneration/Prune/RevealedAnalysis.cs
@@ -74,11 +74,10 @@ class RevealedAnalysis : DataflowAnalysis<Cmd, ImmutableStack<RevealedState>> {
       return new RevealedState(hideRevealCmd.Mode, ImmutableHashSet<Function>.Empty);
     }
 
-    if (hideRevealCmd.Mode == state.Mode) {
-      return state;
-    }
-
-    return state with { Offset = state.Offset.Add(hideRevealCmd.Function) };
+    var newOffset = hideRevealCmd.Mode == state.Mode
+      ? state.Offset.Remove(hideRevealCmd.Function)
+      : state.Offset.Add(hideRevealCmd.Function);
+    return state with { Offset = newOffset };
   }
   
   protected override ImmutableStack<RevealedState> Update(Cmd node, ImmutableStack<RevealedState> state) {

--- a/Test/pruning/Reveal.bpl
+++ b/Test/pruning/Reveal.bpl
@@ -52,3 +52,9 @@ procedure Nesting() {
   pop;
   pop;
 }
+
+procedure HideSpecific() {
+  hide inner;
+  reveal inner;
+  assert inner(3) == 42;
+}

--- a/Test/pruning/Reveal.bpl.expect
+++ b/Test/pruning/Reveal.bpl.expect
@@ -3,4 +3,4 @@ Reveal.bpl(29,7): Error: this assertion could not be proved
 Reveal.bpl(31,7): Error: this assertion could not be proved
 Reveal.bpl(42,3): Error: this assertion could not be proved
 
-Boogie program verifier finished with 1 verified, 4 errors
+Boogie program verifier finished with 2 verified, 4 errors


### PR DESCRIPTION
### Changes
- Fix reveal analysis when focus blocks are used
- Add test and fix bug in reveal analysis, when non-wildcard hide statements are used.