### PR TITLE
Fix culture-sensitive number parsing and keyword casing

### DIFF
--- a/Source/ExecutionEngine/CommandLineParseState.cs
+++ b/Source/ExecutionEngine/CommandLineParseState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 
 namespace Microsoft.Boogie;
 
@@ -319,7 +320,7 @@ public class CommandLineParseState
       {
         Contract.Assume(args[i] != null);
         Contract.Assert(args[i] is string); // needed to prove args[i].IsPeerConsistent
-        double d = Convert.ToDouble(this.args[this.i]);
+        double d = Convert.ToDouble(this.args[this.i], CultureInfo.InvariantCulture);
         if (0 <= d) {
           setArg(d);
           return true;

--- a/Source/Model/Model.cs
+++ b/Source/Model/Model.cs
@@ -25,6 +25,7 @@ An instance of the Model class represents a single model returned from the SMT s
  */
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
@@ -732,7 +733,7 @@ namespace Microsoft.Boogie
             return new Integer(this, name);
           }
         }
-        else if (double.TryParse(name, out var _))
+        else if (double.TryParse(name, NumberStyles.Float, CultureInfo.InvariantCulture, out var _))
         {
           return new Real(this, name);
         }

--- a/Source/Provers/SMTLib/SMTLibSolverOptions.cs
+++ b/Source/Provers/SMTLib/SMTLibSolverOptions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Boogie.SMTLib
       string solverStr = null;
       if (ParseString(opt, "SOLVER", ref solverStr))
       {
-        switch (solverStr.ToLower())
+        switch (solverStr.ToLowerInvariant())
         {
           case "noop":
             Solver = SolverKind.NoOpWithZ3Options;

--- a/Source/UnitTests/CoreTests/Model.cs
+++ b/Source/UnitTests/CoreTests/Model.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Boogie;
+﻿using System.Globalization;
+using System.IO;
+using System.Threading;
+using Microsoft.Boogie;
 using NUnit.Framework;
 
 namespace ModelTests
@@ -6,6 +9,32 @@ namespace ModelTests
   [TestFixture()]
   public class ModelTests
   {
+    [Test]
+    public void ParseRealModelElementsUnderNonInvariantLocale()
+    {
+      // #1133: Z3 emits reals as "0.0", but a CurrentCulture parse rejects
+      // that under comma-decimal locales like fr-FR/pt-PT.
+      var originalCulture = Thread.CurrentThread.CurrentCulture;
+      try
+      {
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+        var m = new Model();
+        var e = m.ConstructElement("0.0");
+        Assert.IsNotNull(e, "ConstructElement should recognize \"0.0\" as a Real under fr-FR");
+        Assert.AreEqual(Model.ElementKind.Real, e.Kind);
+        Assert.AreEqual("0.0", e.ToString());
+
+        const string model = "*** MODEL\nf -> 0.0\n*** END_MODEL\n";
+        Assert.DoesNotThrow(() => Model.ParseModels(new StringReader(model)),
+          "Model parsing should succeed under fr-FR");
+      }
+      finally
+      {
+        Thread.CurrentThread.CurrentCulture = originalCulture;
+      }
+    }
+
     [Test]
     public void ParseRealModelElements()
     {

--- a/Source/UnitTests/ExecutionEngineTests/RegressionTests.cs
+++ b/Source/UnitTests/ExecutionEngineTests/RegressionTests.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Boogie;
 using Microsoft.Boogie.SMTLib;
@@ -14,6 +16,51 @@ namespace ExecutionEngineTests
   [TestFixture]
   public class RegressionTests
   {
+    // #1133 sibling: a CurrentCulture Convert.ToDouble rejects the dotted
+    // "/vcsMaxCost:2.5" under comma-decimal locales like fr-FR/pt-PT.
+    [Test]
+    public void GetDoubleArgumentParsesInvariantUnderCommaDecimalLocale()
+    {
+      var originalCulture = Thread.CurrentThread.CurrentCulture;
+      try
+      {
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+        var options = new CommandLineOptions(TextWriter.Null, new ConsolePrinter());
+        var ok = options.Parse(new[] { "/vcsMaxCost:2.5" });
+
+        Assert.IsTrue(ok, "Parsing /vcsMaxCost:2.5 should succeed under fr-FR");
+        Assert.AreEqual(2.5, options.VcsMaxCost, "VcsMaxCost should be 2.5, not the 1.0 default");
+      }
+      finally
+      {
+        Thread.CurrentThread.CurrentCulture = originalCulture;
+      }
+    }
+
+    // #1133 sibling (Turkish-I): a CurrentCulture ToLower turns "YICES2" into
+    // "yıces2" under tr-TR, so the solver keyword fails to match.
+    [Test]
+    public void SolverOptionParsesInvariantUnderTurkishLocale()
+    {
+      var originalCulture = Thread.CurrentThread.CurrentCulture;
+      try
+      {
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+
+        SMTLibOptions smtLibOptions = CommandLineOptions.FromArguments(TextWriter.Null);
+        var proverOptions = new SMTLibSolverOptions(smtLibOptions);
+
+        Assert.DoesNotThrow(() => proverOptions.Parse(new[] { "SOLVER=YICES2" }),
+          "Parsing SOLVER=YICES2 should not throw under tr-TR");
+        Assert.AreEqual(SolverKind.YICES2, proverOptions.Solver);
+      }
+      finally
+      {
+        Thread.CurrentThread.CurrentCulture = originalCulture;
+      }
+    }
+
     [Test]
     public async Task NoNullPointerExceptionEvenIfConcurrencyRaces()
     {


### PR DESCRIPTION
## Summary

Several string operations used the current culture where invariant was required, breaking under non-invariant locales. Fixes #1133 plus two siblings of the same class.

## Bugs fixed

1. **Model parser (#1133)** — a CurrentCulture `double.TryParse` rejects Z3's `0.0` under `fr-FR`/`pt-PT`, throwing `invalid element name 0.0`. *(Downstream: dafny-lang/dafny#6475.)*
2. **CLI doubles** — `Convert.ToDouble(string)` rejects `/vcsMaxCost:2.5` under comma-decimal locales.
3. **Solver selection (Turkish-I)** — `ToLower()` turns `"YICES2"` into `"yıces2"` under `tr-TR`, so it fails to match.

## Fixes

| Site | Change |
|------|--------|
| `Model.cs` | `double.TryParse(name, NumberStyles.Float, CultureInfo.InvariantCulture, out _)` |
| `CommandLineParseState.cs` | `Convert.ToDouble(arg, CultureInfo.InvariantCulture)` |
| `SMTLibSolverOptions.cs` | `solverStr.ToLowerInvariant()` |

## Tests

Three regression tests, each verified red before / green after, forcing `fr-FR`/`tr-TR`.