### PR TITLE
[Civl] Added Map_Pack and Map_Unpack

### DIFF
--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -156,6 +156,8 @@ public class LinearRewriter
       case "Cell_Unpack":
       case "Set_MakeEmpty":
       case "Map_MakeEmpty":
+      case "Map_Pack":
+      case "Map_Unpack":
       case "Map_Assume":
         return new List<Cmd>{callCmd};
       case "Set_Split":

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -928,14 +928,14 @@ namespace Microsoft.Boogie
       return expr;
     }
 
-    public IEnumerable<Expr> MapWellFormedExpressions(IEnumerable<Variable> availableVars)
+    public IEnumerable<Expr> MapWellFormedExpressions(IEnumerable<Variable> scope)
     {
       var monomorphizer = civlTypeChecker.program.monomorphizer;
       if (monomorphizer == null)
       {
         return Enumerable.Empty<Expr>();
       }
-      return availableVars.Where(v =>
+      return scope.Where(v =>
         {
           if (v.TypedIdent.Type is not CtorType ctorType)
           {

--- a/Source/Concurrency/LinearTypeChecker.cs
+++ b/Source/Concurrency/LinearTypeChecker.cs
@@ -894,8 +894,8 @@ namespace Microsoft.Boogie
 
     public IEnumerable<Expr> PermissionExprs(LinearDomain domain, IEnumerable<Variable> scope)
     {
-      var foo = FilterVariables(domain, scope);
-      return foo.Select(v => ExprHelper.FunctionCall(collectors[v.TypedIdent.Type][domain.permissionType], Expr.Ident(v)));
+      return FilterVariables(domain, scope)
+        .Select(v => ExprHelper.FunctionCall(collectors[v.TypedIdent.Type][domain.permissionType], Expr.Ident(v)));
     }
 
     public IEnumerable<Expr> PermissionExprs(LinearDomain domain, IEnumerable<Expr> availableExprs)

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Boogie
     {
       "One_New", "One_To_Fractions", "Fractions_To_One",
       "Cell_Pack", "Cell_Unpack",
-      "Map_MakeEmpty", "Map_Split", "Map_Join", "Map_Get", "Map_Put", "Map_Assume",
+      "Map_MakeEmpty", "Map_Pack", "Map_Unpack", "Map_Split", "Map_Join", "Map_Get", "Map_Put", "Map_Assume",
       "Set_MakeEmpty", "Set_Split", "Set_Get", "Set_Put", "One_Split", "One_Get", "One_Put"
     };
 
@@ -244,10 +244,14 @@ namespace Microsoft.Boogie
       switch (Monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
       {
         case "One_New":
+        case "One_To_Fractions":
+        case "Fractions_To_One":
         case "Cell_Pack":
         case "Cell_Unpack":
         case "Set_MakeEmpty":
         case "Map_MakeEmpty":
+        case "Map_Pack":
+        case "Map_Unpack":
         case "Map_Assume":
           return null;
         default:

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using BoogiePL = Microsoft.Boogie;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.Boogie
 {
@@ -532,11 +533,8 @@ namespace Microsoft.Boogie
 
       Dictionary<Variable, Expr> substMapOld = new Dictionary<Variable, Expr>();
 
-      foreach (IdentifierExpr /*!*/ mie in proc.Modifies)
+      foreach (var mVar in proc.Modifies.Select(ie => ie.Decl).Distinct())
       {
-        Contract.Assert(mie != null);
-        Variable /*!*/
-          mVar = cce.NonNull(mie.Decl);
         LocalVariable localVar = new LocalVariable(Token.NoToken,
           new TypedIdent(Token.NoToken, GetProcVarName(proc.Name, mVar.Name), mVar.TypedIdent.Type));
         newLocalVars.Add(localVar);

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -340,6 +340,15 @@ pure procedure {:inline 1} Map_MakeEmpty<K,V>() returns ({:linear} m: Map K V)
 {
   m := Map_Empty();
 }
+pure procedure {:inline 1} Map_Pack<K,V>({:linear_in} dom: Set K, val: [K]V) returns ({:linear} m: Map K V)
+{
+  m := Map(dom, MapIte(dom->val, val, MapConst(Default())));
+}
+pure procedure {:inline 1} Map_Unpack<K,V>({:linear_in} m: Map K V) returns ({:linear} dom: Set K, val: [K]V)
+{
+ dom := m->dom;
+ val := m->val;
+}
 pure procedure Map_Split<K,V>({:linear} path: Map K V, s: Set K) returns ({:linear} m: Map K V);
 pure procedure Map_Join<K,V>({:linear} path: Map K V, {:linear_in} m: Map K V);
 pure procedure Map_Get<K,V>({:linear} path: Map K V, k: K) returns ({:linear} c: Cell K V);

--- a/Test/civl/regression-tests/map_split.bpl
+++ b/Test/civl/regression-tests/map_split.bpl
@@ -34,3 +34,23 @@ asserts !Map_Contains(m, j);
     call m' := Map_Pack(s, x);
     assert m == m';
 }
+
+var {:linear} g: Map int int;
+
+atomic action {:layer 1} C(i: int, j: int)
+modifies g;
+asserts Map_Contains(g, i);
+asserts !Map_Contains(g, j);
+{
+    var {:linear} s: Set int;
+    var x: [int]int;
+    var y: [int]int;
+    var m': Map int int;
+
+    m' := g;
+    call s, x := Map_Unpack(g);
+    assert Set_Contains(s, i);
+    x[j] := 42;
+    call g := Map_Pack(s, x);
+    assert g == m';
+}

--- a/Test/civl/regression-tests/map_split.bpl
+++ b/Test/civl/regression-tests/map_split.bpl
@@ -18,3 +18,19 @@ asserts Set_IsSubset(s, m->dom);
     assert Map_Contains(x, i);
     assert Map_At(x, i) == v;
 }
+
+atomic action {:layer 1} B({:linear_in} m: Map int int, i: int, j: int)
+asserts Map_Contains(m, i);
+asserts !Map_Contains(m, j);
+{
+    var {:linear} s: Set int;
+    var x: [int]int;
+    var y: [int]int;
+    var {:linear} m': Map int int;
+
+    call s, x := Map_Unpack(m);
+    assert Set_Contains(s, i);
+    x[j] := 42;
+    call m' := Map_Pack(s, x);
+    assert m == m';
+}

--- a/Test/civl/regression-tests/map_split.bpl.expect
+++ b/Test/civl/regression-tests/map_split.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 2 verified, 0 errors
+Boogie program verifier finished with 3 verified, 0 errors

--- a/Test/civl/regression-tests/map_split.bpl.expect
+++ b/Test/civl/regression-tests/map_split.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 1 verified, 0 errors
+Boogie program verifier finished with 2 verified, 0 errors


### PR DESCRIPTION
In addition to introducing primitives Map_Pack and Map_Unpack, this PR also adds assumptions about well-formed maps to IS checkers (base, step, conclusion). Other checkers introduced by ISR remain. These assumptions should be added once the dust has settled on the implementation of ISR.

cc: @NamrathaG 