### PR TITLE
Add property for generating standalone binary

### DIFF
--- a/Source/BoogieDriver/BoogieDriver.csproj
+++ b/Source/BoogieDriver/BoogieDriver.csproj
@@ -10,6 +10,9 @@
     <AssemblyName>BoogieDriver</AssemblyName>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>boogie</ToolCommandName>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds three items to `<PropertyGroup>` so that using `dotnet publish Source/Boogie.sln -r <RID>` can generate standalone binary of boogie.