### PR TITLE
[Civl] bug fix for global invariants

### DIFF
--- a/Source/Concurrency/YieldingProcInstrumentation.cs
+++ b/Source/Concurrency/YieldingProcInstrumentation.cs
@@ -799,6 +799,7 @@ namespace Microsoft.Boogie
         var locals = oldGlobalMap.Values.Union(localPermissionCollectors.Values).ToList();
         var cmds = new List<Cmd>();
 
+        cmds.AddRange(linearPermissionInstrumentation.DisjointnessAndWellFormedAssumeCmds(action.Impl, true));
         cmds.AddRange(CreateUpdatesToOldGlobalVars());
         cmds.AddRange(CreateUpdatesToPermissionCollector(action.Impl));
         cmds.Add(CmdHelper.CallCmd(action.Impl.Proc, inputs, outputs));

--- a/Test/civl/regression-tests/global-invariant-permissions.bpl
+++ b/Test/civl/regression-tests/global-invariant-permissions.bpl
@@ -1,0 +1,21 @@
+// RUN: %parallel-boogie "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+var {:layer 0,1} {:linear} usedPermissions: Set int;
+var {:layer 0,1} g: int;
+
+invariant {:layer 1} Inv();
+preserves Set_Contains(usedPermissions, 0);
+preserves g == 0;
+
+yield procedure {:layer 1} Foo()
+requires call Inv();
+{
+}
+
+left action {:layer 1} Blah({:linear} x: One int)
+requires call Inv();
+{
+    assert x->val == 0;
+    g := 1;
+}

--- a/Test/civl/regression-tests/global-invariant-permissions.bpl.expect
+++ b/Test/civl/regression-tests/global-invariant-permissions.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 3 verified, 0 errors


### PR DESCRIPTION
This PR adds the assumption about disjoint permissions for all available variables at the start of an atomic action when it is being checked to preserve global invariants.