### PR TITLE
Add kInductionDepth to AttributeHelp

### DIFF
--- a/Source/ExecutionEngine/CommandLineOptions.cs
+++ b/Source/ExecutionEngine/CommandLineOptions.cs
@@ -1813,6 +1813,9 @@ namespace Microsoft.Boogie
                 inline irreducible loops using the bound supplied by /loopUnroll:<n>
   /soundLoopUnrolling
                 sound loop unrolling
+  /kInductionDepth:<k>
+                uses combined-case k-induction to soundly eliminate loops,
+                by unwinding proportional to the supplied parameter
   /inferModifies
                 automatically infer modifies clauses
   /printModel:<n>


### PR DESCRIPTION
This PR addresses Issue #1012.  The option for **k-Induction** was already available (via the `/kInductionDepth`), however it was not part of the _AttributeHelp_.