### PR TITLE
[Civl] Eliminate "par" keyword

### DIFF
--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -873,7 +873,7 @@ SpecYieldRequires<. List<Requires> pre, List<CallCmd> yieldRequires .>
     { Attribute<ref kv> }
     Proposition<out e>  (. pre.Add(new Requires(tok, false, e, null, kv)); .)
     |
-    CallCmd<out cmd>        (. yieldRequires.Add((CallCmd)cmd); .)
+    CallCmd<true, out cmd>        (. yieldRequires.Add((CallCmd)cmd); .)
   )
   ";"
   .
@@ -885,7 +885,7 @@ SpecYieldEnsures<. List<Ensures> post, List<CallCmd> yieldEnsures .>
     { Attribute<ref kv> }
     Proposition<out e>  (. post.Add(new Ensures(tok, false, e, null, kv)); .)
     |
-    CallCmd<out cmd>        (. yieldEnsures.Add((CallCmd)cmd); .)
+    CallCmd<true, out cmd>        (. yieldEnsures.Add((CallCmd)cmd); .)
   )
   ";"
   .
@@ -893,7 +893,7 @@ SpecYieldEnsures<. List<Ensures> post, List<CallCmd> yieldEnsures .>
 SpecYieldPreserves<. List<CallCmd> yieldPreserves .>
 = (. Cmd cmd; Token tok; .)
   "preserves"             (. tok = t; .)
-  CallCmd<out cmd>        (. yieldPreserves.Add((CallCmd)cmd); .)
+  CallCmd<true, out cmd>        (. yieldPreserves.Add((CallCmd)cmd); .)
   ";"
   .
 
@@ -1145,7 +1145,7 @@ WhileCmd<out WhileCmd wcmd>
 						              kv = null;
                         .)
       |
-      CallCmd<out cmd>  (.
+      CallCmd<true, out cmd>  (.
                           yields.Add((CallCmd)cmd);
                           kv = null;
                         .)
@@ -1218,8 +1218,7 @@ LabelOrCmd<out Cmd c, out IToken label>
                              }
                              c = new HavocCmd(x,ids);
                           .)
-  | CallCmd<out cn> ";"   (. c = cn; .)
-  | ParCallCmd<out cn>    (. c = cn; .)
+  | CallCmd<false, out cn>  ";"     (. c = cn; .)
   )
   .
 
@@ -1305,31 +1304,28 @@ FieldAccess<.out IToken x, out FieldAccess fieldAccess.>
   .
 
 /*------------------------------------------------------------------------*/
-CallCmd<out Cmd c>
+CallCmd<bool inSpec, out Cmd c>
 = (. Contract.Ensures(Contract.ValueAtReturn(out c) != null);
      IToken x;
      bool isAsync = false;
      bool isFree = false;
      c = null;
+     List<CallCmd> callCmds = new List<CallCmd>();
   .)
   [ "async" (. isAsync = true; .) ]
   [ "free"  (. isFree = true; .) ]
   "call"                          (. x = t; .)
-  CallParams<isAsync, isFree, x, out c> (. .)
-  .
-
-ParCallCmd<out Cmd d>
-= (.
-    Contract.Ensures(Contract.ValueAtReturn(out d) != null);
-    IToken x;
-    Cmd c = null;
-    List<CallCmd> callCmds = new List<CallCmd>();
+  CallParams<isAsync, isFree, x, out c> (. callCmds.Add((CallCmd)c); .)
+  { "|" CallParams<false, false, x, out c> (. callCmds.Add((CallCmd)c); .) }
+  (.
+    if (callCmds.Count > 1) {
+      if (inSpec || isAsync || isFree) {
+        this.errors.SemErr(x, "parallel call not allowed");
+      } else {
+        c = new ParCallCmd(x, callCmds);
+      }
+    }
   .)
-  "par"                          (. x = t; .)
-  CallParams<false, false, x, out c> (. callCmds.Add((CallCmd)c); .)
-  { "|" CallParams<false, false, x, out c> (. callCmds.Add((CallCmd)c); .)
-  }
-  ";" (. d = new ParCallCmd(x, callCmds); .)
   .
 
 CallParams<bool isAsync, bool isFree, IToken x, out Cmd c>

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -36,7 +36,7 @@ public class Parser {
 	public const int _decimal = 5;
 	public const int _dec_float = 6;
 	public const int _float = 7;
-	public const int maxT = 125;
+	public const int maxT = 124;
 
 	const bool _T = true;
 	const bool _x = false;
@@ -303,7 +303,7 @@ private class BvBounds : Expr {
 					 Pgm.AddTopLevelDeclaration(im);
 					}
 					
-				} else SynErr(126);
+				} else SynErr(125);
 				break;
 			}
 			case 38: case 39: case 40: case 44: case 45: case 46: case 47: case 48: {
@@ -327,7 +327,7 @@ private class BvBounds : Expr {
 					}
 					isPure = false;
 					
-				} else SynErr(127);
+				} else SynErr(126);
 				break;
 			}
 			case 52: {
@@ -366,7 +366,7 @@ private class BvBounds : Expr {
 				axioms.Add(axiom); ds.Add(axiom); 
 			}
 			Expect(27);
-		} else SynErr(128);
+		} else SynErr(127);
 		foreach(TypedIdent x in xs){
 		 Contract.Assert(x != null);
 		 var constant = new Constant(y, x, u, kv, axioms);
@@ -425,7 +425,7 @@ private class BvBounds : Expr {
 			Get();
 			Type(out retTy);
 			retTyd = new TypedIdent(retTy.tok, TypedIdent.NoName, retTy); 
-		} else SynErr(129);
+		} else SynErr(128);
 		if (la.kind == 26) {
 			Get();
 			Expression(out tmp);
@@ -450,7 +450,7 @@ private class BvBounds : Expr {
 			Expect(27);
 		} else if (la.kind == 10) {
 			Get();
-		} else SynErr(130);
+		} else SynErr(129);
 		if (retTyd == null) {
 		 // construct a dummy type for the case of syntax error
 		 retTyd = new TypedIdent(t, TypedIdent.NoName, new BasicType(t, SimpleType.Int));
@@ -637,7 +637,7 @@ private class BvBounds : Expr {
 			impl = new Implementation(name, name.val, new List<TypeVariable>(), Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs),
 			                         locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
 			
-		} else SynErr(131);
+		} else SynErr(130);
 		ypDecl = new YieldProcedureDecl(name, name.val, moverType, ins, outs, pre, mods, post, yieldRequires, yieldEnsures, yieldPreserves, refinedAction, kv); 
 	}
 
@@ -675,7 +675,7 @@ private class BvBounds : Expr {
 			impl = new Implementation(x, x.val, typeParams.ConvertAll(tp => new TypeVariable(tp.tok, tp.Name)),
 			                         Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs), locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone(), this.errors);
 			
-		} else SynErr(132);
+		} else SynErr(131);
 		proc = new Procedure(x, x.val, typeParams, ins, outs, isPure, pre, mods, post, kv); 
 	}
 
@@ -727,7 +727,7 @@ private class BvBounds : Expr {
 			impl = new Implementation(name, name.val, new List<TypeVariable>(), Formal.StripWhereClauses(ins), Formal.StripWhereClauses(outs),
 			                              locals, stmtList, kv == null ? null : (QKeyValue)kv.Clone());
 			
-		} else SynErr(133);
+		} else SynErr(132);
 		if (isPure) {
 		 if (moverType == MoverType.None)
 		 {
@@ -865,7 +865,7 @@ private class BvBounds : Expr {
 			ty = new UnresolvedTypeIdentifier (tok, tok.val, args); 
 		} else if (la.kind == 19 || la.kind == 21) {
 			MapType(out ty);
-		} else SynErr(134);
+		} else SynErr(133);
 	}
 
 	void AttributesIdsTypeWhere(bool allowWhereClauses, string context, System.Action<TypedIdent, QKeyValue> action ) {
@@ -901,7 +901,7 @@ private class BvBounds : Expr {
 	void Expression(out Expr e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken x; Expr e1; 
 		ImpliesExpression(false, out e0);
-		while (la.kind == 74 || la.kind == 75) {
+		while (la.kind == 73 || la.kind == 74) {
 			EquivOp();
 			x = t; 
 			ImpliesExpression(false, out e1);
@@ -924,7 +924,7 @@ private class BvBounds : Expr {
 			Get();
 			Type(out ty);
 			Expect(12);
-		} else SynErr(135);
+		} else SynErr(134);
 	}
 
 	void Ident(out IToken x) {
@@ -974,7 +974,7 @@ private class BvBounds : Expr {
 			t.kind = _ident; 
 			break;
 		}
-		default: SynErr(136); break;
+		default: SynErr(135); break;
 		}
 		x = t;
 		if (x.val.StartsWith("\\"))
@@ -1000,7 +1000,7 @@ private class BvBounds : Expr {
 		} else if (la.kind == 19 || la.kind == 21) {
 			MapType(out ty);
 			ts.Add(ty); 
-		} else SynErr(137);
+		} else SynErr(136);
 	}
 
 	void MapType(out Bpl.Type ty) {
@@ -1161,7 +1161,7 @@ private class BvBounds : Expr {
 		} else if (la.kind == 47) {
 			Get();
 			moverType = MoverType.Atomic; 
-		} else SynErr(138);
+		} else SynErr(137);
 	}
 
 	void SpecAction(ref ActionDeclRef refinedAction, ref ActionDeclRef invariantAction, List<IdentifierExpr> mods, List<ActionDeclRef> creates, List<Requires> requires, List<CallCmd> yieldRequires, List<AssertCmd> asserts) {
@@ -1182,7 +1182,7 @@ private class BvBounds : Expr {
 			SpecYieldRequires(requires, yieldRequires);
 		} else if (la.kind == 49) {
 			SpecAsserts(asserts);
-		} else SynErr(139);
+		} else SynErr(138);
 	}
 
 	void ImplBody(out List<Variable> locals, out StmtList stmtList) {
@@ -1261,7 +1261,7 @@ private class BvBounds : Expr {
 			}
 			
 			Expect(10);
-		} else SynErr(140);
+		} else SynErr(139);
 	}
 
 	void SpecModifies(List<IdentifierExpr> mods) {
@@ -1285,9 +1285,9 @@ private class BvBounds : Expr {
 			Proposition(out e);
 			pre.Add(new Requires(tok, false, e, null, kv)); 
 		} else if (la.kind == 39 || la.kind == 53 || la.kind == 71) {
-			CallCmd(out cmd);
+			CallCmd(true, out cmd);
 			yieldRequires.Add((CallCmd)cmd); 
-		} else SynErr(141);
+		} else SynErr(140);
 		Expect(10);
 	}
 
@@ -1314,15 +1314,16 @@ private class BvBounds : Expr {
 			SpecYieldPreserves(yieldPreserves);
 		} else if (la.kind == 54) {
 			SpecModifies(mods);
-		} else SynErr(142);
+		} else SynErr(141);
 	}
 
-	void CallCmd(out Cmd c) {
+	void CallCmd(bool inSpec, out Cmd c) {
 		Contract.Ensures(Contract.ValueAtReturn(out c) != null);
 		IToken x;
 		bool isAsync = false;
 		bool isFree = false;
 		c = null;
+		List<CallCmd> callCmds = new List<CallCmd>();
 		
 		if (la.kind == 39) {
 			Get();
@@ -1335,6 +1336,19 @@ private class BvBounds : Expr {
 		Expect(71);
 		x = t; 
 		CallParams(isAsync, isFree, x, out c);
+		callCmds.Add((CallCmd)c); 
+		while (la.kind == 72) {
+			Get();
+			CallParams(false, false, x, out c);
+			callCmds.Add((CallCmd)c); 
+		}
+		if (callCmds.Count > 1) {
+		 if (inSpec || isAsync || isFree) {
+		   this.errors.SemErr(x, "parallel call not allowed");
+		 } else {
+		   c = new ParCallCmd(x, callCmds);
+		 }
+		}
 		
 	}
 
@@ -1349,9 +1363,9 @@ private class BvBounds : Expr {
 			Proposition(out e);
 			post.Add(new Ensures(tok, false, e, null, kv)); 
 		} else if (la.kind == 39 || la.kind == 53 || la.kind == 71) {
-			CallCmd(out cmd);
+			CallCmd(true, out cmd);
 			yieldEnsures.Add((CallCmd)cmd); 
-		} else SynErr(143);
+		} else SynErr(142);
 		Expect(10);
 	}
 
@@ -1359,7 +1373,7 @@ private class BvBounds : Expr {
 		Cmd cmd; Token tok; 
 		Expect(37);
 		tok = t; 
-		CallCmd(out cmd);
+		CallCmd(true, out cmd);
 		yieldPreserves.Add((CallCmd)cmd); 
 		Expect(10);
 	}
@@ -1391,7 +1405,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			SpecPrePost(true, pre, post);
 		} else if (la.kind == 50 || la.kind == 51) {
 			SpecPrePost(false, pre, post);
-		} else SynErr(144);
+		} else SynErr(143);
 	}
 
 	void SpecPrePost(bool free, List<Requires> pre, List<Ensures> post) {
@@ -1414,7 +1428,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			Proposition(out e);
 			Expect(10);
 			post.Add(new Ensures(tok, free, e, null, kv)); 
-		} else SynErr(145);
+		} else SynErr(144);
 	}
 
 	void StmtList(out StmtList stmtList) {
@@ -1508,7 +1522,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				hideRevealId = new IdentifierExpr(t, t.val); 
 			} else if (la.kind == 60) {
 				Get();
-			} else SynErr(146);
+			} else SynErr(145);
 			c = hideRevealId == null ? new HideRevealCmd(t, mode) : new HideRevealCmd(hideRevealId, mode); 
 			Expect(10);
 		} else if (la.kind == 64) {
@@ -1552,13 +1566,10 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			c = new HavocCmd(x,ids);
 			
 		} else if (la.kind == 39 || la.kind == 53 || la.kind == 71) {
-			CallCmd(out cn);
+			CallCmd(false, out cn);
 			Expect(10);
 			c = cn; 
-		} else if (la.kind == 72) {
-			ParCallCmd(out cn);
-			c = cn; 
-		} else SynErr(147);
+		} else SynErr(146);
 	}
 
 	void StructuredCmd(out StructuredCmd ec) {
@@ -1574,7 +1585,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 		} else if (la.kind == 61) {
 			BreakCmd(out bcmd);
 			ec = bcmd; 
-		} else SynErr(148);
+		} else SynErr(147);
 	}
 
 	void TransferCmd(out TransferCmd tc) {
@@ -1603,7 +1614,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				Attribute(ref kv);
 			}
 			tc = new ReturnCmd(t) { Attributes = kv }; 
-		} else SynErr(149);
+		} else SynErr(148);
 		Expect(10);
 	}
 
@@ -1632,7 +1643,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				Get();
 				StmtList(out els);
 				elseOption = els; 
-			} else SynErr(150);
+			} else SynErr(149);
 		}
 		ifcmd = new IfCmd(x, guard, thn, elseIfOption, elseOption, kv); 
 	}
@@ -1669,11 +1680,11 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				kv = null;
 				
 			} else if (la.kind == 39 || la.kind == 53 || la.kind == 71) {
-				CallCmd(out cmd);
+				CallCmd(true, out cmd);
 				yields.Add((CallCmd)cmd);
 				kv = null;
 				
-			} else SynErr(151);
+			} else SynErr(150);
 			Expect(10);
 		}
 		Expect(26);
@@ -1704,7 +1715,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 		} else if (StartOf(20)) {
 			Expression(out ee);
 			e = ee; 
-		} else SynErr(152);
+		} else SynErr(151);
 		Expect(12);
 	}
 
@@ -1782,26 +1793,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			}
 			Expect(10);
 			c = new AssignCmd(x, lhss, rhss, kv); 
-		} else SynErr(153);
-	}
-
-	void ParCallCmd(out Cmd d) {
-		Contract.Ensures(Contract.ValueAtReturn(out d) != null);
-		IToken x;
-		Cmd c = null;
-		List<CallCmd> callCmds = new List<CallCmd>();
-		
-		Expect(72);
-		x = t; 
-		CallParams(false, false, x, out c);
-		callCmds.Add((CallCmd)c); 
-		while (la.kind == 73) {
-			Get();
-			CallParams(false, false, x, out c);
-			callCmds.Add((CallCmd)c); 
-		}
-		Expect(10);
-		d = new ParCallCmd(x, callCmds); 
+		} else SynErr(152);
 	}
 
 	void MapAssignIndex(out IToken x, out List<Expr> indexes) {
@@ -1882,7 +1874,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			}
 			Expect(12);
 			c = new CallCmd(x, first.val, es, ids, kv); ((CallCmd) c).IsFree = isFree; ((CallCmd) c).IsAsync = isAsync; 
-		} else SynErr(154);
+		} else SynErr(153);
 	}
 
 	void Expressions(out List<Expr> es) {
@@ -1900,7 +1892,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken x; Expr e1; 
 		LogicalExpression(out e0);
 		if (StartOf(22)) {
-			if (la.kind == 76 || la.kind == 77) {
+			if (la.kind == 75 || la.kind == 76) {
 				ImpliesOp();
 				x = t; 
 				ImpliesExpression(true, out e1);
@@ -1912,7 +1904,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				x = t; 
 				LogicalExpression(out e1);
 				e0 = Expr.Binary(x, BinaryOperator.Opcode.Imp, e1, e0); 
-				while (la.kind == 78 || la.kind == 79) {
+				while (la.kind == 77 || la.kind == 78) {
 					ExpliesOp();
 					x = t; 
 					LogicalExpression(out e1);
@@ -1923,23 +1915,23 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 	}
 
 	void EquivOp() {
-		if (la.kind == 74) {
+		if (la.kind == 73) {
 			Get();
-		} else if (la.kind == 75) {
+		} else if (la.kind == 74) {
 			Get();
-		} else SynErr(155);
+		} else SynErr(154);
 	}
 
 	void LogicalExpression(out Expr e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken x; Expr e1; 
 		RelationalExpression(out e0);
 		if (StartOf(23)) {
-			if (la.kind == 80 || la.kind == 81) {
+			if (la.kind == 79 || la.kind == 80) {
 				AndOp();
 				x = t; 
 				RelationalExpression(out e1);
 				e0 = Expr.Binary(x, BinaryOperator.Opcode.And, e0, e1); 
-				while (la.kind == 80 || la.kind == 81) {
+				while (la.kind == 79 || la.kind == 80) {
 					AndOp();
 					x = t; 
 					RelationalExpression(out e1);
@@ -1950,7 +1942,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				x = t; 
 				RelationalExpression(out e1);
 				e0 = Expr.Binary(x, BinaryOperator.Opcode.Or, e0, e1); 
-				while (la.kind == 82 || la.kind == 83) {
+				while (la.kind == 81 || la.kind == 82) {
 					OrOp();
 					x = t; 
 					RelationalExpression(out e1);
@@ -1961,19 +1953,19 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 	}
 
 	void ImpliesOp() {
-		if (la.kind == 76) {
+		if (la.kind == 75) {
 			Get();
-		} else if (la.kind == 77) {
+		} else if (la.kind == 76) {
 			Get();
-		} else SynErr(156);
+		} else SynErr(155);
 	}
 
 	void ExpliesOp() {
-		if (la.kind == 78) {
+		if (la.kind == 77) {
 			Get();
-		} else if (la.kind == 79) {
+		} else if (la.kind == 78) {
 			Get();
-		} else SynErr(157);
+		} else SynErr(156);
 	}
 
 	void RelationalExpression(out Expr e0) {
@@ -1987,25 +1979,25 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 	}
 
 	void AndOp() {
-		if (la.kind == 80) {
+		if (la.kind == 79) {
 			Get();
-		} else if (la.kind == 81) {
+		} else if (la.kind == 80) {
 			Get();
-		} else SynErr(158);
+		} else SynErr(157);
 	}
 
 	void OrOp() {
-		if (la.kind == 82) {
+		if (la.kind == 81) {
 			Get();
-		} else if (la.kind == 83) {
+		} else if (la.kind == 82) {
 			Get();
-		} else SynErr(159);
+		} else SynErr(158);
 	}
 
 	void BvTerm(out Expr e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken x; Expr e1; 
 		Term(out e0);
-		while (la.kind == 91) {
+		while (la.kind == 90) {
 			Get();
 			x = t; 
 			Term(out e1);
@@ -2016,7 +2008,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 	void RelOp(out IToken x, out BinaryOperator.Opcode op) {
 		Contract.Ensures(Contract.ValueAtReturn(out x) != null); x = Token.NoToken; op=BinaryOperator.Opcode.Add/*(dummy)*/; 
 		switch (la.kind) {
-		case 84: {
+		case 83: {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Eq; 
 			break;
@@ -2031,14 +2023,19 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			x = t; op=BinaryOperator.Opcode.Gt; 
 			break;
 		}
-		case 85: {
+		case 84: {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Le; 
 			break;
 		}
-		case 86: {
+		case 85: {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Ge; 
+			break;
+		}
+		case 86: {
+			Get();
+			x = t; op=BinaryOperator.Opcode.Neq; 
 			break;
 		}
 		case 87: {
@@ -2048,27 +2045,22 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 		}
 		case 88: {
 			Get();
-			x = t; op=BinaryOperator.Opcode.Neq; 
+			x = t; op=BinaryOperator.Opcode.Le; 
 			break;
 		}
 		case 89: {
 			Get();
-			x = t; op=BinaryOperator.Opcode.Le; 
-			break;
-		}
-		case 90: {
-			Get();
 			x = t; op=BinaryOperator.Opcode.Ge; 
 			break;
 		}
-		default: SynErr(160); break;
+		default: SynErr(159); break;
 		}
 	}
 
 	void Term(out Expr e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken x; Expr e1; BinaryOperator.Opcode op; 
 		Factor(out e0);
-		while (la.kind == 92 || la.kind == 93) {
+		while (la.kind == 91 || la.kind == 92) {
 			AddOp(out x, out op);
 			Factor(out e1);
 			e0 = Expr.Binary(x, op, e0, e1); 
@@ -2087,19 +2079,19 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 
 	void AddOp(out IToken x, out BinaryOperator.Opcode op) {
 		Contract.Ensures(Contract.ValueAtReturn(out x) != null); x = Token.NoToken; op=BinaryOperator.Opcode.Add/*(dummy)*/; 
-		if (la.kind == 92) {
+		if (la.kind == 91) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Add; 
-		} else if (la.kind == 93) {
+		} else if (la.kind == 92) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Sub; 
-		} else SynErr(161);
+		} else SynErr(160);
 	}
 
 	void Power(out Expr e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken x; Expr e1; 
 		IsConstructor(out e0);
-		if (la.kind == 97) {
+		if (la.kind == 96) {
 			Get();
 			x = t; 
 			Power(out e1);
@@ -2112,22 +2104,22 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 		if (la.kind == 60) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Mul; 
-		} else if (la.kind == 94) {
+		} else if (la.kind == 93) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Div; 
-		} else if (la.kind == 95) {
+		} else if (la.kind == 94) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.Mod; 
-		} else if (la.kind == 96) {
+		} else if (la.kind == 95) {
 			Get();
 			x = t; op=BinaryOperator.Opcode.RealDiv; 
-		} else SynErr(162);
+		} else SynErr(161);
 	}
 
 	void IsConstructor(out Expr e0) {
 		Contract.Ensures(Contract.ValueAtReturn(out e0) != null); IToken x, id; 
 		UnaryExpression(out e0);
-		if (la.kind == 98) {
+		if (la.kind == 97) {
 			Get();
 			x = t; 
 			Ident(out id);
@@ -2141,27 +2133,27 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 		Contract.Ensures(Contract.ValueAtReturn(out e) != null); IToken x;
 		e = dummyExpr;
 		
-		if (la.kind == 93) {
+		if (la.kind == 92) {
 			Get();
 			x = t; 
 			UnaryExpression(out e);
 			e = Expr.Unary(x, UnaryOperator.Opcode.Neg, e); 
-		} else if (la.kind == 99 || la.kind == 100) {
+		} else if (la.kind == 98 || la.kind == 99) {
 			NegOp();
 			x = t; 
 			UnaryExpression(out e);
 			e = Expr.Unary(x, UnaryOperator.Opcode.Not, e); 
 		} else if (StartOf(26)) {
 			CoercionExpression(out e);
-		} else SynErr(163);
+		} else SynErr(162);
 	}
 
 	void NegOp() {
-		if (la.kind == 99) {
+		if (la.kind == 98) {
 			Get();
-		} else if (la.kind == 100) {
+		} else if (la.kind == 99) {
 			Get();
-		} else SynErr(164);
+		} else SynErr(163);
 	}
 
 	void CoercionExpression(out Expr e) {
@@ -2185,7 +2177,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				 e = new BvBounds(x, bn, ((LiteralExpr)e).asBigNum);
 				}
 				
-			} else SynErr(165);
+			} else SynErr(164);
 		}
 	}
 
@@ -2257,7 +2249,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 					Expression(out e1);
 					Expect(12);
 					e = new NAryExpr(x, new FieldUpdate(id, id.val), new List<Expr> { e, e1 }); 
-				} else SynErr(166);
+				} else SynErr(165);
 			}
 		}
 	}
@@ -2284,18 +2276,18 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 		List<Block> blocks;
 		
 		switch (la.kind) {
-		case 101: {
+		case 100: {
 			Get();
 			e = new LiteralExpr(t, false); 
 			break;
 		}
-		case 102: {
+		case 101: {
 			Get();
 			e = new LiteralExpr(t, true); 
 			break;
 		}
-		case 103: case 104: {
-			if (la.kind == 103) {
+		case 102: case 103: {
+			if (la.kind == 102) {
 				Get();
 			} else {
 				Get();
@@ -2303,8 +2295,8 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, RoundingMode.RNE); 
 			break;
 		}
-		case 105: case 106: {
-			if (la.kind == 105) {
+		case 104: case 105: {
+			if (la.kind == 104) {
 				Get();
 			} else {
 				Get();
@@ -2312,8 +2304,8 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, RoundingMode.RNA); 
 			break;
 		}
-		case 107: case 108: {
-			if (la.kind == 107) {
+		case 106: case 107: {
+			if (la.kind == 106) {
 				Get();
 			} else {
 				Get();
@@ -2321,8 +2313,8 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, RoundingMode.RTP); 
 			break;
 		}
-		case 109: case 110: {
-			if (la.kind == 109) {
+		case 108: case 109: {
+			if (la.kind == 108) {
 				Get();
 			} else {
 				Get();
@@ -2330,8 +2322,8 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			e = new LiteralExpr(t, RoundingMode.RTN); 
 			break;
 		}
-		case 111: case 112: {
-			if (la.kind == 111) {
+		case 110: case 111: {
+			if (la.kind == 110) {
 				Get();
 			} else {
 				Get();
@@ -2374,12 +2366,12 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 					e = new NAryExpr(x, new FunctionCall(id), es); 
 				} else if (la.kind == 12) {
 					e = new NAryExpr(x, new FunctionCall(id), new List<Expr>()); 
-				} else SynErr(167);
+				} else SynErr(166);
 				Expect(12);
 			}
 			break;
 		}
-		case 113: {
+		case 112: {
 			Get();
 			x = t; 
 			Expect(11);
@@ -2412,19 +2404,19 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				Expression(out e);
 				if (e is BvBounds)
 				 this.SemErr("parentheses around bitvector bounds are not allowed"); 
-			} else if (la.kind == 117 || la.kind == 118) {
+			} else if (la.kind == 116 || la.kind == 117) {
 				Forall();
 				x = t; 
 				QuantifierBody(x, out typeParams, out ds, out kv, out trig, out e);
 				if (typeParams.Count + ds.Count > 0)
 				 e = new ForallExpr(x, typeParams, ds, kv, trig, e); 
-			} else if (la.kind == 119 || la.kind == 120) {
+			} else if (la.kind == 118 || la.kind == 119) {
 				Exists();
 				x = t; 
 				QuantifierBody(x, out typeParams, out ds, out kv, out trig, out e);
 				if (typeParams.Count + ds.Count > 0)
 				 e = new ExistsExpr(x, typeParams, ds, kv, trig, e); 
-			} else if (la.kind == 121 || la.kind == 122) {
+			} else if (la.kind == 120 || la.kind == 121) {
 				Lambda();
 				x = t; 
 				QuantifierBody(x, out typeParams, out ds, out kv, out trig, out e);
@@ -2434,7 +2426,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 				 e = new LambdaExpr(x, typeParams, ds, kv, e); 
 			} else if (la.kind == 9) {
 				LetExpr(out e);
-			} else SynErr(168);
+			} else SynErr(167);
 			Expect(12);
 			break;
 		}
@@ -2442,12 +2434,12 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 			IfThenElseExpression(out e);
 			break;
 		}
-		case 114: {
+		case 113: {
 			CodeExpression(out locals, out blocks);
 			e = new CodeExpr(locals, blocks); 
 			break;
 		}
-		default: SynErr(169); break;
+		default: SynErr(168); break;
 		}
 	}
 
@@ -2459,7 +2451,7 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 		} else if (la.kind == 6) {
 			Get();
 			s = t.val; 
-		} else SynErr(170);
+		} else SynErr(169);
 		try {
 		 n = BigDec.FromString(s);
 		} catch (FormatException) {
@@ -2497,11 +2489,11 @@ out List<Variable> ins, out List<Variable> outs, out QKeyValue kv) {
 	}
 
 	void Forall() {
-		if (la.kind == 117) {
+		if (la.kind == 116) {
 			Get();
-		} else if (la.kind == 118) {
+		} else if (la.kind == 117) {
 			Get();
-		} else SynErr(171);
+		} else SynErr(170);
 	}
 
 	void QuantifierBody(IToken q, out List<TypeVariable> typeParams, out List<Variable> ds,
@@ -2519,7 +2511,7 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 			}
 		} else if (StartOf(12)) {
 			BoundVars(out ds);
-		} else SynErr(172);
+		} else SynErr(171);
 		QSep();
 		while (la.kind == 26) {
 			AttributeOrTrigger(ref kv, ref trig);
@@ -2528,19 +2520,19 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 	}
 
 	void Exists() {
-		if (la.kind == 119) {
+		if (la.kind == 118) {
 			Get();
-		} else if (la.kind == 120) {
+		} else if (la.kind == 119) {
 			Get();
-		} else SynErr(173);
+		} else SynErr(172);
 	}
 
 	void Lambda() {
-		if (la.kind == 121) {
+		if (la.kind == 120) {
 			Get();
-		} else if (la.kind == 122) {
+		} else if (la.kind == 121) {
 			Get();
-		} else SynErr(174);
+		} else SynErr(173);
 	}
 
 	void LetExpr(out Expr letexpr) {
@@ -2585,7 +2577,7 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 		Expect(57);
 		tok = t; 
 		Expression(out e0);
-		Expect(116);
+		Expect(115);
 		Expression(out e1);
 		Expect(58);
 		Expression(out e2);
@@ -2596,7 +2588,7 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 		Contract.Ensures(Contract.ValueAtReturn(out locals) != null); Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out blocks))); locals = new List<Variable>(); Block b;
 		blocks = new List<Block>();
 		
-		Expect(114);
+		Expect(113);
 		while (la.kind == 9) {
 			LocalVars(locals);
 		}
@@ -2606,7 +2598,7 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 			SpecBlock(out b);
 			blocks.Add(b); 
 		}
-		Expect(115);
+		Expect(114);
 	}
 
 	void SpecBlock(out Block b) {
@@ -2655,7 +2647,7 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 			 Attributes = kv
 			}); 
 			
-		} else SynErr(175);
+		} else SynErr(174);
 		Expect(10);
 	}
 
@@ -2712,7 +2704,7 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 			 trig.AddLast(new Trigger(tok, true, es, null));
 			}
 			
-		} else SynErr(176);
+		} else SynErr(175);
 		Expect(27);
 	}
 
@@ -2727,15 +2719,15 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 		} else if (StartOf(20)) {
 			Expression(out e);
 			o = e; 
-		} else SynErr(177);
+		} else SynErr(176);
 	}
 
 	void QSep() {
-		if (la.kind == 123) {
+		if (la.kind == 122) {
 			Get();
-		} else if (la.kind == 124) {
+		} else if (la.kind == 123) {
 			Get();
-		} else SynErr(178);
+		} else SynErr(177);
 	}
 
 	void LetVar(out Variable v) {
@@ -2764,34 +2756,34 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 	}
 
 	static readonly bool[,] set = {
-		{_T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_T, _T,_T,_x,_T, _x,_x,_T,_T, _T,_x,_x,_x, _T,_T,_T,_T, _T,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_T,_x,_T, _T,_T,_x,_T, _x,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_x,_x,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
-		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x}
+		{_T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_T, _T,_T,_x,_T, _x,_x,_T,_T, _T,_x,_x,_x, _T,_T,_T,_T, _T,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_T,_x,_T, _T,_T,_x,_T, _x,_T,_T,_T, _T,_T,_T,_T, _T,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_T,_T, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x}
 
 	};
 } // end Parser
@@ -2888,113 +2880,112 @@ public class Errors {
 			case 69: s = "\":=\" expected"; break;
 			case 70: s = "\"->\" expected"; break;
 			case 71: s = "\"call\" expected"; break;
-			case 72: s = "\"par\" expected"; break;
-			case 73: s = "\"|\" expected"; break;
-			case 74: s = "\"<==>\" expected"; break;
-			case 75: s = "\"\\u21d4\" expected"; break;
-			case 76: s = "\"==>\" expected"; break;
-			case 77: s = "\"\\u21d2\" expected"; break;
-			case 78: s = "\"<==\" expected"; break;
-			case 79: s = "\"\\u21d0\" expected"; break;
-			case 80: s = "\"&&\" expected"; break;
-			case 81: s = "\"\\u2227\" expected"; break;
-			case 82: s = "\"||\" expected"; break;
-			case 83: s = "\"\\u2228\" expected"; break;
-			case 84: s = "\"==\" expected"; break;
-			case 85: s = "\"<=\" expected"; break;
-			case 86: s = "\">=\" expected"; break;
-			case 87: s = "\"!=\" expected"; break;
-			case 88: s = "\"\\u2260\" expected"; break;
-			case 89: s = "\"\\u2264\" expected"; break;
-			case 90: s = "\"\\u2265\" expected"; break;
-			case 91: s = "\"++\" expected"; break;
-			case 92: s = "\"+\" expected"; break;
-			case 93: s = "\"-\" expected"; break;
-			case 94: s = "\"div\" expected"; break;
-			case 95: s = "\"mod\" expected"; break;
-			case 96: s = "\"/\" expected"; break;
-			case 97: s = "\"**\" expected"; break;
-			case 98: s = "\"is\" expected"; break;
-			case 99: s = "\"!\" expected"; break;
-			case 100: s = "\"\\u00ac\" expected"; break;
-			case 101: s = "\"false\" expected"; break;
-			case 102: s = "\"true\" expected"; break;
-			case 103: s = "\"roundNearestTiesToEven\" expected"; break;
-			case 104: s = "\"RNE\" expected"; break;
-			case 105: s = "\"roundNearestTiesToAway\" expected"; break;
-			case 106: s = "\"RNA\" expected"; break;
-			case 107: s = "\"roundTowardPositive\" expected"; break;
-			case 108: s = "\"RTP\" expected"; break;
-			case 109: s = "\"roundTowardNegative\" expected"; break;
-			case 110: s = "\"RTN\" expected"; break;
-			case 111: s = "\"roundTowardZero\" expected"; break;
-			case 112: s = "\"RTZ\" expected"; break;
-			case 113: s = "\"old\" expected"; break;
-			case 114: s = "\"|{\" expected"; break;
-			case 115: s = "\"}|\" expected"; break;
-			case 116: s = "\"then\" expected"; break;
-			case 117: s = "\"forall\" expected"; break;
-			case 118: s = "\"\\u2200\" expected"; break;
-			case 119: s = "\"exists\" expected"; break;
-			case 120: s = "\"\\u2203\" expected"; break;
-			case 121: s = "\"lambda\" expected"; break;
-			case 122: s = "\"\\u03bb\" expected"; break;
-			case 123: s = "\"::\" expected"; break;
-			case 124: s = "\"\\u2022\" expected"; break;
-			case 125: s = "??? expected"; break;
+			case 72: s = "\"|\" expected"; break;
+			case 73: s = "\"<==>\" expected"; break;
+			case 74: s = "\"\\u21d4\" expected"; break;
+			case 75: s = "\"==>\" expected"; break;
+			case 76: s = "\"\\u21d2\" expected"; break;
+			case 77: s = "\"<==\" expected"; break;
+			case 78: s = "\"\\u21d0\" expected"; break;
+			case 79: s = "\"&&\" expected"; break;
+			case 80: s = "\"\\u2227\" expected"; break;
+			case 81: s = "\"||\" expected"; break;
+			case 82: s = "\"\\u2228\" expected"; break;
+			case 83: s = "\"==\" expected"; break;
+			case 84: s = "\"<=\" expected"; break;
+			case 85: s = "\">=\" expected"; break;
+			case 86: s = "\"!=\" expected"; break;
+			case 87: s = "\"\\u2260\" expected"; break;
+			case 88: s = "\"\\u2264\" expected"; break;
+			case 89: s = "\"\\u2265\" expected"; break;
+			case 90: s = "\"++\" expected"; break;
+			case 91: s = "\"+\" expected"; break;
+			case 92: s = "\"-\" expected"; break;
+			case 93: s = "\"div\" expected"; break;
+			case 94: s = "\"mod\" expected"; break;
+			case 95: s = "\"/\" expected"; break;
+			case 96: s = "\"**\" expected"; break;
+			case 97: s = "\"is\" expected"; break;
+			case 98: s = "\"!\" expected"; break;
+			case 99: s = "\"\\u00ac\" expected"; break;
+			case 100: s = "\"false\" expected"; break;
+			case 101: s = "\"true\" expected"; break;
+			case 102: s = "\"roundNearestTiesToEven\" expected"; break;
+			case 103: s = "\"RNE\" expected"; break;
+			case 104: s = "\"roundNearestTiesToAway\" expected"; break;
+			case 105: s = "\"RNA\" expected"; break;
+			case 106: s = "\"roundTowardPositive\" expected"; break;
+			case 107: s = "\"RTP\" expected"; break;
+			case 108: s = "\"roundTowardNegative\" expected"; break;
+			case 109: s = "\"RTN\" expected"; break;
+			case 110: s = "\"roundTowardZero\" expected"; break;
+			case 111: s = "\"RTZ\" expected"; break;
+			case 112: s = "\"old\" expected"; break;
+			case 113: s = "\"|{\" expected"; break;
+			case 114: s = "\"}|\" expected"; break;
+			case 115: s = "\"then\" expected"; break;
+			case 116: s = "\"forall\" expected"; break;
+			case 117: s = "\"\\u2200\" expected"; break;
+			case 118: s = "\"exists\" expected"; break;
+			case 119: s = "\"\\u2203\" expected"; break;
+			case 120: s = "\"lambda\" expected"; break;
+			case 121: s = "\"\\u03bb\" expected"; break;
+			case 122: s = "\"::\" expected"; break;
+			case 123: s = "\"\\u2022\" expected"; break;
+			case 124: s = "??? expected"; break;
+			case 125: s = "invalid BoogiePL"; break;
 			case 126: s = "invalid BoogiePL"; break;
-			case 127: s = "invalid BoogiePL"; break;
-			case 128: s = "invalid Consts"; break;
+			case 127: s = "invalid Consts"; break;
+			case 128: s = "invalid Function"; break;
 			case 129: s = "invalid Function"; break;
-			case 130: s = "invalid Function"; break;
-			case 131: s = "invalid YieldProcedureDecl"; break;
-			case 132: s = "invalid Procedure"; break;
-			case 133: s = "invalid ActionDecl"; break;
-			case 134: s = "invalid Type"; break;
-			case 135: s = "invalid TypeAtom"; break;
-			case 136: s = "invalid Ident"; break;
-			case 137: s = "invalid TypeArgs"; break;
-			case 138: s = "invalid MoverQualifier"; break;
-			case 139: s = "invalid SpecAction"; break;
-			case 140: s = "invalid SpecRefinedActionForYieldProcedure"; break;
-			case 141: s = "invalid SpecYieldRequires"; break;
-			case 142: s = "invalid SpecYieldPrePost"; break;
-			case 143: s = "invalid SpecYieldEnsures"; break;
-			case 144: s = "invalid Spec"; break;
-			case 145: s = "invalid SpecPrePost"; break;
+			case 130: s = "invalid YieldProcedureDecl"; break;
+			case 131: s = "invalid Procedure"; break;
+			case 132: s = "invalid ActionDecl"; break;
+			case 133: s = "invalid Type"; break;
+			case 134: s = "invalid TypeAtom"; break;
+			case 135: s = "invalid Ident"; break;
+			case 136: s = "invalid TypeArgs"; break;
+			case 137: s = "invalid MoverQualifier"; break;
+			case 138: s = "invalid SpecAction"; break;
+			case 139: s = "invalid SpecRefinedActionForYieldProcedure"; break;
+			case 140: s = "invalid SpecYieldRequires"; break;
+			case 141: s = "invalid SpecYieldPrePost"; break;
+			case 142: s = "invalid SpecYieldEnsures"; break;
+			case 143: s = "invalid Spec"; break;
+			case 144: s = "invalid SpecPrePost"; break;
+			case 145: s = "invalid LabelOrCmd"; break;
 			case 146: s = "invalid LabelOrCmd"; break;
-			case 147: s = "invalid LabelOrCmd"; break;
-			case 148: s = "invalid StructuredCmd"; break;
-			case 149: s = "invalid TransferCmd"; break;
-			case 150: s = "invalid IfCmd"; break;
-			case 151: s = "invalid WhileCmd"; break;
-			case 152: s = "invalid Guard"; break;
-			case 153: s = "invalid LabelOrAssign"; break;
-			case 154: s = "invalid CallParams"; break;
-			case 155: s = "invalid EquivOp"; break;
-			case 156: s = "invalid ImpliesOp"; break;
-			case 157: s = "invalid ExpliesOp"; break;
-			case 158: s = "invalid AndOp"; break;
-			case 159: s = "invalid OrOp"; break;
-			case 160: s = "invalid RelOp"; break;
-			case 161: s = "invalid AddOp"; break;
-			case 162: s = "invalid MulOp"; break;
-			case 163: s = "invalid UnaryExpression"; break;
-			case 164: s = "invalid NegOp"; break;
-			case 165: s = "invalid CoercionExpression"; break;
-			case 166: s = "invalid ArrayExpression"; break;
+			case 147: s = "invalid StructuredCmd"; break;
+			case 148: s = "invalid TransferCmd"; break;
+			case 149: s = "invalid IfCmd"; break;
+			case 150: s = "invalid WhileCmd"; break;
+			case 151: s = "invalid Guard"; break;
+			case 152: s = "invalid LabelOrAssign"; break;
+			case 153: s = "invalid CallParams"; break;
+			case 154: s = "invalid EquivOp"; break;
+			case 155: s = "invalid ImpliesOp"; break;
+			case 156: s = "invalid ExpliesOp"; break;
+			case 157: s = "invalid AndOp"; break;
+			case 158: s = "invalid OrOp"; break;
+			case 159: s = "invalid RelOp"; break;
+			case 160: s = "invalid AddOp"; break;
+			case 161: s = "invalid MulOp"; break;
+			case 162: s = "invalid UnaryExpression"; break;
+			case 163: s = "invalid NegOp"; break;
+			case 164: s = "invalid CoercionExpression"; break;
+			case 165: s = "invalid ArrayExpression"; break;
+			case 166: s = "invalid AtomExpression"; break;
 			case 167: s = "invalid AtomExpression"; break;
 			case 168: s = "invalid AtomExpression"; break;
-			case 169: s = "invalid AtomExpression"; break;
-			case 170: s = "invalid Dec"; break;
-			case 171: s = "invalid Forall"; break;
-			case 172: s = "invalid QuantifierBody"; break;
-			case 173: s = "invalid Exists"; break;
-			case 174: s = "invalid Lambda"; break;
-			case 175: s = "invalid SpecBlock"; break;
-			case 176: s = "invalid AttributeOrTrigger"; break;
-			case 177: s = "invalid AttributeParameter"; break;
-			case 178: s = "invalid QSep"; break;
+			case 169: s = "invalid Dec"; break;
+			case 170: s = "invalid Forall"; break;
+			case 171: s = "invalid QuantifierBody"; break;
+			case 172: s = "invalid Exists"; break;
+			case 173: s = "invalid Lambda"; break;
+			case 174: s = "invalid SpecBlock"; break;
+			case 175: s = "invalid AttributeOrTrigger"; break;
+			case 176: s = "invalid AttributeParameter"; break;
+			case 177: s = "invalid QSep"; break;
 
 			default: s = "error " + n; break;
 		}

--- a/Source/Core/Scanner.cs
+++ b/Source/Core/Scanner.cs
@@ -220,8 +220,8 @@ public class UTF8Buffer: Buffer {
 public class Scanner {
 	const char EOL = '\n';
 	const int eofSym = 0; /* pdt */
-	const int maxT = 125;
-	const int noSym = 125;
+	const int maxT = 124;
+	const int noSym = 124;
 
 
 	[ContractInvariantMethod]
@@ -562,27 +562,26 @@ public class Scanner {
 			case "assume": t.kind = 67; break;
 			case "havoc": t.kind = 68; break;
 			case "call": t.kind = 71; break;
-			case "par": t.kind = 72; break;
-			case "div": t.kind = 94; break;
-			case "mod": t.kind = 95; break;
-			case "is": t.kind = 98; break;
-			case "false": t.kind = 101; break;
-			case "true": t.kind = 102; break;
-			case "roundNearestTiesToEven": t.kind = 103; break;
-			case "RNE": t.kind = 104; break;
-			case "roundNearestTiesToAway": t.kind = 105; break;
-			case "RNA": t.kind = 106; break;
-			case "roundTowardPositive": t.kind = 107; break;
-			case "RTP": t.kind = 108; break;
-			case "roundTowardNegative": t.kind = 109; break;
-			case "RTN": t.kind = 110; break;
-			case "roundTowardZero": t.kind = 111; break;
-			case "RTZ": t.kind = 112; break;
-			case "old": t.kind = 113; break;
-			case "then": t.kind = 116; break;
-			case "forall": t.kind = 117; break;
-			case "exists": t.kind = 119; break;
-			case "lambda": t.kind = 121; break;
+			case "div": t.kind = 93; break;
+			case "mod": t.kind = 94; break;
+			case "is": t.kind = 97; break;
+			case "false": t.kind = 100; break;
+			case "true": t.kind = 101; break;
+			case "roundNearestTiesToEven": t.kind = 102; break;
+			case "RNE": t.kind = 103; break;
+			case "roundNearestTiesToAway": t.kind = 104; break;
+			case "RNA": t.kind = 105; break;
+			case "roundTowardPositive": t.kind = 106; break;
+			case "RTP": t.kind = 107; break;
+			case "roundTowardNegative": t.kind = 108; break;
+			case "RTN": t.kind = 109; break;
+			case "roundTowardZero": t.kind = 110; break;
+			case "RTZ": t.kind = 111; break;
+			case "old": t.kind = 112; break;
+			case "then": t.kind = 115; break;
+			case "forall": t.kind = 116; break;
+			case "exists": t.kind = 118; break;
+			case "lambda": t.kind = 120; break;
 			default: break;
 		}
 	}
@@ -870,63 +869,63 @@ public class Scanner {
 			case 69:
 				{t.kind = 70; break;}
 			case 70:
-				{t.kind = 74; break;}
+				{t.kind = 73; break;}
 			case 71:
-				{t.kind = 75; break;}
+				{t.kind = 74; break;}
 			case 72:
-				{t.kind = 76; break;}
+				{t.kind = 75; break;}
 			case 73:
-				{t.kind = 77; break;}
+				{t.kind = 76; break;}
 			case 74:
-				{t.kind = 79; break;}
+				{t.kind = 78; break;}
 			case 75:
 				if (ch == '&') {AddCh(); goto case 76;}
 				else {goto case 0;}
 			case 76:
-				{t.kind = 80; break;}
+				{t.kind = 79; break;}
 			case 77:
-				{t.kind = 81; break;}
+				{t.kind = 80; break;}
 			case 78:
-				{t.kind = 82; break;}
+				{t.kind = 81; break;}
 			case 79:
-				{t.kind = 83; break;}
+				{t.kind = 82; break;}
 			case 80:
-				{t.kind = 86; break;}
+				{t.kind = 85; break;}
 			case 81:
-				{t.kind = 87; break;}
+				{t.kind = 86; break;}
 			case 82:
-				{t.kind = 88; break;}
+				{t.kind = 87; break;}
 			case 83:
-				{t.kind = 89; break;}
+				{t.kind = 88; break;}
 			case 84:
-				{t.kind = 90; break;}
+				{t.kind = 89; break;}
 			case 85:
-				{t.kind = 91; break;}
+				{t.kind = 90; break;}
 			case 86:
-				{t.kind = 96; break;}
+				{t.kind = 95; break;}
 			case 87:
-				{t.kind = 97; break;}
+				{t.kind = 96; break;}
 			case 88:
-				{t.kind = 100; break;}
+				{t.kind = 99; break;}
 			case 89:
-				{t.kind = 114; break;}
+				{t.kind = 113; break;}
 			case 90:
-				{t.kind = 115; break;}
+				{t.kind = 114; break;}
 			case 91:
-				{t.kind = 118; break;}
+				{t.kind = 117; break;}
 			case 92:
-				{t.kind = 120; break;}
+				{t.kind = 119; break;}
 			case 93:
-				{t.kind = 122; break;}
+				{t.kind = 121; break;}
 			case 94:
-				{t.kind = 123; break;}
+				{t.kind = 122; break;}
 			case 95:
-				{t.kind = 124; break;}
+				{t.kind = 123; break;}
 			case 96:
-				recEnd = pos; recKind = 93;
+				recEnd = pos; recKind = 92;
 				if (ch == '0') {AddCh(); goto case 16;}
 				else if (ch == '>') {AddCh(); goto case 69;}
-				else {t.kind = 93; break;}
+				else {t.kind = 92; break;}
 			case 97:
 				recEnd = pos; recKind = 13;
 				if (ch == '=') {AddCh(); goto case 68;}
@@ -953,30 +952,30 @@ public class Scanner {
 				if (ch == '*') {AddCh(); goto case 87;}
 				else {t.kind = 60; break;}
 			case 103:
-				recEnd = pos; recKind = 73;
+				recEnd = pos; recKind = 72;
 				if (ch == '|') {AddCh(); goto case 78;}
 				else if (ch == '{') {AddCh(); goto case 89;}
-				else {t.kind = 73; break;}
+				else {t.kind = 72; break;}
 			case 104:
-				recEnd = pos; recKind = 99;
+				recEnd = pos; recKind = 98;
 				if (ch == '=') {AddCh(); goto case 81;}
-				else {t.kind = 99; break;}
+				else {t.kind = 98; break;}
 			case 105:
-				recEnd = pos; recKind = 92;
+				recEnd = pos; recKind = 91;
 				if (ch == '+') {AddCh(); goto case 85;}
-				else {t.kind = 92; break;}
+				else {t.kind = 91; break;}
 			case 106:
-				recEnd = pos; recKind = 85;
-				if (ch == '=') {AddCh(); goto case 108;}
-				else {t.kind = 85; break;}
-			case 107:
 				recEnd = pos; recKind = 84;
-				if (ch == '>') {AddCh(); goto case 72;}
+				if (ch == '=') {AddCh(); goto case 108;}
 				else {t.kind = 84; break;}
+			case 107:
+				recEnd = pos; recKind = 83;
+				if (ch == '>') {AddCh(); goto case 72;}
+				else {t.kind = 83; break;}
 			case 108:
-				recEnd = pos; recKind = 78;
+				recEnd = pos; recKind = 77;
 				if (ch == '>') {AddCh(); goto case 70;}
-				else {t.kind = 78; break;}
+				else {t.kind = 77; break;}
 
 		}
 		t.val = new String(tval, 0, tlen);

--- a/Test/civl/large-samples/GC.bpl
+++ b/Test/civl/large-samples/GC.bpl
@@ -252,8 +252,8 @@ ensures call Yield_Iso();
 ensures call Yield_RootScanBarrierInv();
 ensures call Yield_InitVars99(mutatorTids, Set_Empty(), numMutators);
 {
-    par InitVars99(tid, mutatorTids) | Yield_Lock();
-    par InitVars100(tid, mutatorTids) | Yield_Lock();
+    call InitVars99(tid, mutatorTids) | Yield_Lock();
+    call InitVars100(tid, mutatorTids) | Yield_Lock();
     async call GarbageCollect(tid);
 }
 
@@ -281,11 +281,11 @@ requires {:layer 96} tid->i == i;
     var ptr: int;
     var absPtr: obj;
 
-    par TestRootScanBarrier(tid) | Yield_Lock();
-    par Yield_Iso();
+    call TestRootScanBarrier(tid) | Yield_Lock();
+    call Yield_Iso();
     call UpdateMutatorPhase(tid, i);
-    par Yield_Iso();
-    par ptr, absPtr := AllocRaw(tid, y) | Yield_Lock();
+    call Yield_Iso();
+    call ptr, absPtr := AllocRaw(tid, y) | Yield_Lock();
     assert {:layer 100} Iso(root, rootAbs, mem, memAbs, Color, toAbs, allocSet);
 }
 
@@ -302,8 +302,8 @@ preserves call Yield_Lock();
 requires {:layer 95, 96, 99} tid->i == i;
 {
     call WriteBarrier(tid, i, y);
-    par Yield_Iso() | Yield_WriteField(tid, x, y);
-    par WriteFieldRaw(tid, x, f, y) | Yield_Lock();
+    call Yield_Iso() | Yield_WriteField(tid, x, y);
+    call WriteFieldRaw(tid, x, f, y) | Yield_Lock();
 }
 
 atomic action {:layer 101} AtomicReadField({:linear} tid:Tid, x: idx, f: fld, y: idx) // y = x.f
@@ -353,24 +353,24 @@ requires call Yield_Lock();
         invariant call Yield_Lock();
     {
         call nextPhase := HandshakeCollector(tid); // IDLE --> MARK
-        par Yield_WaitForMutators(tid, collectorPhase, false, 0) |
+        call Yield_WaitForMutators(tid, collectorPhase, false, 0) |
             Yield_Iso() |
             Yield_MsWellFormed(tid, 0) |
             Yield_RootScanBarrierInv() |
             Yield_GarbageCollect_100(tid) |
             Yield_CollectorPhase_100(tid, collectorPhase) |
             Yield_SweepPtr_100(tid, sweepPtr);
-        par WaitForMutators(tid, nextPhase) | Yield_Lock();
+        call WaitForMutators(tid, nextPhase) | Yield_Lock();
         call MarkOuterLoop(tid);
         call nextPhase := HandshakeCollector(tid); // MARK --> SWEEP
-        par Yield_WaitForMutators(tid, collectorPhase, false, 0) |
+        call Yield_WaitForMutators(tid, collectorPhase, false, 0) |
             Yield_Iso() |
             Yield_MsWellFormed(tid, 0) |
             Yield_RootScanBarrierInv() |
             Yield_GarbageCollect_100(tid) |
             Yield_CollectorPhase_100(tid, collectorPhase) |
             Yield_SweepPtr_100(tid, sweepPtr);
-        par WaitForMutators(tid, nextPhase) | Yield_Lock();
+        call WaitForMutators(tid, nextPhase) | Yield_Lock();
         call Sweep(tid);
         call nextPhase := HandshakeCollector(tid); // SWEEP --> IDLE
     }
@@ -442,7 +442,7 @@ preserves call Yield_Lock();
             invariant call Yield_MarkInnerLoopFieldIter(tid, fldIter, nodeProcessed);
             invariant call Yield_Lock();
         {
-            par child := ReadFieldByCollector(tid, nodeProcessed, fldIter) | Yield_Lock();
+            call child := ReadFieldByCollector(tid, nodeProcessed, fldIter) | Yield_Lock();
             if (memAddr(child))
             {
                 call InsertIntoSetIfWhiteByCollector(tid, nodeProcessed, child);
@@ -468,7 +468,7 @@ preserves call Yield_Lock();
 
     localSweepPtr := memLo;
     call ClearToAbsWhite(tid);
-    par Yield_SweepBegin(tid, true, Color) | Yield_MsWellFormed(tid, 0) | Yield_RootScanBarrierInv() | Yield_Iso();
+    call Yield_SweepBegin(tid, true, Color) | Yield_MsWellFormed(tid, 0) | Yield_RootScanBarrierInv() | Yield_Iso();
 
     call {:layer 100} snapColor := Copy(Color);
     while (localSweepPtr < memHi)
@@ -540,13 +540,13 @@ preserves call Yield_Lock();
     var isRootScanOn: bool;
     var {:layer 95, 99} {:linear} tid_tmp: Tid;
 
-    par isRootScanOn := PollMutatorReadBarrierOn(tid) | Yield_Lock();
-    par Yield_RootScanBarrierInv() | Yield_RootScanBarrierEnter(tid) | Yield_97() | Yield_98();
+    call isRootScanOn := PollMutatorReadBarrierOn(tid) | Yield_Lock();
+    call Yield_RootScanBarrierInv() | Yield_RootScanBarrierEnter(tid) | Yield_97() | Yield_98();
     if (isRootScanOn)
     {
         assert{:layer 99} !Set_Contains(mutatorsInRootScanBarrier, Right(tid->i));
         call tid_tmp := MutatorRootScanBarrierEnter(tid);
-        par Yield_RootScanBarrierInv() | Yield_RootScanBarrierWait(tid_tmp) | Yield_97() | Yield_98();
+        call Yield_RootScanBarrierInv() | Yield_RootScanBarrierWait(tid_tmp) | Yield_97() | Yield_98();
         assert{:layer 99} Set_Contains(mutatorsInRootScanBarrier, Right(tid_tmp->i));
         call tid_tmp := MutatorRootScanBarrierWait(tid_tmp);
         call {:layer 99} Move(tid_tmp, tid);
@@ -579,10 +579,10 @@ preserves call Yield_Lock();
 
     call CollectorRootScanBarrierStart(tid);
 
-    par Yield_MsWellFormed(tid, 0) | Yield_CollectorPhase_98(tid, old(collectorPhase)) | Yield_RootScanBarrierInv() | Yield_RootScanOn(tid, true) | Yield_97();
+    call Yield_MsWellFormed(tid, 0) | Yield_CollectorPhase_98(tid, old(collectorPhase)) | Yield_RootScanBarrierInv() | Yield_RootScanOn(tid, true) | Yield_97();
 
     call {:layer 99} snapColor := Copy(Color);
-    par CollectorRootScanBarrierWait(tid) | Yield_Lock();
+    call CollectorRootScanBarrierWait(tid) | Yield_Lock();
 
     i := 0;
     while (i < numRoots)
@@ -594,10 +594,10 @@ preserves call Yield_Lock();
         invariant {:layer 99} Color == (lambda u: int :: if memAddr(u) && White(snapColor[u]) && (exists k: int :: 0 <= k && k < i && root[k] == u) then GRAY() else snapColor[u]);
         invariant call Yield_Lock();
     {
-        par o := ReadRootInRootScanBarrier(tid, i) | Yield_Lock();
+        call o := ReadRootInRootScanBarrier(tid, i) | Yield_Lock();
         if (memAddr(o))
         {
-            par InsertIntoSetIfWhiteInRootScanBarrier(tid, o) | Yield_Lock();
+            call InsertIntoSetIfWhiteInRootScanBarrier(tid, o) | Yield_Lock();
         }
         i := i + 1;
     }
@@ -683,7 +683,7 @@ preserves call Yield_Lock();
     call {:layer 99} Assume(memAddrAbs(absPtr) && !allocSet[absPtr] && absPtr != nil);
     call {:layer 99} allocSet := Copy(allocSet[absPtr := true]);
     call ptr := FindFreePtr(tid, absPtr);
-    par WriteRoot(tid, y, ptr) | Yield_Lock();
+    call WriteRoot(tid, y, ptr) | Yield_Lock();
     call {:layer 99} memAbs := Copy(memAbs[absPtr := (lambda z: int :: if (fieldAddr(z)) then absPtr else memAbs[absPtr][z])]);
     call {:layer 99} rootAbs := Copy(rootAbs[y := absPtr]);
 }
@@ -708,10 +708,10 @@ preserves call Yield_Lock();
     var phase: int;
     var rootVal: int;
 
-    par rootVal := ReadRoot(tid, y) | Yield_Lock();
+    call rootVal := ReadRoot(tid, y) | Yield_Lock();
     if (memAddr(rootVal))
     {
-        par phase := ReadMutatorPhaseByMutator(tid, i) | Yield_Lock();
+        call phase := ReadMutatorPhaseByMutator(tid, i) | Yield_Lock();
         if (MarkPhase(phase))
         {
             call InsertIntoSetIfWhiteByMutator(tid, rootVal);
@@ -815,13 +815,13 @@ preserves call Yield_Lock();
 {
     var color:int;
 
-    par color := ReadColorByMutator3(tid, memLocal) | Yield_Lock();
+    call color := ReadColorByMutator3(tid, memLocal) | Yield_Lock();
     if (!White(color))
     {
         return;
     }
 
-    par Yield_97() | Yield_MarkPhase(tid, memLocal);
+    call Yield_97() | Yield_MarkPhase(tid, memLocal);
 
     call MsPushByMutator(tid, memLocal);
     assert {:layer 98} MST(MarkStackPtr-1);
@@ -1054,7 +1054,7 @@ refines AtomicSetColorToBlack;
 preserves call Yield_Lock();
 {
     call LockAcquire(tid);
-    par SetColorInMarkPhase(tid, scannedLocal, BLACK()) | Yield_Lock();
+    call SetColorInMarkPhase(tid, scannedLocal, BLACK()) | Yield_Lock();
     call LockRelease(tid);
 }
 
@@ -1077,14 +1077,14 @@ preserves call Yield_Lock();
     var stack:int;
 
     call LockAcquire(tid);
-    par color := ReadColorByCollector(tid, val) | Yield_Lock();
+    call color := ReadColorByCollector(tid, val) | Yield_Lock();
     if (White(color))
     {
-        par SetColorInMarkPhase(tid, val, GRAY()) | Yield_Lock();
-        par stack := ReadMarkStackPtr(tid) | Yield_Lock();
-        par WriteMarkStack(tid, stack, val) | Yield_Lock();
+        call SetColorInMarkPhase(tid, val, GRAY()) | Yield_Lock();
+        call stack := ReadMarkStackPtr(tid) | Yield_Lock();
+        call WriteMarkStack(tid, stack, val) | Yield_Lock();
         stack := stack + 1;
-        par SetMarkStackPtr(tid, stack) | Yield_Lock();
+        call SetMarkStackPtr(tid, stack) | Yield_Lock();
     }
     call LockRelease(tid);
 }
@@ -1108,14 +1108,14 @@ preserves call Yield_Lock();
     var stack:int;
 
     call LockAcquire(tid);
-    par color := ReadColorByMutator2(tid, val) | Yield_Lock();
+    call color := ReadColorByMutator2(tid, val) | Yield_Lock();
     if (White(color))
     {
-        par SetColorInMarkPhase(tid, val, GRAY()) | Yield_Lock();
-        par stack := ReadMarkStackPtr(tid) | Yield_Lock();
-        par WriteMarkStack(tid, stack, val) | Yield_Lock();
+        call SetColorInMarkPhase(tid, val, GRAY()) | Yield_Lock();
+        call stack := ReadMarkStackPtr(tid) | Yield_Lock();
+        call WriteMarkStack(tid, stack, val) | Yield_Lock();
         stack := stack + 1;
-        par SetMarkStackPtr(tid, stack) | Yield_Lock();
+        call SetMarkStackPtr(tid, stack) | Yield_Lock();
     }
     call LockRelease(tid);
 }
@@ -1141,12 +1141,12 @@ preserves call Yield_Lock();
     var stack:int;
 
     call LockAcquire(tid);
-    par stack := ReadMarkStackPtr(tid) | Yield_Lock();
+    call stack := ReadMarkStackPtr(tid) | Yield_Lock();
     if (stack > 0)
     {
         stack := stack - 1;
-        par SetMarkStackPtr(tid, stack) | Yield_Lock();
-        par val := ReadMarkStack(tid, stack) | Yield_Lock();
+        call SetMarkStackPtr(tid, stack) | Yield_Lock();
+        call val := ReadMarkStack(tid, stack) | Yield_Lock();
         isEmpty := false;
     }
     else
@@ -1167,7 +1167,7 @@ preserves call Yield_Lock();
     var v:int;
 
     call LockAcquire(tid);
-    par v := ReadMarkStackPtr(tid) | Yield_Lock();
+    call v := ReadMarkStackPtr(tid) | Yield_Lock();
     isEmpty := v == 0;
     call LockRelease(tid);
 }
@@ -1181,7 +1181,7 @@ refines AtomicResetSweepPtr;
 preserves call Yield_Lock();
 {
     call LockAcquire(tid);
-    par SetSweepPtrLocked(tid, memLo) | Yield_Lock();
+    call SetSweepPtrLocked(tid, memLo) | Yield_Lock();
     call LockRelease(tid);
 }
 
@@ -1204,12 +1204,12 @@ preserves call Yield_Lock();
     var sweep:int;
 
     call LockAcquire(tid);
-    par sweep := ReadSweepPtr(tid) | Yield_Lock();
-    par color := ReadColorByCollector(tid, sweep) | Yield_Lock();
+    call sweep := ReadSweepPtr(tid) | Yield_Lock();
+    call color := ReadColorByCollector(tid, sweep) | Yield_Lock();
     color := if White(color) then UNALLOC() else if Black(color) then WHITE() else color;
-    par SetColor(tid, sweep, color) | Yield_Lock();
+    call SetColor(tid, sweep, color) | Yield_Lock();
     sweep := sweep + 1;
-    par SetSweepPtrLocked(tid, sweep) | Yield_Lock();
+    call SetSweepPtrLocked(tid, sweep) | Yield_Lock();
     call LockRelease(tid);
 }
 
@@ -1237,9 +1237,9 @@ preserves call Yield_Lock();
     var phase:int;
 
     call LockAcquire(tid);
-    par phase := ReadCollectorPhase(tid) | Yield_Lock();
+    call phase := ReadCollectorPhase(tid) | Yield_Lock();
     nextPhase := if IdlePhase(phase) then MARK() else if MarkPhase(phase) then SWEEP() else IDLE();
-    par SetCollectorPhase(tid, nextPhase) | Yield_Lock();
+    call SetCollectorPhase(tid, nextPhase) | Yield_Lock();
     call LockRelease(tid);
 }
 
@@ -1255,8 +1255,8 @@ requires {:layer 96} tid->i == i;
     var p:int;
 
     call LockAcquire(tid);
-    par p := ReadCollectorPhaseLocked(tid) | Yield_Lock();
-    par SetMutatorPhaseLocked(tid, i, p) | Yield_Lock();
+    call p := ReadCollectorPhaseLocked(tid) | Yield_Lock();
+    call SetMutatorPhaseLocked(tid, i, p) | Yield_Lock();
     call LockRelease(tid);
 }
 
@@ -1269,7 +1269,7 @@ refines AtomicCollectorRootScanBarrierStart;
 preserves call Yield_Lock();
 {
     call LockAcquire(tid);
-    par CollectorRootScanBarrierStartLocked(tid) | Yield_Lock();
+    call CollectorRootScanBarrierStartLocked(tid) | Yield_Lock();
     call LockRelease(tid);
 }
 
@@ -1282,7 +1282,7 @@ refines AtomicCollectorRootScanBarrierEnd;
 preserves call Yield_Lock();
 {
     call LockAcquire(tid);
-    par CollectorRootScanBarrierEndLocked(tid) | Yield_Lock();
+    call CollectorRootScanBarrierEndLocked(tid) | Yield_Lock();
     call LockRelease(tid);
 }
 
@@ -1326,8 +1326,8 @@ preserves call Yield_Lock();
 
     call {:layer 95, 96} tid_left, tid_right := TidSplit(tid);
     call LockAcquire(tid_left);
-    par MutatorsInRootScanBarrierAdd(tid_left, tid_right) | Yield_Lock();
-    par AddRootScanBarrier(tid_left, -1) | Yield_Lock();
+    call MutatorsInRootScanBarrierAdd(tid_left, tid_right) | Yield_Lock();
+    call AddRootScanBarrier(tid_left, -1) | Yield_Lock();
     call LockRelease(tid_left);
 }
 
@@ -1357,11 +1357,11 @@ preserves call Yield_Lock();
         assert {:yields} {:layer 96} true;
         call Yield_Lock();
         call LockAcquire(tid_left);
-        par b := MutatorReadBarrierOn(tid_left) | Yield_Lock();
+        call b := MutatorReadBarrierOn(tid_left) | Yield_Lock();
         if (!b)
         {
-            par AddRootScanBarrier(tid_left, 1) | Yield_Lock();
-            par tid_right := MutatorsInRootScanBarrierRemove(tid_left) | Yield_Lock();
+            call AddRootScanBarrier(tid_left, 1) | Yield_Lock();
+            call tid_right := MutatorsInRootScanBarrierRemove(tid_left) | Yield_Lock();
             call LockRelease(tid_left);
             call {:layer 95, 96} tid := TidCombine(tid_left, tid_right);
             return;
@@ -1395,16 +1395,16 @@ preserves call Yield_Lock();
     var fldIter:fld;
     var {:layer 96} snapMem: [int][fld]int;
 
-    par color := ReadColorByMutator1(tid, ptr) | Yield_Lock();
+    call color := ReadColorByMutator1(tid, ptr) | Yield_Lock();
     if (Unalloc(color))
     {
         call Yield_96();
         call LockAcquire(tid);
-        par color := ReadColorByMutator2(tid, ptr) | Yield_Lock();
+        call color := ReadColorByMutator2(tid, ptr) | Yield_Lock();
         if (Unalloc(color))
         {
             spaceFound := true;
-            par sweep := ReadSweepPtr(tid) | Yield_Lock();
+            call sweep := ReadSweepPtr(tid) | Yield_Lock();
             if (sweep <= ptr)
             {
                 color := BLACK();
@@ -1422,11 +1422,11 @@ preserves call Yield_Lock();
                 invariant {:layer 96} mem == snapMem[ptr := (lambda z: int :: if (0 <= z && z < fldIter) then ptr else snapMem[ptr][z])];
                 invariant call Yield_Lock();
             {
-                par InitializeFieldInAlloc(tid, ptr, fldIter) | Yield_Lock();
+                call InitializeFieldInAlloc(tid, ptr, fldIter) | Yield_Lock();
                 fldIter := fldIter + 1;
             }
 
-            par SetColorInAlloc(tid, ptr, color, absPtr) | Yield_Lock();
+            call SetColorInAlloc(tid, ptr, color, absPtr) | Yield_Lock();
             call LockRelease(tid);
             return;
         }
@@ -1445,7 +1445,7 @@ preserves call Yield_Lock();
     var v:int;
 
     call LockAcquire(tid);
-    par v := ReadColorByCollector(tid, i) | Yield_Lock();
+    call v := ReadColorByCollector(tid, i) | Yield_Lock();
     isWhite := White(v);
     call LockRelease(tid);
 }
@@ -1459,7 +1459,7 @@ refines AtomicClearToAbsWhite;
 preserves call Yield_Lock();
 {
     call LockAcquire(tid);
-    par LockedClearToAbsWhite(tid) | Yield_Lock();
+    call LockedClearToAbsWhite(tid) | Yield_Lock();
     call LockRelease(tid);
 }
 

--- a/Test/civl/large-samples/cache-coherence.bpl
+++ b/Test/civl/large-samples/cache-coherence.bpl
@@ -583,7 +583,7 @@ requires call YieldEvict(i, ma, value, drp);
   call dirState, dp := dir_req_begin(ma);
   // do not change dirState in case this is a stale evict request due to a race condition with an invalidate
   if (dirState == Owner(i)) {
-    par write_mem(ma, value, dp) | YieldInv#1();
+    call write_mem(ma, value, dp) | YieldInv#1();
     dirState := Sharers(Set_Empty());
     call cache_evict_resp#1(i, ma, drp, dp);
   } else if (dirState is Sharers && Set_Contains(dirState->iset, i)) {
@@ -606,12 +606,12 @@ requires call YieldRead(i, ma, drp);
 
   call dirState, dp := dir_req_begin(ma);
   if (dirState is Owner) {
-    par value := cache_invalidate_exc#1(dirState->i, ma, Shared(), dp) | YieldInv#1();
-    par write_mem(ma, value, dp) | YieldInv#1();
+    call value := cache_invalidate_exc#1(dirState->i, ma, Shared(), dp) | YieldInv#1();
+    call write_mem(ma, value, dp) | YieldInv#1();
     call cache_read_resp#1(i, ma, value, Shared(), drp, dp);
     call dir_req_end(ma, Sharers(Set_Add(Set_Add(Set_Empty(), dirState->i), i)), dp);
   } else {
-    par value := read_mem(ma, dp) | YieldInv#1();
+    call value := read_mem(ma, dp) | YieldInv#1();
     call cache_read_resp#1(i, ma, value, if dirState->iset == Set_Empty() then Exclusive() else Shared(), drp, dp);
     call dir_req_end(ma, if dirState->iset == Set_Empty() then Owner(i) else Sharers(Set_Add(dirState->iset, i)), dp);
   }
@@ -628,11 +628,11 @@ requires call YieldRead(i, ma, drp);
 
   call dirState, dp := dir_req_begin(ma);
   if (dirState is Owner) {
-    par value := cache_invalidate_exc#1(dirState->i, ma, Invalid(), dp) | YieldInv#1();
-    par write_mem(ma, value, dp) | YieldInv#1();
+    call value := cache_invalidate_exc#1(dirState->i, ma, Invalid(), dp) | YieldInv#1();
+    call write_mem(ma, value, dp) | YieldInv#1();
   } else {
-    par dp := invalidate_sharers(ma, dirState->iset, dp) | YieldInv#1();
-    par value := read_mem(ma, dp) | YieldInv#1();
+    call dp := invalidate_sharers(ma, dirState->iset, dp) | YieldInv#1();
+    call value := read_mem(ma, dp) | YieldInv#1();
   }
   call cache_read_resp#1(i, ma, value, Exclusive(), drp, dp);
   call dir_req_end(ma, Owner(i), dp);
@@ -663,7 +663,7 @@ ensures {:layer 2} dp == dp';
   victim := Choice(victims->val);
   victims' := Set_Remove(victims, victim);
   call dpOne, dp' := get_victim(victim, ma, dp');
-  par cache_invalidate_shd#1(victim, ma, Invalid(), dpOne) | dp' := invalidate_sharers(ma, victims', dp');
+  call cache_invalidate_shd#1(victim, ma, Invalid(), dpOne) | dp' := invalidate_sharers(ma, victims', dp');
   call dp' := put_victim(dpOne, dp');
 }
 

--- a/Test/civl/large-samples/treiber-stack.bpl
+++ b/Test/civl/large-samples/treiber-stack.bpl
@@ -119,7 +119,7 @@ preserves call StackDom();
   call {:layer 4} old_treiber := Copy(TreiberPoolLow->val[loc_t]);
   call loc_n, new_loc_n, tagged_loc := CreateNewTopOfStack(loc_t, x);
   call {:layer 4} FrameLemma(old_treiber, TreiberPoolLow->val[loc_t]);
-  par ReachInStack(loc_t) | StackDom() | PushLocInStack(loc_t, Node(loc_n, x), new_loc_n, tagged_loc);
+  call ReachInStack(loc_t) | StackDom() | PushLocInStack(loc_t, Node(loc_n, x), new_loc_n, tagged_loc);
   call success := WriteTopOfStack#0(loc_t, loc_n, Some(new_loc_n));
   if (success) {
     call {:layer 4} TreiberPool := Copy(Map_Update(TreiberPool, loc_t, Vec_Append(Map_At(TreiberPool, loc_t), x)));
@@ -240,7 +240,7 @@ preserves call TopInStack(loc_t);
     success := true;
     return;
   }
-  par LocInStack(loc_t, loc_n->t) | LocInStackOrNone(loc_t, loc_n) | TopInStack(loc_t);
+  call LocInStack(loc_t, loc_n->t) | LocInStackOrNone(loc_t, loc_n) | TopInStack(loc_t);
   call node := LoadNode#0(loc_t, loc_n->t);
   call Yield();
   Node(new_loc_n, x) := node;

--- a/Test/civl/large-samples/verified-ft.bpl
+++ b/Test/civl/large-samples/verified-ft.bpl
@@ -770,8 +770,8 @@ preserves call Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(s
       return;
     }
 
-  par Yield_FTRepOk_10() | Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
-  par Yield_FTRepOk_20() | Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  call Yield_FTRepOk_10() | Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  call Yield_FTRepOk_20() | Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
 
   call AcquireVarLock(tid, x);
   call w := VarStateGetW(tid, x);
@@ -890,8 +890,8 @@ preserves call Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(s
        }
      }
 
-  par Yield_FTRepOk_10() | Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
-  par Yield_FTRepOk_20() | Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  call Yield_FTRepOk_10() | Yield_FTPreserved_10(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
+  call Yield_FTRepOk_20() | Yield_FTPreserved_20(tid, old(shadow.Lock), old(shadow.VC), old(sx.W), old(sx.R));
 
   call AcquireVarLock(tid, x);
   call w := VarStateGetW(tid, x);
@@ -979,13 +979,13 @@ requires call Yield_ThreadState_30(tid);
     } else if (*) {
       assert {:layer 10,20} shadow.Lock[ShadowableTid(tid->val)] == tid->val;
       call l := ChooseLockToAcquire(tid);
-      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
+      call Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Acquire(tid, l);
     } else if (*) {
       call l := ChooseLockToRelease(tid);
-      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
+      call Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Release(tid, l);
-      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
+      call Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call ReleaseChosenLock(tid, l);
     } else if (*) {
       call uid := AllocTid(tid);
@@ -995,17 +995,17 @@ requires call Yield_ThreadState_30(tid);
       assert {:layer 10,20,30} tid->val != uid;
       assert {:layer 10,20,30} ValidTid(tid->val);
       assert {:layer 10,20,30} ValidTid(uid);
-      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
+      call Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       assert {:layer 10,20,30} ValidTid(tid->val);
       assert {:layer 10,20,30} ValidTid(uid);
       call Fork(tid, uid);
-      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
+      call Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call StartThread(tid, uid);
     } else {
       call uid := ChooseThreadToJoin(tid);
-      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
+      call Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call Join(tid, uid);
-      par Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
+      call Yield_ThreadState_30(tid) | Yield_Preserved_30(tid, shadow.Lock, thread.State);
       call ReleaseJoinLock(tid, uid);
     }
     assert {:layer 20} shadow.Lock[ShadowableTid(tid->val)] == tid->val;

--- a/Test/civl/regression-tests/call-yield-invariant-errors.bpl
+++ b/Test/civl/regression-tests/call-yield-invariant-errors.bpl
@@ -12,14 +12,14 @@ p2({:linear_in "lin"} b: int);
 yield procedure {:layer 1}
 P1({:linear "lin"} x: int, {:linear_in "lin"} y: int)
 {
-  par Q(x) | Q(x);
+  call Q(x) | Q(x);
 }
 
 yield procedure {:layer 1}
 P2({:linear "lin"} x: int, {:linear_in "lin"} y: int)
 {
-  par Q(x) | linear_yield_x(y) | linear_yield_x(y);
-  par Q(x) | linear_yield_x(x) | linear_yield_x(y);
+  call Q(x) | linear_yield_x(y) | linear_yield_x(y);
+  call Q(x) | linear_yield_x(x) | linear_yield_x(y);
 }
 
 yield procedure {:layer 1}

--- a/Test/civl/regression-tests/chris3.bpl
+++ b/Test/civl/regression-tests/chris3.bpl
@@ -15,5 +15,5 @@ refines skip;
 
 yield procedure {:layer 95} P()
 {
-  par A() | H();
+  call A() | H();
 }

--- a/Test/civl/regression-tests/funky.bpl
+++ b/Test/civl/regression-tests/funky.bpl
@@ -157,12 +157,12 @@ requires call YieldCounter();
             call cid := AllocTid();
             async call TA(cid);
         }
-        par Yield() | YieldCounter();
+        call Yield() | YieldCounter();
         if (*) {
             call cid := AllocTid();
             async call AbsTB(cid);
         }
-        par Yield() | YieldCounter();
+        call Yield() | YieldCounter();
         call LockA(tid);
         call AbsAssertA(tid);
         call LockB(tid);

--- a/Test/civl/regression-tests/ghost.bpl
+++ b/Test/civl/regression-tests/ghost.bpl
@@ -25,7 +25,7 @@ refines AtomicIncr2;
 
   call {:layer 1} a := ghost(1);
   assert {:layer 1} a == 2;
-  par Incr() | Incr();
+  call Incr() | Incr();
 }
 
 yield procedure {:layer 1} Incr2'()
@@ -35,7 +35,7 @@ refines AtomicIncr2;
   var {:layer 1} b: int;
 
   call {:layer 1} a := Copy(x);
-  par Incr() | Incr();
+  call Incr() | Incr();
   call {:layer 1} b := Copy(x);
   assert {:layer 1} b == a + 2;
 }

--- a/Test/civl/regression-tests/linear/typecheck.bpl
+++ b/Test/civl/regression-tests/linear/typecheck.bpl
@@ -71,12 +71,12 @@ yield procedure {:layer 1} J()
 
 yield procedure {:layer 1} P1({:linear_in} x: One int) returns({:linear} x': One int)
 {
-  par x' := I(x) | J();
+  call x' := I(x) | J();
   call x' := I(x');
 }
 
 yield procedure {:layer 1} P2({:linear_in} x: One int) returns({:linear} x': One int)
 {
   call x' := I(x);
-  par x' := I(x') | J();
+  call x' := I(x') | J();
 }

--- a/Test/civl/regression-tests/mover-proc-in-parcall.bpl
+++ b/Test/civl/regression-tests/mover-proc-in-parcall.bpl
@@ -12,14 +12,14 @@ yield right procedure {:layer 1} A()
 modifies x;
 ensures {:layer 1} x == old(x) + 2;
 {
-    par Incr() | Incr();
+    call Incr() | Incr();
 }
 
 yield right procedure {:layer 1} B()
 modifies x;
 ensures {:layer 1} x == old(x) + 4;
 {
-    par A() | A();
+    call A() | A();
 }
 
 yield right procedure {:layer 1} R1(i: int)
@@ -30,7 +30,7 @@ ensures {:layer 1} x == old(x) + i;
     if (i == 0) {
         return;
     }
-    par Incr() | R1(i-1);
+    call Incr() | R1(i-1);
 }
 
 yield right procedure {:layer 1} R2(i: int)
@@ -41,7 +41,7 @@ ensures {:layer 1} x == old(x) + i;
     if (i == 0) {
         return;
     }
-    par R2(i-1) | Incr();
+    call R2(i-1) | Incr();
 }
 
 yield right procedure {:layer 1} M1(i: int)
@@ -52,7 +52,7 @@ ensures {:layer 1} x == old(x) + i;
     if (i == 0) {
         return;
     }
-    par Incr() | M2(i-1);
+    call Incr() | M2(i-1);
 }
 
 yield right procedure {:layer 1} M2(i: int)
@@ -63,5 +63,5 @@ ensures {:layer 1} x == old(x) + i;
     if (i == 0) {
         return;
     }
-    par M1(i-1) | Incr();
+    call M1(i-1) | Incr();
 }

--- a/Test/civl/regression-tests/parallel-patterns.bpl
+++ b/Test/civl/regression-tests/parallel-patterns.bpl
@@ -5,23 +5,23 @@ yield invariant {:layer 1} Yield();
 
 yield procedure {:layer 1} foo()
 {
-    par A() | L();
+    call A() | L();
     call Yield();
-    par A() | bar();
+    call A() | bar();
     call Yield();
-    par bar() | L();
+    call bar() | L();
 }
 
 yield procedure {:layer 1} bar();
 
 yield procedure {:layer 1} baz1()
 {
-    par L() | A();
+    call L() | A();
 }
 
 yield procedure {:layer 1} baz2()
 {
-    par A() | R();
+    call A() | R();
 }
 
 atomic action {:layer 1,1} atomic_A()

--- a/Test/civl/regression-tests/parallel0.bpl
+++ b/Test/civl/regression-tests/parallel0.bpl
@@ -4,7 +4,7 @@
 yield procedure {:layer 1} P()
 {
   var x, y: int;
-  par x := A(y) | y := B(x);
+  call x := A(y) | y := B(x);
 }
 
 left action {:layer 1} AtomicA(a: int) returns (b: int)

--- a/Test/civl/regression-tests/parallel1.bpl
+++ b/Test/civl/regression-tests/parallel1.bpl
@@ -41,6 +41,6 @@ yield procedure {:layer 1} Main()
   while (*)
   invariant {:yields} true;
   {
-    par PB() | PC() | PD();
+    call PB() | PC() | PD();
   }
 }

--- a/Test/civl/regression-tests/parallel2.bpl
+++ b/Test/civl/regression-tests/parallel2.bpl
@@ -18,8 +18,8 @@ yield procedure {:layer 1} main()
     var {:linear} j: One int;
     call i := Allocate();
     call j := Allocate();
-    par i := t(i) | j := t(j);
-    par i := u(i) | j := u(j);
+    call i := t(i) | j := t(j);
+    call i := u(i) | j := u(j);
 }
 
 yield procedure {:layer 1} t({:linear_in} i': One int) returns ({:linear} i: One int)

--- a/Test/civl/regression-tests/parallel4.bpl
+++ b/Test/civl/regression-tests/parallel4.bpl
@@ -16,7 +16,7 @@ yield procedure {:layer 1} main()
   var {:linear "tid"} j: int;
   call i := Allocate();
   call j := Allocate();
-  par i := t(i) | j := t(j);
+  call i := t(i) | j := t(j);
 }
 
 yield procedure {:layer 1} t({:linear_in "tid"} i': int) returns ({:linear "tid"} i: int)

--- a/Test/civl/regression-tests/parallel5.bpl
+++ b/Test/civl/regression-tests/parallel5.bpl
@@ -18,8 +18,8 @@ yield procedure {:layer 1} main()
     var {:linear} j: One int;
     call i := Allocate();
     call j := Allocate();
-    par i := t(i) | Yield(j, a);
-    par i := u(i) | j := u(j);
+    call i := t(i) | Yield(j, a);
+    call i := u(i) | j := u(j);
 }
 
 yield procedure {:layer 1} t({:linear_in} i': One int) returns ({:linear} i: One int)

--- a/Test/civl/regression-tests/parallel6.bpl
+++ b/Test/civl/regression-tests/parallel6.bpl
@@ -8,14 +8,14 @@ yield invariant {:layer 1} Yield();
 yield procedure {:layer 1} incr_by_two_bad()
 refines atomic_incr_by_two;
 {
-    par incr() | incr() | Yield() | incr();
+    call incr() | incr() | Yield() | incr();
     call incr();
 }
 
 yield procedure {:layer 1} incr_by_two()
 refines atomic_incr_by_two;
 {
-    par incr() | decr() | Yield() | incr();
+    call incr() | decr() | Yield() | incr();
     call incr();
 }
 both action {:layer 1,2} atomic_incr_by_two()

--- a/Test/civl/regression-tests/refinement2.bpl
+++ b/Test/civl/regression-tests/refinement2.bpl
@@ -7,13 +7,13 @@ var {:layer 0,2} x: int;
 yield procedure {:layer 1} foo1()
 refines atomic_incr;
 {
-    par {:mark} incr() | nop() | nop();
+    call {:mark} incr() | nop() | nop();
 }
 
 yield procedure {:layer 1} foo2()
 refines atomic_incr;
 {
-    par incr() | {:mark} nop() | nop();
+    call incr() | {:mark} nop() | nop();
 }
 
 atomic action {:layer 1,2} atomic_incr()

--- a/Test/civl/samples/2pc.bpl
+++ b/Test/civl/samples/2pc.bpl
@@ -90,7 +90,7 @@ requires call XidNotInCommitted(xid);
 
     if (d == COMMIT())
     {
-        par LockedNoConflicts() | CommittedSubsetLocked() |  XidNotInCommitted(xid) | XidInLocked(xid);
+        call LockedNoConflicts() | CommittedSubsetLocked() |  XidNotInCommitted(xid) | XidInLocked(xid);
         assume {:add_to_pool "J", 1} true;
         call add_to_committed_transactions(xid);
     }
@@ -113,7 +113,7 @@ modifies locked_transactions;
     if (1 <= i)
     {
         call vr := One_Get(vrs', VoteRequest(xid, i));
-        par votes, vrs' := vote_all(xid, vrs', i-1) |  out := vote(vr);
+        call votes, vrs' := vote_all(xid, vrs', i-1) |  out := vote(vr);
         votes[i] := out;
         call One_Put(vrs', vr);
     }

--- a/Test/civl/samples/ABD.bpl
+++ b/Test/civl/samples/ABD.bpl
@@ -195,11 +195,11 @@ preserves call ValueStoreInv#3(LeastTimeStamp(), InitValue);
     var {:layer 2, 3} tsq: ReplicaSet;
     var {:layer 2} tsq': ReplicaSet;
 
-    par old_ts, tsq := Begin(one_pid) | ValueStoreInv#1(LeastTimeStamp(), InitValue) | ValidTimeStamp() | ValueStoreInv#3(LeastTimeStamp(), InitValue);
+    call old_ts, tsq := Begin(one_pid) | ValueStoreInv#1(LeastTimeStamp(), InitValue) | ValidTimeStamp() | ValueStoreInv#3(LeastTimeStamp(), InitValue);
     call Yield#4();
     call ts, value, tsq' := Read(one_pid, old_ts, tsq);
     call Yield#4();
-    par End(one_pid, ts);
+    call End(one_pid, ts);
 }
 
 // lwq is the quorum witnessing the last write
@@ -218,7 +218,7 @@ preserves call ValueStoreInv#3(LeastTimeStamp(), InitValue);
     var {:layer 2, 3} tsq: ReplicaSet;
     var {:layer 2} tsq': ReplicaSet;
 
-    par old_ts, tsq := Begin(one_pid) | ValidTimeStamp() | ValueStoreInv#3(LeastTimeStamp(), InitValue);
+    call old_ts, tsq := Begin(one_pid) | ValidTimeStamp() | ValueStoreInv#3(LeastTimeStamp(), InitValue);
     call Yield#4();
     call ts, lwq', tsq' := Write(one_pid, value, old_ts, lwq, tsq);
     call Yield#4();
@@ -259,7 +259,7 @@ preserves call ValueStoreInv#3(LeastTimeStamp(), InitValue);
 
     call {:layer 1} old_replica_store := Copy(replica_store);
     call ts, value, tsq' := QueryPhase(old_ts, old_replica_store, tsq);
-    par tsq' := UpdatePhase(ts, value) | MonotonicInduction#2(tsq, old_ts, 0) | ValidTimeStamp() | ValueStoreInv#1(LeastTimeStamp(), InitValue);
+    call tsq' := UpdatePhase(ts, value) | MonotonicInduction#2(tsq, old_ts, 0) | ValidTimeStamp() | ValueStoreInv#1(LeastTimeStamp(), InitValue);
 }
 
 yield procedure {:layer 3}
@@ -287,10 +287,10 @@ preserves call ValueStoreInv#3(LeastTimeStamp(), InitValue);
     var {:layer 1} old_replica_store: [ReplicaId]StampedValue;
 
     call {:layer 1} old_replica_store := Copy(replica_store);
-    par ts, _value, q := QueryPhase(old_ts, old_replica_store, tsq) | LastWriteInv(one_pid, TimeStamp(last_write[one_pid->val], one_pid->val));
+    call ts, _value, q := QueryPhase(old_ts, old_replica_store, tsq) | LastWriteInv(one_pid, TimeStamp(last_write[one_pid->val], one_pid->val));
     ts := TimeStamp(ts->t + 1, one_pid->val);
     call AddToValueStore(one_pid, ts, value);
-    par q := UpdatePhase(ts, value) | LastWriteInv(one_pid, ts) | MonotonicInduction#2(tsq, old_ts, 0) | ValidTimeStamp();
+    call q := UpdatePhase(ts, value) | LastWriteInv(one_pid, ts) | MonotonicInduction#2(tsq, old_ts, 0) | ValidTimeStamp();
     lwq' := q;
     tsq' := q;
 }
@@ -339,7 +339,7 @@ ensures {:layer 3} Map_Contains(value_store, max_ts) && Map_At(value_store, max_
         max_value := InitValue;
         return;
     }
-    par ts, value := Query#2(i, q, old_replica_store[i]->ts, old_ts, tsq) | 
+    call ts, value := Query#2(i, q, old_replica_store[i]->ts, old_ts, tsq) | 
         max_ts, max_value := QueryPhaseHelper(i + 1, q, old_ts, old_replica_store, tsq);
     if (lt(max_ts, ts))
     {
@@ -373,7 +373,7 @@ ensures call MonotonicInduction#2(q, ts, i);
     {
         return;
     }
-    par Update#2(i, ts, value, q) | UpdatePhaseHelper(i + 1, ts, value, q);
+    call Update#2(i, ts, value, q) | UpdatePhaseHelper(i + 1, ts, value, q);
 }
 
 yield procedure {:layer 2} Begin#2({:linear} one_pid: One ProcessId) returns (ts: TimeStamp, {:layer 2} tsq: ReplicaSet)

--- a/Test/civl/samples/DeviceCache.bpl
+++ b/Test/civl/samples/DeviceCache.bpl
@@ -40,7 +40,7 @@ requires {:layer 1} xls->val == MapConst(true);
     invariant {:yields} true;
     invariant call Yield();
     {
-        par tid := Allocate() | Yield();
+        call tid := Allocate() | Yield();
         async call Thread(tid);
     }
 }

--- a/Test/civl/samples/MutexOverFutex.bpl
+++ b/Test/civl/samples/MutexOverFutex.bpl
@@ -37,13 +37,13 @@ preserves call YieldWait(tid);
       if (oldValue != 2) {
         call temp := CmpXchg(1, 2);
       }
-      par YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
+      call YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
       if (oldValue == 2 || temp != 0) {
         call WaitEnter(tid->val, 2);
-        par YieldInv() | YieldSlowPath(tid);
+        call YieldInv() | YieldSlowPath(tid);
         call WaitExit(tid->val);
       }
-      par YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
+      call YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
       call oldValue := CmpXchg(0, 2);
       if (oldValue == 0) {
         call {:layer 1} inSlowPath := Copy(inSlowPath[tid->val := false]);
@@ -71,10 +71,10 @@ preserves call YieldWait(tid);
     call {:layer 1} mutex := Copy(None());
   } else {
     call {:layer 1} inSlowPath := Copy(inSlowPath[tid->val := true]);
-    par YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
+    call YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
     call Store(0);
     call {:layer 1} mutex := Copy(None());
-    par YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
+    call YieldInv() | YieldWait(tid) | YieldSlowPath(tid);
     call Wake();
     call {:layer 1} inSlowPath := Copy(inSlowPath[tid->val := false]);
   }

--- a/Test/civl/samples/StoreBuffer.bpl
+++ b/Test/civl/samples/StoreBuffer.bpl
@@ -76,7 +76,7 @@ preserves call YieldLock();
 preserves call YieldStoreBufferLockAddrAbsent(tid);
 {
     call LockZero(tid->val);
-    par YieldLock() | YieldStoreBufferLockAddrPresent(tid);
+    call YieldLock() | YieldStoreBufferLockAddrPresent(tid);
     call FlushStoreBufferEntryForLock(tid->val);
 }
 

--- a/Test/civl/samples/alloc-tid.bpl
+++ b/Test/civl/samples/alloc-tid.bpl
@@ -35,7 +35,7 @@ ensures call Yield2(tid, old(a)[tid->val] + 1);
   var t:int;
 
   call t := Read(tid, i);
-  par Yield1() | Yield2(tid, t);
+  call Yield1() | Yield2(tid, t);
   call Write(tid, i, t + 1);
 }
 

--- a/Test/civl/samples/cav2020-1.bpl
+++ b/Test/civl/samples/cav2020-1.bpl
@@ -33,8 +33,8 @@ requires call yield_y(0);
     if (*) {
         async call incr_x_y();
     }
-    par incr_x(0) | yield_y(0);
-    par incr_y(0) | yield_x(0);
+    call incr_x(0) | yield_y(0);
+    call incr_y(0) | yield_x(0);
     assert {:layer 1} 0 <= x && 0 <= y;
 }
 

--- a/Test/civl/samples/cav2020-2.bpl
+++ b/Test/civl/samples/cav2020-2.bpl
@@ -22,8 +22,8 @@ preserves call LockInv();
     var t: int;
 
     call Acquire(tid);
-    par t := Read(tid) | LockInv();
-    par Write(tid, t+1) | LockInv();
+    call t := Read(tid) | LockInv();
+    call Write(tid, t+1) | LockInv();
     call Release(tid);
 }
 

--- a/Test/civl/samples/cav2020-3.bpl
+++ b/Test/civl/samples/cav2020-3.bpl
@@ -92,7 +92,7 @@ preserves call BarrierInv();
         i := tid->i;
         call BarrierInv();
         call tid' := EnterBarrier(tid);
-        par BarrierInv() | MutatorInv(tid');
+        call BarrierInv() | MutatorInv(tid');
         call tid' := WaitForBarrierRelease(tid');
         call Move(tid', tid);
     }
@@ -104,10 +104,10 @@ requires {:layer 1} tid == All(0);
 preserves call BarrierInv();
 {
     call SetBarrier(true);
-    par BarrierInv() | CollectorInv(tid, false);
+    call BarrierInv() | CollectorInv(tid, false);
     call WaitBarrier();
     call {:layer 1} Lemma_SubsetSize(mutatorsInBarrier, Mutators);
-    par BarrierInv() | CollectorInv(tid, true);
+    call BarrierInv() | CollectorInv(tid, true);
     // do root scan here
     assert {:layer 1} mutatorsInBarrier == Mutators;
     call SetBarrier(false);

--- a/Test/civl/samples/cav2020-talk.bpl
+++ b/Test/civl/samples/cav2020-talk.bpl
@@ -32,8 +32,8 @@ yield procedure {:layer 1} double_inc_x_y()
 requires call yield_x(0);
 requires call yield_y(0);
 {
-    par double_inc_x() | yield_y(y);
-    par double_inc_y() | yield_x(x);
+    call double_inc_x() | yield_y(y);
+    call double_inc_y() | yield_x(x);
     assert {:layer 1} x >= 2 && y >= 2;
 }
 

--- a/Test/civl/samples/multiset.bpl
+++ b/Test/civl/samples/multiset.bpl
@@ -87,7 +87,7 @@ preserves call Yield1();
   var j : int;
   var elt_j : int;
 
-  par Yield1();
+  call Yield1();
 
   j := 0;
   while(j < max)
@@ -103,18 +103,18 @@ preserves call Yield1();
       call release(j, tid);
       r := j;
 
-      par Yield1();
+      call Yield1();
       return;
     }
     call release(j,tid);
 
-    par Yield1();
+    call Yield1();
 
     j := j + 1;
   }
   r := -1;
 
-  par Yield1();
+  call Yield1();
   return;
 }
 
@@ -144,16 +144,16 @@ preserves call Yield1();
 preserves call Yield2();
 {
   var i: int;
-  par Yield1() | Yield2();
+  call Yield1() | Yield2();
   call i := FindSlot(x, tid);
 
   if(i == -1)
   {
     result := false;
-    par Yield1() | Yield2();
+    call Yield1() | Yield2();
     return;
   }
-  par Yield1();
+  call Yield1();
   assert {:layer 1} i != -1;
   assert {:layer 2} i != -1;
   call acquire(i, tid);
@@ -162,7 +162,7 @@ preserves call Yield2();
   call setValid(i, tid);
   call release(i, tid);
   result := true;
-  par Yield1() | Yield2();
+  call Yield1() | Yield2();
   return;
 }
 
@@ -198,32 +198,32 @@ preserves call Yield2();
 {
   var i : int;
   var j : int;
-  par Yield1() | Yield2();
+  call Yield1() | Yield2();
 
   call i := FindSlot(x, tid);
 
   if (i == -1)
   {
     result := false;
-    par Yield1() | Yield2();
+    call Yield1() | Yield2();
     return;
   }
 
-  par Yield1();
+  call Yield1();
   call j := FindSlot(y, tid);
 
   if(j == -1)
   {
-    par Yield1();
+    call Yield1();
     call acquire(i,tid);
     call setEltToNull(i, tid);
     call release(i,tid);
     result := false;
-    par Yield1() | Yield2();
+    call Yield1() | Yield2();
     return;
   }
 
-  par Yield1();
+  call Yield1();
   assert {:layer 2} i != -1 && j != -1;
   call acquire(i, tid);
   call acquire(j, tid);
@@ -236,7 +236,7 @@ preserves call Yield2();
   call release(j, tid);
   call release(i, tid);
   result := true;
-  par Yield1() | Yield2();
+  call Yield1() | Yield2();
   return;
 }
 
@@ -260,7 +260,7 @@ preserves call YieldLookUp2(old_valid, old_elt);
   var j : int;
   var isThere : bool;
 
-  par Yield1() | Yield2() | YieldLookUp1(old_valid, old_elt) | YieldLookUp2(old_valid, old_elt);
+  call Yield1() | Yield2() | YieldLookUp1(old_valid, old_elt) | YieldLookUp2(old_valid, old_elt);
 
   j := 0;
 
@@ -279,16 +279,16 @@ preserves call YieldLookUp2(old_valid, old_elt);
     {
       call release(j, tid);
       found := true;
-      par Yield1() | Yield2() | YieldLookUp1(old_valid, old_elt) | YieldLookUp2(old_valid, old_elt);
+      call Yield1() | Yield2() | YieldLookUp1(old_valid, old_elt) | YieldLookUp2(old_valid, old_elt);
       return;
     }
     call release(j,tid);
-    par Yield1() | Yield2() | YieldLookUp1(old_valid, old_elt) | YieldLookUp2(old_valid, old_elt);
+    call Yield1() | Yield2() | YieldLookUp1(old_valid, old_elt) | YieldLookUp2(old_valid, old_elt);
     j := j + 1;
   }
   found := false;
 
-  par Yield1() | Yield2() | YieldLookUp1(old_valid, old_elt) | YieldLookUp2(old_valid, old_elt);
+  call Yield1() | Yield2() | YieldLookUp1(old_valid, old_elt) | YieldLookUp2(old_valid, old_elt);
   return;
 }
 

--- a/Test/civl/samples/ogcounter.bpl
+++ b/Test/civl/samples/ogcounter.bpl
@@ -16,7 +16,7 @@ modifies x;
 yield procedure {:layer 1} IncrBy2()
 refines AtomicIncrBy2;
 {
-  par Incr() | Incr();
+  call Incr() | Incr();
 }
 
 left action {:layer 2} AtomicIncrBy2()

--- a/Test/civl/samples/ogcounter2.bpl
+++ b/Test/civl/samples/ogcounter2.bpl
@@ -72,7 +72,7 @@ refines AtomicIncrBy2;
 
   call tid1 := AllocTid();
   call tid2 := AllocTid();
-  par Incr(tid1) | Incr(tid2);
+  call Incr(tid1) | Incr(tid2);
 }
 
 yield procedure {:layer 5} EqualTo2({:linear} tid: One X)

--- a/Test/civl/samples/par-incr.bpl
+++ b/Test/civl/samples/par-incr.bpl
@@ -17,7 +17,7 @@ modifies x;
 yield procedure {:layer 1} Incr2()
 refines AtomicIncr2;
 {
-  par Incr() | Incr();
+  call Incr() | Incr();
 }
 
 yield invariant {:layer 1} Yield();
@@ -29,5 +29,5 @@ modifies x;
 yield procedure {:layer 2} Incr4()
 refines AtomicIncr4;
 {
-  par Incr2() | Incr2() | Yield();
+  call Incr2() | Incr2() | Yield();
 }

--- a/Test/civl/samples/seqlock.bpl
+++ b/Test/civl/samples/seqlock.bpl
@@ -57,7 +57,7 @@ preserves call SeqLockInv();
   call locked_inc_seq(tid);
   call locked_write_x(tid, v);
   call locked_write_y(tid, w);
-  par SeqLockInv() | HoldLock(tid);
+  call SeqLockInv() | HoldLock(tid);
   call locked_inc_seq(tid);
   call release(tid);
 }

--- a/Test/civl/samples/snapshot-parallel.bpl
+++ b/Test/civl/samples/snapshot-parallel.bpl
@@ -71,7 +71,7 @@ ensures {:layer 2} (forall j:int :: 1 <= j && j <= i ==>
     if (i == 0) {
         return;
     }
-    par snapshot := scan_f(i-1) | out := read_f(i);
+    call snapshot := scan_f(i-1) | out := read_f(i);
     snapshot[i] := out;
 }
 
@@ -86,7 +86,7 @@ ensures {:layer 2} (forall j:int :: 1 <= j && j <= i ==>
     if (i == 0) {
         return;
     }
-    par snapshot := scan_s(i-1) | out := read_s(i);
+    call snapshot := scan_s(i-1) | out := read_s(i);
     snapshot[i] := out;
 }
 

--- a/Test/civl/samples/ticket.bpl
+++ b/Test/civl/samples/ticket.bpl
@@ -46,7 +46,7 @@ requires call Yield2();
   invariant call Yield2();
   {
     call Enter(tid);
-    par Yield1() | Yield2() | YieldSpec(tid);
+    call Yield1() | Yield2() | YieldSpec(tid);
     call Leave(tid);
   }
 }


### PR DESCRIPTION
The "call" keyword doubles for "par" as well.