### PR TITLE
[Civl] Added explicit gates to atomic actions

### DIFF
--- a/Source/Concurrency/CivlCoreTypes.cs
+++ b/Source/Concurrency/CivlCoreTypes.cs
@@ -52,10 +52,12 @@ namespace Microsoft.Boogie
         DropSetChoice(civlTypeChecker, Impl);
       }
 
-      Gate = HoistAsserts(Impl, civlTypeChecker.Options);
+      ModifiedGlobalVars = new HashSet<Variable>(Impl.Proc.Modifies.Select(x => x.Decl));
+
+      AddGateSufficiencyCheckerAndHoistAsserts(civlTypeChecker);
+
       UsedGlobalVarsInGate = new HashSet<Variable>(VariableCollector.Collect(Gate).Where(x => x is GlobalVariable));
       UsedGlobalVarsInAction = new HashSet<Variable>(VariableCollector.Collect(Impl).Where(x => x is GlobalVariable));
-      ModifiedGlobalVars = new HashSet<Variable>(Impl.Proc.Modifies.Select(x => x.Decl));
 
       InputOutputRelation = ComputeInputOutputRelation(civlTypeChecker, Impl);
       if (ImplWithChoice != null)
@@ -157,6 +159,51 @@ namespace Microsoft.Boogie
         proc.OutParams, proc.IsPure, proc.Requires, proc.Modifies, proc.Ensures);
       CivlUtil.AddInlineAttribute(duplicateImpl.Proc);
       return duplicateImpl;
+    }
+
+    public static void AddGateSufficiencyCheckers(CivlTypeChecker civlTypeChecker, List<Declaration> decls)
+    {
+      decls.AddRange(gateSufficiencyCheckerDecls);
+    }
+
+    private static List<Declaration> gateSufficiencyCheckerDecls = new List<Declaration>();
+
+    private void AddGateSufficiencyCheckerAndHoistAsserts(CivlTypeChecker civlTypeChecker)
+    {
+      if (ActionDecl.Requires.Count == 0)
+      {
+        Gate = HoistAsserts(Impl, civlTypeChecker.Options);
+        return;
+      }
+      var duplicateImpl = CreateDuplicateImplementation(Impl, $"{Name}_GateSufficiencyCheckerHelper");
+      HoistAsserts(Impl, civlTypeChecker.Options);
+      var gateSubst = Substituter.SubstitutionFromDictionary(ActionDecl.InParams
+            .Zip(Impl.InParams)
+            .ToDictionary(x => x.Item1, x => (Expr)Expr.Ident(x.Item2)));
+      Gate = ActionDecl.Requires.Select(
+        requires => new AssertCmd(requires.tok, Substituter.Apply(gateSubst, requires.Condition))).ToList();
+      var checkerSubst = Substituter.SubstitutionFromDictionary(ActionDecl.InParams
+            .Zip(duplicateImpl.InParams)
+            .ToDictionary(x => x.Item1, x => (Expr)Expr.Ident(x.Item2)));
+      var cmds = new List<Cmd>(ActionDecl.Requires.Select(requires => CmdHelper.AssumeCmd(Substituter.Apply(checkerSubst, requires.Condition)))) {
+        CmdHelper.CallCmd(duplicateImpl.Proc, duplicateImpl.InParams, duplicateImpl.OutParams)
+      };
+      CivlUtil.ResolveAndTypecheck(civlTypeChecker.Options, cmds, ResolutionContext.State.Two);
+      var checkerName = $"{Name}_GateSufficiencyChecker";
+      var proc = DeclHelper.Procedure(
+        civlTypeChecker.AddNamePrefix(checkerName),
+        duplicateImpl.InParams,
+        duplicateImpl.OutParams,
+        new List<Requires>(),
+        ModifiedGlobalVars.Select(Expr.Ident).ToList(),
+        new List<Ensures>());
+      var impl = DeclHelper.Implementation(
+        proc,
+        proc.InParams,
+        proc.OutParams,
+        new List<Variable>(),
+        new List<Block> { BlockHelper.Block(checkerName, cmds) });
+      gateSufficiencyCheckerDecls.AddRange(new Declaration[] { duplicateImpl.Proc, duplicateImpl, proc, impl });
     }
 
     private Function ComputeInputOutputRelation(CivlTypeChecker civlTypeChecker, Implementation impl)

--- a/Source/Concurrency/CivlRewriter.cs
+++ b/Source/Concurrency/CivlRewriter.cs
@@ -21,8 +21,12 @@ namespace Microsoft.Boogie
       var originalDecls = origActionDecls.Union<Declaration>(origActionImpls).Union(origYieldProcs)
         .Union(origYieldImpls).Union(origYieldInvariants).ToHashSet();
 
-      // Commutativity checks
       var decls = new List<Declaration>();
+
+      // Gate sufficiency checks
+      Action.AddGateSufficiencyCheckers(civlTypeChecker, decls);
+
+      // Commutativity checks
       civlTypeChecker.AtomicActions.ForEach(x =>
       {
         decls.AddRange(new Declaration[] { x.Impl, x.Impl.Proc, x.InputOutputRelation });

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -2481,17 +2481,9 @@ namespace Microsoft.Boogie
       }
       if (rc.Proc is ActionDecl actionDecl)
       {
-        if (Layers.Count == 0)
+        if (Layers.Count > 0)
         {
-          rc.Error(this, "expected layers");
-        }
-        else
-        {
-          var assertLayerRange = new LayerRange(Layers[0], Layers[^1]);
-          if (!assertLayerRange.Subset(actionDecl.LayerRange))
-          {
-            rc.Error(this, $"each layer must be in the range {actionDecl.LayerRange}");
-          }
+          rc.Error(this, "did not expect layers");
         }
       }
     }

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -3013,9 +3013,7 @@ namespace Microsoft.Boogie
     {
       var oldProc = tc.Proc;
       tc.Proc = this;
-      tc.GlobalAccessOnlyInOld = true;
       base.Typecheck(tc);
-      tc.GlobalAccessOnlyInOld = false;
       YieldRequires.ForEach(callCmd => callCmd.Typecheck(tc));
       Contract.Assert(tc.Proc == this);
       tc.Proc = oldProc;

--- a/Test/civl/inductive-sequentialization/ChangRoberts.bpl
+++ b/Test/civl/inductive-sequentialization/ChangRoberts.bpl
@@ -76,8 +76,7 @@ modifies leader;
     assume (forall {:pool "ORDER"} x: int :: {:add_to_pool "ORDER", x} Pos(pid) < x && x <= Prev(Pos(self)) ==> Below(Pid(x), pid));
     // create prefix
     call create_asyncs(
-      (lambda {:pool "P_INV2"} pa: P :: {:add_to_pool "P_MAIN2", pa} {:add_to_pool "P_INV2", pa}
-        ValidPid(pa->pid) && Pos(pa->pid) < Pos(pid) && pa->self == Next(pa->pid)));
+      (lambda pa: P :: ValidPid(pa->pid) && Pos(pa->pid) < Pos(pid) && pa->self == Next(pa->pid)));
     // create singleton and set the choice
     call create_async(choice);
     call set_choice(choice);
@@ -94,9 +93,7 @@ creates P;
   assert Init(pids->val, leader);
   assume {:add_to_pool "INV2", P(ExpectedLeader, Prev(ExpectedLeader))} true;
   call create_asyncs(
-    (lambda {:pool "P_MAIN2"} pa: P :: 
-      {:add_to_pool "P_INV2", pa} 
-      ValidPid(pa->pid) && pa->self == Next(pa->pid)));
+    (lambda pa: P :: ValidPid(pa->pid) && pa->self == Next(pa->pid)));
 }
 
 action {:layer 2} INV1({:linear_in} pids: Set int)

--- a/Test/civl/regression-tests/assert-layers.bpl.expect
+++ b/Test/civl/regression-tests/assert-layers.bpl.expect
@@ -1,5 +1,4 @@
 assert-layers.bpl(5,0): Error: expected layers
 assert-layers.bpl(6,0): Error: expected layers
 assert-layers.bpl(8,2): Error: expected layers
-assert-layers.bpl(12,0): Error: expected layers
-4 name resolution errors detected in assert-layers.bpl
+3 name resolution errors detected in assert-layers.bpl

--- a/Test/civl/regression-tests/gate-sufficiency-checker.bpl
+++ b/Test/civl/regression-tests/gate-sufficiency-checker.bpl
@@ -1,0 +1,10 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,1} x: int;
+
+atomic action {:layer 1} Foo()
+requires x > 0;
+{
+    assert x != 0;
+}

--- a/Test/civl/regression-tests/gate-sufficiency-checker.bpl.expect
+++ b/Test/civl/regression-tests/gate-sufficiency-checker.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 1 verified, 0 errors

--- a/Test/civl/regression-tests/yield-pre-post.bpl
+++ b/Test/civl/regression-tests/yield-pre-post.bpl
@@ -9,5 +9,9 @@ ensures {:layer 1} g > 0;
 { }
 
 atomic action {:layer 1} A()
-requires {:layer 1} g > 0;
+requires g > 0;
+{}
+
+atomic action {:layer 2} B()
+requires g > 0;
 {}

--- a/Test/civl/regression-tests/yield-pre-post.bpl.expect
+++ b/Test/civl/regression-tests/yield-pre-post.bpl.expect
@@ -1,4 +1,4 @@
 yield-pre-post.bpl(7,20): Error: global variable must be accessed inside old expression: g
 yield-pre-post.bpl(8,19): Error: global variable must be accessed inside old expression: g
-yield-pre-post.bpl(12,20): Error: global variable must be accessed inside old expression: g
+yield-pre-post.bpl(16,9): Error: global variable must be available across all layers ([2, 2]) of action B: g
 3 type checking errors detected in yield-pre-post.bpl

--- a/Test/civl/samples/treiber-stack.bpl
+++ b/Test/civl/samples/treiber-stack.bpl
@@ -1,4 +1,4 @@
-// RUN: %parallel-boogie -lib:base -lib:node "%s" > "%t"
+// RUN: %parallel-boogie -lib:base -lib:node -vcsSplitOnEveryAssert "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 datatype LocPiece { Left(), Right() }
@@ -162,7 +162,7 @@ preserves call StackDom();
 atomic action {:layer 4} AtomicAllocNode#3(loc_t: Loc (Treiber X), x: X)
   returns (loc_n: Option (LocTreiberNode X), new_loc_n: LocTreiberNode X, {:linear} right_loc_piece: One (LocTreiberNode X))
 modifies ts;
-requires {:layer 4} Map_Contains(ts, loc_t);
+requires Map_Contains(ts, loc_t);
 {
   var {:linear} one_loc_t: One (Loc (Treiber X));
   var {:linear} treiber: Treiber X;

--- a/Test/civl/samples/treiber-stack.bpl
+++ b/Test/civl/samples/treiber-stack.bpl
@@ -162,6 +162,7 @@ preserves call StackDom();
 atomic action {:layer 4} AtomicAllocNode#3(loc_t: Loc (Treiber X), x: X)
   returns (loc_n: Option (LocTreiberNode X), new_loc_n: LocTreiberNode X, {:linear} right_loc_piece: One (LocTreiberNode X))
 modifies ts;
+requires {:layer 4} Map_Contains(ts, loc_t);
 {
   var {:linear} one_loc_t: One (Loc (Treiber X));
   var {:linear} treiber: Treiber X;

--- a/Test/civl/samples/treiber-stack.bpl.expect
+++ b/Test/civl/samples/treiber-stack.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 33 verified, 0 errors
+Boogie program verifier finished with 34 verified, 0 errors


### PR DESCRIPTION
This PR allows gates of atomic actions to be explicitly specified. The convention is as follows:

var {:layer 0,1} x: int;

yield invariant YieldInv();
invariant ...

atomic action Foo()
requires x > 0; // gate (must be sufficient to prove absence of failures in atomic action)
requires call YieldInv(); // precondition used only in special circumstances
{
   assert x != 0;
}