### PR TITLE
Release version 3.5.7

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <Version>3.5.6</Version>
+    <Version>3.5.7</Version>
     <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Boogie</Authors>


### PR DESCRIPTION
Version bump for a patch release, following the pattern of #1083.

Notable since v3.5.6 (2025-12-10), 36 commits:
- Fix culture-sensitive number parsing and keyword casing (#1134) — fixes #1133 and unblocks dafny-lang/dafny#6475
- Fix chained bitvector concatenation failing with `/lib:base` (#1112)
- Fix: preserve `{:id}` for trivial assignments during passification (#1131)
- Termination checking, parts 1 and 2 (#1102, #1107)
- Extended trust options (#1090)
- Numerous Civl fixes, refactorings, and examples

After merging, tagging the merge commit `v3.5.7` will publish to NuGet and create the GitHub release via CI.