### PR TITLE
[Civl] Global invariants

### DIFF
--- a/Source/Concurrency/NoninterferenceChecker.cs
+++ b/Source/Concurrency/NoninterferenceChecker.cs
@@ -15,18 +15,13 @@ namespace Microsoft.Boogie
       return $"linear_{domain.permissionType}_available";
     }
 
-    public static List<Declaration> CreateNoninterferenceCheckerDecls(
+    public static (Procedure, Implementation) CreateNoninterferenceCheckerDecls(
       CivlTypeChecker civlTypeChecker,
       int layerNum,
       AbsyMap absyMap,
       YieldInvariantDecl yieldInvariantDecl,
       List<Variable> declLocalVariables)
     {
-      if (!yieldInvariantDecl.Requires.Any())
-      {
-        return new List<Declaration>();
-      }
-
       var linearTypeChecker = civlTypeChecker.linearTypeChecker;
       var domainToHoleVar = new Dictionary<LinearDomain, Variable>();
       Dictionary<Variable, Variable> localVarMap = new Dictionary<Variable, Variable>();
@@ -107,7 +102,7 @@ namespace Microsoft.Boogie
       // Create the yield checker implementation
       var noninterferenceCheckerImpl = DeclHelper.Implementation(noninterferenceCheckerProc,
         inputs, new List<Variable>(), locals, noninterferenceCheckerBlocks);
-      return new List<Declaration> { noninterferenceCheckerProc, noninterferenceCheckerImpl };
+      return (noninterferenceCheckerProc, noninterferenceCheckerImpl);
     }
 
     private static LocalVariable CopyLocal(Variable v)

--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -29,11 +29,36 @@ namespace Microsoft.Boogie
       yieldingProcInstrumentation.TransformImpls(implToPreconditions);
 
       List<Declaration> decls = new List<Declaration>();
-      decls.AddRange(yieldingProcInstrumentation.noninterferenceCheckerDecls);
+      decls.AddRange(yieldingProcInstrumentation.noninterferenceCheckerProcs.Values);
+      decls.AddRange(yieldingProcInstrumentation.noninterferenceCheckerImpls.Values);
       decls.AddRange(yieldingProcInstrumentation.parallelCallAggregators.Values);
-      decls.AddRange(yieldingProcInstrumentation.PendingAsyncNoninterferenceCheckers());
-      decls.Add(yieldingProcInstrumentation.wrapperNoninterferenceCheckerProc);
-      decls.Add(yieldingProcInstrumentation.WrapperNoninterferenceCheckerImpl());
+
+      decls.Add(yieldingProcInstrumentation.wrapperYieldToYieldNoninterferenceCheckerProc);
+      decls.Add(yieldingProcInstrumentation.wrapperGlobalNoninterferenceCheckerProc);
+
+      var yieldToYieldNoninterferenceCheckerProcs =
+        yieldingProcInstrumentation.noninterferenceCheckerProcs.Where(pair => !pair.Key.IsGlobal).Select(pair => pair.Value);
+      var globalNoninterferenceCheckerProcs =
+        yieldingProcInstrumentation.noninterferenceCheckerProcs.Where(pair => pair.Key.IsGlobal).Select(pair => pair.Value);
+      decls.Add(yieldingProcInstrumentation.WrapperNoninterferenceCheckerImpl(
+        yieldingProcInstrumentation.wrapperYieldToYieldNoninterferenceCheckerProc,
+        yieldToYieldNoninterferenceCheckerProcs));
+      decls.Add(yieldingProcInstrumentation.WrapperNoninterferenceCheckerImpl(
+        yieldingProcInstrumentation.wrapperGlobalNoninterferenceCheckerProc,
+        globalNoninterferenceCheckerProcs));
+      if (yieldToYieldNoninterferenceCheckerProcs.Count() > 0)
+      {
+        decls.AddRange(yieldingProcInstrumentation.ActionNoninterferenceCheckers(
+          civlTypeChecker.MoverActions.Where(a => a.LayerRange.Contains(layerNum) && a.ActionDecl.MaybePendingAsync),
+          false));
+      }
+      if (globalNoninterferenceCheckerProcs.Count() > 0)
+      {
+        decls.AddRange(yieldingProcInstrumentation.ActionNoninterferenceCheckers(
+          civlTypeChecker.MoverActions.Where(a => a.LayerRange.Contains(layerNum)),
+          true));
+      }
+
       return decls;
     }
 
@@ -42,8 +67,10 @@ namespace Microsoft.Boogie
     private AbsyMap absyMap;
 
     private Dictionary<string, Procedure> parallelCallAggregators;
-    private List<Declaration> noninterferenceCheckerDecls;
-    private Procedure wrapperNoninterferenceCheckerProc;
+    private Dictionary<YieldInvariantDecl, Procedure> noninterferenceCheckerProcs;
+    private Dictionary<YieldInvariantDecl, Implementation> noninterferenceCheckerImpls;
+    private Procedure wrapperYieldToYieldNoninterferenceCheckerProc;
+    private Procedure wrapperGlobalNoninterferenceCheckerProc;
     
     private RefinementInstrumentation refinementInstrumentation;
     private LinearPermissionInstrumentation linearPermissionInstrumentation;
@@ -67,7 +94,8 @@ namespace Microsoft.Boogie
       this.linearPermissionInstrumentation = linearPermissionInstrumentation;
       this.refinementBlocks = refinementBlocks;
       parallelCallAggregators = new Dictionary<string, Procedure>();
-      noninterferenceCheckerDecls = new List<Declaration>();
+      noninterferenceCheckerProcs = new Dictionary<YieldInvariantDecl, Procedure>();
+      noninterferenceCheckerImpls = new Dictionary<YieldInvariantDecl, Implementation>();
       localPermissionCollectors = new Dictionary<LinearDomain, Variable>();
       oldGlobalMap = new Dictionary<Variable, Variable>();
       wrapperNoninterferenceCheckerCallArgs = new List<Variable>();
@@ -92,11 +120,16 @@ namespace Microsoft.Boogie
         wrapperNoninterferenceCheckerCallArgs.Add(oldGlobalMap[g]);
       }
 
-      wrapperNoninterferenceCheckerProc = DeclHelper.Procedure(
-        civlTypeChecker.AddNamePrefix($"Wrapper_NoninterferenceChecker_{layerNum}"),
+      wrapperYieldToYieldNoninterferenceCheckerProc = DeclHelper.Procedure(
+        civlTypeChecker.AddNamePrefix($"Wrapper_YieldToYield_NoninterferenceChecker_{layerNum}"),
         wrapperNoninterferenceCheckerFormals, new List<Variable>(), new List<Requires>(), new List<IdentifierExpr>(), new List<Ensures>());
-      CivlUtil.AddInlineAttribute(wrapperNoninterferenceCheckerProc);
+      CivlUtil.AddInlineAttribute(wrapperYieldToYieldNoninterferenceCheckerProc);
       
+      wrapperGlobalNoninterferenceCheckerProc = DeclHelper.Procedure(
+        civlTypeChecker.AddNamePrefix($"Wrapper_Global_NoninterferenceChecker_{layerNum}"),
+        wrapperNoninterferenceCheckerFormals, new List<Variable>(), new List<Requires>(), new List<IdentifierExpr>(), new List<Ensures>());
+      CivlUtil.AddInlineAttribute(wrapperGlobalNoninterferenceCheckerProc);
+
       if (civlTypeChecker.Options.TrustNoninterference)
       {
         localPermissionCollectors.Clear();
@@ -134,7 +167,7 @@ namespace Microsoft.Boogie
       return cmds;
     }
     
-    private List<Cmd> CreateCallToNoninterferenceChecker()
+    private List<Cmd> CreateCallToNoninterferenceChecker(Procedure wrapperNoninterferenceCheckerProc)
     {
       var cmds = new List<Cmd>();
       if (!civlTypeChecker.Options.TrustNoninterference)
@@ -156,17 +189,18 @@ namespace Microsoft.Boogie
       return (YieldProcedureDecl)absyMap.Original(impl).Proc;
     }
 
-    private Implementation WrapperNoninterferenceCheckerImpl()
+    private Implementation WrapperNoninterferenceCheckerImpl(
+      Procedure wrapperNoninterferenceCheckerProc, IEnumerable<Procedure> noninterferenceCheckerProcs)
     {
       var inputs = wrapperNoninterferenceCheckerProc.InParams
         .Select(v => civlTypeChecker.Formal(v.Name, v.TypedIdent.Type, true)).ToList<Variable>();
       List<Block> blocks = new List<Block>();
       TransferCmd transferCmd = CmdHelper.ReturnCmd;
-      if (noninterferenceCheckerDecls.Count > 0)
+      if (noninterferenceCheckerProcs.Count() > 0)
       {
         List<Block> blockTargets = new List<Block>();
         int labelCount = 0;
-        foreach (Procedure proc in noninterferenceCheckerDecls.OfType<Procedure>())
+        foreach (Procedure proc in noninterferenceCheckerProcs)
         {
           List<Expr> exprSeq = new List<Expr>();
           foreach (Variable v in inputs)
@@ -198,13 +232,14 @@ namespace Microsoft.Boogie
         return;
       }
 
-      foreach (var yieldInvariant in civlTypeChecker.program.TopLevelDeclarations.OfType<YieldInvariantDecl>().ToList())
+      foreach (var yieldInvariantDecl in civlTypeChecker.program.TopLevelDeclarations.OfType<YieldInvariantDecl>().ToList())
       {
-        if (layerNum == yieldInvariant.Layer)
+        if (layerNum == yieldInvariantDecl.Layer && yieldInvariantDecl.Requires.Any())
         {
-          noninterferenceCheckerDecls.AddRange(
-            NoninterferenceChecker.CreateNoninterferenceCheckerDecls(civlTypeChecker,
-              layerNum, absyMap, yieldInvariant, new List<Variable>()));
+          var (proc, impl) = NoninterferenceChecker.CreateNoninterferenceCheckerDecls(civlTypeChecker,
+              layerNum, absyMap, yieldInvariantDecl, new List<Variable>());
+          noninterferenceCheckerProcs[yieldInvariantDecl] = proc;
+          noninterferenceCheckerImpls[yieldInvariantDecl] = impl;
         }
       }
     }
@@ -604,7 +639,7 @@ namespace Microsoft.Boogie
     private Block CreateNoninterferenceCheckerBlock()
     {
       var newCmds = new List<Cmd>();
-      newCmds.AddRange(CreateCallToNoninterferenceChecker());
+      newCmds.AddRange(CreateCallToNoninterferenceChecker(wrapperYieldToYieldNoninterferenceCheckerProc));
       newCmds.Add(CmdHelper.AssumeCmd(Expr.False));
       return BlockHelper.Block(civlTypeChecker.AddNamePrefix("NoninterferenceChecker"), newCmds);
     }
@@ -745,18 +780,16 @@ namespace Microsoft.Boogie
       }
     }
 
-    private IEnumerable<Declaration> PendingAsyncNoninterferenceCheckers()
+    private IEnumerable<Declaration> ActionNoninterferenceCheckers(IEnumerable<Action> actions, bool isGlobal)
     {
       if (civlTypeChecker.Options.TrustNoninterference)
       {
         yield break;
       }
 
-      var pendingAsyncsToCheck =
-        new HashSet<Action>(civlTypeChecker.MoverActions.Where(a =>
-          a.LayerRange.Contains(layerNum) && a.ActionDecl.MaybePendingAsync));
-
-      foreach (var action in pendingAsyncsToCheck)
+      var wrapperNoninterferenceCheckerProc = isGlobal ? wrapperGlobalNoninterferenceCheckerProc : wrapperYieldToYieldNoninterferenceCheckerProc;
+      var checkerNamePrefix = isGlobal ? "Global" : "YieldToYield";
+      foreach (var action in actions.Where(action => action.ModifiedGlobalVars.Count > 0))
       {
         var inputs = action.Impl.InParams;
         var outputs = action.Impl.OutParams;
@@ -769,10 +802,10 @@ namespace Microsoft.Boogie
         cmds.AddRange(CreateUpdatesToOldGlobalVars());
         cmds.AddRange(CreateUpdatesToPermissionCollector(action.Impl));
         cmds.Add(CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs));
-        cmds.AddRange(CreateCallToNoninterferenceChecker());
+        cmds.AddRange(CreateCallToNoninterferenceChecker(wrapperNoninterferenceCheckerProc));
         var blocks = new List<Block> { BlockHelper.Block("init", cmds) };
 
-        var name = civlTypeChecker.AddNamePrefix($"PendingAsyncNoninterferenceChecker_{action.Name}_{layerNum}");
+        var name = civlTypeChecker.AddNamePrefix($"{checkerNamePrefix}_NoninterferenceChecker_{action.Name}_{layerNum}");
         var proc = DeclHelper.Procedure(name, inputs, outputs, requires, modifies, ensures);
         var impl = DeclHelper.Implementation(proc, inputs, outputs, locals, blocks);
         yield return proc;

--- a/Source/Core/AST/Absy.cs
+++ b/Source/Core/AST/Absy.cs
@@ -2728,10 +2728,13 @@ namespace Microsoft.Boogie
   {
     public int Layer; // set during registration
 
+    public bool IsGlobal;
+
     public YieldInvariantDecl(IToken tok, string name, List<Variable> inParams, List<Requires> requires, QKeyValue kv) :
       base(tok, name, new List<TypeVariable>(), inParams, new List<Variable>(), false, requires, new List<IdentifierExpr>(),
         requires.Select(x => new Ensures(x.tok, false, x.Condition, null)).ToList(), kv)
     {
+      IsGlobal = true;
     }
 
     public override void Register(ResolutionContext rc)

--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -212,9 +212,10 @@ BoogiePL
                                     Pgm.AddTopLevelDeclaration(v);
                                   }
                                .)
+  | InvariantDecl<out yi>   (. Pgm.AddTopLevelDeclaration(yi); .)
   | "yield" 
     (
-      YieldInvariantDecl<out yi> (. Pgm.AddTopLevelDeclaration(yi); .)
+      InvariantDecl<out yi> (. yi.IsGlobal = false; Pgm.AddTopLevelDeclaration(yi); .)
     | YieldProcedureDecl<out yp, out im>     
                                (. Pgm.AddTopLevelDeclaration(yp);
                                   if (im != null) {
@@ -647,7 +648,7 @@ Constructor<DatatypeTypeCtorDecl datatypeTypeCtorDecl>
   .
 
 /*------------------------------------------------------------------------*/
-YieldInvariantDecl<out YieldInvariantDecl yieldInvariant>
+InvariantDecl<out YieldInvariantDecl yieldInvariant>
 = (. List<Requires> invariants = new List<Requires>(); QKeyValue kv = null; IToken name = null; List<Variable> ins; .)
   "invariant"
   { Attribute<ref kv> }

--- a/Source/Core/Parser.cs
+++ b/Source/Core/Parser.cs
@@ -291,11 +291,16 @@ private class BvBounds : Expr {
 				
 				break;
 			}
+			case 36: {
+				InvariantDecl(out yi);
+				Pgm.AddTopLevelDeclaration(yi); 
+				break;
+			}
 			case 8: {
 				Get();
 				if (la.kind == 36) {
-					YieldInvariantDecl(out yi);
-					Pgm.AddTopLevelDeclaration(yi); 
+					InvariantDecl(out yi);
+					yi.IsGlobal = false; Pgm.AddTopLevelDeclaration(yi); 
 				} else if (StartOf(2)) {
 					YieldProcedureDecl(out yp, out im);
 					Pgm.AddTopLevelDeclaration(yp);
@@ -580,7 +585,7 @@ private class BvBounds : Expr {
 		Expect(10);
 	}
 
-	void YieldInvariantDecl(out YieldInvariantDecl yieldInvariant) {
+	void InvariantDecl(out YieldInvariantDecl yieldInvariant) {
 		List<Requires> invariants = new List<Requires>(); QKeyValue kv = null; IToken name = null; List<Variable> ins; 
 		Expect(36);
 		while (la.kind == 26) {
@@ -2757,7 +2762,7 @@ out QKeyValue kv, out Trigger trig, out Expr body) {
 
 	static readonly bool[,] set = {
 		{_T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
-		{_x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_T, _T,_T,_x,_T, _x,_x,_T,_T, _T,_x,_x,_x, _T,_T,_T,_T, _T,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_x,_T, _T,_T,_x,_T, _T,_x,_T,_T, _T,_x,_x,_x, _T,_T,_T,_T, _T,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
 		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _T,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
 		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _T,_T,_T,_T, _x,_T,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},

--- a/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl.expect
+++ b/Test/civl/inductive-sequentialization/BroadcastConsensus.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 26 verified, 0 errors
+Boogie program verifier finished with 24 verified, 0 errors

--- a/Test/civl/paxos/is.sh.expect
+++ b/Test/civl/paxos/is.sh.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 67 verified, 0 errors
+Boogie program verifier finished with 62 verified, 0 errors

--- a/Test/civl/regression-tests/NoChoice.bpl.expect
+++ b/Test/civl/regression-tests/NoChoice.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 5 verified, 0 errors
+Boogie program verifier finished with 3 verified, 0 errors

--- a/Test/civl/regression-tests/async3.bpl.expect
+++ b/Test/civl/regression-tests/async3.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 7 verified, 0 errors
+Boogie program verifier finished with 5 verified, 0 errors

--- a/Test/civl/regression-tests/async4.bpl.expect
+++ b/Test/civl/regression-tests/async4.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 7 verified, 0 errors
+Boogie program verifier finished with 6 verified, 0 errors

--- a/Test/civl/regression-tests/global-invariant-fail.bpl
+++ b/Test/civl/regression-tests/global-invariant-fail.bpl
@@ -1,0 +1,27 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,1} x: int;
+
+invariant {:layer 1} Inv();
+preserves x > 0;
+
+
+yield procedure {:layer 1} P()
+preserves call Inv();
+{
+    call Incr();
+    call Decr();
+}
+
+yield procedure {:layer 0} Incr();
+refines both action {:layer 1} _
+{
+    x := x + 1;
+}
+
+yield procedure {:layer 0} Decr();
+refines both action {:layer 1} _
+{
+    x := x - 1;
+}

--- a/Test/civl/regression-tests/global-invariant-fail.bpl.expect
+++ b/Test/civl/regression-tests/global-invariant-fail.bpl.expect
@@ -1,0 +1,7 @@
+global-invariant-fail.bpl(7,1): Error: Non-interference check failed
+Execution trace:
+    (0,0): init
+    global-invariant-fail.bpl(26,7): inline$AnonymousAction_65$0$anon0
+    global-invariant-fail.bpl(24,14): inline$AnonymousAction_65$0$Return
+
+Boogie program verifier finished with 4 verified, 1 error

--- a/Test/civl/regression-tests/global-invariant.bpl
+++ b/Test/civl/regression-tests/global-invariant.bpl
@@ -1,0 +1,20 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,1} x: int;
+
+invariant {:layer 1} Inv();
+preserves x > 0;
+
+
+yield procedure {:layer 1} P()
+preserves call Inv();
+{
+    call Incr();
+}
+
+yield procedure {:layer 0} Incr();
+refines atomic action {:layer 1} _
+{
+    x := x + 1;
+}

--- a/Test/civl/regression-tests/global-invariant.bpl.expect
+++ b/Test/civl/regression-tests/global-invariant.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 2 verified, 0 errors

--- a/Test/civl/regression-tests/hide-params-pa-2.bpl.expect
+++ b/Test/civl/regression-tests/hide-params-pa-2.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 4 verified, 0 errors
+Boogie program verifier finished with 3 verified, 0 errors

--- a/Test/civl/regression-tests/pa-noninterference-check.bpl.expect
+++ b/Test/civl/regression-tests/pa-noninterference-check.bpl.expect
@@ -4,4 +4,4 @@ Execution trace:
     pa-noninterference-check.bpl(19,7): inline$A_Incr$0$anon0
     pa-noninterference-check.bpl(16,34): inline$A_Incr$0$Return
 
-Boogie program verifier finished with 4 verified, 1 error
+Boogie program verifier finished with 3 verified, 1 error

--- a/Test/civl/regression-tests/pending-async-1.bpl.expect
+++ b/Test/civl/regression-tests/pending-async-1.bpl.expect
@@ -13,4 +13,4 @@ Execution trace:
     pending-async-1.bpl(18,11): inline$C$0$anon2_Then
     pending-async-1.bpl(67,3): anon0$1
 
-Boogie program verifier finished with 5 verified, 2 errors
+Boogie program verifier finished with 4 verified, 2 errors

--- a/Test/civl/regression-tests/rec-IS1.bpl.expect
+++ b/Test/civl/regression-tests/rec-IS1.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 4 verified, 0 errors
+Boogie program verifier finished with 3 verified, 0 errors

--- a/Test/civl/samples/lock-service.bpl.expect
+++ b/Test/civl/samples/lock-service.bpl.expect
@@ -1,2 +1,2 @@
 
-Boogie program verifier finished with 33 verified, 0 errors
+Boogie program verifier finished with 32 verified, 0 errors


### PR DESCRIPTION
This PR adds the feature of global invariants. They are similar to yield invariants in how they are used. But they are checked for noninterference against actions instead of yield-to-yield code fragments.