### PR TITLE
Fix resource limit & timeout handling if some assertion in the batch has already failed

### DIFF
--- a/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
+++ b/Source/Provers/SMTLib/SMTLibInteractiveTheoremProver.cs
@@ -252,9 +252,15 @@ namespace Microsoft.Boogie.SMTLib
             currentErrorHandler.OnModel(labels, model, result);
           }
 
+          // if the solver is out of resources or has timed out, the global result needs to reflect that.
+          if (result == SolverOutcome.OutOfResource || result == SolverOutcome.TimeOut) {
+            globalResult = result;
+          }
+
           Debug.Assert(errorsDiscovered > 0);
           // if errorLimit is 0, loop will break only if there are no more 
-          // counterexamples to be discovered.
+          // counterexamples to be discovered or the solver is out of resources
+          // or has timed out.
           if (labels == null || !labels.Any() || errorsDiscovered == errorLimit)
           {
             break;


### PR DESCRIPTION
This PR addresses the root cause of dafny-lang/dafny#5805. In short, this issue arises when boogie runs into a timeout or resource limit while trying to verify subsequent assertions in an assertion batch where one assertion already failed.

In that case, the record `VerificationRunResult` has set the `SolverOutcome` to `Invalid` and contains the counterexamples that were found before running into a timeout. The method `VerificationRunResult.ComputePerAssertOutcomes` then assigns `Valid` to all assertions for which no counterexamples have been found because of the timeout, giving issue dafny-lang/dafny#5805.

From the standpoint of the method `ComputePerAssertOutcomes` two scenarios are indistinguishable:

- One or more assertions are found invalid and the rest have been verified
- One or more assertions are found invalid and the the verification of the rest has hit a timeout

This PR suggests to fix this by reporting the timeout alongside the found counterexamples.

This change is expected to have some effects for programs built on boogie: I assume that the `VerificationRunResult` only had a nonempty list of `CounterExamples` when the `SolverOutcome` is `Invalid`. I expect that programs built on boogie would need to adapt to this new possibility and report the verification failure errors accordingly.
