### PR TITLE
fix: Printing `Add` and `Mul` with non-associative types

### DIFF
--- a/Source/Core/AST/Expression/AbsyExpr.cs
+++ b/Source/Core/AST/Expression/AbsyExpr.cs
@@ -2162,6 +2162,45 @@ namespace Microsoft.Boogie
       }
     }
 
+    /// <summary>
+    /// Decides whether the right operand of "op" ("+" or "*") needs parentheses, given that it binds
+    /// equally strongly. Since "+" and "*" are printed left-associatively, dropping the parentheses of
+    /// "x op (y op' z)" makes it re-parse as "(x op y) op' z", so they may only be dropped when those
+    /// two groupings agree.
+    ///
+    /// On int and real they agree whenever "op'" is the inverse-free counterpart of "op": "+" regroups
+    /// with "+" and "-", and "*" regroups only with "*". "i * (j div k)" keeps its parentheses, because
+    /// "i * j div k" means "(i * j) div k", which differs as soon as the division truncates; likewise
+    /// "r * (s / t)" differs from "(r * s) / t" when t is 0.
+    ///
+    /// Floating-point "+" and "*" are not associative at all -- rounding makes "x + (y + z)" and
+    /// "(x + y) + z" genuinely different -- so on any other type the parentheses always stay.
+    ///
+    /// A null type means Typecheck has not run yet (e.g. /print, which prints before typechecking), in
+    /// which case we conservatively keep the parentheses.
+    /// </summary>
+    private static bool RightOperandNeedsParens(Opcode op, Expr rhs)
+    {
+      Contract.Requires(op == Opcode.Add || op == Opcode.Mul);
+      var type = rhs.Type;
+      if (type == null || !(type.IsInt || type.IsReal))
+      {
+        return true;
+      }
+
+      if (rhs is not NAryExpr { Fun: BinaryOperator rightOperator })
+      {
+        return true;
+      }
+
+      return rightOperator.Op switch
+      {
+        Opcode.Add or Opcode.Sub => op != Opcode.Add,
+        Opcode.Mul => op != Opcode.Mul,
+        _ => true
+      };
+    }
+
     public void Emit(IList<Expr> args, TokenTextWriter stream, int contextBindingStrength, bool fragileContext)
     {
       stream.SetToken(ref this.tok);
@@ -2174,6 +2213,7 @@ namespace Microsoft.Boogie
       {
         case Opcode.Add:
           opBindingStrength = 0x40;
+          fragileRightContext = RightOperandNeedsParens(Opcode.Add, args[1]);
           break;
         case Opcode.Sub:
           opBindingStrength = 0x40;
@@ -2181,6 +2221,7 @@ namespace Microsoft.Boogie
           break;
         case Opcode.Mul:
           opBindingStrength = 0x50;
+          fragileRightContext = RightOperandNeedsParens(Opcode.Mul, args[1]);
           break;
         case Opcode.Div:
           opBindingStrength = 0x50;

--- a/Source/Core/AST/Expression/AbsyExpr.cs
+++ b/Source/Core/AST/Expression/AbsyExpr.cs
@@ -2184,17 +2184,14 @@ namespace Microsoft.Boogie
         return false;
       }
 
-      if (rhs is not NAryExpr { Fun: BinaryOperator rightOperator })
+      if (rhs is not NAryExpr { Fun: BinaryOperator inner })
       {
         return false;
       }
 
-      return rightOperator.Op switch
-      {
-        Opcode.Add or Opcode.Sub => op == Opcode.Add,
-        Opcode.Mul => op == Opcode.Mul,
-        _ => false
-      };
+      return op == Opcode.Add
+        ? inner.Op is Opcode.Add or Opcode.Sub
+        : inner.Op is Opcode.Mul;
     }
 
     public void Emit(IList<Expr> args, TokenTextWriter stream, int contextBindingStrength, bool fragileContext)

--- a/Source/Core/AST/Expression/AbsyExpr.cs
+++ b/Source/Core/AST/Expression/AbsyExpr.cs
@@ -2163,41 +2163,41 @@ namespace Microsoft.Boogie
     }
 
     /// <summary>
-    /// Decides whether the right operand of "op" ("+" or "*") needs parentheses, given that it binds
-    /// equally strongly. Since "+" and "*" are printed left-associatively, dropping the parentheses of
-    /// "x op (y op' z)" makes it re-parse as "(x op y) op' z", so they may only be dropped when those
+    /// True if "x op (rhs)" would still mean the same thing printed as "x op rhs", where "op" is "+"
+    /// or "*" and "rhs" binds equally strongly. Since "+" and "*" print left-associatively, dropping
+    /// those parentheses re-reads "x op (y op' z)" as "(x op y) op' z", so it is only safe when the
     /// two groupings agree.
     ///
-    /// On int and real they agree whenever "op'" is the inverse-free counterpart of "op": "+" regroups
-    /// with "+" and "-", and "*" regroups only with "*". "i * (j div k)" keeps its parentheses, because
-    /// "i * j div k" means "(i * j) div k", which differs as soon as the division truncates; likewise
-    /// "r * (s / t)" differs from "(r * s) / t" when t is 0.
+    /// On int and real they agree when "op'" is "op" or its inverse: "+" regroups with "+" and "-",
+    /// "*" regroups only with "*". "i * (j div k)" does not regroup, because "i * j div k" means
+    /// "(i * j) div k", which differs as soon as the division truncates; likewise "r * (s / t)"
+    /// differs from "(r * s) / t" when t is 0.
     ///
     /// Floating-point "+" and "*" are not associative at all -- rounding makes "x + (y + z)" and
-    /// "(x + y) + z" genuinely different -- so on any other type the parentheses always stay.
+    /// "(x + y) + z" genuinely different -- so nothing regroups at any other type.
     ///
-    /// A null type means Typecheck has not run yet (e.g. /print, which prints before typechecking), in
-    /// which case we conservatively keep the parentheses.
+    /// A null type means Typecheck has not run yet (e.g. /print, which prints before typechecking),
+    /// so nothing is known about the operand and it cannot be regrouped.
     /// </summary>
-    private static bool RightOperandNeedsParens(Opcode op, Expr rhs)
+    private static bool RegroupsWith(Opcode op, Expr rhs)
     {
       Contract.Requires(op == Opcode.Add || op == Opcode.Mul);
       var type = rhs.Type;
       if (type == null || !(type.IsInt || type.IsReal))
       {
-        return true;
+        return false;
       }
 
       if (rhs is not NAryExpr { Fun: BinaryOperator rightOperator })
       {
-        return true;
+        return false;
       }
 
       return rightOperator.Op switch
       {
-        Opcode.Add or Opcode.Sub => op != Opcode.Add,
-        Opcode.Mul => op != Opcode.Mul,
-        _ => true
+        Opcode.Add or Opcode.Sub => op == Opcode.Add,
+        Opcode.Mul => op == Opcode.Mul,
+        _ => false
       };
     }
 
@@ -2213,7 +2213,7 @@ namespace Microsoft.Boogie
       {
         case Opcode.Add:
           opBindingStrength = 0x40;
-          fragileRightContext = RightOperandNeedsParens(Opcode.Add, args[1]);
+          fragileRightContext = !RegroupsWith(Opcode.Add, args[1]);
           break;
         case Opcode.Sub:
           opBindingStrength = 0x40;
@@ -2221,7 +2221,7 @@ namespace Microsoft.Boogie
           break;
         case Opcode.Mul:
           opBindingStrength = 0x50;
-          fragileRightContext = RightOperandNeedsParens(Opcode.Mul, args[1]);
+          fragileRightContext = !RegroupsWith(Opcode.Mul, args[1]);
           break;
         case Opcode.Div:
           opBindingStrength = 0x50;

--- a/Source/Core/AST/Expression/AbsyExpr.cs
+++ b/Source/Core/AST/Expression/AbsyExpr.cs
@@ -2163,21 +2163,17 @@ namespace Microsoft.Boogie
     }
 
     /// <summary>
-    /// True if "x op (rhs)" would still mean the same thing printed as "x op rhs", where "op" is "+"
-    /// or "*" and "rhs" binds equally strongly. Since "+" and "*" print left-associatively, dropping
-    /// those parentheses re-reads "x op (y op' z)" as "(x op y) op' z", so it is only safe when the
-    /// two groupings agree.
+    /// True if "x op (rhs)" still means the same printed as "x op rhs", for "op" in {"+", "*"} and
+    /// "rhs" of equal binding power. These print left-associatively, so dropping the parentheses
+    /// re-reads "x op (y op' z)" as "(x op y) op' z" -- safe only where the two groupings agree.
     ///
-    /// On int and real they agree when "op'" is "op" or its inverse: "+" regroups with "+" and "-",
-    /// "*" regroups only with "*". "i * (j div k)" does not regroup, because "i * j div k" means
-    /// "(i * j) div k", which differs as soon as the division truncates; likewise "r * (s / t)"
-    /// differs from "(r * s) / t" when t is 0.
+    /// On int and real that means "op'" is "op" or its inverse: "+" with "+" and "-", "*" with "*".
+    /// Not "i * (j div k)", since "i * j div k" is "(i * j) div k", which differs once the division
+    /// truncates; nor "r * (s / t)", which differs from "(r * s) / t" at t = 0. Float "+" and "*"
+    /// are not associative at all, so nothing regroups at any other type.
     ///
-    /// Floating-point "+" and "*" are not associative at all -- rounding makes "x + (y + z)" and
-    /// "(x + y) + z" genuinely different -- so nothing regroups at any other type.
-    ///
-    /// A null type means Typecheck has not run yet (e.g. /print, which prints before typechecking),
-    /// so nothing is known about the operand and it cannot be regrouped.
+    /// A null type means Typecheck has not run (/print prints beforehand), so nothing is known and
+    /// nothing regroups.
     /// </summary>
     private static bool RegroupsWith(Opcode op, Expr rhs)
     {

--- a/Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs
+++ b/Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs
@@ -7,32 +7,24 @@ using NUnit.Framework;
 namespace CoreTests
 {
   /// <summary>
-  /// The printer omits parentheses wherever the binding powers in BinaryOperator.Emit make them
-  /// redundant. Getting that wrong is not a cosmetic bug: a printed program that re-parses to a
-  /// different expression silently changes what gets verified.
+  /// BinaryOperator.Emit drops parentheses its binding powers make redundant. An error there is not
+  /// cosmetic: a printed program that re-parses differently changes what gets verified.
   ///
-  /// The printer is allowed to reassociate where that is sound -- "a + (b + c)" may print as
-  /// "a + b + c" on int and real, and Test/test0/PrettyPrint.bpl pins that flattening down. So the
-  /// property checked here is not structural identity but preservation of meaning: re-parsing the
-  /// printed text must yield either the same AST or a provably equal regrouping.
+  /// The check is preservation of meaning, not structural identity -- "a + (b + c)" may legitimately
+  /// print as "a + b + c" on int and real, which Test/test0/PrettyPrint.bpl pins down. So rather than
+  /// read the fragileLeftContext/fragileRightContext table, enumerate every same-precedence operator
+  /// pair against every operand type and re-parse.
   ///
-  /// Rather than trust the fragileLeftContext/fragileRightContext table by inspection, these tests
-  /// enumerate every same-precedence operator pair against every operand type. Any future edit that
-  /// drops a parenthesis it should have kept -- on floats, or across "div"/"mod"/"/" -- fails here.
-  ///
-  /// Note what this deliberately does not check: a change that adds redundant parentheses is sound,
-  /// so it passes. Output that is merely uglier than necessary is caught by the golden files
-  /// (Test/test0/PrettyPrint.bpl and Test/test0/PrintAssoc.bpl), not here.
+  /// Adding redundant parentheses is sound and so passes here; the golden files catch that instead.
   /// </summary>
   [TestFixture]
   public class ExprPrintRoundTrip
   {
     /// <summary>
-    /// Operators to nest at each operand type, restricted to those that both typecheck there and
-    /// return that same type -- so that the result can be assigned back and nested again. That rules
-    /// out "div" and "mod" outside int, and "/" outside real and float (on ints it returns real).
-    /// All of these bind at 0x40 ("+", "-") or 0x50 (the rest), the two levels within which
-    /// BinaryOperator.Emit can drop parentheses.
+    /// Operators that both typecheck at each type and return it, so the result can be assigned back
+    /// and nested again. That excludes "div"/"mod" outside int, and "/" outside real and float (on
+    /// ints it returns real). All bind at 0x40 ("+", "-") or 0x50 (the rest) -- the two levels Emit
+    /// can drop parentheses within.
     /// </summary>
     private static readonly (string Type, string[] Operators)[] TypedOperators = {
       ("int", new[] { "+", "-", "*", "div", "mod" }),
@@ -48,8 +40,7 @@ namespace CoreTests
         {
           foreach (var inner in ops)
           {
-            // Only same-precedence pairs can lose parentheses, but feeding every pair through
-            // costs nothing and guards the cross-precedence cases too.
+            // Only same-precedence pairs can lose parentheses; the rest are cheap extra coverage.
             yield return new TestCaseData(type, outer, inner, true).SetName(
               $"RightNested_{type}_{Sanitize(outer)}_{Sanitize(inner)}");
             yield return new TestCaseData(type, outer, inner, false).SetName(
@@ -63,11 +54,8 @@ namespace CoreTests
       op.Replace("+", "add").Replace("-", "sub").Replace("*", "mul").Replace("/", "rdiv");
 
     /// <summary>
-    /// The only regroupings the printer may perform. On int and real, "+" is associative and absorbs
-    /// a nested "-" ("a + (b - c)" = "(a + b) - c"), and "*" is associative. Everything else -- any
-    /// float, and "div"/"mod"/"/" at any type -- must keep its parentheses, either because rounding
-    /// makes the operator non-associative or because truncation and division by zero make the two
-    /// groupings differ.
+    /// The regroupings the printer may perform, stated independently of BinaryOperator.RegroupsWith
+    /// so that a wrong rule there cannot make these tests agree with it.
     /// </summary>
     private static bool MayReassociate(string type, string outer, string inner)
     {
@@ -98,19 +86,17 @@ namespace CoreTests
         return;
       }
 
-      // The AST changed, so the printer reassociated. Only a right-nested operand can even reach
-      // that: under left-associative printing "(a op b) op' c" needs no parentheses to begin with,
-      // so it must round-trip exactly.
+      // The AST changed, so the printer reassociated. Only a right-nested operand can: printing is
+      // left-associative, so "(a op b) op' c" never had parentheses to drop.
       Assert.IsTrue(nestRight && MayReassociate(type, outer, inner),
         $"printing \"{body}\" as \"{printed}\" changed the expression"
         + $" (re-parsed as \"{reParsed}\")");
     }
 
     /// <summary>
-    /// /print emits the program before ResolveAndTypecheck runs, so on that path every Expr.Type is
-    /// still null and Emit cannot tell an int from a float. Reassociating there would be unsound for
-    /// exactly the float programs this guards, so with no type information the parentheses have to
-    /// stay -- printing must round-trip structurally, not just semantically.
+    /// /print runs before ResolveAndTypecheck, leaving every Expr.Type null, so Emit cannot tell an
+    /// int from a float. It must therefore keep the parentheses: here the round-trip has to be
+    /// structural, not just meaning-preserving.
     /// </summary>
     [TestCaseSource(nameof(NestedCases))]
     public void PrintingBeforeTypecheckingKeepsParentheses(string type, string outer, string inner, bool nestRight)
@@ -128,10 +114,7 @@ namespace CoreTests
     }
 
     /// <summary>
-    /// Parses "expr" as the right-hand side of an assignment over three variables of the given type.
-    /// Typechecking matters: BinaryOperator.Emit consults operand types, so a typechecked and an
-    /// untypechecked expression exercise different paths. Pass typecheck: false to reach the latter,
-    /// which is what /print does.
+    /// Parses "expr" as the right-hand side of an assignment over variables of the given type.
     /// </summary>
     private static Expr ParseExprInProcedure(string type, string expr, bool typecheck = true)
     {
@@ -151,7 +134,7 @@ namespace CoreTests
       else
       {
         // ProgramLoader always typechecks, so parse and resolve by hand. Resolution is needed for
-        // the printer to see the operators at all, but it leaves every Expr.Type null.
+        // the printer to see the operators, but leaves every Expr.Type null.
         Assert.AreEqual(0, Parser.Parse(programText, "roundtrip.bpl", out program, useBaseName: false));
         Assert.AreEqual(0, program.Resolve(options));
       }

--- a/Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs
+++ b/Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs
@@ -19,6 +19,10 @@ namespace CoreTests
   /// Rather than trust the fragileLeftContext/fragileRightContext table by inspection, these tests
   /// enumerate every same-precedence operator pair against every operand type. Any future edit that
   /// drops a parenthesis it should have kept -- on floats, or across "div"/"mod"/"/" -- fails here.
+  ///
+  /// Note what this deliberately does not check: a change that adds redundant parentheses is sound,
+  /// so it passes. Output that is merely uglier than necessary is caught by the golden files
+  /// (Test/test0/PrettyPrint.bpl and Test/test0/PrintAssoc.bpl), not here.
   /// </summary>
   [TestFixture]
   public class ExprPrintRoundTrip
@@ -101,22 +105,54 @@ namespace CoreTests
     }
 
     /// <summary>
-    /// Parses "expr" as the right-hand side of an assignment over three variables of the given type,
-    /// and returns the resolved, typechecked expression. Typechecking matters: BinaryOperator.Emit
-    /// consults operand types, so an untypechecked expression exercises a different path.
+    /// /print emits the program before ResolveAndTypecheck runs, so on that path every Expr.Type is
+    /// still null and Emit cannot tell an int from a float. Reassociating there would be unsound for
+    /// exactly the float programs this guards, so with no type information the parentheses have to
+    /// stay -- printing must round-trip structurally, not just semantically.
     /// </summary>
-    private static Expr ParseExprInProcedure(string type, string expr)
+    [TestCaseSource(nameof(NestedCases))]
+    public void PrintingBeforeTypecheckingKeepsParentheses(string type, string outer, string inner, bool nestRight)
+    {
+      var body = nestRight ? $"a {outer} (b {inner} c)" : $"(a {inner} b) {outer} c";
+      var original = ParseExprInProcedure(type, body, typecheck: false);
+      Assert.IsNull(original.Type, "expression was typechecked; this test must exercise the null-type path");
+
+      var printed = original.ToString();
+      var reParsed = ParseExprInProcedure(type, printed, typecheck: false);
+
+      Assert.AreEqual(original.ContentHash, reParsed.ContentHash,
+        $"before typechecking, printing \"{body}\" as \"{printed}\" changed the expression"
+        + $" (re-parsed as \"{reParsed}\")");
+    }
+
+    /// <summary>
+    /// Parses "expr" as the right-hand side of an assignment over three variables of the given type.
+    /// Typechecking matters: BinaryOperator.Emit consults operand types, so a typechecked and an
+    /// untypechecked expression exercise different paths. Pass typecheck: false to reach the latter,
+    /// which is what /print does.
+    /// </summary>
+    private static Expr ParseExprInProcedure(string type, string expr, bool typecheck = true)
     {
       var options = CommandLineOptions.FromArguments(TextWriter.Null);
-      var program = TestUtil.ProgramLoader.LoadProgramFrom(options, $@"
+      var programText = $@"
         procedure main()
         {{
           var a, b, c, r: {type};
           r := {expr};
-        }}", "roundtrip.bpl");
+        }}";
 
-      var typeErrors = program.Typecheck(options);
-      Assert.AreEqual(0, typeErrors, $"\"{expr}\" did not typecheck at type {type}");
+      Program program;
+      if (typecheck)
+      {
+        program = TestUtil.ProgramLoader.LoadProgramFrom(options, programText, "roundtrip.bpl");
+      }
+      else
+      {
+        // ProgramLoader always typechecks, so parse and resolve by hand. Resolution is needed for
+        // the printer to see the operators at all, but it leaves every Expr.Type null.
+        Assert.AreEqual(0, Parser.Parse(programText, "roundtrip.bpl", out program, useBaseName: false));
+        Assert.AreEqual(0, program.Resolve(options));
+      }
 
       var assign = program.Implementations
         .SelectMany(i => i.Blocks)

--- a/Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs
+++ b/Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs
@@ -28,9 +28,11 @@ namespace CoreTests
   public class ExprPrintRoundTrip
   {
     /// <summary>
-    /// Every arithmetic operator that typechecks at each type: "div" and "mod" are int-only, "/" is
-    /// real- and float-only. All of these bind at one of the two precedence levels ("+"/"-" at 0x40,
-    /// the rest at 0x50) that BinaryOperator.Emit can strip parentheses within.
+    /// Operators to nest at each operand type, restricted to those that both typecheck there and
+    /// return that same type -- so that the result can be assigned back and nested again. That rules
+    /// out "div" and "mod" outside int, and "/" outside real and float (on ints it returns real).
+    /// All of these bind at 0x40 ("+", "-") or 0x50 (the rest), the two levels within which
+    /// BinaryOperator.Emit can drop parentheses.
     /// </summary>
     private static readonly (string Type, string[] Operators)[] TypedOperators = {
       ("int", new[] { "+", "-", "*", "div", "mod" }),
@@ -96,9 +98,9 @@ namespace CoreTests
         return;
       }
 
-      // The AST changed, so the printer reassociated. That is only allowed for the left-associative
-      // regroupings above; a right-nested operand at any other type or operator must have kept its
-      // parentheses and so must have round-tripped exactly.
+      // The AST changed, so the printer reassociated. Only a right-nested operand can even reach
+      // that: under left-associative printing "(a op b) op' c" needs no parentheses to begin with,
+      // so it must round-trip exactly.
       Assert.IsTrue(nestRight && MayReassociate(type, outer, inner),
         $"printing \"{body}\" as \"{printed}\" changed the expression"
         + $" (re-parsed as \"{reParsed}\")");

--- a/Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs
+++ b/Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs
@@ -1,0 +1,129 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Boogie;
+using NUnit.Framework;
+
+namespace CoreTests
+{
+  /// <summary>
+  /// The printer omits parentheses wherever the binding powers in BinaryOperator.Emit make them
+  /// redundant. Getting that wrong is not a cosmetic bug: a printed program that re-parses to a
+  /// different expression silently changes what gets verified.
+  ///
+  /// The printer is allowed to reassociate where that is sound -- "a + (b + c)" may print as
+  /// "a + b + c" on int and real, and Test/test0/PrettyPrint.bpl pins that flattening down. So the
+  /// property checked here is not structural identity but preservation of meaning: re-parsing the
+  /// printed text must yield either the same AST or a provably equal regrouping.
+  ///
+  /// Rather than trust the fragileLeftContext/fragileRightContext table by inspection, these tests
+  /// enumerate every same-precedence operator pair against every operand type. Any future edit that
+  /// drops a parenthesis it should have kept -- on floats, or across "div"/"mod"/"/" -- fails here.
+  /// </summary>
+  [TestFixture]
+  public class ExprPrintRoundTrip
+  {
+    /// <summary>
+    /// Every arithmetic operator that typechecks at each type: "div" and "mod" are int-only, "/" is
+    /// real- and float-only. All of these bind at one of the two precedence levels ("+"/"-" at 0x40,
+    /// the rest at 0x50) that BinaryOperator.Emit can strip parentheses within.
+    /// </summary>
+    private static readonly (string Type, string[] Operators)[] TypedOperators = {
+      ("int", new[] { "+", "-", "*", "div", "mod" }),
+      ("real", new[] { "+", "-", "*", "/" }),
+      ("float24e8", new[] { "+", "-", "*", "/" })
+    };
+
+    private static IEnumerable<TestCaseData> NestedCases()
+    {
+      foreach (var (type, ops) in TypedOperators)
+      {
+        foreach (var outer in ops)
+        {
+          foreach (var inner in ops)
+          {
+            // Only same-precedence pairs can lose parentheses, but feeding every pair through
+            // costs nothing and guards the cross-precedence cases too.
+            yield return new TestCaseData(type, outer, inner, true).SetName(
+              $"RightNested_{type}_{Sanitize(outer)}_{Sanitize(inner)}");
+            yield return new TestCaseData(type, outer, inner, false).SetName(
+              $"LeftNested_{type}_{Sanitize(outer)}_{Sanitize(inner)}");
+          }
+        }
+      }
+    }
+
+    private static string Sanitize(string op) =>
+      op.Replace("+", "add").Replace("-", "sub").Replace("*", "mul").Replace("/", "rdiv");
+
+    /// <summary>
+    /// The only regroupings the printer may perform. On int and real, "+" is associative and absorbs
+    /// a nested "-" ("a + (b - c)" = "(a + b) - c"), and "*" is associative. Everything else -- any
+    /// float, and "div"/"mod"/"/" at any type -- must keep its parentheses, either because rounding
+    /// makes the operator non-associative or because truncation and division by zero make the two
+    /// groupings differ.
+    /// </summary>
+    private static bool MayReassociate(string type, string outer, string inner)
+    {
+      if (type != "int" && type != "real")
+      {
+        return false;
+      }
+
+      return outer switch
+      {
+        "+" => inner is "+" or "-",
+        "*" => inner is "*",
+        _ => false
+      };
+    }
+
+    [TestCaseSource(nameof(NestedCases))]
+    public void PrintedExpressionPreservesMeaning(string type, string outer, string inner, bool nestRight)
+    {
+      var body = nestRight ? $"a {outer} (b {inner} c)" : $"(a {inner} b) {outer} c";
+      var original = ParseExprInProcedure(type, body);
+
+      var printed = original.ToString();
+      var reParsed = ParseExprInProcedure(type, printed);
+
+      if (original.ContentHash == reParsed.ContentHash)
+      {
+        return;
+      }
+
+      // The AST changed, so the printer reassociated. That is only allowed for the left-associative
+      // regroupings above; a right-nested operand at any other type or operator must have kept its
+      // parentheses and so must have round-tripped exactly.
+      Assert.IsTrue(nestRight && MayReassociate(type, outer, inner),
+        $"printing \"{body}\" as \"{printed}\" changed the expression"
+        + $" (re-parsed as \"{reParsed}\")");
+    }
+
+    /// <summary>
+    /// Parses "expr" as the right-hand side of an assignment over three variables of the given type,
+    /// and returns the resolved, typechecked expression. Typechecking matters: BinaryOperator.Emit
+    /// consults operand types, so an untypechecked expression exercises a different path.
+    /// </summary>
+    private static Expr ParseExprInProcedure(string type, string expr)
+    {
+      var options = CommandLineOptions.FromArguments(TextWriter.Null);
+      var program = TestUtil.ProgramLoader.LoadProgramFrom(options, $@"
+        procedure main()
+        {{
+          var a, b, c, r: {type};
+          r := {expr};
+        }}", "roundtrip.bpl");
+
+      var typeErrors = program.Typecheck(options);
+      Assert.AreEqual(0, typeErrors, $"\"{expr}\" did not typecheck at type {type}");
+
+      var assign = program.Implementations
+        .SelectMany(i => i.Blocks)
+        .SelectMany(b => b.Cmds)
+        .OfType<AssignCmd>()
+        .Single();
+      return assign.Rhss.Single();
+    }
+  }
+}

--- a/Test/test0/PrintAssoc.bpl
+++ b/Test/test0/PrintAssoc.bpl
@@ -1,31 +1,31 @@
 // RUN: %boogie -noVerify -print:- -env:0 -printDesugared "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-// "+" and "*" are printed left-associatively, so the parentheses of "x + (y + z)" may
-// only be dropped when "(x + y) + z" is the same expression:
-//   - on int and real, "+" regroups with "+" and "-", and "*" regroups with "*";
-//   - "i * (j div k)" keeps its parentheses, since "i * j div k" is "(i * j) div k";
-//   - floating-point "+" and "*" are not associative, so "x + (y + z)" keeps its
-//     parentheses even though the operator matches.
-// Before typechecking no type is known, so everything is parenthesized (first printout).
+// "+" and "*" print left-associatively, so "x + (y + z)" may lose its parentheses only
+// where "(x + y) + z" is the same expression:
+//   - on int and real, "+" regroups with "+" and "-", and "*" with "*";
+//   - "i * j div k" is "(i * j) div k", so "i * (j div k)" keeps its parentheses;
+//   - float "+" and "*" are not associative, so they keep theirs even when the
+//     operator matches.
+// The first printout is pre-typecheck, where no type is known and nothing regroups.
 procedure main() returns () {
   var i, j, k: int;
   var r, s, t: real;
   var x, y, z: float24e8;
 
-  // associative type, regrouping operator: parentheses may be dropped
+  // regroups: parentheses may be dropped
   i := i + (j + k);
   i := i * (j * k);
   r := r + (s + t);
   r := r * (s * t);
   i := i + (j - k);
 
-  // same precedence, but truncating or undefined at zero: parentheses must stay
+  // truncating or undefined at zero: parentheses stay
   i := i * (j div k);
   i := i * (j mod k);
   r := r * (s / t);
 
-  // non-associative type: parentheses must stay
+  // float: parentheses stay
   x := x + (y + z);
   x := x * (y * z);
   x := x + (y - z);

--- a/Test/test0/PrintAssoc.bpl
+++ b/Test/test0/PrintAssoc.bpl
@@ -1,0 +1,33 @@
+// RUN: %boogie -noVerify -print:- -env:0 -printDesugared "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// "+" and "*" are printed left-associatively, so the parentheses of "x + (y + z)" may
+// only be dropped when "(x + y) + z" is the same expression:
+//   - on int and real, "+" regroups with "+" and "-", and "*" regroups with "*";
+//   - "i * (j div k)" keeps its parentheses, since "i * j div k" is "(i * j) div k";
+//   - floating-point "+" and "*" are not associative, so "x + (y + z)" keeps its
+//     parentheses even though the operator matches.
+// Before typechecking no type is known, so everything is parenthesized (first printout).
+procedure main() returns () {
+  var i, j, k: int;
+  var r, s, t: real;
+  var x, y, z: float24e8;
+
+  // associative type, regrouping operator: parentheses may be dropped
+  i := i + (j + k);
+  i := i * (j * k);
+  r := r + (s + t);
+  r := r * (s * t);
+  i := i + (j - k);
+
+  // same precedence but truncating or partial operator: parentheses must stay
+  i := i * (j div k);
+  i := i * (j mod k);
+  r := r * (s / t);
+
+  // non-associative type: parentheses must stay
+  x := x + (y + z);
+  x := x * (y * z);
+  x := x + (y - z);
+  x := x * (y / z);
+}

--- a/Test/test0/PrintAssoc.bpl
+++ b/Test/test0/PrintAssoc.bpl
@@ -20,7 +20,7 @@ procedure main() returns () {
   r := r * (s * t);
   i := i + (j - k);
 
-  // same precedence but truncating or partial operator: parentheses must stay
+  // same precedence, but truncating or undefined at zero: parentheses must stay
   i := i * (j div k);
   i := i * (j mod k);
   r := r * (s / t);

--- a/Test/test0/PrintAssoc.bpl.expect
+++ b/Test/test0/PrintAssoc.bpl.expect
@@ -1,0 +1,66 @@
+
+procedure main();
+
+
+
+implementation main()
+{
+  var i: int;
+  var j: int;
+  var k: int;
+  var r: real;
+  var s: real;
+  var t: real;
+  var x: float24e8;
+  var y: float24e8;
+  var z: float24e8;
+
+    i := i + (j + k);
+    i := i * (j * k);
+    r := r + (s + t);
+    r := r * (s * t);
+    i := i + (j - k);
+    i := i * (j div k);
+    i := i * (j mod k);
+    r := r * (s / t);
+    x := x + (y + z);
+    x := x * (y * z);
+    x := x + (y - z);
+    x := x * (y / z);
+}
+
+
+
+procedure main();
+
+
+
+implementation main()
+{
+  var i: int;
+  var j: int;
+  var k: int;
+  var r: real;
+  var s: real;
+  var t: real;
+  var x: float24e8;
+  var y: float24e8;
+  var z: float24e8;
+
+    i := i + j + k;
+    i := i * j * k;
+    r := r + s + t;
+    r := r * s * t;
+    i := i + j - k;
+    i := i * (j div k);
+    i := i * (j mod k);
+    r := r * (s / t);
+    x := x + (y + z);
+    x := x * (y * z);
+    x := x + (y - z);
+    x := x * (y / z);
+}
+
+
+
+Boogie program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
`+` and `*` print left-associatively, so the printer dropped the parentheses of `x + (y + z)` and emitted `x + y + z`. That re-parses as `(x + y) + z` — the same expression only when the regrouping is valid. Two cases where it is not:

**Floating point.** `+` and `*` are not associative:

```boogie
procedure main() {
  var x, y, z, a, b: float24e8;
  a := x + (y + z);
  b := (x + y) + z;
  assert a == b;      // correctly fails: 0 verified, 1 error
}
```

Through `/print`, both assignments printed as `x + y + z` and the result verified — **1 verified, 0 errors**. The counterexample disappeared.

**Integers.** Not only a float problem. `i * (j div k)` printed as `i * j div k`, which means `(i * j) div k`: `2 * (3 div 2) = 2`, but `(2 * 3) div 2 = 3`. Same for `mod`, and for real `r * (s / t)` vs `(r * s) / t` at `t = 0`.

## Fix

Parentheses around a right operand of equal binding power are dropped only when the operand has an associative type (`int`/`real`) **and** applies a regrouping operator: `+` regroups with `+` and `-`, `*` only with `*`.

Both conditions are needed — the type check alone misses `div`/`mod`/`/`, the operator check alone misses floats.

`/print` runs before typechecking, so no type is known there and the parentheses stay. `Expr.ShallowType` is not an alternative: `IdentifierExpr.ShallowType` asserts `Type != null` and aborts the process.

## Testing

`Test/test0/PrintAssoc.bpl` is a golden file beside the existing `PrettyPrint.bpl`, covering valid regrouping, same precedence but truncating, and non-associative types. `-printDesugared` prints both before and after typechecking, pinning down both phases.

`Source/UnitTests/CoreTests/ExprPrintRoundTrip.cs` checks the property rather than the output text: for every arithmetic operator at every operand type it typechecks at, print the nested expression, re-parse, compare ASTs by `ContentHash`. 228 cases over two passes — the first permits the sound regroupings, the second parses without typechecking, where no type is known and nothing may be reassociated.

That second layer is worth keeping even if the fix changes shape. The parenthesization table is hand-maintained, an error in it is invisible (the program still prints, just as a different expression), and the same table governs `-`, `div`, `mod`, `/` and `**`. Against `master` it fails 20 of 228 cases across six shapes — `a + (b + c)`, `a + (b - c)`, `a * (b * c)`, `a * (b div c)`, `a * (b mod c)`, `a * (b / c)` — each reporting the offending printout.

The rule is tight, not merely safe: the 5 regroupings it permits all verify as equalities, and the 7 it rejects all genuinely differ.

No lit regressions. `z3-hard-timeout`, `CaptureInlineUnroll` and `InterestingExamples4` fail on this branch and identically on `master`; `prover/exitcode.bpl` is load-sensitive under `-j 8` but passes in isolation.
