### PR TITLE
Provide more flexibility in configuring which return statements get separate VCs with isolate_assertions

### DIFF
--- a/Source/Core/Generic/TokenWrapper.cs
+++ b/Source/Core/Generic/TokenWrapper.cs
@@ -14,7 +14,7 @@ public class TokenWrapper : IToken {
     return Inner.CompareTo(other);
   }
 
-  public bool SourceToken => false;
+  public bool IsSourceToken => false;
 
   public int kind {
     get => Inner.kind;

--- a/Source/Core/Generic/TokenWrapper.cs
+++ b/Source/Core/Generic/TokenWrapper.cs
@@ -14,6 +14,8 @@ public class TokenWrapper : IToken {
     return Inner.CompareTo(other);
   }
 
+  public bool SourceToken => false;
+
   public int kind {
     get => Inner.kind;
     set => Inner.kind = value;

--- a/Source/Core/Token.cs
+++ b/Source/Core/Token.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Boogie
     /// <summary>
     /// True if this token was created during parsing
     /// </summary>
-    bool SourceToken { get; }
+    bool IsSourceToken { get; }
     int kind { get; set; } // token kind
     string filename { get; set; } // token file
     int pos { get; set; } // token position in the source text (starting at 0)
@@ -52,7 +52,7 @@ namespace Microsoft.Boogie
       this._val = "anything so that it is nonnull";
     }
 
-    public bool SourceToken => true;
+    public bool IsSourceToken => true;
 
     public int kind
     {

--- a/Source/Core/Token.cs
+++ b/Source/Core/Token.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Boogie
   [Immutable]
   public interface IToken : IComparable<IToken>
   {
+    /// <summary>
+    /// True if this token was created during parsing
+    /// </summary>
+    bool SourceToken { get; }
     int kind { get; set; } // token kind
     string filename { get; set; } // token file
     int pos { get; set; } // token position in the source text (starting at 0)
@@ -47,6 +51,8 @@ namespace Microsoft.Boogie
       this._col = colnum;
       this._val = "anything so that it is nonnull";
     }
+
+    public bool SourceToken => true;
 
     public int kind
     {

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>3.4.1</Version>
+    <Version>3.4.2</Version>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>

--- a/Source/VCGeneration/Splits/IsolateAttributeOnJumpsHandler.cs
+++ b/Source/VCGeneration/Splits/IsolateAttributeOnJumpsHandler.cs
@@ -33,7 +33,7 @@ class IsolateAttributeOnJumpsHandler {
 
       var gotoFromReturn = gotoCmd.tok as GotoFromReturn;
       var isolateAttribute = QKeyValue.FindAttribute(gotoCmd.Attributes, p => p.Key == "isolate");
-      var isTypeOfAssert = gotoFromReturn != null && gotoFromReturn.Origin.tok.SourceToken;
+      var isTypeOfAssert = gotoFromReturn != null && gotoFromReturn.Origin.tok.IsSourceToken;
       var isolate = BlockRewriter.ShouldIsolate(isTypeOfAssert && splitOnEveryAssert, isolateAttribute);
       if (!isolate) {
         continue;

--- a/Source/VCGeneration/Splits/IsolateAttributeOnJumpsHandler.cs
+++ b/Source/VCGeneration/Splits/IsolateAttributeOnJumpsHandler.cs
@@ -33,7 +33,7 @@ class IsolateAttributeOnJumpsHandler {
 
       var gotoFromReturn = gotoCmd.tok as GotoFromReturn;
       var isolateAttribute = QKeyValue.FindAttribute(gotoCmd.Attributes, p => p.Key == "isolate");
-      var isTypeOfAssert = gotoFromReturn != null && gotoFromReturn.Origin.tok is Token;
+      var isTypeOfAssert = gotoFromReturn != null && gotoFromReturn.Origin.tok.SourceToken;
       var isolate = BlockRewriter.ShouldIsolate(isTypeOfAssert && splitOnEveryAssert, isolateAttribute);
       if (!isolate) {
         continue;


### PR DESCRIPTION
### Changes
Enable isolate_assertions to isolate explicit return statements in Dafny programs