### PR TITLE
[Civl] Change signature of KeyedLocSet_New

### DIFF
--- a/Source/Concurrency/LinearRewriter.cs
+++ b/Source/Concurrency/LinearRewriter.cs
@@ -145,7 +145,7 @@ public class LinearRewriter
     switch (Monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
     {
       case "Loc_New":
-      case "KeyedLocSet_New":
+      case "TaggedLocSet_New":
       case "Set_MakeEmpty":
       case "Map_MakeEmpty":
       case "Map_Pack":

--- a/Source/Core/CivlAttributes.cs
+++ b/Source/Core/CivlAttributes.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Boogie
   {
     public static HashSet<string> LinearPrimitives = new()
     {
-      "Loc_New", "KeyedLocSet_New",
+      "Loc_New", "TaggedLocSet_New",
       "Map_MakeEmpty", "Map_Pack", "Map_Unpack", "Map_Split", "Map_Join",
       "Map_Get", "Map_Put", "Map_GetValue", "Map_PutValue",
       "Set_MakeEmpty", "Set_Split", "Set_Get", "Set_Put", "One_Split", "One_Get", "One_Put"
@@ -246,7 +246,7 @@ namespace Microsoft.Boogie
       switch (Monomorphizer.GetOriginalDecl(callCmd.Proc).Name)
       {
         case "Loc_New":
-        case "KeyedLocSet_New":
+        case "TaggedLocSet_New":
         case "Set_MakeEmpty":
         case "Map_MakeEmpty":
         case "Map_Pack":

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -338,10 +338,10 @@ pure procedure {:inline 1} Loc_New() returns ({:linear} {:pool "Loc_New"} l: One
 
 datatype KeyedLoc<K> { KeyedLoc(l: Loc, k: K) }
 
-pure procedure {:inline 1} KeyedLocSet_New<K>(ks: Set K) returns ({:pool "Loc_New"} l: Loc, {:linear} keyed_locs: Set (KeyedLoc K))
+pure procedure {:inline 1} KeyedLocSet_New<K>(ks: Set K) returns ({:linear} {:pool "Loc_New"} l: One Loc, {:linear} keyed_locs: Set (KeyedLoc K))
 {
   assume {:add_to_pool "Loc_New", l} true;
-  keyed_locs := Set((lambda x: KeyedLoc K :: x->l == l && Set_Contains(ks, x->k)));
+  keyed_locs := Set((lambda x: KeyedLoc K :: x->l == l->val && Set_Contains(ks, x->k)));
 }
 
 procedure create_async<T>(PA: T);

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -336,12 +336,12 @@ pure procedure {:inline 1} Loc_New() returns ({:linear} {:pool "Loc_New"} l: One
   assume {:add_to_pool "Loc_New", l} true;
 }
 
-datatype KeyedLoc<K> { KeyedLoc(l: Loc, k: K) }
+datatype TaggedLoc<K> { TaggedLoc(loc: Loc, tag: K) }
 
-pure procedure {:inline 1} KeyedLocSet_New<K>(ks: Set K) returns ({:linear} {:pool "Loc_New"} l: One Loc, {:linear} keyed_locs: Set (KeyedLoc K))
+pure procedure {:inline 1} TaggedLocSet_New<K>(ks: Set K) returns ({:linear} {:pool "Loc_New"} l: One Loc, {:linear} tagged_locs: Set (TaggedLoc K))
 {
   assume {:add_to_pool "Loc_New", l} true;
-  keyed_locs := Set((lambda x: KeyedLoc K :: x->l == l->val && Set_Contains(ks, x->k)));
+  tagged_locs := Set((lambda x: TaggedLoc K :: x->loc == l->val && Set_Contains(ks, x->tag)));
 }
 
 procedure create_async<T>(PA: T);

--- a/Source/Core/base.bpl
+++ b/Source/Core/base.bpl
@@ -359,3 +359,8 @@ ensures b;
 
 pure procedure Move<T>({:linear_in} v: T, {:linear_out} v': T);
 requires v == v';
+
+datatype Unit { Unit() }
+function {:inline} UnitSet(): Set Unit {
+  Set_Add(Set_Empty(), Unit())
+}

--- a/Test/civl/large-samples/treiber-stack.bpl
+++ b/Test/civl/large-samples/treiber-stack.bpl
@@ -1,11 +1,6 @@
 // RUN: %parallel-boogie -lib:base -lib:node -timeLimit:0 -vcsSplitOnEveryAssert "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-datatype LocPiece { Right() }
-function {:inline} AllLocPieces(): Set LocPiece {
-  Set_Add(Set_Empty(), Right())
-}
-
 type LocTreiberStack = Loc;
 type LocTreiberNode = Loc;
 type StackElem T = Node LocTreiberNode T;
@@ -61,32 +56,32 @@ invariant Map_At(TreiberPool, loc_t) == Abs(Map_At(TreiberPoolLow, loc_t));
 yield invariant {:layer 4} StackDom();
 invariant TreiberPool->dom == TreiberPoolLow->dom;
 
-yield invariant {:layer 4} PushLocInStack(loc_t: LocTreiberStack, node: StackElem X, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc LocPiece));
+yield invariant {:layer 4} PushLocInStack(loc_t: LocTreiberStack, node: StackElem X, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc Unit));
 invariant Map_Contains(TreiberPoolLow, loc_t);
 invariant Set_Contains(Domain(TreiberPoolLow, loc_t), new_loc_n);
-invariant right_loc_piece->val == TaggedLoc(new_loc_n, Right());
+invariant right_loc_piece->val == TaggedLoc(new_loc_n, Unit());
 invariant (var t := TreiberPoolLow->val[loc_t]; Map_At(t->nodes, new_loc_n) == node && !BetweenSet(t->nodes->val, t->top, None())[new_loc_n]);
 
 /// Layered implementation
 
-atomic action {:layer 5} AtomicAlloc() returns ({:linear} right_loc_piece: One (TaggedLoc LocPiece))
+atomic action {:layer 5} AtomicAlloc() returns ({:linear} right_loc_piece: One (TaggedLoc Unit))
 {
   var {:linear} one_loc_t: One LocTreiberStack;
-  var {:linear} loc_pieces: Set (TaggedLoc LocPiece);
+  var {:linear} loc_pieces: Set (TaggedLoc Unit);
 
-  call one_loc_t, loc_pieces := TaggedLocSet_New(AllLocPieces());
-  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(one_loc_t->val, Right()));
+  call one_loc_t, loc_pieces := TaggedLocSet_New(UnitSet());
+  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(one_loc_t->val, Unit()));
   assume !Map_Contains(TreiberPool, one_loc_t->val);
   TreiberPool := Map_Update(TreiberPool, one_loc_t->val, Vec_Empty());
 }
-yield procedure {:layer 4} Alloc() returns ({:linear} right_loc_piece: One (TaggedLoc LocPiece))
+yield procedure {:layer 4} Alloc() returns ({:linear} right_loc_piece: One (TaggedLoc Unit))
 refines AtomicAlloc;
 ensures call TopInStack(right_loc_piece->val->loc);
 ensures call ReachInStack(right_loc_piece->val->loc);
 preserves call StackDom();
 {
   var {:linear} one_loc_t: One LocTreiberStack;
-  var {:linear} loc_pieces: Set (TaggedLoc LocPiece);
+  var {:linear} loc_pieces: Set (TaggedLoc Unit);
   var top: Option LocTreiberNode;
   var {:linear} stack: StackMap X;
   var {:linear} treiber: Treiber X;
@@ -94,8 +89,8 @@ preserves call StackDom();
   top := None();
   call stack := Map_MakeEmpty();
   treiber := Treiber(top, stack);
-  call one_loc_t, loc_pieces := TaggedLocSet_New(AllLocPieces());
-  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(one_loc_t->val, Right()));
+  call one_loc_t, loc_pieces := TaggedLocSet_New(UnitSet());
+  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(one_loc_t->val, Unit()));
   call AllocTreiber#0(one_loc_t, treiber);
   call {:layer 4} TreiberPool := Copy(Map_Update(TreiberPool, one_loc_t->val, Vec_Empty()));
   call {:layer 4} AbsLemma(treiber);
@@ -118,7 +113,7 @@ preserves call StackDom();
 {
   var loc_n: Option LocTreiberNode;
   var new_loc_n: LocTreiberNode;
-  var {:linear} right_loc_piece: One (TaggedLoc LocPiece);
+  var {:linear} right_loc_piece: One (TaggedLoc Unit);
   var {:layer 4} old_treiber: Treiber X;
 
   call {:layer 4} old_treiber := Copy(TreiberPoolLow->val[loc_t]);
@@ -166,7 +161,7 @@ preserves call StackDom();
 }
 
 atomic action {:layer 4} AtomicCreateNewTopOfStack(loc_t: LocTreiberStack, x: X)
-  returns (loc_n: Option LocTreiberNode, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc LocPiece))
+  returns (loc_n: Option LocTreiberNode, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc Unit))
 asserts Map_Contains(TreiberPoolLow, loc_t);
 {
   var {:linear} one_loc_t: One LocTreiberStack;
@@ -174,31 +169,31 @@ asserts Map_Contains(TreiberPoolLow, loc_t);
   var top: Option LocTreiberNode;
   var {:linear} stack: StackMap X;
   var {:linear} one_loc_n: One LocTreiberNode;
-  var {:linear} loc_pieces: Set (TaggedLoc LocPiece);
+  var {:linear} loc_pieces: Set (TaggedLoc Unit);
   
   call one_loc_t, treiber := Map_Get(TreiberPoolLow, loc_t);
   Treiber(top, stack) := treiber;
   assume loc_n is None || Map_Contains(stack, loc_n->t);
-  call one_loc_n, loc_pieces := TaggedLocSet_New(AllLocPieces());
+  call one_loc_n, loc_pieces := TaggedLocSet_New(UnitSet());
   new_loc_n := one_loc_n->val;
-  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(new_loc_n, Right()));
+  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(new_loc_n, Unit()));
   call Map_Put(stack, one_loc_n, Node(loc_n, x));
   treiber := Treiber(top, stack);
   call Map_Put(TreiberPoolLow, one_loc_t, treiber);
 }
 yield procedure {:layer 3} CreateNewTopOfStack(loc_t: LocTreiberStack, x: X)
-  returns (loc_n: Option LocTreiberNode, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc LocPiece))
+  returns (loc_n: Option LocTreiberNode, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc Unit))
 preserves call TopInStack(loc_t);
 ensures call LocInStackOrNone(loc_t, Some(new_loc_n));
 refines AtomicCreateNewTopOfStack;
 {
   var {:linear} one_loc_n: One LocTreiberNode;
-  var {:linear} loc_pieces: Set (TaggedLoc LocPiece);
+  var {:linear} loc_pieces: Set (TaggedLoc Unit);
 
   call loc_n := ReadTopOfStack#Push(loc_t);
-  call one_loc_n, loc_pieces := TaggedLocSet_New(AllLocPieces());
+  call one_loc_n, loc_pieces := TaggedLocSet_New(UnitSet());
   new_loc_n := one_loc_n->val;
-  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(new_loc_n, Right()));
+  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(new_loc_n, Unit()));
   call AllocNode#0(loc_t, one_loc_n, Node(loc_n, x));
 }
 

--- a/Test/civl/large-samples/treiber-stack.bpl
+++ b/Test/civl/large-samples/treiber-stack.bpl
@@ -56,32 +56,32 @@ invariant Map_At(TreiberPool, loc_t) == Abs(Map_At(TreiberPoolLow, loc_t));
 yield invariant {:layer 4} StackDom();
 invariant TreiberPool->dom == TreiberPoolLow->dom;
 
-yield invariant {:layer 4} PushLocInStack(loc_t: LocTreiberStack, node: StackElem X, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc Unit));
+yield invariant {:layer 4} PushLocInStack(loc_t: LocTreiberStack, node: StackElem X, new_loc_n: LocTreiberNode, {:linear} tagged_loc: One (TaggedLoc Unit));
 invariant Map_Contains(TreiberPoolLow, loc_t);
 invariant Set_Contains(Domain(TreiberPoolLow, loc_t), new_loc_n);
-invariant right_loc_piece->val == TaggedLoc(new_loc_n, Unit());
+invariant tagged_loc->val == TaggedLoc(new_loc_n, Unit());
 invariant (var t := TreiberPoolLow->val[loc_t]; Map_At(t->nodes, new_loc_n) == node && !BetweenSet(t->nodes->val, t->top, None())[new_loc_n]);
 
 /// Layered implementation
 
-atomic action {:layer 5} AtomicAlloc() returns ({:linear} right_loc_piece: One (TaggedLoc Unit))
+atomic action {:layer 5} AtomicAlloc() returns ({:linear} tagged_loc: One (TaggedLoc Unit))
 {
   var {:linear} one_loc_t: One LocTreiberStack;
-  var {:linear} loc_pieces: Set (TaggedLoc Unit);
+  var {:linear} tagged_locs: Set (TaggedLoc Unit);
 
-  call one_loc_t, loc_pieces := TaggedLocSet_New(UnitSet());
-  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(one_loc_t->val, Unit()));
+  call one_loc_t, tagged_locs := TaggedLocSet_New(UnitSet());
+  call tagged_loc := One_Get(tagged_locs, TaggedLoc(one_loc_t->val, Unit()));
   assume !Map_Contains(TreiberPool, one_loc_t->val);
   TreiberPool := Map_Update(TreiberPool, one_loc_t->val, Vec_Empty());
 }
-yield procedure {:layer 4} Alloc() returns ({:linear} right_loc_piece: One (TaggedLoc Unit))
+yield procedure {:layer 4} Alloc() returns ({:linear} tagged_loc: One (TaggedLoc Unit))
 refines AtomicAlloc;
-ensures call TopInStack(right_loc_piece->val->loc);
-ensures call ReachInStack(right_loc_piece->val->loc);
+ensures call TopInStack(tagged_loc->val->loc);
+ensures call ReachInStack(tagged_loc->val->loc);
 preserves call StackDom();
 {
   var {:linear} one_loc_t: One LocTreiberStack;
-  var {:linear} loc_pieces: Set (TaggedLoc Unit);
+  var {:linear} tagged_locs: Set (TaggedLoc Unit);
   var top: Option LocTreiberNode;
   var {:linear} stack: StackMap X;
   var {:linear} treiber: Treiber X;
@@ -89,8 +89,8 @@ preserves call StackDom();
   top := None();
   call stack := Map_MakeEmpty();
   treiber := Treiber(top, stack);
-  call one_loc_t, loc_pieces := TaggedLocSet_New(UnitSet());
-  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(one_loc_t->val, Unit()));
+  call one_loc_t, tagged_locs := TaggedLocSet_New(UnitSet());
+  call tagged_loc := One_Get(tagged_locs, TaggedLoc(one_loc_t->val, Unit()));
   call AllocTreiber#0(one_loc_t, treiber);
   call {:layer 4} TreiberPool := Copy(Map_Update(TreiberPool, one_loc_t->val, Vec_Empty()));
   call {:layer 4} AbsLemma(treiber);
@@ -113,13 +113,13 @@ preserves call StackDom();
 {
   var loc_n: Option LocTreiberNode;
   var new_loc_n: LocTreiberNode;
-  var {:linear} right_loc_piece: One (TaggedLoc Unit);
+  var {:linear} tagged_loc: One (TaggedLoc Unit);
   var {:layer 4} old_treiber: Treiber X;
 
   call {:layer 4} old_treiber := Copy(TreiberPoolLow->val[loc_t]);
-  call loc_n, new_loc_n, right_loc_piece := CreateNewTopOfStack(loc_t, x);
+  call loc_n, new_loc_n, tagged_loc := CreateNewTopOfStack(loc_t, x);
   call {:layer 4} FrameLemma(old_treiber, TreiberPoolLow->val[loc_t]);
-  par ReachInStack(loc_t) | StackDom() | PushLocInStack(loc_t, Node(loc_n, x), new_loc_n, right_loc_piece);
+  par ReachInStack(loc_t) | StackDom() | PushLocInStack(loc_t, Node(loc_n, x), new_loc_n, tagged_loc);
   call success := WriteTopOfStack#0(loc_t, loc_n, Some(new_loc_n));
   if (success) {
     call {:layer 4} TreiberPool := Copy(Map_Update(TreiberPool, loc_t, Vec_Append(Map_At(TreiberPool, loc_t), x)));
@@ -161,7 +161,7 @@ preserves call StackDom();
 }
 
 atomic action {:layer 4} AtomicCreateNewTopOfStack(loc_t: LocTreiberStack, x: X)
-  returns (loc_n: Option LocTreiberNode, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc Unit))
+  returns (loc_n: Option LocTreiberNode, new_loc_n: LocTreiberNode, {:linear} tagged_loc: One (TaggedLoc Unit))
 asserts Map_Contains(TreiberPoolLow, loc_t);
 {
   var {:linear} one_loc_t: One LocTreiberStack;
@@ -169,31 +169,31 @@ asserts Map_Contains(TreiberPoolLow, loc_t);
   var top: Option LocTreiberNode;
   var {:linear} stack: StackMap X;
   var {:linear} one_loc_n: One LocTreiberNode;
-  var {:linear} loc_pieces: Set (TaggedLoc Unit);
+  var {:linear} tagged_locs: Set (TaggedLoc Unit);
   
   call one_loc_t, treiber := Map_Get(TreiberPoolLow, loc_t);
   Treiber(top, stack) := treiber;
   assume loc_n is None || Map_Contains(stack, loc_n->t);
-  call one_loc_n, loc_pieces := TaggedLocSet_New(UnitSet());
+  call one_loc_n, tagged_locs := TaggedLocSet_New(UnitSet());
   new_loc_n := one_loc_n->val;
-  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(new_loc_n, Unit()));
+  call tagged_loc := One_Get(tagged_locs, TaggedLoc(new_loc_n, Unit()));
   call Map_Put(stack, one_loc_n, Node(loc_n, x));
   treiber := Treiber(top, stack);
   call Map_Put(TreiberPoolLow, one_loc_t, treiber);
 }
 yield procedure {:layer 3} CreateNewTopOfStack(loc_t: LocTreiberStack, x: X)
-  returns (loc_n: Option LocTreiberNode, new_loc_n: LocTreiberNode, {:linear} right_loc_piece: One (TaggedLoc Unit))
+  returns (loc_n: Option LocTreiberNode, new_loc_n: LocTreiberNode, {:linear} tagged_loc: One (TaggedLoc Unit))
 preserves call TopInStack(loc_t);
 ensures call LocInStackOrNone(loc_t, Some(new_loc_n));
 refines AtomicCreateNewTopOfStack;
 {
   var {:linear} one_loc_n: One LocTreiberNode;
-  var {:linear} loc_pieces: Set (TaggedLoc Unit);
+  var {:linear} tagged_locs: Set (TaggedLoc Unit);
 
   call loc_n := ReadTopOfStack#Push(loc_t);
-  call one_loc_n, loc_pieces := TaggedLocSet_New(UnitSet());
+  call one_loc_n, tagged_locs := TaggedLocSet_New(UnitSet());
   new_loc_n := one_loc_n->val;
-  call right_loc_piece := One_Get(loc_pieces, TaggedLoc(new_loc_n, Unit()));
+  call tagged_loc := One_Get(tagged_locs, TaggedLoc(new_loc_n, Unit()));
   call AllocNode#0(loc_t, one_loc_n, Node(loc_n, x));
 }
 

--- a/Test/civl/samples/two-lists.bpl
+++ b/Test/civl/samples/two-lists.bpl
@@ -1,0 +1,134 @@
+// RUN: %parallel-boogie -lib:base -lib:node -vcsSplitOnEveryAssert "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type ListElem T = Node Loc T;
+
+datatype Queue<T> { Queue(head: Loc, tail: Loc, {:linear} nodes: Map Loc (ListElem T)) }
+
+var {:linear} {:layer 0, 1} lists: Map Loc (Queue int);
+
+var {:linear} {:layer 0, 1} pos: One (TaggedLoc Unit);
+var {:linear} {:layer 0, 1} neg: One (TaggedLoc Unit);
+
+yield procedure {:layer 0} ReadPos() returns (loc: Loc);
+refines both action {:layer 1} _ {
+    loc := pos->val->loc;
+}
+
+yield procedure {:layer 0} ReadNeg() returns (loc: Loc);
+refines both action {:layer 1} _ {
+    loc := neg->val->loc;
+}
+
+yield procedure {:layer 0} Enqueue(loc_q: Loc, i: int);
+refines action {:layer 1} _
+{
+    var {:linear} one_loc_q: One Loc;
+    var {:linear} queue: Queue int;
+    var head, tail: Loc;
+    var {:linear} nodes: Map Loc (ListElem int);
+    var {:linear} one_loc_n, new_one_loc_n: One Loc;
+    var node: ListElem int;
+
+    call one_loc_q, queue := Map_Get(lists, loc_q);
+    Queue(head, tail, nodes) := queue;
+
+    call new_one_loc_n := Loc_New();
+    call Map_Put(nodes, new_one_loc_n, Node(None(), 0));
+
+    call one_loc_n, node := Map_Get(nodes, tail);
+    node := Node(Some(new_one_loc_n->val), i);
+    call Map_Put(nodes, one_loc_n, node);
+
+    queue := Queue(head, new_one_loc_n->val, nodes);
+    call Map_Put(lists, one_loc_q, queue);
+}
+
+yield procedure {:layer 0} Dequeue(loc_q: Loc) returns (i: int);
+refines action {:layer 1} _
+{
+    var {:linear} one_loc_q: One Loc;
+    var {:linear} queue: Queue int;
+    var head, tail: Loc;
+    var {:linear} nodes: Map Loc (ListElem int);
+    var {:linear} one_loc_n: One Loc;
+    var node: ListElem int;
+    var next: Option Loc;
+
+    call one_loc_q, queue := Map_Get(lists, loc_q);
+    Queue(head, tail, nodes) := queue;
+    
+    assume head != tail;
+    call one_loc_n, node := Map_Get(nodes, head);
+    Node(next, i) := node;
+
+    assert next is Some;
+    queue := Queue(next->t, tail, nodes);
+    call Map_Put(lists, one_loc_q, queue);
+}
+
+
+function {:inline} IsAcyclic(q: Queue int): bool
+{
+    Between(q->nodes->val, Some(q->head), Some(q->tail), None())
+}
+
+function {:inline} QueueElems(q: Queue int): [Loc]bool 
+{
+    BetweenSet(q->nodes->val, Some(q->head), Some(q->tail))
+}
+
+yield invariant {:layer 1} PosInv();
+invariant Map_Contains(lists, pos->val->loc);
+invariant (var q := Map_At(lists, pos->val->loc); IsAcyclic(q) &&
+            (forall loc_n: Loc:: QueueElems(q)[loc_n] ==>
+                Map_Contains(q->nodes, loc_n) &&
+                (loc_n == q->tail || (var node := Map_At(q->nodes, loc_n); node->val > 0))));
+
+yield invariant {:layer 1} NegInv();
+invariant Map_Contains(lists, neg->val->loc);
+invariant (var q := Map_At(lists, neg->val->loc); IsAcyclic(q) &&
+            (forall loc_n: Loc:: QueueElems(q)[loc_n] ==>
+                Map_Contains(q->nodes, loc_n) &&
+                (loc_n == q->tail || (var node := Map_At(q->nodes, loc_n); node->val < 0))));
+
+
+yield procedure {:layer 1} Producer(i: int)
+preserves call PosInv();
+preserves call NegInv();
+{
+    var loc: Loc;
+
+    assert {:layer 1} pos->val->loc != neg->val->loc;
+    if (i == 0) {
+        return;
+    }
+    if (i > 0) {
+        call loc := ReadPos();
+    } else {
+        call loc := ReadNeg();
+    }
+    call Enqueue(loc, i);
+}
+
+yield procedure {:layer 1} PosConsumer()
+preserves call PosInv();
+{
+    var loc: Loc;
+    var i: int;
+
+    call loc := ReadPos();
+    call i := Dequeue(loc);
+    assert {:layer 1} i > 0;
+}
+
+yield procedure {:layer 1} NegConsumer()
+preserves call NegInv();
+{
+    var loc: Loc;
+    var i: int;
+
+    call loc := ReadNeg();
+    call i := Dequeue(loc);
+    assert {:layer 1} i < 0;
+}

--- a/Test/civl/samples/two-lists.bpl.expect
+++ b/Test/civl/samples/two-lists.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 3 verified, 0 errors


### PR DESCRIPTION
This PR changes the signature of KeyedLocSet_New. The new signature and implementation are as follows:
```
pure procedure {:inline 1} KeyedLocSet_New<K>(ks: Set K) returns ({:linear} {:pool "Loc_New"} l: One Loc, {:linear} keyed_locs: Set (KeyedLoc K))
{
  assume {:add_to_pool "Loc_New", l} true;
  keyed_locs := Set((lambda x: KeyedLoc K :: x->l == l->val && Set_Contains(ks, x->k)));
}
```

The realization is that a linear Loc and a linear collection of KeyedLoc's can both be returned without any impact on soundness. 

The new signature does not change the expressiveness of NPL (the linear typing system underlying Civl), but it allows us to program without putting KeyedLoc's into the domain of a linear map. This maps it easy to erase the code using standard pointer-based memory management.

As a result of this change, the proof of Treiber only requires one member in the enum LocPiece.

The following changes are done in addition:
- KeyedLoc is changed to TaggedLoc
- a new example two-lists.bpl is added
- a Unit type is added to base.bpl