### PR TITLE
Record the SMT input size for each split

### DIFF
--- a/Source/Core/Xml.cs
+++ b/Source/Core/Xml.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Boogie
     }
 
     public void WriteSplit(int splitNum, int iteration, IEnumerable<AssertCmd> asserts, DateTime startTime,
-                           string outcome, TimeSpan elapsed, int? resourceCount)
+                           string outcome, TimeSpan elapsed, int? resourceCount, int? smtInputSize)
     {
       Contract.Requires(splitNum > 0);
       Contract.Requires(outcome != null);
@@ -144,6 +144,10 @@ namespace Microsoft.Boogie
         if (resourceCount is not null)
         {
           wr.WriteAttributeString("resourceCount", resourceCount.ToString());
+        }
+        if (smtInputSize is not null)
+        {
+          wr.WriteAttributeString("smtInputSize", smtInputSize.ToString());
         }
         wr.WriteEndElement(); // conclusion
 

--- a/Source/ExecutionEngine/ImplementationRunResult.cs
+++ b/Source/ExecutionEngine/ImplementationRunResult.cs
@@ -78,7 +78,7 @@ public sealed class ImplementationRunResult
 
       foreach (var vcResult in RunResults.OrderBy(s => (vcNum: s.VcNum, iteration: s.Iteration))) {
         engine.Options.XmlSink.WriteSplit(vcResult.VcNum, vcResult.Iteration, vcResult.Asserts, vcResult.StartTime,
-          vcResult.Outcome.ToString().ToLowerInvariant(), vcResult.RunTime, vcResult.ResourceCount);
+          vcResult.Outcome.ToString().ToLowerInvariant(), vcResult.RunTime, vcResult.ResourceCount, vcResult.SmtInputSize);
       }
 
       engine.Options.XmlSink.WriteEndMethod(VcOutcome.ToString().ToLowerInvariant(),

--- a/Source/ExecutionEngine/ImplementationRunResult.cs
+++ b/Source/ExecutionEngine/ImplementationRunResult.cs
@@ -78,7 +78,7 @@ public sealed class ImplementationRunResult
 
       foreach (var vcResult in RunResults.OrderBy(s => (vcNum: s.VcNum, iteration: s.Iteration))) {
         engine.Options.XmlSink.WriteSplit(vcResult.VcNum, vcResult.Iteration, vcResult.Asserts, vcResult.StartTime,
-          vcResult.Outcome.ToString().ToLowerInvariant(), vcResult.RunTime, vcResult.ResourceCount, vcResult.SmtInputSize);
+          vcResult.Outcome.ToString().ToLowerInvariant(), vcResult.RunTime, vcResult.ResourceCount, vcResult.CheckInputs.TotalSize);
       }
 
       engine.Options.XmlSink.WriteEndMethod(VcOutcome.ToString().ToLowerInvariant(),

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -23,7 +23,6 @@ public enum SolverOutcome
 public abstract class ProverInterface
 {
   public int SentSize { get; protected set; }
-  public StringBuilder SentSmt { get; } = new();
   
   public static ProverInterface CreateProver(SMTLibOptions libOptions, Program prog,
     string /*?*/ logFilePath, bool appendLogFile, uint timeout,

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -22,7 +22,8 @@ public enum SolverOutcome
 
 public abstract class ProverInterface
 {
-  public int SentSize { get; protected set; }
+  public int VCExprSize { get; protected set; }
+  public abstract int CommonSize { get; }
   
   public static ProverInterface CreateProver(SMTLibOptions libOptions, Program prog,
     string /*?*/ logFilePath, bool appendLogFile, uint timeout,

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Boogie.SMTLib;
@@ -22,6 +23,7 @@ public enum SolverOutcome
 public abstract class ProverInterface
 {
   public int SentSize { get; protected set; }
+  public StringBuilder SentSmt { get; } = new();
   
   public static ProverInterface CreateProver(SMTLibOptions libOptions, Program prog,
     string /*?*/ logFilePath, bool appendLogFile, uint timeout,

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -21,6 +21,8 @@ public enum SolverOutcome
 
 public abstract class ProverInterface
 {
+  public int SentSize { get; protected set; }
+  
   public static ProverInterface CreateProver(SMTLibOptions libOptions, Program prog,
     string /*?*/ logFilePath, bool appendLogFile, uint timeout,
     int taskID = -1)

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Boogie.SMTLib
       DeclCollector.Reset();
       NamedAssumes.Clear();
       SentSize = 0;
+      SentSmt.Clear();
     }
 
     private Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests, CancellationToken cancellationToken) {
@@ -285,7 +286,10 @@ namespace Microsoft.Boogie.SMTLib
       // Boogie emits comments after the solver has responded. In batch
       // mode, sending these to the solver is problematic. But they'll
       // still get sent to the log below.
-      if (Process != null && !checkSatSent) {
+      if (Process != null && !checkSatSent)
+      {
+        SentSize += s.Length;
+        SentSmt.AppendLine(s);
         Process.Send(s);
       }
 

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -71,9 +71,9 @@ namespace Microsoft.Boogie.SMTLib
         SetupProcess();
         checkSatSent = false;
         FullReset(gen);
-
         if (options.LogFilename != null && currentLogFile == null)
         {
+          
           currentLogFile = OpenOutputFile(descriptiveName);
           await currentLogFile.WriteAsync(common.ToString());
         }
@@ -123,6 +123,7 @@ namespace Microsoft.Boogie.SMTLib
       AxiomsAreSetup = false;
       DeclCollector.Reset();
       NamedAssumes.Clear();
+      SentSize = 0;
     }
 
     private Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests, CancellationToken cancellationToken) {

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -124,7 +124,6 @@ namespace Microsoft.Boogie.SMTLib
       DeclCollector.Reset();
       NamedAssumes.Clear();
       SentSize = 0;
-      SentSmt.Clear();
     }
 
     private Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests, CancellationToken cancellationToken) {
@@ -289,7 +288,6 @@ namespace Microsoft.Boogie.SMTLib
       if (Process != null && !checkSatSent)
       {
         SentSize += s.Length;
-        SentSmt.AppendLine(s);
         Process.Send(s);
       }
 

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Boogie.SMTLib
         OptimizationRequests.Clear();
 
         string vcString = "(assert (not\n" + VcExpr2String(vc, 1) + "\n))";
+        FlushAxioms();
         VCExprSize = vcString.Length;
 
         Push();

--- a/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibBatchTheoremProver.cs
@@ -73,9 +73,7 @@ namespace Microsoft.Boogie.SMTLib
         FullReset(gen);
         if (options.LogFilename != null && currentLogFile == null)
         {
-          
           currentLogFile = OpenOutputFile(descriptiveName);
-          await currentLogFile.WriteAsync(common.ToString());
         }
 
         SendVCOptions();
@@ -84,8 +82,8 @@ namespace Microsoft.Boogie.SMTLib
 
         OptimizationRequests.Clear();
 
-        string vcString = "(assert (not\n" + VCExpr2String(vc, 1) + "\n))";
-        FlushAxioms();
+        string vcString = "(assert (not\n" + VcExpr2String(vc, 1) + "\n))";
+        VCExprSize = vcString.Length;
 
         Push();
         SendVCId(descriptiveName);
@@ -123,7 +121,6 @@ namespace Microsoft.Boogie.SMTLib
       AxiomsAreSetup = false;
       DeclCollector.Reset();
       NamedAssumes.Clear();
-      SentSize = 0;
     }
 
     private Task<IReadOnlyList<SExpr>> SendRequestsAndClose(IReadOnlyList<string> requests, CancellationToken cancellationToken) {
@@ -287,7 +284,6 @@ namespace Microsoft.Boogie.SMTLib
       // still get sent to the log below.
       if (Process != null && !checkSatSent)
       {
-        SentSize += s.Length;
         Process.Send(s);
       }
 

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Boogie.SMTLib
         SetupProcess();
         var c = common.ToString();
         SentSize += c.Length;
-        SentSmt.AppendLine(c);
         Process.Send(c);
       }
     }
@@ -128,7 +127,6 @@ namespace Microsoft.Boogie.SMTLib
 
         var result = await CheckSat(cancellationToken, errorLimit);
         SentSize = 0;
-        SentSmt.Clear();
         SendThisVC("(pop 1)");
 
         return result;
@@ -148,7 +146,6 @@ namespace Microsoft.Boogie.SMTLib
       {
         var c = common.ToString();
         SentSize += c.Length;
-        SentSmt.AppendLine(c);
         Process.Send(c);
         if (currentLogFile != null)
         {
@@ -272,7 +269,6 @@ namespace Microsoft.Boogie.SMTLib
           if (popLater)
           {
             SentSize = 0;
-            SentSmt.Clear();
             SendThisVC("(pop 1)");
           }
         }
@@ -311,7 +307,6 @@ namespace Microsoft.Boogie.SMTLib
       if (popLater)
       {
         SentSize = 0;
-        SentSmt.Clear();
         SendThisVC("(pop 1)");
       }
       SendThisVC("(push 1)");
@@ -659,7 +654,6 @@ namespace Microsoft.Boogie.SMTLib
       if (Process != null)
       {
         SentSize += s.Length;
-        SentSmt.AppendLine(s);
         Process.Send(s);
       }
 

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -647,6 +647,7 @@ namespace Microsoft.Boogie.SMTLib
 
       if (Process != null)
       {
+        SentSize += s.Length;
         Process.Send(s);
       }
 

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -46,7 +46,10 @@ namespace Microsoft.Boogie.SMTLib
       if (Process != null && processNeedsRestart) {
         processNeedsRestart = false;
         SetupProcess();
-        Process.Send(common.ToString());
+        var c = common.ToString();
+        SentSize += c.Length;
+        SentSmt.AppendLine(c);
+        Process.Send(c);
       }
     }
 
@@ -124,6 +127,8 @@ namespace Microsoft.Boogie.SMTLib
         }
 
         var result = await CheckSat(cancellationToken, errorLimit);
+        SentSize = 0;
+        SentSmt.Clear();
         SendThisVC("(pop 1)");
 
         return result;
@@ -142,10 +147,12 @@ namespace Microsoft.Boogie.SMTLib
       if (0 < common.Length)
       {
         var c = common.ToString();
+        SentSize += c.Length;
+        SentSmt.AppendLine(c);
         Process.Send(c);
         if (currentLogFile != null)
         {
-          currentLogFile.WriteLine(c);
+          await currentLogFile.WriteLineAsync(c);
         }
       }
 
@@ -264,6 +271,8 @@ namespace Microsoft.Boogie.SMTLib
         {
           if (popLater)
           {
+            SentSize = 0;
+            SentSmt.Clear();
             SendThisVC("(pop 1)");
           }
         }
@@ -301,6 +310,8 @@ namespace Microsoft.Boogie.SMTLib
     {
       if (popLater)
       {
+        SentSize = 0;
+        SentSmt.Clear();
         SendThisVC("(pop 1)");
       }
       SendThisVC("(push 1)");
@@ -648,6 +659,7 @@ namespace Microsoft.Boogie.SMTLib
       if (Process != null)
       {
         SentSize += s.Length;
+        SentSmt.AppendLine(s);
         Process.Send(s);
       }
 

--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Boogie.SMTLib
         processNeedsRestart = false;
         SetupProcess();
         var c = common.ToString();
-        SentSize += c.Length;
         Process.Send(c);
       }
     }
@@ -65,7 +64,8 @@ namespace Microsoft.Boogie.SMTLib
     }
 
     private bool hasReset = true;
-    public override async Task<SolverOutcome> Check(string descriptiveName, VCExpr vc, ErrorHandler handler, int errorLimit, CancellationToken cancellationToken)
+    public override async Task<SolverOutcome> Check(string descriptiveName, VCExpr vc, ErrorHandler handler, 
+      int errorLimit, CancellationToken cancellationToken)
     {
       currentErrorHandler = handler;
       try
@@ -102,7 +102,8 @@ namespace Microsoft.Boogie.SMTLib
 
         SendThisVC("(push 1)");
         DeclCollector.Push();
-        string vcString = "(assert (not\n" + VCExpr2String(vc, 1) + "\n))";
+        string vcString = "(assert (not\n" + VcExpr2String(vc, 1) + "\n))";
+        VCExprSize = vcString.Length;
         FlushAxioms();
         SendVCId(descriptiveName);
         SendVCOptions();
@@ -126,7 +127,6 @@ namespace Microsoft.Boogie.SMTLib
         }
 
         var result = await CheckSat(cancellationToken, errorLimit);
-        SentSize = 0;
         SendThisVC("(pop 1)");
 
         return result;
@@ -145,7 +145,6 @@ namespace Microsoft.Boogie.SMTLib
       if (0 < common.Length)
       {
         var c = common.ToString();
-        SentSize += c.Length;
         Process.Send(c);
         if (currentLogFile != null)
         {
@@ -268,7 +267,6 @@ namespace Microsoft.Boogie.SMTLib
         {
           if (popLater)
           {
-            SentSize = 0;
             SendThisVC("(pop 1)");
           }
         }
@@ -306,7 +304,6 @@ namespace Microsoft.Boogie.SMTLib
     {
       if (popLater)
       {
-        SentSize = 0;
         SendThisVC("(pop 1)");
       }
       SendThisVC("(push 1)");
@@ -439,7 +436,7 @@ namespace Microsoft.Boogie.SMTLib
         expr = VCExprGen.AndSimp(expr, lit);
       }
 
-      SendThisVC("(assert " + VCExpr2String(expr, 1) + ")");
+      SendThisVC("(assert " + VcExpr2String(expr, 1) + ")");
       if (options.Solver == SolverKind.Z3)
       {
         SendThisVC("(apply (then (using-params propagate-values :max_rounds 1) simplify) :print false)");
@@ -539,7 +536,7 @@ namespace Microsoft.Boogie.SMTLib
 
     public override async Task<object> Evaluate(VCExpr expr)
     {
-      string vcString = VCExpr2String(expr, 1);
+      string vcString = VcExpr2String(expr, 1);
       var resp = await SendVcRequest($"(get-value ({vcString}))");
       if (resp == null)
       {
@@ -653,7 +650,6 @@ namespace Microsoft.Boogie.SMTLib
 
       if (Process != null)
       {
-        SentSize += s.Length;
         Process.Send(s);
       }
 
@@ -704,7 +700,7 @@ namespace Microsoft.Boogie.SMTLib
           nameCounter++;
           nameToAssumption.Add(name, i);
 
-          string vcString = VCExpr2String(vc, 1);
+          string vcString = VcExpr2String(vc, 1);
           AssertAxioms();
           SendThisVC(string.Format("(assert (! {0} :named {1}))", vcString, name));
           i++;
@@ -755,13 +751,13 @@ namespace Microsoft.Boogie.SMTLib
         var hardAssumptionStrings = new List<string>();
         foreach (var a in hardAssumptions)
         {
-          hardAssumptionStrings.Add(VCExpr2String(a, 1));
+          hardAssumptionStrings.Add(VcExpr2String(a, 1));
         }
 
         var currAssumptionStrings = new List<string>();
         foreach (var a in softAssumptions)
         {
-          currAssumptionStrings.Add(VCExpr2String(a, 1));
+          currAssumptionStrings.Add(VcExpr2String(a, 1));
         }
 
         Push();

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1111,6 +1111,8 @@ namespace Microsoft.Boogie.SMTLib
 
     public override void Pop()
     {
+      SentSize = 0;
+      SentSmt.Clear();
       SendThisVC("(pop 1)");
       DeclCollector.Pop();
     }

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -1112,7 +1112,6 @@ namespace Microsoft.Boogie.SMTLib
     public override void Pop()
     {
       SentSize = 0;
-      SentSmt.Clear();
       SendThisVC("(pop 1)");
       DeclCollector.Pop();
     }

--- a/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibProcessTheoremProver.cs
@@ -91,11 +91,11 @@ namespace Microsoft.Boogie.SMTLib
       string vcString;
       if (polarity)
       {
-        vcString = VCExpr2String(vc, 1);
+        vcString = VcExpr2String(vc, 1);
       }
       else
       {
-        vcString = "(not " + VCExpr2String(vc, 1) + ")";
+        vcString = "(not " + VcExpr2String(vc, 1) + ")";
       }
 
       AssertAxioms();
@@ -149,6 +149,8 @@ namespace Microsoft.Boogie.SMTLib
       return msg;
     }
 
+    public override int CommonSize => common.Length;
+
     public override void LogComment(string comment)
     {
       SendCommon("; " + comment);
@@ -191,63 +193,65 @@ namespace Microsoft.Boogie.SMTLib
 
     private void PrepareDataTypes()
     {
-      if (ctx.KnownDatatypes.Count > 0)
+      if (ctx.KnownDatatypes.Count <= 0)
       {
-        GraphUtil.Graph<DatatypeTypeCtorDecl> dependencyGraph = new GraphUtil.Graph<DatatypeTypeCtorDecl>();
-        foreach (var datatype in ctx.KnownDatatypes)
+        return;
+      }
+
+      var dependencyGraph = new GraphUtil.Graph<DatatypeTypeCtorDecl>();
+      foreach (var datatype in ctx.KnownDatatypes)
+      {
+        dependencyGraph.AddSource(datatype);
+        foreach (DatatypeConstructor f in datatype.Constructors)
         {
-          dependencyGraph.AddSource(datatype);
+          var dependentTypes = new List<DatatypeTypeCtorDecl>();
+          foreach (Variable v in f.InParams)
+          {
+            FindDependentTypes(v.TypedIdent.Type, dependentTypes);
+          }
+          foreach (var result in dependentTypes)
+          {
+            dependencyGraph.AddEdge(datatype, result);
+          }
+        }
+      }
+
+      var sccs =
+        new GraphUtil.StronglyConnectedComponents<DatatypeTypeCtorDecl>(dependencyGraph.Nodes, dependencyGraph.Predecessors,
+          dependencyGraph.Successors);
+      sccs.Compute();
+      foreach (var scc in sccs)
+      {
+        string datatypesString = "";
+        string datatypeConstructorsString = "";
+        foreach (var datatype in scc)
+        {
+          datatypesString += "(" + new SMTLibExprLineariser(libOptions).TypeToString(new CtorType(Token.NoToken, datatype, new List<Type>())) + " 0)";
+          string datatypeConstructorString = "";
           foreach (Function f in datatype.Constructors)
           {
-            var dependentTypes = new List<DatatypeTypeCtorDecl>();
+            string quotedConstructorName = Namer.GetQuotedName(f, f.Name);
+            datatypeConstructorString += "(" + quotedConstructorName + " ";
             foreach (Variable v in f.InParams)
             {
-              FindDependentTypes(v.TypedIdent.Type, dependentTypes);
+              string quotedSelectorName = Namer.GetQuotedName(v, v.Name + "#" + f.Name);
+              datatypeConstructorString += "(" + quotedSelectorName + " " +
+                                           DeclCollector.TypeToStringReg(v.TypedIdent.Type) + ") ";
             }
-            foreach (var result in dependentTypes)
-            {
-              dependencyGraph.AddEdge(datatype, result);
-            }
+
+            datatypeConstructorString += ") ";
           }
+
+          datatypeConstructorsString += "(" + datatypeConstructorString + ") ";
         }
 
-        GraphUtil.StronglyConnectedComponents<DatatypeTypeCtorDecl> sccs =
-          new GraphUtil.StronglyConnectedComponents<DatatypeTypeCtorDecl>(dependencyGraph.Nodes, dependencyGraph.Predecessors,
-            dependencyGraph.Successors);
-        sccs.Compute();
-        foreach (GraphUtil.SCC<DatatypeTypeCtorDecl> scc in sccs)
+        List<string> decls = DeclCollector.GetNewDeclarations();
+        foreach (string decl in decls)
         {
-          string datatypesString = "";
-          string datatypeConstructorsString = "";
-          foreach (var datatype in scc)
-          {
-            datatypesString += "(" + new SMTLibExprLineariser(libOptions).TypeToString(new CtorType(Token.NoToken, datatype, new List<Type>())) + " 0)";
-            string datatypeConstructorString = "";
-            foreach (Function f in datatype.Constructors)
-            {
-              string quotedConstructorName = Namer.GetQuotedName(f, f.Name);
-              datatypeConstructorString += "(" + quotedConstructorName + " ";
-              foreach (Variable v in f.InParams)
-              {
-                string quotedSelectorName = Namer.GetQuotedName(v, v.Name + "#" + f.Name);
-                datatypeConstructorString += "(" + quotedSelectorName + " " +
-                                             DeclCollector.TypeToStringReg(v.TypedIdent.Type) + ") ";
-              }
-
-              datatypeConstructorString += ") ";
-            }
-
-            datatypeConstructorsString += "(" + datatypeConstructorString + ") ";
-          }
-
-          List<string> decls = DeclCollector.GetNewDeclarations();
-          foreach (string decl in decls)
-          {
-            SendCommon(decl);
-          }
-
-          SendCommon("(declare-datatypes (" + datatypesString + ") (" + datatypeConstructorsString + "))");
+          SendCommon(decl);
         }
+
+        SendCommon("(declare-datatypes (" + datatypesString + ") (" + datatypeConstructorsString + "))");
       }
     }
 
@@ -318,7 +322,7 @@ namespace Microsoft.Boogie.SMTLib
           funcDef += ") ";
 
           funcDef += new SMTLibExprLineariser(libOptions).TypeToString(defBody[0].Type) + " ";
-          funcDef += VCExpr2String(defBody[1], -1);
+          funcDef += VcExpr2String(defBody[1], -1);
           funcDef += ")";
           generatedFuncDefs.Add(funcDef);
           definitionAdded.Add(f);
@@ -402,13 +406,13 @@ namespace Microsoft.Boogie.SMTLib
       var axioms = ctx.Axioms;
       if (axioms is VCExprNAry nary && nary.Op == VCExpressionGenerator.AndOp) {
         foreach (var expr in nary.UniformArguments) {
-          var str = VCExpr2String(expr, -1);
+          var str = VcExpr2String(expr, -1);
           if (str != "true") {
             AddAxiom(str);
           }
         }
       } else {
-        AddAxiom(VCExpr2String(axioms, -1));
+        AddAxiom(VcExpr2String(axioms, -1));
       }
 
       AxiomsAreSetup = true;
@@ -970,7 +974,7 @@ namespace Microsoft.Boogie.SMTLib
 
     protected readonly IList<string> OptimizationRequests = new List<string>();
 
-    protected string VCExpr2String(VCExpr expr, int polarity)
+    public string VcExpr2String(VCExpr expr, int polarity)
     {
       Contract.Requires(expr != null);
       Contract.Ensures(Contract.Result<string>() != null);
@@ -1101,7 +1105,7 @@ namespace Microsoft.Boogie.SMTLib
     //int numRealPushes;
     public override string VCExpressionToString(VCExpr vc)
     {
-      return VCExpr2String(vc, 1);
+      return VcExpr2String(vc, 1);
     }
 
     public override void PushVCExpression(VCExpr vc)
@@ -1111,7 +1115,6 @@ namespace Microsoft.Boogie.SMTLib
 
     public override void Pop()
     {
-      SentSize = 0;
       SendThisVC("(pop 1)");
       DeclCollector.Pop();
     }
@@ -1136,7 +1139,7 @@ namespace Microsoft.Boogie.SMTLib
         assert += "-soft";
       }
 
-      var expr = polarity ? VCExpr2String(vc, 1) : "(not\n" + VCExpr2String(vc, 1) + "\n)";
+      var expr = polarity ? VcExpr2String(vc, 1) : "(not\n" + VcExpr2String(vc, 1) + "\n)";
       if (options.Solver == SolverKind.Z3 && isSoft)
       {
         expr += " :weight " + weight;
@@ -1158,7 +1161,7 @@ namespace Microsoft.Boogie.SMTLib
       string printedName = Namer.GetQuotedName(f, f.Name);
       var argTypes = string.Join(" ", f.InParams.Select(p => DeclCollector.TypeToStringReg(p.TypedIdent.Type)));
       string decl = "(define-fun " + printedName + " (" + argTypes + ") " +
-                    DeclCollector.TypeToStringReg(f.OutParams[0].TypedIdent.Type) + " " + VCExpr2String(vc, 1) + ")";
+                    DeclCollector.TypeToStringReg(f.OutParams[0].TypedIdent.Type) + " " + VcExpr2String(vc, 1) + ")";
       AssertAxioms();
       SendThisVC(decl);
     }

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -259,6 +259,8 @@ namespace Microsoft.Boogie
       get { return proverRunTime; }
     }
 
+    public int SmtInputSize => thmProver.SentSize;
+
     public int GetProverResourceCount()
     {
       return thmProver.GetRCount();

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -260,7 +260,6 @@ namespace Microsoft.Boogie
     }
 
     public int SmtInputSize => thmProver.SentSize;
-    public string SmtUsed => thmProver.SentSmt.ToString();
 
     public int GetProverResourceCount()
     {

--- a/Source/VCGeneration/Checker.cs
+++ b/Source/VCGeneration/Checker.cs
@@ -260,6 +260,7 @@ namespace Microsoft.Boogie
     }
 
     public int SmtInputSize => thmProver.SentSize;
+    public string SmtUsed => thmProver.SentSmt.ToString();
 
     public int GetProverResourceCount()
     {

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -980,8 +980,11 @@ namespace VC
         checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions()
           .Select(kv => new OptionValue(kv.Key, kv.Value)));
         await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
+        SmtUsed = checker.SmtUsed;
         SmtInputSize = checker.SmtInputSize;
       }
+
+      public string SmtUsed { get; set; }
 
       public string Description
       {

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -39,16 +39,14 @@ namespace VC
         }
       }
 
-      readonly Dictionary<Block /*!*/, BlockStats /*!*/> /*!*/
-        stats = new Dictionary<Block /*!*/, BlockStats /*!*/>();
+      readonly Dictionary<Block /*!*/, BlockStats /*!*/> /*!*/ stats = new();
 
       static int currentId = -1;
 
       Block splitBlock;
       bool assertToAssume;
 
-      List<Block /*!*/> /*!*/
-        assumizedBranches = new List<Block /*!*/>();
+      List<Block /*!*/> /*!*/ assumizedBranches = new();
 
       double score;
       bool scoreComputed;
@@ -58,8 +56,7 @@ namespace VC
 
       public Dictionary<TransferCmd, ReturnCmd> GotoCmdOrigins { get; }
 
-      public readonly VerificationConditionGenerator /*!*/
-        parent;
+      public readonly VerificationConditionGenerator /*!*/ parent;
 
       public Implementation /*!*/ Implementation => Run.Implementation;
 
@@ -78,6 +75,7 @@ namespace VC
       // async interface
       public int SplitIndex { get; set; }
       public VerificationConditionGenerator.ErrorReporter reporter;
+      public int SmtInputSize { get; set; }
 
       public Split(VCGenOptions options, List<Block /*!*/> /*!*/ blocks,
         Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
@@ -915,6 +913,7 @@ namespace VC
           Asserts: Asserts,
           CoveredElements: CoveredElements,
           ResourceCount: resourceCount,
+          SmtInputSize,
           SolverUsed: (Options as SMTLibSolverOptions)?.Solver);
         callback.OnVCResult(result);
 
@@ -981,6 +980,7 @@ namespace VC
         checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions()
           .Select(kv => new OptionValue(kv.Key, kv.Value)));
         await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
+        SmtInputSize = checker.SmtInputSize;
       }
 
       public string Description

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -980,11 +980,8 @@ namespace VC
         checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions()
           .Select(kv => new OptionValue(kv.Key, kv.Value)));
         await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
-        SmtUsed = checker.SmtUsed;
         SmtInputSize = checker.SmtInputSize;
       }
-
-      public string SmtUsed { get; set; }
 
       public string Description
       {

--- a/Source/VCGeneration/Split.cs
+++ b/Source/VCGeneration/Split.cs
@@ -75,7 +75,7 @@ namespace VC
       // async interface
       public int SplitIndex { get; set; }
       public VerificationConditionGenerator.ErrorReporter reporter;
-      public int SmtInputSize { get; set; }
+      public CheckInputs CheckInputs { get; set; }
 
       public Split(VCGenOptions options, List<Block /*!*/> /*!*/ blocks,
         Dictionary<TransferCmd, ReturnCmd> /*!*/ gotoCmdOrigins,
@@ -913,7 +913,7 @@ namespace VC
           Asserts: Asserts,
           CoveredElements: CoveredElements,
           ResourceCount: resourceCount,
-          SmtInputSize,
+          CheckInputs,
           SolverUsed: (Options as SMTLibSolverOptions)?.Solver);
         callback.OnVCResult(result);
 
@@ -979,8 +979,7 @@ namespace VC
 
         checker.TheoremProver.SetAdditionalSmtOptions(Implementation.GetExtraSMTOptions()
           .Select(kv => new OptionValue(kv.Key, kv.Value)));
-        await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
-        SmtInputSize = checker.SmtInputSize;
+        CheckInputs = await checker.BeginCheck(Description, vc, reporter, timeout, rlimit, cancellationToken);
       }
 
       public string Description

--- a/Source/VCGeneration/VerificationRunResult.cs
+++ b/Source/VCGeneration/VerificationRunResult.cs
@@ -18,6 +18,7 @@ namespace VC
     List<AssertCmd> Asserts,
     IEnumerable<TrackedNodeComponent> CoveredElements,
     int ResourceCount,
+    int SmtInputSize,
     SolverKind? SolverUsed
   ) {
     public void ComputePerAssertOutcomes(out Dictionary<AssertCmd, SolverOutcome> perAssertOutcome,

--- a/Source/VCGeneration/VerificationRunResult.cs
+++ b/Source/VCGeneration/VerificationRunResult.cs
@@ -18,7 +18,7 @@ namespace VC
     List<AssertCmd> Asserts,
     IEnumerable<TrackedNodeComponent> CoveredElements,
     int ResourceCount,
-    int SmtInputSize,
+    CheckInputs CheckInputs,
     SolverKind? SolverUsed
   ) {
     public void ComputePerAssertOutcomes(out Dictionary<AssertCmd, SolverOutcome> perAssertOutcome,

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -11,11 +11,11 @@
 // CHECK: \<method name="ExampleWithSplits" startTime=".*"\>
 // CHECK:   \<assertionBatch number="1" iteration="0" startTime=".*"\>
 // CHECK:     \<assertion file="xml.bpl" line="25" column="3" /\>
-// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="601" /\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="491" /\>
 // CHECK:   \</assertionBatch\>
 // CHECK:   \<assertionBatch number="2" iteration="0" startTime=".*"\>
 // CHECK:     \<assertion file="xml.bpl" line="27" column="3" /\>
-// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="630" /\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="520" /\>
 // CHECK:   \</assertionBatch\>
 // CHECK:   \<conclusion endTime=".*" duration=".*" resourceCount=".*" outcome="correct" /\>
 // CHECK: \</method\>

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -1,5 +1,5 @@
-// RUN: %parallel-boogie -randomSeed:0 -xml:"%t-1.xml" "%s"
-// RUN: %parallel-boogie -randomSeed:0 -xml:"%t-2.xml" "%s"
+// RUN: %parallel-boogie -randomSeed:0 -proverLog:%t-1.smt -xml:"%t-1.xml" "%s"
+// RUN: %parallel-boogie -randomSeed:0 -proverLog:%t-2.smt -xml:"%t-2.xml" "%s"
 // RUN: grep -Eo "resourceCount=\"[0-9]+\"" "%t-1.xml" | sort -g > "%t-res1"
 // RUN: grep -Eo "resourceCount=\"[0-9]+\"" "%t-2.xml" | sort -g > "%t-res2"
 // RUN: diff "%t-res1" "%t-res2"

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -11,11 +11,11 @@
 // CHECK: \<method name="ExampleWithSplits" startTime=".*"\>
 // CHECK:   \<assertionBatch number="1" iteration="0" startTime=".*"\>
 // CHECK:     \<assertion file="xml.bpl" line="25" column="3" /\>
-// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="865" /\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="601" /\>
 // CHECK:   \</assertionBatch\>
 // CHECK:   \<assertionBatch number="2" iteration="0" startTime=".*"\>
 // CHECK:     \<assertion file="xml.bpl" line="27" column="3" /\>
-// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="881" /\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="630" /\>
 // CHECK:   \</assertionBatch\>
 // CHECK:   \<conclusion endTime=".*" duration=".*" resourceCount=".*" outcome="correct" /\>
 // CHECK: \</method\>

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -15,7 +15,7 @@
 // CHECK:   \</assertionBatch\>
 // CHECK:   \<assertionBatch number="2" iteration="0" startTime=".*"\>
 // CHECK:     \<assertion file="xml.bpl" line="27" column="3" /\>
-// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="1490" /\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="881" /\>
 // CHECK:   \</assertionBatch\>
 // CHECK:   \<conclusion endTime=".*" duration=".*" resourceCount=".*" outcome="correct" /\>
 // CHECK: \</method\>

--- a/Test/commandline/xml.bpl
+++ b/Test/commandline/xml.bpl
@@ -11,11 +11,11 @@
 // CHECK: \<method name="ExampleWithSplits" startTime=".*"\>
 // CHECK:   \<assertionBatch number="1" iteration="0" startTime=".*"\>
 // CHECK:     \<assertion file="xml.bpl" line="25" column="3" /\>
-// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" /\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="865" /\>
 // CHECK:   \</assertionBatch\>
 // CHECK:   \<assertionBatch number="2" iteration="0" startTime=".*"\>
 // CHECK:     \<assertion file="xml.bpl" line="27" column="3" /\>
-// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" /\>
+// CHECK:     \<conclusion duration=".*" outcome="valid" resourceCount=".*" smtInputSize="1490" /\>
 // CHECK:   \</assertionBatch\>
 // CHECK:   \<conclusion endTime=".*" duration=".*" resourceCount=".*" outcome="correct" /\>
 // CHECK: \</method\>


### PR DESCRIPTION
### Changes
Record the SMT input string size for each split, which can be used to detect regressions in encoding performance

### Testing
Updated existing test xml.bpl