### PR TITLE
Accept +zero and -zero in BigFloat.TryCreateSpecialFromString

### DIFF
--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -509,9 +509,13 @@ namespace Microsoft.BaseTypes
 
     /// <summary>
     /// Tries to create special values from string representation for SMT-LIB integration.
-    /// Supports: "NaN", "+oo", "-oo" (case insensitive)
+    /// Supports: "NaN", "+oo", "-oo", "+zero", "-zero" (case insensitive)
+    ///
+    /// These are the five special values the SMT-LIB FloatingPoint theory can name,
+    /// and a solver may return any of them from (get-value ...) as
+    /// ((x (_ &lt;special&gt; &lt;eb&gt; &lt;sb&gt;))).
     /// </summary>
-    /// <param name="specialValue">Special value string ("NaN", "+oo", "-oo")</param>
+    /// <param name="specialValue">Special value string ("NaN", "+oo", "-oo", "+zero", "-zero")</param>
     /// <param name="sigSize">Significand size in bits</param>
     /// <param name="expSize">Exponent size in bits</param>
     /// <param name="result">The resulting BigFloat if successful; default(BigFloat) otherwise</param>
@@ -526,6 +530,12 @@ namespace Microsoft.BaseTypes
           return true;
         case "-oo":
           result = CreateInfinity(true, sigSize, expSize);
+          return true;
+        case "+zero":
+          result = CreateZero(false, sigSize, expSize);
+          return true;
+        case "-zero":
+          result = CreateZero(true, sigSize, expSize);
           return true;
         default:
           result = default;

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -1024,6 +1024,47 @@ namespace BaseTypesTests
         #region Special Values Tests
 
         [Test]
+        public void TestTryCreateSpecialFromString()
+        {
+            // The five special values the SMT-LIB FloatingPoint theory can name. A solver
+            // may return any of them from (get-value ...), e.g. z3 answers
+            // ((x (_ +zero 8 24))) for a Float32 that is positive zero, so all five must
+            // round-trip here or SMTLibInteractiveTheoremProver.Evaluate throws
+            // VCExprEvaluationException on a legal solver response.
+            Assert.IsTrue(BigFloat.TryCreateSpecialFromString("NaN", 24, 8, out var nan));
+            Assert.IsTrue(nan.IsNaN);
+
+            Assert.IsTrue(BigFloat.TryCreateSpecialFromString("+oo", 24, 8, out var posInf));
+            Assert.IsTrue(posInf.IsInfinity);
+            Assert.IsFalse(posInf.IsNegative);
+
+            Assert.IsTrue(BigFloat.TryCreateSpecialFromString("-oo", 24, 8, out var negInf));
+            Assert.IsTrue(negInf.IsInfinity);
+            Assert.IsTrue(negInf.IsNegative);
+
+            Assert.IsTrue(BigFloat.TryCreateSpecialFromString("+zero", 24, 8, out var posZero));
+            Assert.IsTrue(posZero.IsZero);
+            Assert.IsFalse(posZero.IsNegative);
+            Assert.AreEqual(BigFloat.CreateZero(false, 24, 8), posZero);
+
+            Assert.IsTrue(BigFloat.TryCreateSpecialFromString("-zero", 24, 8, out var negZero));
+            Assert.IsTrue(negZero.IsZero);
+            Assert.IsTrue(negZero.IsNegative);
+            Assert.AreEqual(BigFloat.CreateZero(true, 24, 8), negZero);
+
+            // Case insensitive, and honouring the caller's format sizes
+            Assert.IsTrue(BigFloat.TryCreateSpecialFromString("+ZERO", 53, 11, out var doubleZero));
+            Assert.IsTrue(doubleZero.IsZero);
+            Assert.AreEqual(53, doubleZero.SignificandSize);
+            Assert.AreEqual(11, doubleZero.ExponentSize);
+
+            // Anything else is still rejected
+            Assert.IsFalse(BigFloat.TryCreateSpecialFromString("zero", 24, 8, out _));
+            Assert.IsFalse(BigFloat.TryCreateSpecialFromString("+inf", 24, 8, out _));
+            Assert.IsFalse(BigFloat.TryCreateSpecialFromString("", 24, 8, out _));
+        }
+
+        [Test]
         public void TestZeroValues()
         {
             BigFloat.FromRational(0, 1, 24, 8, out var zero);


### PR DESCRIPTION
## Problem

The SMT-LIB `FloatingPoint` theory names five special values: `NaN`, `+oo`, `-oo`, `+zero` and `-zero`. `BigFloat.TryCreateSpecialFromString` recognises only the first three, so the two zeros fall through to `return false`.

That return value is load-bearing: `SMTLibInteractiveTheoremProver.Evaluate` converts it into a thrown `VCExprEvaluationException`. And a solver may legitimately answer `(get-value ...)` with either zero — z3 does exactly that:

```smt2
(set-option :produce-models true)
(set-logic QF_FP)
(declare-const x Float32)
(assert (fp.isZero x))
(assert (fp.isPositive x))
(check-sat)
(get-value (x))
```
```
sat
((x (_ +zero 8 24)))
```

`Evaluate` routes `(_ <special> <eb> <sb>)` to this function, and no other branch can accept it — the `fp` branch requires `Name == "fp"`, and the bitvector branch requires two arguments. So asking a solver for the value of a zero-valued float aborts with an exception on a well-formed reply.

## Fix

`BigFloat` already models both zeros — `CreateZero(isNegative, ...)` is used throughout the arithmetic in the same file. Only the mapping from the SMT-LIB spelling was missing, so this adds the two cases.

## This is not the removed source syntax

`Test/floats/RemovedZeroSpecialValue.bpl` documents that `0+zero53e11` was deliberately removed as *Boogie source* syntax. This change does not resurrect it, for two independent reasons:

1. That rejection is lexical — `0+zero53e11` resolves as `0 + zero53e11` and errors with `undeclared identifier: zero53e11`, before this function is involved.
2. The in-file caller passes a fixed three-character slice, `TryCreateSpecialFromString(s[1..4], ...)`, so it can never produce the five-character `"+zero"`.

`RemovedZeroSpecialValue.bpl` still passes unchanged.