### PR TITLE
implement inlining for call attributes

### DIFF
--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Boogie
 
       public int getDepth(Implementation impl) {
         var procName = getName(impl);
-        var c = -1;
-        if (procUnrollDepth.TryGetValue(procName, out c)) {
+        if (procUnrollDepth.TryGetValue(procName, out var c)) {
           return c;
         }
         return -1;
@@ -305,12 +304,12 @@ namespace Microsoft.Boogie
         return depth;
       }
 
-      int countCall (CallCmd cmd) {
+      int callInlineDepth (CallCmd cmd) {
         return QKeyValue.FindIntAttribute(cmd.Attributes, "inline", -1);
       }
 
       // first check the inline depth on the call command.
-      depth = countCall(callCmd);
+      depth = callInlineDepth(callCmd);
       if (depth < 0) {
         // if call cmd doesn't define the depth, then check the procedure.
         impl.CheckIntAttribute("inline", ref depth);

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Boogie
 
     protected class UnrollDepthTracker
     {
-      protected Dictionary <string, int> procUnrollDepth = new ();
-      protected Dictionary <string, CallCmd> procUnrollSrc = new ();
+      protected Dictionary <string, int> procUnrollDepth = new();
+      protected Dictionary <string, CallCmd> procUnrollSrc = new();
 
       private string getName (Implementation impl) {
         string procName = impl.Name;
@@ -222,7 +222,7 @@ namespace Microsoft.Boogie
 
       // we need to resolve the new code
       ResolveImpl(impl);
-
+      Console.WriteLine("printing here for " + impl.Name + " num blocks after inlining = " + impl.Blocks.Count());
       if (options.PrintInlined)
       {
         EmitImpl(impl);
@@ -281,7 +281,7 @@ namespace Microsoft.Boogie
       impl.Proc = null; // to force Resolve() redo the operation
       impl.Resolve(rc);
       Debug.Assert(rc.ErrorCount == 0);
-      
+
       TypecheckingContext tc = new TypecheckingContext(new DummyErrorSink(), options);
       impl.Typecheck(tc);
       Debug.Assert(tc.ErrorCount == 0);
@@ -512,6 +512,8 @@ namespace Microsoft.Boogie
           {
             newCmds.Add(codeCopier.CopyCmd(cmd));
           }
+
+
         }
 
         Block newBlock = new Block(block.tok, lblCount == 0 ? block.Label : block.Label + "$" + lblCount,

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -222,7 +222,6 @@ namespace Microsoft.Boogie
 
       // we need to resolve the new code
       ResolveImpl(impl);
-      Console.WriteLine("printing here for " + impl.Name + " num blocks after inlining = " + impl.Blocks.Count());
       if (options.PrintInlined)
       {
         EmitImpl(impl);
@@ -318,7 +317,6 @@ namespace Microsoft.Boogie
         impl.Proc.CheckIntAttribute("inline", ref depth);
       }
       if (depth >= 0) {
-        Console.WriteLine("assinging " + impl.Proc.Name + " depth = " + depth);
         depthTracker.setDepth (callCmd, impl, depth);
       }
       return depth;

--- a/Source/Core/Inline.cs
+++ b/Source/Core/Inline.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Boogie
 
     protected class UnrollDepthTracker
     {
-      protected Dictionary <string, int> procUnrollDepth = new();
-      protected Dictionary <string, CallCmd> procUnrollSrc = new();
+      protected Dictionary<string, int> procUnrollDepth = new();
+      protected Dictionary<string, CallCmd> procUnrollSrc = new();
 
       private string getName (Implementation impl) {
         string procName = impl.Name;


### PR DESCRIPTION
Description

This PR implements support for inlining based on call sites, while maintaining the behavior of inlining based on procedure definitions. When there is a clash, the inlining depth specified at the call site "wins", because its more precise. 

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).