### PR TITLE
fix: Round `BigFloat` arithmetic once, against a sticky bit

### DIFF
--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -682,15 +682,10 @@ namespace Microsoft.BaseTypes
         return CreateZero(resultSign, x.SignificandSize, x.ExponentSize);
       }
 
-      // Normalize and round the product
-      var (normalizedProduct, normalShift) = NormalizeAndRound(product, BigInteger.Zero, x.SignificandSize);
-
-      // Calculate the final exponent - all values are already BigInteger
-      var bias = x.bias;
-      var resultExp = xExp + yExp - bias + normalShift - (x.SignificandSize - 1);
-
-      // Handle overflow, underflow, and create final result
-      return HandleExponentBounds(normalizedProduct, resultExp, resultSign, x.SignificandSize, x.ExponentSize);
+      // The product is exact, so RoundToFormat performs the only rounding. Each prepared significand
+      // is weighted by 2^(exp - bias - (significandSize - 1)), and multiplying adds those weights.
+      var productScale = xExp + yExp - 2 * x.bias - 2 * (x.SignificandSize - 1);
+      return RoundToFormat(product, productScale, resultSign, x.SignificandSize, x.ExponentSize);
     }
 
     [Pure]
@@ -721,6 +716,57 @@ namespace Microsoft.BaseTypes
       var resultExp = xExp - yExp + x.bias + normalShift - 2;
 
       return HandleExponentBounds(normalizedQuotient, resultExp, resultSign, x.SignificandSize, x.ExponentSize);
+    }
+
+    /// <summary>
+    /// Rounds the exact value "significand * 2^scale" into the given format, performing the single
+    /// IEEE 754 round-to-nearest-even the standard requires.
+    ///
+    /// Callers are expected to compute their result exactly first and hand the full-width value here.
+    /// Rounding on the way in and again here would discard the residual that decides ties: once a
+    /// value has been rounded to the target width, a later shift onto the subnormal grid can no longer
+    /// tell "exactly halfway" from "just above halfway", and rounds to even where it should round up.
+    /// </summary>
+    /// <param name="significand">Exact significand, which may be wider than the format holds.</param>
+    /// <param name="scale">Power-of-two weight of bit 0 of "significand" (unbiased).</param>
+    private static BigFloat RoundToFormat(BigInteger significand, BigInteger scale, bool isNegative,
+      int significandSize, int exponentSize)
+    {
+      if (significand.IsZero) {
+        return CreateZero(isNegative, significandSize, exponentSize);
+      }
+
+      var bias = GetBias(exponentSize);
+
+      // Scale the leading bit would have if the value were normalized where it stands, and the
+      // smallest scale a normal number can have.
+      var leadingScale = scale + significand.GetBitLength() - 1;
+      var minNormalScale = BigInteger.One - bias;
+
+      // A normal result keeps significandSize bits; a subnormal one lands on the fixed grid that every
+      // subnormal shares, whose least significant bit has scale minNormalScale - (significandSize - 1).
+      // Either way this is the only shift, and therefore the only rounding.
+      var shift = leadingScale >= minNormalScale
+        ? significand.GetBitLength() - significandSize
+        : minNormalScale - (significandSize - 1) - scale;
+
+      var (rounded, _, _) = ApplyShiftWithRounding(significand, shift);
+      if (rounded.IsZero) {
+        return CreateZero(isNegative, significandSize, exponentSize);
+      }
+
+      // Recompute the exponent from the rounded value: rounding can carry a subnormal up to the
+      // smallest normal, or a normal up into the next binade.
+      var biasedExp = scale + shift + rounded.GetBitLength() - 1 + bias;
+
+      if (biasedExp >= GetMaxExponent(exponentSize)) {
+        return CreateInfinity(isNegative, significandSize, exponentSize);
+      }
+
+      return biasedExp > 0
+        ? new BigFloat(isNegative, rounded & (GetLeadingBitPower(significandSize) - 1), biasedExp,
+            significandSize, exponentSize)
+        : new BigFloat(isNegative, rounded, 0, significandSize, exponentSize);
     }
 
     private static (BigInteger significand, BigInteger exponent) NormalizeAndRound(BigInteger value, BigInteger exponent, int targetBits)

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -258,24 +258,20 @@ namespace Microsoft.BaseTypes
       numerator = BigInteger.Abs(numerator);
       denominator = BigInteger.Abs(denominator);
 
-      // Pre-scale the numerator so the quotient carries three bits more than the format keeps: two for
-      // the guard and sticky positions RoundToFormat needs, and one of slack. The shift is clamped at
-      // zero for the case where the numerator already dwarfs the denominator, which needs no scaling --
-      // there the quotient is wide on its own, so bit 0 still falls well below the retained bits and
-      // the sticky bit below cannot disturb them.
+      // Pre-scale so the quotient carries three bits more than the format keeps: a guard bit, a sticky
+      // bit and one of slack. No scaling is needed when the numerator already dwarfs the denominator,
+      // since the quotient is then wide on its own.
       var scaleBitsLong = (long)significandSize + 3 + (denominator.GetBitLength() - numerator.GetBitLength());
       var scaleBits = scaleBitsLong < 0 ? BigInteger.Zero : new BigInteger(scaleBitsLong);
       var scaledNumerator = BigIntegerMath.LeftShift(numerator, scaleBits);
       var quotient = BigInteger.DivRem(scaledNumerator, denominator, out var remainder);
 
-      // Bit 0 of the scaled quotient has weight 2^-scaleBits, so RoundToFormat finishes the job: it
-      // performs the single rounding and handles the normal, subnormal, overflow and underflow cases.
+      // Bit 0 of the scaled quotient has weight 2^-scaleBits; RoundToFormat does the single rounding.
       result = RoundToFormat(WithStickyBit(quotient, remainder), -scaleBits, isNegative,
         significandSize, exponentSize);
 
-      // Whether the conversion was exact is a question about the input, not about what rounding did, so
-      // it is answered by asking whether the result still represents numerator/denominator. Deciding it
-      // that way keeps this method from having to reimplement the rounding in order to observe it.
+      // Exactness is a property of the input, so check the result against it rather than observing the
+      // rounding.
       return RepresentsExactly(result, numerator, denominator);
     }
 
@@ -346,10 +342,8 @@ namespace Microsoft.BaseTypes
 
     /// <summary>
     /// This value's magnitude as significand * 2^scale, with the implicit leading bit restored and the
-    /// sign dropped. Zero, the infinities and NaN do not decompose this way.
-    ///
-    /// Subnormals need no case of their own: one stores no implicit bit, and shares its actual exponent
-    /// with the smallest normal, so <see cref="GetActualExponent"/> covers both.
+    /// sign dropped. Zero, the infinities and NaN do not decompose this way. The scale needs no subnormal
+    /// case, since a subnormal shares its actual exponent with the smallest normal.
     /// </summary>
     private (BigInteger Significand, BigInteger Scale) AsScaledInteger()
     {
@@ -401,10 +395,9 @@ namespace Microsoft.BaseTypes
         return BigIntegerMath.LeftShift(value, -shift);
       }
 
-      // Exponent sizes are unbounded, so a shift can exceed the value's width by an astronomical
-      // margin -- a 40-bit exponent field puts the subnormal boundary around 2^-549755813888. Handle
-      // that case by comparing against the halfway point rather than by shifting, since neither
-      // 2^shift nor the shifted value can be materialized.
+      // A shift can exceed the value's width by an astronomical margin, since exponent sizes are
+      // unbounded: at a 40-bit exponent the smallest normal is 2^-549755813886. Compare against the
+      // halfway point instead, since neither 2^shift nor the shifted value fits.
       if (shift > value.GetBitLength()) {
         // Everything is discarded. The result is 1 only if the value exceeded half of the discarded
         // range, i.e. 2^(shift-1); a value exactly at the halfway point ties to the even 0.
@@ -634,15 +627,10 @@ namespace Microsoft.BaseTypes
       // Prepare operands and calculate result sign
       var ((xSig, xExp), (ySig, yExp), resultSign) = PrepareOperandsForMultDiv(x, y);
 
-      // Long division produces bits from the top down, so the dividend must be pre-shifted by however
-      // many quotient bits are wanted. Two beyond the format's width suffice: one guard bit, so the
-      // value just past the rounding position is visible, and one sticky bit position, so
-      // WithStickyBit has a bit to set that RoundToFormat will shift away.
-      //
-      // The shift cannot be a constant. xSig / ySig lands in [1/2, 2), so the quotient's width is
-      // (shift) give or take one -- but only when both significands are the same width. A subnormal
-      // dividend is narrower than the format allows, and the quotient loses exactly that many bits, so
-      // widen the shift by the shortfall.
+      // Long division produces bits from the top down, so pre-shift the dividend by as many quotient
+      // bits as are wanted: the format's width plus a guard bit and a sticky bit. The quotient loses one
+      // bit for every bit by which the dividend is narrower than the divisor, as a subnormal dividend is,
+      // so add that shortfall.
       var dividendShortfall = BigInteger.Max(ySig.GetBitLength() - xSig.GetBitLength(), BigInteger.Zero);
       var guardShift = x.SignificandSize + 2 + dividendShortfall;
       var shiftedDividend = BigIntegerMath.LeftShift(xSig, guardShift);
@@ -659,12 +647,8 @@ namespace Microsoft.BaseTypes
     }
 
     /// <summary>
-    /// Power-of-two weight of bit 0 of the significand <see cref="PrepareOperand"/> returns.
-    ///
-    /// PrepareOperand restores the implicit leading bit, so the significand it hands back is an integer
-    /// rather than a fraction: the value it represents is significand * 2^ScaleOfPreparedOperand(exp).
-    /// Every operator needs this to state the scale of its own exact result, and stating it once keeps
-    /// those derivations short enough to check by eye.
+    /// Power-of-two weight of bit 0 of the significand <see cref="PrepareOperand"/> returns. That
+    /// significand is a plain integer rather than a 1.f fraction, hence the significandSize - 1 term.
     /// </summary>
     private static BigInteger ScaleOfPreparedOperand(BigInteger biasedExponent, BigInteger bias, int significandSize)
     {
@@ -672,14 +656,9 @@ namespace Microsoft.BaseTypes
     }
 
     /// <summary>
-    /// Folds an inexact residual into bit 0 of a value destined for <see cref="RoundToFormat"/>.
-    ///
-    /// Rounding correctly needs to know whether a discarded tail was exactly zero, exactly half, or
-    /// somewhere above half. A quotient loses that distinction as soon as its remainder is dropped, so
-    /// callers that divide record "there was a remainder" in the lowest bit and let RoundToFormat do the
-    /// arithmetic. This is only sound because the caller computed strictly more bits than the format
-    /// keeps -- see the guard margins at the call sites -- so bit 0 is always among the bits shifted
-    /// out, and setting it can never disturb the retained significand.
+    /// Folds an inexact residual into bit 0 of a value destined for <see cref="RoundToFormat"/>, so that
+    /// rounding can still tell a tail above half from one exactly at half. Callers must have computed more
+    /// bits than the format keeps, so that bit 0 is among the bits rounding shifts away.
     /// </summary>
     private static BigInteger WithStickyBit(BigInteger value, BigInteger remainder)
     {
@@ -687,11 +666,8 @@ namespace Microsoft.BaseTypes
     }
 
     /// <summary>
-    /// True if "value" is exactly numerator/denominator, with both taken as positive.
-    ///
-    /// The comparison is done in integers: a float is significand * 2^scale, so cross-multiplying by the
-    /// denominator and by 2^-scale (whichever side needs it) turns the question into one BigInteger
-    /// equality with no rounding of its own.
+    /// True if "value" is exactly numerator/denominator, with both taken as positive. Cross-multiplying
+    /// turns this into one BigInteger equality, with no rounding of its own.
     /// </summary>
     private static bool RepresentsExactly(BigFloat value, BigInteger numerator, BigInteger denominator)
     {
@@ -723,12 +699,8 @@ namespace Microsoft.BaseTypes
 
     /// <summary>
     /// Rounds the exact value "significand * 2^scale" into the given format, performing the single
-    /// IEEE 754 round-to-nearest-even the standard requires.
-    ///
-    /// Callers are expected to compute their result exactly first and hand the full-width value here.
-    /// Rounding on the way in and again here would discard the residual that decides ties: once a
-    /// value has been rounded to the target width, a later shift onto the subnormal grid can no longer
-    /// tell "exactly halfway" from "just above halfway", and rounds to even where it should round up.
+    /// IEEE 754 round-to-nearest-even the standard requires. Callers must hand over an exact, full-width
+    /// value: rounding on the way in as well loses the residual that decides ties.
     /// </summary>
     /// <param name="significand">Exact significand, which may be wider than the format holds.</param>
     /// <param name="scale">Power-of-two weight of bit 0 of "significand" (unbiased).</param>
@@ -741,13 +713,8 @@ namespace Microsoft.BaseTypes
 
       var bias = GetBias(exponentSize);
 
-      // Everything below is expressed as a biased exponent, so that the one test distinguishing normal
-      // from subnormal ("is it above zero?") is the same test before and after rounding. Stating the
-      // two in different terms would leave them free to disagree at the seam.
-      //
-      // BiasedExponentOf gives the exponent a value would have if normalized where it stands; for a
-      // subnormal that is at or below zero, which is exactly the case the format cannot represent
-      // without shifting onto its fixed grid.
+      // BiasedExponentOf gives the exponent this value would have if normalized where it stands. At or
+      // below zero means it is subnormal, i.e. below what the format holds without shifting onto its grid.
       var biasedExp = BiasedExponentOf(scale, significand.GetBitLength(), bias);
 
       // A normal result keeps significandSize bits. A subnormal one instead lands on the grid every
@@ -757,11 +724,9 @@ namespace Microsoft.BaseTypes
         ? significand.GetBitLength() - significandSize
         : BigInteger.One - bias - (significandSize - 1) - scale;
 
-      // The overflow flag is deliberately ignored. It reports that rounding carried into an extra bit,
-      // which callers of the old two-step path corrected for by hand; here the exponent is recomputed
-      // from the rounded value's own width, so a carry is absorbed rather than compensated. That covers
-      // both forms it takes: a subnormal rounding up to the smallest normal, and a normal rounding up
-      // into the next binade.
+      // A rounding carry needs no correction, since the exponent below is recomputed from the rounded
+      // value's own width. That covers a subnormal reaching the smallest normal as well as a normal
+      // carrying into the next binade.
       var rounded = ApplyShiftWithRounding(significand, shift);
       if (rounded.IsZero) {
         return CreateZero(isNegative, significandSize, exponentSize);
@@ -1226,12 +1191,9 @@ namespace Microsoft.BaseTypes
       return BigInteger.TryParse("0" + hex, System.Globalization.NumberStyles.HexNumber, null, out value);
     }
     /// <summary>
-    /// Handles a literal whose exponent falls at or below the subnormal range.
-    ///
-    /// The rounding itself is RoundToFormat's job; what is specific here is strict mode, which rejects
-    /// any literal that does not survive a round trip. Underflow always loses information -- to zero, or
-    /// onto the coarser subnormal grid, or by rounding up into the smallest normal -- so strict mode
-    /// accepts only a value that lands exactly on a subnormal.
+    /// Handles a literal whose exponent falls at or below the subnormal range. RoundToFormat does the
+    /// rounding; what is specific here is strict mode, which accepts only a literal that lands exactly on
+    /// a subnormal.
     /// </summary>
     private static bool HandleUnderflow(bool signBit, BigInteger sig, BigInteger biasedExp, int sigSize, int expSize, bool strict, out BigFloat result)
     {

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -634,25 +634,22 @@ namespace Microsoft.BaseTypes
         return farApartResult;
       }
 
-      // Align significands and add
+      // Align by scaling the operand with the larger exponent up, rather than shifting the smaller one
+      // down. Shifting down truncates the low bits before the sum is formed, and no later rounding can
+      // recover them; scaling up keeps the sum exact.
+      var absDiff = BigInteger.Abs(expDiff);
       var sum = expDiff == 0 ? xSigned + ySigned :
-        expDiff > 0 ? xSigned + BigIntegerMath.RightShift(ySigned, expDiff) :
-        BigIntegerMath.RightShift(xSigned, -expDiff) + ySigned;
+        expDiff > 0 ? BigIntegerMath.LeftShift(xSigned, absDiff) + ySigned :
+        xSigned + BigIntegerMath.LeftShift(ySigned, absDiff);
 
       if (sum == 0) {
-        var zeroSumResult = CreateZero(x.signBit && y.signBit, x.SignificandSize, x.ExponentSize);
-        return zeroSumResult;
+        // IEEE 754: cancellation gives -0 only when both operands are negative.
+        return CreateZero(x.signBit && y.signBit, x.SignificandSize, x.ExponentSize);
       }
 
-      // Normalize result
-      var isNegative = sum < 0;
-      var absSum = isNegative ? -sum : sum;
-
-      var baseExp = xExp > yExp ? xExp : yExp;
-      var (normSig, normExp) = NormalizeAndRound(absSum, baseExp, x.SignificandSize);
-
-      var result = HandleExponentBounds(normSig, normExp, isNegative, x.SignificandSize, x.ExponentSize);
-      return result;
+      // Both significands are now weighted by the smaller of the two exponents.
+      var sumScale = BigInteger.Min(xExp, yExp) - x.bias - (x.SignificandSize - 1);
+      return RoundToFormat(BigInteger.Abs(sum), sumScale, sum < 0, x.SignificandSize, x.ExponentSize);
     }
 
     [Pure] public static BigFloat operator -(BigFloat x, BigFloat y) => x + -y;

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -265,12 +265,10 @@ namespace Microsoft.BaseTypes
       var scaledNumerator = BigIntegerMath.LeftShift(numerator, scaleBits);
       var quotient = BigInteger.DivRem(scaledNumerator, denominator, out var remainder);
 
-      // Record inexactness in a sticky bit rather than rounding here. The shift further down performs
-      // the only rounding, and needs the residual to tell a tie from a value just above one.
+      // The +3 margin above means the significand carries three bits more than the format keeps, so
+      // the sticky bit is safely below the retained bits.
       var isExact = remainder.IsZero;
-      if (!isExact) {
-        quotient |= BigInteger.One;
-      }
+      quotient = WithStickyBit(quotient, remainder);
 
       var quotientBits = quotient.GetBitLength();
       var biasedExp = GetBias(exponentSize) + quotientBits - scaleBits - 1;
@@ -637,8 +635,9 @@ namespace Microsoft.BaseTypes
         return CreateZero(x.signBit && y.signBit, x.SignificandSize, x.ExponentSize);
       }
 
-      // Both significands are now weighted by the smaller of the two exponents.
-      var sumScale = BigInteger.Min(xExp, yExp) - x.bias - (x.SignificandSize - 1);
+      // Aligning upward left both significands weighted by the smaller of the two exponents, so the
+      // exact sum carries that operand's scale.
+      var sumScale = ScaleOfPreparedOperand(BigInteger.Min(xExp, yExp), x.bias, x.SignificandSize);
       return RoundToFormat(BigInteger.Abs(sum), sumScale, sum < 0, x.SignificandSize, x.ExponentSize);
     }
 
@@ -669,9 +668,10 @@ namespace Microsoft.BaseTypes
         return CreateZero(resultSign, x.SignificandSize, x.ExponentSize);
       }
 
-      // The product is exact, so RoundToFormat performs the only rounding. Each prepared significand
-      // is weighted by 2^(exp - bias - (significandSize - 1)), and multiplying adds those weights.
-      var productScale = xExp + yExp - 2 * x.bias - 2 * (x.SignificandSize - 1);
+      // The product is exact, so RoundToFormat performs the only rounding. Multiplying two values adds
+      // their scales.
+      var productScale = ScaleOfPreparedOperand(xExp, x.bias, x.SignificandSize)
+                       + ScaleOfPreparedOperand(yExp, x.bias, x.SignificandSize);
       return RoundToFormat(product, productScale, resultSign, x.SignificandSize, x.ExponentSize);
     }
 
@@ -689,22 +689,56 @@ namespace Microsoft.BaseTypes
       // Prepare operands and calculate result sign
       var ((xSig, xExp), (ySig, yExp), resultSign) = PrepareOperandsForMultDiv(x, y);
 
-      // Shift the dividend far enough that the quotient always has at least significandSize + 2 bits.
-      // A fixed shift is not enough: a subnormal dividend carries fewer significant bits than the
-      // format allows, so the quotient comes out short and the missing precision cannot be recovered.
-      var deficit = ySig.GetBitLength() - xSig.GetBitLength();
-      var guardShift = x.SignificandSize + 2 + BigInteger.Max(deficit, BigInteger.Zero);
+      // Long division produces bits from the top down, so the dividend must be pre-shifted by however
+      // many quotient bits are wanted. Two beyond the format's width suffice: one guard bit, so the
+      // value just past the rounding position is visible, and one sticky bit position, so
+      // WithStickyBit has a bit to set that RoundToFormat will shift away.
+      //
+      // The shift cannot be a constant. xSig / ySig lands in [1/2, 2), so the quotient's width is
+      // (shift) give or take one -- but only when both significands are the same width. A subnormal
+      // dividend is narrower than the format allows, and the quotient loses exactly that many bits, so
+      // widen the shift by the shortfall.
+      var dividendShortfall = BigInteger.Max(ySig.GetBitLength() - xSig.GetBitLength(), BigInteger.Zero);
+      var guardShift = x.SignificandSize + 2 + dividendShortfall;
       var shiftedDividend = BigIntegerMath.LeftShift(xSig, guardShift);
       var quotient = BigInteger.DivRem(shiftedDividend, ySig, out var remainder);
 
-      // A nonzero remainder means the quotient is inexact. Record that in a sticky bit rather than
-      // rounding here, so RoundToFormat can still tell a tie from a value just above one.
-      if (!remainder.IsZero) {
-        quotient |= BigInteger.One;
-      }
+      quotient = WithStickyBit(quotient, remainder);
 
-      var quotientScale = xExp - yExp - guardShift;
+      // Dividing subtracts the operands' scales; pre-shifting the dividend by guardShift lowered its
+      // scale by the same amount, and the two bias terms cancel.
+      var quotientScale = ScaleOfPreparedOperand(xExp, x.bias, x.SignificandSize)
+                        - ScaleOfPreparedOperand(yExp, x.bias, x.SignificandSize)
+                        - guardShift;
       return RoundToFormat(quotient, quotientScale, resultSign, x.SignificandSize, x.ExponentSize);
+    }
+
+    /// <summary>
+    /// Power-of-two weight of bit 0 of the significand <see cref="PrepareOperand"/> returns.
+    ///
+    /// PrepareOperand restores the implicit leading bit, so the significand it hands back is an integer
+    /// rather than a fraction: the value it represents is significand * 2^ScaleOfPreparedOperand(exp).
+    /// Every operator needs this to state the scale of its own exact result, and stating it once keeps
+    /// those derivations short enough to check by eye.
+    /// </summary>
+    private static BigInteger ScaleOfPreparedOperand(BigInteger biasedExponent, BigInteger bias, int significandSize)
+    {
+      return biasedExponent - bias - (significandSize - 1);
+    }
+
+    /// <summary>
+    /// Folds an inexact residual into bit 0 of a value destined for <see cref="RoundToFormat"/>.
+    ///
+    /// Rounding correctly needs to know whether a discarded tail was exactly zero, exactly half, or
+    /// somewhere above half. A quotient loses that distinction as soon as its remainder is dropped, so
+    /// callers that divide record "there was a remainder" in the lowest bit and let RoundToFormat do the
+    /// arithmetic. This is only sound because the caller computed strictly more bits than the format
+    /// keeps -- see the guard margins at the call sites -- so bit 0 is always among the bits shifted
+    /// out, and setting it can never disturb the retained significand.
+    /// </summary>
+    private static BigInteger WithStickyBit(BigInteger value, BigInteger remainder)
+    {
+      return remainder.IsZero ? value : value | BigInteger.One;
     }
 
     /// <summary>
@@ -739,24 +773,30 @@ namespace Microsoft.BaseTypes
         ? significand.GetBitLength() - significandSize
         : minNormalScale - (significandSize - 1) - scale;
 
+      // The overflow flag is deliberately ignored. It reports that rounding carried into an extra bit,
+      // which callers of the old two-step path had to correct for by hand; here the exponent is derived
+      // from the rounded value's own width below, so a carry is absorbed rather than compensated. That
+      // covers both forms it takes: a subnormal rounding up to the smallest normal, and a normal
+      // rounding up into the next binade.
       var (rounded, _, _) = ApplyShiftWithRounding(significand, shift);
       if (rounded.IsZero) {
         return CreateZero(isNegative, significandSize, exponentSize);
       }
 
-      // Recompute the exponent from the rounded value: rounding can carry a subnormal up to the
-      // smallest normal, or a normal up into the next binade.
       var biasedExp = scale + shift + rounded.GetBitLength() - 1 + bias;
 
       if (biasedExp >= GetMaxExponent(exponentSize)) {
         return CreateInfinity(isNegative, significandSize, exponentSize);
       }
 
+      // A normal number stores only the trailing significand; its leading bit is implied by a nonzero
+      // exponent, so mask it off. A subnormal stores every bit it has and takes exponent zero.
       return biasedExp > 0
         ? new BigFloat(isNegative, rounded & (GetLeadingBitPower(significandSize) - 1), biasedExp,
             significandSize, exponentSize)
         : new BigFloat(isNegative, rounded, 0, significandSize, exponentSize);
     }
+
     /// <summary>
     /// Arithmetic operation types for special value handling
     /// </summary>

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -265,10 +265,11 @@ namespace Microsoft.BaseTypes
       var scaledNumerator = BigIntegerMath.LeftShift(numerator, scaleBits);
       var quotient = BigInteger.DivRem(scaledNumerator, denominator, out var remainder);
 
-      // Apply rounding if inexact
+      // Record inexactness in a sticky bit rather than rounding here. The shift further down performs
+      // the only rounding, and needs the residual to tell a tie from a value just above one.
       var isExact = remainder.IsZero;
       if (!isExact) {
-        quotient = ApplyRoundToNearestEven(quotient, remainder, denominator);
+        quotient |= BigInteger.One;
       }
 
       var quotientBits = quotient.GetBitLength();

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -742,6 +742,16 @@ namespace Microsoft.BaseTypes
     }
 
     /// <summary>
+    /// Biased exponent of the value "significand * 2^scale", where the significand is "width" bits wide,
+    /// as if it were normalized so that its leading bit is the implicit one. A result at or below zero
+    /// means the value is below the smallest normal and must be stored as a subnormal instead.
+    /// </summary>
+    private static BigInteger BiasedExponentOf(BigInteger scale, long width, BigInteger bias)
+    {
+      return scale + width - 1 + bias;
+    }
+
+    /// <summary>
     /// Rounds the exact value "significand * 2^scale" into the given format, performing the single
     /// IEEE 754 round-to-nearest-even the standard requires.
     ///
@@ -761,36 +771,40 @@ namespace Microsoft.BaseTypes
 
       var bias = GetBias(exponentSize);
 
-      // Scale the leading bit would have if the value were normalized where it stands, and the
-      // smallest scale a normal number can have.
-      var leadingScale = scale + significand.GetBitLength() - 1;
-      var minNormalScale = BigInteger.One - bias;
+      // Everything below is expressed as a biased exponent, so that the one test distinguishing normal
+      // from subnormal ("is it above zero?") is the same test before and after rounding. Stating the
+      // two in different terms would leave them free to disagree at the seam.
+      //
+      // BiasedExponentOf gives the exponent a value would have if normalized where it stands; for a
+      // subnormal that is at or below zero, which is exactly the case the format cannot represent
+      // without shifting onto its fixed grid.
+      var biasedExp = BiasedExponentOf(scale, significand.GetBitLength(), bias);
 
-      // A normal result keeps significandSize bits; a subnormal one lands on the fixed grid that every
-      // subnormal shares, whose least significant bit has scale minNormalScale - (significandSize - 1).
-      // Either way this is the only shift, and therefore the only rounding.
-      var shift = leadingScale >= minNormalScale
+      // A normal result keeps significandSize bits. A subnormal one instead lands on the grid every
+      // subnormal shares, whose least significant bit has scale (1 - bias) - (significandSize - 1).
+      // Either way there is one shift, and therefore one rounding.
+      var shift = biasedExp > 0
         ? significand.GetBitLength() - significandSize
-        : minNormalScale - (significandSize - 1) - scale;
+        : BigInteger.One - bias - (significandSize - 1) - scale;
 
       // The overflow flag is deliberately ignored. It reports that rounding carried into an extra bit,
-      // which callers of the old two-step path had to correct for by hand; here the exponent is derived
-      // from the rounded value's own width below, so a carry is absorbed rather than compensated. That
-      // covers both forms it takes: a subnormal rounding up to the smallest normal, and a normal
-      // rounding up into the next binade.
+      // which callers of the old two-step path corrected for by hand; here the exponent is recomputed
+      // from the rounded value's own width, so a carry is absorbed rather than compensated. That covers
+      // both forms it takes: a subnormal rounding up to the smallest normal, and a normal rounding up
+      // into the next binade.
       var (rounded, _, _) = ApplyShiftWithRounding(significand, shift);
       if (rounded.IsZero) {
         return CreateZero(isNegative, significandSize, exponentSize);
       }
 
-      var biasedExp = scale + shift + rounded.GetBitLength() - 1 + bias;
+      biasedExp = BiasedExponentOf(scale + shift, rounded.GetBitLength(), bias);
 
       if (biasedExp >= GetMaxExponent(exponentSize)) {
         return CreateInfinity(isNegative, significandSize, exponentSize);
       }
 
-      // A normal number stores only the trailing significand; its leading bit is implied by a nonzero
-      // exponent, so mask it off. A subnormal stores every bit it has and takes exponent zero.
+      // A normal number stores only the trailing significand, its leading bit being implied by the
+      // nonzero exponent, so mask that bit off. A subnormal stores every bit it has, at exponent zero.
       return biasedExp > 0
         ? new BigFloat(isNegative, rounded & (GetLeadingBitPower(significandSize) - 1), biasedExp,
             significandSize, exponentSize)

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -1212,41 +1212,21 @@ namespace Microsoft.BaseTypes
         return HandleUnderflow(isNegative, sig, biasedExp, sigSize, expSize, strict, out result);
       }
 
-      // Normal number - check precision loss and normalize
+      // Strict mode rejects any literal that would not survive the round trip, so a nonzero tail below
+      // the retained bits is an error rather than something to round away.
       var shift = new BigInteger(msbPos) - (sigSize - 1);
       if (strict && shift > 0 && shift < sig.GetBitLength() && (sig & GetMask(shift)) != 0) {
         return false;
       }
 
-      // Apply IEEE 754 rounding instead of truncation
-      BigInteger roundedSig;
-      BigInteger adjustedBiasedExp = biasedExp;
+      // Bit 0 of "sig" sits fracBits below the hex point, which decExp scales by four bits per digit.
+      var scale = (decExp * 4) - fracBits;
+      result = RoundToFormat(sig, scale, isNegative, sigSize, expSize);
 
-      if (shift > 0) {
-        var (shifted, _, overflow) = ApplyShiftWithRounding(sig, shift);
-        roundedSig = shifted;
-
-        // Check if rounding caused overflow to next power of 2
-        if (overflow) {
-          roundedSig >>= 1;
-          adjustedBiasedExp++;
-
-          // Check for exponent overflow
-          if (adjustedBiasedExp >= GetMaxExponent(expSize)) {
-            if (strict) {
-              return false;
-            }
-            result = CreateInfinity(isNegative, sigSize, expSize);
-            return true;
-          }
-        }
-
-        roundedSig &= (GetLeadingBitPower(sigSize) - 1);
-      } else {
-        roundedSig = BigIntegerMath.RightShift(sig, shift) & (GetLeadingBitPower(sigSize) - 1);
+      if (strict && result.IsInfinity) {
+        return false;
       }
 
-      result = new BigFloat(isNegative, roundedSig, adjustedBiasedExp, sigSize, expSize);
       return true;
     }
 
@@ -1259,51 +1239,29 @@ namespace Microsoft.BaseTypes
       }
       return BigInteger.TryParse("0" + hex, System.Globalization.NumberStyles.HexNumber, null, out value);
     }
-
+    /// <summary>
+    /// Handles a literal whose exponent falls at or below the subnormal range.
+    ///
+    /// The rounding itself is RoundToFormat's job; what is specific here is strict mode, which rejects
+    /// any literal that does not survive a round trip. Underflow always loses information -- to zero, or
+    /// onto the coarser subnormal grid, or by rounding up into the smallest normal -- so strict mode
+    /// accepts only a value that lands exactly on a subnormal.
+    /// </summary>
     private static bool HandleUnderflow(bool signBit, BigInteger sig, BigInteger biasedExp, int sigSize, int expSize, bool strict, out BigFloat result)
     {
-      result = default;
-      var bias = GetBias(expSize);
-      var minSubnormalExp = BigInteger.One - bias - (sigSize - 1);
-      var actualExp = biasedExp - bias;
+      // Bit 0 of "sig" has weight 2^(actualExp - msb), since the caller placed the leading bit at
+      // actualExp.
+      var actualExp = biasedExp - GetBias(expSize);
+      var scale = actualExp - (sig.GetBitLength() - 1);
 
-      // Complete underflow to zero
-      if (actualExp < minSubnormalExp) {
-        if (strict) {
-          return false;
-        }
-        result = CreateZero(signBit, sigSize, expSize);
+      result = RoundToFormat(sig, scale, signBit, sigSize, expSize);
+
+      if (!strict) {
         return true;
       }
 
-      // Calculate required shift for subnormal representation
-      var currentMsb = sig.GetBitLength() - 1;
-      var targetPosition = actualExp - minSubnormalExp;
-      var shiftAmount = new BigInteger(currentMsb) - targetPosition;
-
-      // Apply shift with IEEE 754 rounding
-      var (subnormalSig, _, _) = ApplyShiftWithRounding(sig, shiftAmount);
-
-      if (subnormalSig.IsZero) {
-        if (strict) {
-          return false;
-        }
-        result = CreateZero(signBit, sigSize, expSize);
-        return true;
-      }
-
-      // Check if rounding caused overflow to normal range
-      if (subnormalSig.GetBitLength() > sigSize - 1) {
-        if (strict) {
-          return false;
-        }
-        // Overflow to smallest normal number
-        result = new BigFloat(signBit, 0, 1, sigSize, expSize);
-        return true;
-      }
-
-      result = new BigFloat(signBit, subnormalSig, 0, sigSize, expSize);
-      return true;
+      // Rejected in strict mode: flushed to zero, or rounded up out of the subnormal range.
+      return !result.IsZero && result.exponent == 0;
     }
 
     /// <summary>

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -702,20 +702,22 @@ namespace Microsoft.BaseTypes
       // Prepare operands and calculate result sign
       var ((xSig, xExp), (ySig, yExp), resultSign) = PrepareOperandsForMultDiv(x, y);
 
-      // Shift dividend left for precision and divide with rounding
-      var shiftedDividend = BigIntegerMath.LeftShift(xSig, x.SignificandSize + 1);
+      // Shift the dividend far enough that the quotient always has at least significandSize + 2 bits.
+      // A fixed shift is not enough: a subnormal dividend carries fewer significant bits than the
+      // format allows, so the quotient comes out short and the missing precision cannot be recovered.
+      var deficit = ySig.GetBitLength() - xSig.GetBitLength();
+      var guardShift = x.SignificandSize + 2 + BigInteger.Max(deficit, BigInteger.Zero);
+      var shiftedDividend = BigIntegerMath.LeftShift(xSig, guardShift);
       var quotient = BigInteger.DivRem(shiftedDividend, ySig, out var remainder);
-      quotient = ApplyRoundToNearestEven(quotient, remainder, ySig);
 
-      if (quotient == 0) {
-        return CreateZero(resultSign, x.SignificandSize, x.ExponentSize);
+      // A nonzero remainder means the quotient is inexact. Record that in a sticky bit rather than
+      // rounding here, so RoundToFormat can still tell a tie from a value just above one.
+      if (!remainder.IsZero) {
+        quotient |= BigInteger.One;
       }
 
-      // Normalize and calculate final exponent
-      var (normalizedQuotient, normalShift) = NormalizeAndRound(quotient, BigInteger.Zero, x.SignificandSize);
-      var resultExp = xExp - yExp + x.bias + normalShift - 2;
-
-      return HandleExponentBounds(normalizedQuotient, resultExp, resultSign, x.SignificandSize, x.ExponentSize);
+      var quotientScale = xExp - yExp - guardShift;
+      return RoundToFormat(quotient, quotientScale, resultSign, x.SignificandSize, x.ExponentSize);
     }
 
     /// <summary>

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -23,9 +23,8 @@ namespace Microsoft.BaseTypes
     private readonly BigInteger maxExponent;    // Maximum exponent value
     private readonly BigInteger leadingBit;      // Power value for the implicit leading significand bit
 
-    // SignificandSize represents the precision: trailing significand field width + 1 (for the implicit leading significand bit)
-    // For IEEE 754 double: SignificandSize = 53 (52-bit trailing significand field + 1 implicit leading significand bit)
-    // The trailing significand field always uses SignificandSize - 1 bits
+    // The precision: the trailing significand field's width plus the implicit leading bit, so 53 for an
+    // IEEE 754 double. The stored field always uses SignificandSize - 1 bits.
     public int SignificandSize { get; }
     public int ExponentSize { get; }            // Total bits for exponent
     public bool IsZero => significand == 0 && exponent == 0;
@@ -46,8 +45,7 @@ namespace Microsoft.BaseTypes
     #region Constructors and Factory Methods
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="BigFloat"/> struct.
-    /// Primary constructor for IEEE 754 representation
+    /// Initializes a new instance of the <see cref="BigFloat"/> struct from its IEEE 754 fields.
     /// </summary>
     /// <param name="signBit">The sign bit: true for negative, false for positive</param>
     /// <param name="significand">The trailing significand field (without implicit leading significand bit for normal numbers)</param>
@@ -92,7 +90,6 @@ namespace Microsoft.BaseTypes
       SignificandSize = significandSize;
       ExponentSize = exponentSize;
 
-      // Initialize cached values
       bias = GetBias(exponentSize);
       maxExponent = GetMaxExponent(exponentSize);
       leadingBit = GetLeadingBitPower(significandSize);
@@ -111,16 +108,10 @@ namespace Microsoft.BaseTypes
     }
 
     /// <summary>
-    /// Tries to parse a string representation of a BigFloat with strict Boogie verification requirements.
-    /// This method enforces:
-    /// - No precision loss (significand must have trailing zeros for full nibble inclusion)
-    /// - No extreme underflow (rejects values that would underflow to zero)
-    /// - Strict size validation
-    ///
-    /// DESIGN NOTE: This "strict" mode is arguably overly restrictive. It rejects:
-    /// - ALL extreme underflow, even representable subnormals (e.g., 0x0.8e-126f24e8)
-    /// - ANY precision loss, even standard IEEE 754 rounding
-    ///
+    /// As <see cref="TryParse"/>, but rejects a literal the format cannot hold: one with a nonzero tail
+    /// below the retained significand, one that overflows to infinity, and one that underflows to zero or
+    /// rounds up out of the subnormal range. A literal that rounds onto a subnormal is accepted, so this
+    /// is not quite exactness. Boogie's parser uses this mode.
     /// </summary>
     /// <param name="s">The string to parse in format: [-]0x^.^e*f*e* or 0NaN*e* or 0+/-oo*e*</param>
     /// <param name="result">The parsed BigFloat value if successful; default(BigFloat) otherwise</param>
@@ -147,16 +138,7 @@ namespace Microsoft.BaseTypes
     }
 
     /// <summary>
-    /// Parses a string representation of a BigFloat with strict Boogie verification requirements.
-    /// This method enforces:
-    /// - No precision loss (significand must have trailing zeros for full nibble inclusion)
-    /// - No extreme underflow (rejects values that would underflow to zero)
-    /// - Strict size validation with FormatException
-    ///
-    /// DESIGN NOTE: This "strict" mode is arguably overly restrictive. It rejects:
-    /// - ALL extreme underflow, even representable subnormals (e.g., 0x0.8e-126f24e8)
-    /// - ANY precision loss, even standard IEEE 754 rounding
-    ///
+    /// As <see cref="TryParseExact"/>, but throws instead of returning false.
     /// </summary>
     /// <param name="s">The string to parse in format: [-]0x^.^e*f*e* or 0NaN*e* or 0+/-oo*e*</param>
     /// <returns>The parsed BigFloat value</returns>
@@ -173,8 +155,8 @@ namespace Microsoft.BaseTypes
     /// Core parsing logic that handles both IEEE 754 compliant and Boogie strict parsing modes
     /// </summary>
     /// <param name="s">The string to parse</param>
-    /// <param name="strict">When true, enforces Boogie's verification requirements (no precision loss, no extreme underflow);
-    /// when false, follows IEEE 754 standard (allows graceful underflow and rounding)</param>
+    /// <param name="strict">When true, applies the restrictions described on <see cref="TryParseExact"/>;
+    /// when false, rounds and underflows as IEEE 754 prescribes</param>
     /// <param name="result">The parsed BigFloat value if successful; default(BigFloat) otherwise</param>
     /// <returns>True if the parse was successful; false otherwise</returns>
     private static bool TryParseFloatString(string s, bool strict, out BigFloat result)
@@ -434,12 +416,8 @@ namespace Microsoft.BaseTypes
       new (isNegative, GetSignificandMask(significandSize - 1), GetMaxExponent(exponentSize), significandSize, exponentSize);
 
     /// <summary>
-    /// Tries to create special values from string representation for SMT-LIB integration.
-    /// Supports: "NaN", "+oo", "-oo", "+zero", "-zero" (case insensitive)
-    ///
-    /// These are the five special values the SMT-LIB FloatingPoint theory can name,
-    /// and a solver may return any of them from (get-value ...) as
-    /// ((x (_ &lt;special&gt; &lt;eb&gt; &lt;sb&gt;))).
+    /// Creates one of the five special values the SMT-LIB FloatingPoint theory can name, which a solver may
+    /// return from (get-value ...) as ((x (_ &lt;special&gt; &lt;eb&gt; &lt;sb&gt;))). Case insensitive.
     /// </summary>
     /// <param name="specialValue">Special value string ("NaN", "+oo", "-oo", "+zero", "-zero")</param>
     /// <param name="sigSize">Significand size in bits</param>
@@ -523,7 +501,6 @@ namespace Microsoft.BaseTypes
     {
       ValidateSizeCompatibility(x, y);
 
-      // Handle special values
       var specialResult = HandleSpecialValues(x, y, ArithmeticOperation.Addition);
       if (specialResult.HasValue) {
         return specialResult.Value;
@@ -551,10 +528,8 @@ namespace Microsoft.BaseTypes
 
       var expDiff = xExp - yExp;
 
-      // If operands are far apart, the smaller cannot affect the larger
-      // For same sign: no cancellation possible
-      // For opposite signs: when difference > significandSize + 1, the smaller value
-      // shifts completely out of range and doesn't affect the result
+      // Beyond significandSize + 1 apart, the smaller operand shifts out of range entirely and cannot
+      // affect the larger, whatever the signs.
       if (BigInteger.Abs(expDiff) > x.SignificandSize + 1) {
         var farApartResult = expDiff > 0 ? x : y;
         return farApartResult;
@@ -586,7 +561,6 @@ namespace Microsoft.BaseTypes
     {
       ValidateSizeCompatibility(x, y);
 
-      // Handle special values
       var specialResult = HandleSpecialValues(x, y, ArithmeticOperation.Multiplication);
       if (specialResult.HasValue) {
         return specialResult.Value;
@@ -597,7 +571,6 @@ namespace Microsoft.BaseTypes
         return CreateZero(x.signBit ^ y.signBit, x.SignificandSize, x.ExponentSize);
       }
 
-      // Prepare operands and calculate result sign
       var ((xSig, xExp), (ySig, yExp), resultSign) = PrepareOperandsForMultDiv(x, y);
 
       // Multiply and check for zero
@@ -618,13 +591,11 @@ namespace Microsoft.BaseTypes
     {
       ValidateSizeCompatibility(x, y);
 
-      // Handle special cases
       var specialResult = HandleSpecialValues(x, y, ArithmeticOperation.Division);
       if (specialResult.HasValue) {
         return specialResult.Value;
       }
 
-      // Prepare operands and calculate result sign
       var ((xSig, xExp), (ySig, yExp), resultSign) = PrepareOperandsForMultDiv(x, y);
 
       // Long division produces bits from the top down, so pre-shift the dividend by as many quotient
@@ -910,18 +881,9 @@ namespace Microsoft.BaseTypes
     #region Comparison Operations
 
     /// <summary>
-    /// Compares this BigFloat with another BigFloat for ordering purposes.
-    /// This method follows the specification for C#'s Single.CompareTo method.
-    /// As a result, it handles NaNs differently than how the ==, !=, <, >, <=, and >= operators do.
-    /// For example, the expression (0.0f / 0.0f).CompareTo(0.0f / 0.0f) should return 0,
-    /// whereas the expression (0.0f / 0.0f) == (0.0f / 0.0f) should return false.
-    ///
-    /// IMPORTANT: This dual behavior is intentional and correct:
-    /// - CompareTo: Provides consistent total ordering for sorting (NaN == NaN returns 0)
-    /// - == operator: Follows IEEE 754 mathematical semantics (NaN == NaN returns false)
-    ///
-    /// This allows collections containing NaN values to be sorted while maintaining
-    /// IEEE 754 compliance for mathematical operations.
+    /// Orders two values as C#'s Single.CompareTo does, which means a total order in which a NaN compares
+    /// equal to itself so that collections containing one can be sorted. The comparison operators keep
+    /// IEEE 754 semantics instead, where every NaN comparison is false; the difference is deliberate.
     /// </summary>
     /// <param name="that">The BigFloat to compare with</param>
     /// <returns>
@@ -931,7 +893,6 @@ namespace Microsoft.BaseTypes
     /// </returns>
     public int CompareTo(BigFloat that)
     {
-      // Validate size compatibility first
       ValidateSizeCompatibility(this, that);
 
       // NaN handling - special ordering for collections

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -489,8 +489,8 @@ namespace Microsoft.BaseTypes
         xSigned + BigIntegerMath.LeftShift(ySigned, absDiff);
 
       if (sum == 0) {
-        // IEEE 754: cancellation gives -0 only when both operands are negative.
-        return CreateZero(x.signBit && y.signBit, x.SignificandSize, x.ExponentSize);
+        // Two nonzero operands can only cancel if their signs differ, and IEEE 754 makes that sum +0.
+        return CreateZero(false, x.SignificandSize, x.ExponentSize);
       }
 
       // Aligning upward left both significands weighted by the smaller of the two exponents, so the

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -344,6 +344,20 @@ namespace Microsoft.BaseTypes
     /// </summary>
     private BigInteger GetActualExponent() => exponent == 0 ? BigInteger.One : exponent;
 
+    /// <summary>
+    /// This value's magnitude as significand * 2^scale, with the implicit leading bit restored and the
+    /// sign dropped. Zero, the infinities and NaN do not decompose this way.
+    ///
+    /// Subnormals need no case of their own: one stores no implicit bit, and shares its actual exponent
+    /// with the smallest normal, so <see cref="GetActualExponent"/> covers both.
+    /// </summary>
+    private (BigInteger Significand, BigInteger Scale) AsScaledInteger()
+    {
+      Contract.Requires(!IsZero && !IsInfinity && !IsNaN);
+      return (exponent == 0 ? significand : significand | leadingBit,
+        ScaleOfPreparedOperand(GetActualExponent(), bias, SignificandSize));
+    }
+
     #endregion
 
     #region Arithmetic Helpers
@@ -370,12 +384,12 @@ namespace Microsoft.BaseTypes
 
       return ((xSig, xExp), (ySig, yExp), resultSign);
     }
+    /// <summary>
+    /// The low "bits" bits set, i.e. 2^bits - 1, and zero for a non-positive width.
+    /// </summary>
     private static BigInteger GetMask(BigInteger bits)
     {
-      if (bits <= 0) {
-        return BigInteger.Zero;
-      }
-      return BigIntegerMath.LeftShift(BigInteger.One, bits) - 1;
+      return bits <= 0 ? BigInteger.Zero : BigIntegerMath.LeftShift(BigInteger.One, bits) - 1;
     }
     /// <summary>
     /// Shifts "value" right by "shift" bits, rounding the discarded tail to nearest with ties to even.
@@ -483,7 +497,7 @@ namespace Microsoft.BaseTypes
     public static BigInteger GetBias(int exponentSize) => (BigInteger.One << (exponentSize - 1)) - 1;
     public static BigInteger GetMaxExponent(int exponentSize) => (BigInteger.One << exponentSize) - 1;
     public static BigInteger GetLeadingBitPower(int significandSize) => BigInteger.One << (significandSize - 1);  // Returns power value for the implicit leading significand bit
-    public static BigInteger GetSignificandMask(int significandSize) => (BigInteger.One << significandSize) - 1;
+    public static BigInteger GetSignificandMask(int significandSize) => GetMask(significandSize);
 
     #endregion
 
@@ -689,10 +703,7 @@ namespace Microsoft.BaseTypes
         return numerator.IsZero;
       }
 
-      var significand = value.exponent == 0
-        ? value.significand
-        : value.significand | GetLeadingBitPower(value.SignificandSize);
-      var scale = ScaleOfPreparedOperand(value.GetActualExponent(), value.bias, value.SignificandSize);
+      var (significand, scale) = value.AsScaledInteger();
 
       // significand * 2^scale == numerator / denominator, rearranged to avoid division.
       return scale >= 0
@@ -902,8 +913,7 @@ namespace Microsoft.BaseTypes
       }
 
       // Convert to rational and compute integer part
-      var significandValue = IsNormal ? (significand | leadingBit) : significand;
-      var shift = (IsNormal ? GetActualExponent() : BigInteger.One) - bias - (SignificandSize - 1);
+      var (significandValue, shift) = AsScaledInteger();
 
       BigInteger integerPart;
       bool hasRemainder;
@@ -1038,8 +1048,7 @@ namespace Microsoft.BaseTypes
       }
 
       // Convert to rational number
-      var significandValue = IsNormal ? (significand | leadingBit) : significand;
-      var shift = (IsNormal ? GetActualExponent() : BigInteger.One) - bias - (SignificandSize - 1);
+      var (significandValue, shift) = AsScaledInteger();
 
       // Calculate numerator and denominator
       var (numerator, denominator) = shift >= 0
@@ -1075,19 +1084,23 @@ namespace Microsoft.BaseTypes
     {
       Contract.Ensures(Contract.Result<string>() != null);
 
-      // Handle special values
-      if (exponent == maxExponent) {
-        return $"0{(significand == 0 ? $"{(signBit ? "-" : "+")}oo" : "NaN")}{SignificandSize}e{ExponentSize}";
+      // NaN and the infinities name their sizes without the leading "f", so they cannot reuse "format".
+      var format = $"f{SignificandSize}e{ExponentSize}";
+      var sign = signBit ? "-" : "";
+
+      if (IsNaN) {
+        return $"0NaN{SignificandSize}e{ExponentSize}";
       }
 
-      // Handle zero
+      if (IsInfinity) {
+        return $"0{(signBit ? "-" : "+")}oo{SignificandSize}e{ExponentSize}";
+      }
+
       if (IsZero) {
-        return $"{(signBit ? "-" : "")}0x0.0e0f{SignificandSize}e{ExponentSize}";
+        return $"{sign}0x0.0e0{format}";
       }
 
-      // Get significand and binary exponent
-      var significandBits = IsSubnormal ? significand : (significand | leadingBit);
-      var binaryExp = (IsSubnormal ? BigInteger.One - bias : exponent - bias) - (SignificandSize - 1);
+      var (significandBits, binaryExp) = AsScaledInteger();
 
       // Calculate hex exponent and adjust significand for bit remainder
       var hexExp = binaryExp / 4;
@@ -1103,7 +1116,7 @@ namespace Microsoft.BaseTypes
       // Convert to hex and format as H.HHH
       var hexStr = significandBits.ToString("X");
       if (hexStr.Length == 1) {
-        return $"{(signBit ? "-" : "")}0x{hexStr}.0e{hexExp}f{SignificandSize}e{ExponentSize}";
+        return $"{sign}0x{hexStr}.0e{hexExp}{format}";
       }
 
       // Format with decimal point after first digit
@@ -1113,7 +1126,7 @@ namespace Microsoft.BaseTypes
       }
       hexExp += hexStr.Length - 1;
 
-      return $"{(signBit ? "-" : "")}0x{hexStr[0]}.{fracPart}e{hexExp}f{SignificandSize}e{ExponentSize}";
+      return $"{sign}0x{hexStr[0]}.{fracPart}e{hexExp}{format}";
     }
 
     #endregion

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -38,20 +38,12 @@ namespace Microsoft.BaseTypes
 
     #endregion
 
-    // ============================================================================
-    // PUBLIC INTERFACE
-    // ============================================================================
-
     #region Constructors and Factory Methods
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BigFloat"/> struct from its IEEE 754 fields.
-    /// </summary>
+    /// <summary>Initializes a new instance of the <see cref="BigFloat"/> struct from its IEEE 754 fields.</summary>
     /// <param name="signBit">The sign bit: true for negative, false for positive</param>
     /// <param name="significand">The trailing significand field (without implicit leading significand bit for normal numbers)</param>
     /// <param name="exponent">The biased exponent value</param>
-    /// <param name="significandSize">Total bits for significand (including implicit leading significand bit)</param>
-    /// <param name="exponentSize">Total bits for exponent</param>
     public BigFloat(bool signBit, BigInteger significand, BigInteger exponent, int significandSize, int exponentSize)
       : this(signBit, significand, exponent, significandSize, exponentSize, false)
     {
@@ -95,12 +87,8 @@ namespace Microsoft.BaseTypes
       leadingBit = GetLeadingBitPower(significandSize);
     }
 
-    /// <summary>
-    /// Tries to parse a string representation of a BigFloat with IEEE 754 compliant behavior
-    /// </summary>
+    /// <summary>Tries to parse a string representation of a BigFloat with IEEE 754 compliant behavior</summary>
     /// <param name="s">The string to parse in format: [-]0x^.^e*f*e* or 0NaN*e* or 0+/-oo*e*</param>
-    /// <param name="result">The parsed BigFloat value if successful; default(BigFloat) otherwise</param>
-    /// <returns>True if the parse was successful; false otherwise</returns>
     [Pure]
     public static bool TryParse(string s, out BigFloat result)
     {
@@ -114,19 +102,14 @@ namespace Microsoft.BaseTypes
     /// is not quite exactness. Boogie's parser uses this mode.
     /// </summary>
     /// <param name="s">The string to parse in format: [-]0x^.^e*f*e* or 0NaN*e* or 0+/-oo*e*</param>
-    /// <param name="result">The parsed BigFloat value if successful; default(BigFloat) otherwise</param>
-    /// <returns>True if the parse was successful; false otherwise</returns>
     [Pure]
     public static bool TryParseExact(string s, out BigFloat result)
     {
       return TryParseFloatString(s, strict: true, out result);
     }
 
-    /// <summary>
-    /// Parses a string representation of a BigFloat with IEEE 754 compliant behavior
-    /// </summary>
+    /// <summary>Parses a string representation of a BigFloat with IEEE 754 compliant behavior</summary>
     /// <param name="s">The string to parse in format: [-]0x^.^e*f*e* or 0NaN*e* or 0+/-oo*e*</param>
-    /// <returns>The parsed BigFloat value</returns>
     [Pure]
     public static BigFloat FromString(string s)
     {
@@ -137,11 +120,8 @@ namespace Microsoft.BaseTypes
       throw new FormatException($"Unable to parse '{s}' as BigFloat");
     }
 
-    /// <summary>
-    /// As <see cref="TryParseExact"/>, but throws instead of returning false.
-    /// </summary>
+    /// <summary>As <see cref="TryParseExact"/>, but throws instead of returning false.</summary>
     /// <param name="s">The string to parse in format: [-]0x^.^e*f*e* or 0NaN*e* or 0+/-oo*e*</param>
-    /// <returns>The parsed BigFloat value</returns>
     [Pure]
     public static BigFloat FromStringStrict(string s)
     {
@@ -151,14 +131,9 @@ namespace Microsoft.BaseTypes
       throw new FormatException($"Unable to parse '{s}' as BigFloat in strict mode");
     }
 
-    /// <summary>
-    /// Core parsing logic that handles both IEEE 754 compliant and Boogie strict parsing modes
-    /// </summary>
-    /// <param name="s">The string to parse</param>
+    /// <summary>Core parsing logic that handles both IEEE 754 compliant and Boogie strict parsing modes</summary>
     /// <param name="strict">When true, applies the restrictions described on <see cref="TryParseExact"/>;
     /// when false, rounds and underflows as IEEE 754 prescribes</param>
-    /// <param name="result">The parsed BigFloat value if successful; default(BigFloat) otherwise</param>
-    /// <returns>True if the parse was successful; false otherwise</returns>
     private static bool TryParseFloatString(string s, bool strict, out BigFloat result)
     {
       result = default;
@@ -202,9 +177,7 @@ namespace Microsoft.BaseTypes
         TryCreateSpecialFromString(s[1..4], significandSize, exponentSize, out result);
     }
 
-    /// <summary>
-    /// Creates a BigFloat from an integer value (default: double precision)
-    /// </summary>
+    /// <summary>Creates a BigFloat from an integer value (default: double precision)</summary>
     [Pure] public static BigFloat FromInt(int v) => ConvertIntegerToBigFloat(v, 53, 11);
     [Pure] public static BigFloat FromInt(int v, int significandSize, int exponentSize) => ConvertIntegerToBigFloat(v, significandSize, exponentSize);
     public static BigFloat FromBigInt(BigInteger v, int significandSize, int exponentSize) => ConvertIntegerToBigFloat(v, significandSize, exponentSize);
@@ -213,11 +186,6 @@ namespace Microsoft.BaseTypes
     /// Converts a rational number to a BigFloat.
     /// Returns false if the number cannot be accurately represented as a BigFloat.
     /// </summary>
-    /// <param name="numerator">The numerator of the rational number</param>
-    /// <param name="denominator">The denominator of the rational number</param>
-    /// <param name="significandSize">The size of the significand in bits</param>
-    /// <param name="exponentSize">The size of the exponent in bits</param>
-    /// <param name="result">The resulting BigFloat</param>
     /// <returns>True if the conversion is exact, false otherwise</returns>
     [Pure]
     public static bool FromRational(
@@ -261,10 +229,6 @@ namespace Microsoft.BaseTypes
     /// Converts a BigDec (decimal) value to a BigFloat.
     /// Returns false if the number cannot be accurately represented as a BigFloat.
     /// </summary>
-    /// <param name="value">The BigDec value to convert</param>
-    /// <param name="significandSize">The size of the significand in bits</param>
-    /// <param name="exponentSize">The size of the exponent in bits</param>
-    /// <param name="result">The resulting BigFloat</param>
     /// <returns>True if the conversion is exact, false otherwise</returns>
     [Pure]
     public static bool FromBigDec(
@@ -290,11 +254,7 @@ namespace Microsoft.BaseTypes
 
     #region Validation and Parameter Checking
 
-    /// <summary>
-    /// Validates that significand and exponent sizes meet minimum requirements (must be > 1)
-    /// </summary>
-    /// <param name="significandSize">The size of the significand in bits</param>
-    /// <param name="exponentSize">The size of the exponent in bits</param>
+    /// <summary>Validates that significand and exponent sizes meet minimum requirements (must be > 1)</summary>
     private static void ValidateSizeParameters(int significandSize, int exponentSize)
     {
       if (significandSize <= 1) {
@@ -348,9 +308,7 @@ namespace Microsoft.BaseTypes
       return (sig, exp);
     }
 
-    /// <summary>
-    /// Prepares operands for multiplication/division operations (with combined sign calculation)
-    /// </summary>
+    /// <summary>Prepares operands for multiplication/division operations (with combined sign calculation)</summary>
     private static ((BigInteger sig, BigInteger exp) x, (BigInteger sig, BigInteger exp) y, bool resultSign) PrepareOperandsForMultDiv(BigFloat x, BigFloat y)
     {
       var leadingBit = x.leadingBit;
@@ -360,9 +318,7 @@ namespace Microsoft.BaseTypes
 
       return ((xSig, xExp), (ySig, yExp), resultSign);
     }
-    /// <summary>
-    /// The low "bits" bits set, i.e. 2^bits - 1, and zero for a non-positive width.
-    /// </summary>
+    /// <summary>The low "bits" bits set, i.e. 2^bits - 1, and zero for a non-positive width.</summary>
     private static BigInteger GetMask(BigInteger bits)
     {
       return bits <= 0 ? BigInteger.Zero : BigIntegerMath.LeftShift(BigInteger.One, bits) - 1;
@@ -420,9 +376,6 @@ namespace Microsoft.BaseTypes
     /// return from (get-value ...) as ((x (_ &lt;special&gt; &lt;eb&gt; &lt;sb&gt;))). Case insensitive.
     /// </summary>
     /// <param name="specialValue">Special value string ("NaN", "+oo", "-oo", "+zero", "-zero")</param>
-    /// <param name="sigSize">Significand size in bits</param>
-    /// <param name="expSize">Exponent size in bits</param>
-    /// <param name="result">The resulting BigFloat if successful; default(BigFloat) otherwise</param>
     /// <returns>True if the special value was recognized and created; false otherwise</returns>
     public static bool TryCreateSpecialFromString(string specialValue, int sigSize, int expSize, out BigFloat result) {
       switch (specialValue.ToLowerInvariant()) {
@@ -447,9 +400,7 @@ namespace Microsoft.BaseTypes
       }
     }
 
-    /// <summary>
-    /// Convert integer to BigFloat using direct IEEE 754 conversion
-    /// </summary>
+    /// <summary>Convert integer to BigFloat using direct IEEE 754 conversion</summary>
     private static BigFloat ConvertIntegerToBigFloat(BigInteger value, int significandSize, int exponentSize)
     {
       ValidateSizeParameters(significandSize, exponentSize);
@@ -472,10 +423,6 @@ namespace Microsoft.BaseTypes
 
     #endregion
 
-    // ============================================================================
-    // ARITHMETIC AND COMPARISON OPERATIONS
-    // ============================================================================
-
     #region Arithmetic Operations
 
     [Pure] public static BigFloat operator -(BigFloat x) => new (!x.signBit, x.significand, x.exponent, x.SignificandSize, x.ExponentSize);
@@ -491,9 +438,7 @@ namespace Microsoft.BaseTypes
       return x.signBit == y.signBit ? x : -x;
     }
 
-    /// <summary>
-    /// Returns the sign: -1 for negative, 0 for zero/NaN, 1 for positive
-    /// </summary>
+    /// <summary>Returns the sign: -1 for negative, 0 for zero/NaN, 1 for positive</summary>
     public int Sign() => IsNaN || IsZero ? 0 : (signBit ? -1 : 1);
 
     [Pure]
@@ -717,9 +662,7 @@ namespace Microsoft.BaseTypes
         : new BigFloat(isNegative, rounded, 0, significandSize, exponentSize);
     }
 
-    /// <summary>
-    /// Arithmetic operation types for special value handling
-    /// </summary>
+    /// <summary>Arithmetic operation types for special value handling</summary>
     private enum ArithmeticOperation
     {
       Addition,
@@ -885,7 +828,6 @@ namespace Microsoft.BaseTypes
     /// equal to itself so that collections containing one can be sorted. The comparison operators keep
     /// IEEE 754 semantics instead, where every NaN comparison is false; the difference is deliberate.
     /// </summary>
-    /// <param name="that">The BigFloat to compare with</param>
     /// <returns>
     /// Less than zero: This instance is less than 'that'
     /// Zero: This instance equals 'that' (including NaN == NaN for ordering)
@@ -1059,16 +1001,10 @@ namespace Microsoft.BaseTypes
 
     #region String Parsing
 
-    /// <summary>
-    /// Tries to parse hex format BigFloat strings according to the specification
-    /// </summary>
+    /// <summary>Tries to parse hex format BigFloat strings according to the specification</summary>
     /// <param name="s">The hex format string to parse (without size suffixes)</param>
-    /// <param name="sigSize">The significand size in bits</param>
-    /// <param name="expSize">The exponent size in bits</param>
     /// <param name="strict">When true, enforces Boogie's strict parsing rules (no precision loss, no extreme underflow);
     /// when false, follows IEEE 754 standard behavior</param>
-    /// <param name="result">The parsed BigFloat value if successful; default(BigFloat) otherwise</param>
-    /// <returns>True if the parse was successful; false otherwise</returns>
     private static bool TryParseHexFormat(string s, int sigSize, int expSize, bool strict, out BigFloat result)
     {
       result = default;
@@ -1173,9 +1109,7 @@ namespace Microsoft.BaseTypes
       return !result.IsZero && result.exponent == 0;
     }
 
-    /// <summary>
-    /// Converts to SMT-LIB format string
-    /// </summary>
+    /// <summary>Converts to SMT-LIB format string</summary>
     public string ToSMTLibString() =>
       exponent == maxExponent ?
         $"_ {(significand == 0 ? $"{(signBit ? "-" : "+")}oo" : "NaN")} {ExponentSize} {SignificandSize}" :
@@ -1184,15 +1118,10 @@ namespace Microsoft.BaseTypes
     #endregion
   }
 
-  /// <summary>
-  /// Helper class for BigInteger arithmetic operations that require shift amounts larger than int.MaxValue
-  /// </summary>
+  /// <summary>Helper class for BigInteger arithmetic operations that require shift amounts larger than int.MaxValue</summary>
   internal static class BigIntegerMath
   {
-    /// <summary>
-    /// Left shift operation that handles BigInteger shift amounts
-    /// </summary>
-    /// <param name="value">The value to shift</param>
+    /// <summary>Left shift operation that handles BigInteger shift amounts</summary>
     /// <param name="shift">The number of bits to shift left (can be negative for right shift)</param>
     /// <returns>The result of value << shift, handling shifts larger than int.MaxValue</returns>
     public static BigInteger LeftShift(BigInteger value, BigInteger shift)
@@ -1217,10 +1146,7 @@ namespace Microsoft.BaseTypes
       return result;
     }
 
-    /// <summary>
-    /// Right shift operation that handles BigInteger shift amounts
-    /// </summary>
-    /// <param name="value">The value to shift</param>
+    /// <summary>Right shift operation that handles BigInteger shift amounts</summary>
     /// <param name="shift">The number of bits to shift right (can be negative for left shift)</param>
     /// <returns>The result of value >> shift, handling shifts larger than int.MaxValue</returns>
     public static BigInteger RightShift(BigInteger value, BigInteger shift)

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -518,11 +518,9 @@ namespace Microsoft.BaseTypes
 
       var ((xSig, xExp), (ySig, yExp), resultSign) = PrepareOperandsForMultDiv(x, y);
 
-      // Multiply and check for zero
+      // Both operands are nonzero here, so their prepared significands are too and the product cannot
+      // be zero.
       var product = xSig * ySig;
-      if (product == 0) {
-        return CreateZero(resultSign, x.SignificandSize, x.ExponentSize);
-      }
 
       // The product is exact, so RoundToFormat performs the only rounding. Multiplying two values adds
       // their scales.

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -1153,8 +1153,8 @@ namespace Microsoft.BaseTypes
     }
     /// <summary>
     /// Handles a literal whose exponent falls at or below the subnormal range. RoundToFormat does the
-    /// rounding; what is specific here is strict mode, which accepts only a literal that lands exactly on
-    /// a subnormal.
+    /// rounding; what is specific here is strict mode, which accepts only a literal that lands on a nonzero
+    /// subnormal, whether or not it got there exactly.
     /// </summary>
     private static bool HandleUnderflow(bool signBit, BigInteger sig, BigInteger biasedExp, int sigSize, int expSize, bool strict, out BigFloat result)
     {

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -414,17 +414,6 @@ namespace Microsoft.BaseTypes
 
       return ((xSig, xExp), (ySig, yExp), resultSign);
     }
-
-    private static BigInteger ApplyRoundToNearestEven(BigInteger quotient, BigInteger remainder, BigInteger denominator)
-    {
-      // Round up if remainder > denominator/2, or if remainder == denominator/2 and quotient is odd
-      if (remainder * 2 > denominator || (remainder * 2 == denominator && !quotient.IsEven)) {
-        quotient++;
-      }
-
-      return quotient;
-    }
-
     private static BigInteger GetMask(BigInteger bits)
     {
       if (bits <= 0) {
@@ -768,58 +757,6 @@ namespace Microsoft.BaseTypes
             significandSize, exponentSize)
         : new BigFloat(isNegative, rounded, 0, significandSize, exponentSize);
     }
-
-    private static (BigInteger significand, BigInteger exponent) NormalizeAndRound(BigInteger value, BigInteger exponent, int targetBits)
-    {
-      var valueBits = value.GetBitLength();
-      var shift = valueBits - targetBits;
-
-      // Use IEEE 754 compliant shift and round method
-      var (shiftedValue, _, overflow) = ApplyShiftWithRounding(value, shift);
-      var adjustedExponent = exponent + shift;
-
-      // Handle potential overflow from rounding (only for right shifts)
-      if (overflow) {
-        shiftedValue >>= 1;
-        adjustedExponent++;
-      }
-
-      return (shiftedValue, adjustedExponent);
-    }
-
-    private static BigFloat HandleExponentBounds(BigInteger significand, BigInteger exponent, bool isNegative, int significandSize, int exponentSize)
-    {
-      var maxExponent = GetMaxExponent(exponentSize);
-
-      // Handle overflow to infinity
-      if (exponent >= maxExponent) {
-        return CreateInfinity(isNegative, significandSize, exponentSize);
-      }
-
-      // Handle normal numbers
-      if (exponent > 0) {
-        // Remove implicit leading bit for storage (it's encoded in the biased exponent)
-        var leadingBitMask = GetLeadingBitPower(significandSize) - 1;
-        return new BigFloat(isNegative, significand & leadingBitMask, exponent, significandSize, exponentSize);
-      }
-
-      // Handle complete underflow to zero
-      var bias = GetBias(exponentSize);
-      if (exponent < BigInteger.One - bias - (significandSize - 1)) {
-        return CreateZero(isNegative, significandSize, exponentSize);
-      }
-
-      // Handle subnormal numbers with gradual underflow
-      var (shiftedSig, _, _) = ApplyShiftWithRounding(significand, BigInteger.One - exponent);
-
-      // Check if rounding caused overflow back to smallest normal number
-      if (shiftedSig.GetBitLength() == significandSize) {
-        return new BigFloat(isNegative, 0, 1, significandSize, exponentSize);
-      }
-
-      return new BigFloat(isNegative, shiftedSig, 0, significandSize, exponentSize);
-    }
-
     /// <summary>
     /// Arithmetic operation types for special value handling
     /// </summary>

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -258,28 +258,25 @@ namespace Microsoft.BaseTypes
       numerator = BigInteger.Abs(numerator);
       denominator = BigInteger.Abs(denominator);
 
-      // Scale numerator for precision
-      // Use long to avoid overflow in bit length calculation
+      // Pre-scale the numerator so the quotient carries three bits more than the format keeps: two for
+      // the guard and sticky positions RoundToFormat needs, and one of slack. The shift is clamped at
+      // zero for the case where the numerator already dwarfs the denominator, which needs no scaling --
+      // there the quotient is wide on its own, so bit 0 still falls well below the retained bits and
+      // the sticky bit below cannot disturb them.
       var scaleBitsLong = (long)significandSize + 3 + (denominator.GetBitLength() - numerator.GetBitLength());
       var scaleBits = scaleBitsLong < 0 ? BigInteger.Zero : new BigInteger(scaleBitsLong);
       var scaledNumerator = BigIntegerMath.LeftShift(numerator, scaleBits);
       var quotient = BigInteger.DivRem(scaledNumerator, denominator, out var remainder);
 
-      // The +3 margin above means the significand carries three bits more than the format keeps, so
-      // the sticky bit is safely below the retained bits.
-      var isExact = remainder.IsZero;
-      quotient = WithStickyBit(quotient, remainder);
-
       // Bit 0 of the scaled quotient has weight 2^-scaleBits, so RoundToFormat finishes the job: it
       // performs the single rounding and handles the normal, subnormal, overflow and underflow cases.
-      result = RoundToFormat(quotient, -scaleBits, isNegative, significandSize, exponentSize);
+      result = RoundToFormat(WithStickyBit(quotient, remainder), -scaleBits, isNegative,
+        significandSize, exponentSize);
 
       // Whether the conversion was exact is a question about the input, not about what rounding did, so
       // it is answered by asking whether the result still represents numerator/denominator. Deciding it
       // that way keeps this method from having to reimplement the rounding in order to observe it.
-      isExact = RepresentsExactly(result, numerator, denominator);
-
-      return isExact;
+      return RepresentsExactly(result, numerator, denominator);
     }
 
     /// <summary>
@@ -380,68 +377,45 @@ namespace Microsoft.BaseTypes
       }
       return BigIntegerMath.LeftShift(BigInteger.One, bits) - 1;
     }
-
     /// <summary>
-    /// Applies a shift with IEEE 754 round-to-nearest-even rounding.
+    /// Shifts "value" right by "shift" bits, rounding the discarded tail to nearest with ties to even.
+    /// A negative shift shifts left, which discards nothing and so needs no rounding.
     /// </summary>
-    /// <param name="value">The value to shift</param>
-    /// <param name="shift">The shift amount (positive for right shift, negative for left shift)</param>
-    /// <returns>The shifted and rounded value.</returns>
     private static BigInteger ApplyShiftWithRounding(BigInteger value, BigInteger shift)
     {
-      // Handle left shifts (no rounding needed, no overflow possible)
       if (shift <= 0) {
         return BigIntegerMath.LeftShift(value, -shift);
       }
 
-      // Handle very large shifts - but still need to check for rounding
-      if (value.GetBitLength() < shift) {
-        // All bits shifted out, but check if we need to round up
-        // For round-to-nearest-even, we round up if value > 2^(shift-1)
-        var halfValue = BigIntegerMath.LeftShift(BigInteger.One, shift - 1);
-        if (value > halfValue) {
-          return BigInteger.One; // rounds up to 1
-        }
-        return BigInteger.Zero;
+      // Exponent sizes are unbounded, so a shift can exceed the value's width by an astronomical
+      // margin -- a 40-bit exponent field puts the subnormal boundary around 2^-549755813888. Handle
+      // that case by comparing against the halfway point rather than by shifting, since neither
+      // 2^shift nor the shifted value can be materialized.
+      if (shift > value.GetBitLength()) {
+        // Everything is discarded. The result is 1 only if the value exceeded half of the discarded
+        // range, i.e. 2^(shift-1); a value exactly at the halfway point ties to the even 0.
+        return value.GetBitLength() == shift && (value & (value - 1)) != 0
+          ? BigInteger.One
+          : BigInteger.Zero;
       }
 
-      // For very large right shifts, perform in chunks
-      var remaining = shift;
-      var current = value;
+      // Split the value at the rounding position. The tail is whatever the retained part does not
+      // account for, and both shifts here are bounded by the value's own width.
+      var retained = BigIntegerMath.RightShift(value, shift);
+      var tail = value - BigIntegerMath.LeftShift(retained, shift);
 
-      // Shift by int.MaxValue chunks if needed
-      while (remaining > int.MaxValue) {
-        current >>= int.MaxValue;
-        remaining -= int.MaxValue;
-        if (current.IsZero) {
-          return BigInteger.Zero;
-        }
+      if (tail.IsZero) {
+        return retained;
       }
 
-      // Perform final shift with IEEE 754 round-to-nearest-even
-      var intShift = (int)remaining;
-      var mask = (BigInteger.One << intShift) - 1;
-      var lostBits = current & mask;
-      var result = current >> intShift;
+      // Round to nearest, ties to even. Comparing twice the tail against the discarded range avoids
+      // materializing the halfway value itself.
+      var tailRange = BigIntegerMath.LeftShift(BigInteger.One, shift);
+      var doubledTail = tail * 2;
 
-      // If no bits lost, result is exact, no overflow
-      if (lostBits.IsZero) {
-        return result;
-      }
-
-      // Round to nearest even
-      var halfBit = BigInteger.One << (intShift - 1);
-      var needsRounding = lostBits > halfBit || (lostBits == halfBit && !result.IsEven);
-
-      // Check for overflow: when rounding up causes bit length to increase
-      var overflow = false;
-      if (needsRounding) {
-        var originalBitLength = result.GetBitLength();
-        result++;
-        overflow = result.GetBitLength() > originalBitLength;
-      }
-
-      return result;
+      return doubledTail > tailRange || (doubledTail == tailRange && !retained.IsEven)
+        ? retained + 1
+        : retained;
     }
 
     // Public convenience methods for special values

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -270,53 +270,14 @@ namespace Microsoft.BaseTypes
       var isExact = remainder.IsZero;
       quotient = WithStickyBit(quotient, remainder);
 
-      var quotientBits = quotient.GetBitLength();
-      var biasedExp = GetBias(exponentSize) + quotientBits - scaleBits - 1;
-      if (biasedExp > GetMaxExponent(exponentSize) - 1) {
-        result = CreateInfinity(isNegative, significandSize, exponentSize);
-        return false;
-      }
-      var targetBits = significandSize - 1;
-      var minBiasedExp = 2 - significandSize;
+      // Bit 0 of the scaled quotient has weight 2^-scaleBits, so RoundToFormat finishes the job: it
+      // performs the single rounding and handles the normal, subnormal, overflow and underflow cases.
+      result = RoundToFormat(quotient, -scaleBits, isNegative, significandSize, exponentSize);
 
-      if (biasedExp <= 0) {
-        if (biasedExp < minBiasedExp) {
-          isExact = false;
-
-          if (biasedExp == minBiasedExp - 1) {
-            if (quotient == BigIntegerMath.LeftShift(BigInteger.One, quotientBits - 1)) {
-              result = CreateZero(isNegative, significandSize, exponentSize);
-            } else {
-              var (boundaryShifted, _, _) = ApplyShiftWithRounding(quotient, BigInteger.One);
-              result = boundaryShifted > 0
-                ? new BigFloat(isNegative, 1, 0, significandSize, exponentSize)
-                : CreateZero(isNegative, significandSize, exponentSize);
-            }
-          } else {
-            result = CreateZero(isNegative, significandSize, exponentSize);
-          }
-        } else {
-          var shiftAmount = (quotientBits - targetBits) - biasedExp;
-          var (shifted, _, _) = ApplyShiftWithRounding(quotient, shiftAmount);
-
-          if (shifted >= BigInteger.One << targetBits) {
-            result = new BigFloat(isNegative, 0, 1, significandSize, exponentSize);
-          } else {
-            result = new BigFloat(isNegative, shifted, 0, significandSize, exponentSize);
-          }
-        }
-      } else {
-        var (normalShifted, wasExact, overflow) = ApplyShiftWithRounding(quotient, quotientBits - significandSize);
-        isExact &= wasExact;
-
-        if (overflow) {
-          normalShifted >>= 1;
-          biasedExp++;
-        }
-
-        var leadingBitMask = GetLeadingBitPower(significandSize) - 1;
-        result = new BigFloat(isNegative, normalShifted & leadingBitMask, biasedExp, significandSize, exponentSize);
-      }
+      // Whether the conversion was exact is a question about the input, not about what rounding did, so
+      // it is answered by asking whether the result still represents numerator/denominator. Deciding it
+      // that way keeps this method from having to reimplement the rounding in order to observe it.
+      isExact = RepresentsExactly(result, numerator, denominator);
 
       return isExact;
     }
@@ -425,16 +386,12 @@ namespace Microsoft.BaseTypes
     /// </summary>
     /// <param name="value">The value to shift</param>
     /// <param name="shift">The shift amount (positive for right shift, negative for left shift)</param>
-    /// <returns>A tuple containing:
-    /// - result: The shifted and rounded value
-    /// - isExact: Whether the operation was exact (no bits were lost)
-    /// - overflow: Whether rounding caused the result to gain an extra bit (e.g., 111...111 -> 1000...000)
-    /// </returns>
-    private static (BigInteger result, bool isExact, bool overflow) ApplyShiftWithRounding(BigInteger value, BigInteger shift)
+    /// <returns>The shifted and rounded value.</returns>
+    private static BigInteger ApplyShiftWithRounding(BigInteger value, BigInteger shift)
     {
       // Handle left shifts (no rounding needed, no overflow possible)
       if (shift <= 0) {
-        return (BigIntegerMath.LeftShift(value, -shift), true, false);
+        return BigIntegerMath.LeftShift(value, -shift);
       }
 
       // Handle very large shifts - but still need to check for rounding
@@ -443,9 +400,9 @@ namespace Microsoft.BaseTypes
         // For round-to-nearest-even, we round up if value > 2^(shift-1)
         var halfValue = BigIntegerMath.LeftShift(BigInteger.One, shift - 1);
         if (value > halfValue) {
-          return (BigInteger.One, false, false); // Result is 1, no overflow
+          return BigInteger.One; // rounds up to 1
         }
-        return (BigInteger.Zero, !value.IsZero, false);
+        return BigInteger.Zero;
       }
 
       // For very large right shifts, perform in chunks
@@ -457,7 +414,7 @@ namespace Microsoft.BaseTypes
         current >>= int.MaxValue;
         remaining -= int.MaxValue;
         if (current.IsZero) {
-          return (BigInteger.Zero, false, false);
+          return BigInteger.Zero;
         }
       }
 
@@ -469,7 +426,7 @@ namespace Microsoft.BaseTypes
 
       // If no bits lost, result is exact, no overflow
       if (lostBits.IsZero) {
-        return (result, true, false);
+        return result;
       }
 
       // Round to nearest even
@@ -484,7 +441,7 @@ namespace Microsoft.BaseTypes
         overflow = result.GetBitLength() > originalBitLength;
       }
 
-      return (result, false, overflow);
+      return result;
     }
 
     // Public convenience methods for special values
@@ -742,6 +699,34 @@ namespace Microsoft.BaseTypes
     }
 
     /// <summary>
+    /// True if "value" is exactly numerator/denominator, with both taken as positive.
+    ///
+    /// The comparison is done in integers: a float is significand * 2^scale, so cross-multiplying by the
+    /// denominator and by 2^-scale (whichever side needs it) turns the question into one BigInteger
+    /// equality with no rounding of its own.
+    /// </summary>
+    private static bool RepresentsExactly(BigFloat value, BigInteger numerator, BigInteger denominator)
+    {
+      if (value.IsInfinity || value.IsNaN) {
+        return false;
+      }
+
+      if (value.IsZero) {
+        return numerator.IsZero;
+      }
+
+      var significand = value.exponent == 0
+        ? value.significand
+        : value.significand | GetLeadingBitPower(value.SignificandSize);
+      var scale = ScaleOfPreparedOperand(value.GetActualExponent(), value.bias, value.SignificandSize);
+
+      // significand * 2^scale == numerator / denominator, rearranged to avoid division.
+      return scale >= 0
+        ? BigIntegerMath.LeftShift(significand, scale) * denominator == numerator
+        : significand * denominator == BigIntegerMath.LeftShift(numerator, -scale);
+    }
+
+    /// <summary>
     /// Biased exponent of the value "significand * 2^scale", where the significand is "width" bits wide,
     /// as if it were normalized so that its leading bit is the implicit one. A result at or below zero
     /// means the value is below the smallest normal and must be stored as a subnormal instead.
@@ -792,7 +777,7 @@ namespace Microsoft.BaseTypes
       // from the rounded value's own width, so a carry is absorbed rather than compensated. That covers
       // both forms it takes: a subnormal rounding up to the smallest normal, and a normal rounding up
       // into the next binade.
-      var (rounded, _, _) = ApplyShiftWithRounding(significand, shift);
+      var rounded = ApplyShiftWithRounding(significand, shift);
       if (rounded.IsZero) {
         return CreateZero(isNegative, significandSize, exponentSize);
       }

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -8,15 +8,17 @@ using Microsoft.BaseTypes;
 namespace BaseTypesTests
 {
     /// <summary>
-    /// Compares BigFloat against two oracles that share no code with it, since every conversion and
-    /// operator routes through the same rounding helpers and so cannot catch an error in them:
+    /// Checks BigFloat against expectations that share no code with it, since every conversion and operator
+    /// routes through the same rounding helpers and so cannot catch an error in them:
     ///
     ///   1. ExactRoundToNearestEven - a rational rounded in BigInteger with exactly one rounding step.
     ///   2. Hardware - float is bit-for-bit BigFloat(24,8) and double is bit-for-bit BigFloat(53,11).
     ///      Arithmetic must be done in the target precision, since computing a float result via double
     ///      rounds twice and reproduces the defect under test.
+    ///   3. Closed forms, where the format makes the answer derivable by hand. These are the only ones that
+    ///      reach the wide exponent sizes, since both oracles above are limited to the narrow formats.
     ///
-    /// The two are cross-checked against each other in <see cref="OraclesAgreeWithEachOther"/>.
+    /// The two oracles are cross-checked against each other in <see cref="OraclesAgreeWithEachOther"/>.
     /// </summary>
     [TestFixture]
     public class BigFloatDifferentialTests
@@ -25,15 +27,20 @@ namespace BaseTypesTests
         private const int SingleExponent = 8;
 
         /// <summary>
-        /// Correctly rounded round-to-nearest-even value of numerator/denominator in the given format, as
-        /// (biasedExponent, trailingSignificand), or null if it overflows to infinity.
+        /// Correctly rounded round-to-nearest-even value of numerator/denominator in the given format,
+        /// shaped like <see cref="Internals"/> so the two compare directly, or null if it overflows to
+        /// infinity. The scale is kept in an int, which bounds this to the narrow formats.
         /// </summary>
-        private static (BigInteger exponent, BigInteger significand)? ExactRoundToNearestEven(
+        private static (BigInteger exponent, BigInteger significand, bool signBit)? ExactRoundToNearestEven(
             BigInteger numerator, BigInteger denominator, int significandSize, int exponentSize)
         {
+            var signBit = (numerator < 0) != (denominator < 0);
+            numerator = BigInteger.Abs(numerator);
+            denominator = BigInteger.Abs(denominator);
+
             if (numerator.IsZero)
             {
-                return (BigInteger.Zero, BigInteger.Zero);
+                return (BigInteger.Zero, BigInteger.Zero, signBit);
             }
 
             BigInteger bias = (BigInteger.One << (exponentSize - 1)) - 1;
@@ -55,19 +62,10 @@ namespace BaseTypesTests
 
             // Below the smallest normal, every value shares one exponent, so clamp onto that grid.
             var minScale = (int)(1 - bias - (significandSize - 1));
-            if (scale + significandSize - 1 < 1 - bias)
+            if (scale < minScale)
             {
-                while (scale < minScale)
-                {
-                    denominator <<= 1;
-                    scale++;
-                }
-
-                while (scale > minScale)
-                {
-                    numerator <<= 1;
-                    scale--;
-                }
+                denominator <<= minScale - scale;
+                scale = minScale;
             }
 
             var quotient = BigInteger.DivRem(numerator, denominator, out var remainder);
@@ -86,13 +84,13 @@ namespace BaseTypesTests
 
             if (quotient < BigInteger.One << (significandSize - 1))
             {
-                return (BigInteger.Zero, quotient); // subnormal
+                return (BigInteger.Zero, quotient, signBit); // subnormal
             }
 
             var biasedExponent = scale + significandSize - 1 + bias;
             return biasedExponent >= maxExponent
                 ? null
-                : (biasedExponent, quotient - (BigInteger.One << (significandSize - 1)));
+                : (biasedExponent, quotient - (BigInteger.One << (significandSize - 1)), signBit);
         }
 
         /// <summary>
@@ -168,6 +166,60 @@ namespace BaseTypesTests
                 : Describe(FromSingle(value));
         }
 
+        private static string DescribeDouble(double value)
+        {
+            if (double.IsNaN(value))
+            {
+                return "NaN";
+            }
+
+            return double.IsInfinity(value)
+                ? (value < 0 ? "-inf" : "+inf")
+                : Describe(FromDouble(value));
+        }
+
+        private static float Apply(char op, float left, float right)
+        {
+            return op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
+        }
+
+        private static double Apply(char op, double left, double right)
+        {
+            return op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
+        }
+
+        /// <summary>
+        /// Describes how BigFloat and hardware differ on one operation, or null if they agree.
+        /// </summary>
+        private static string Mismatch(char op, float left, float right)
+        {
+            var expected = DescribeSingle(Apply(op, left, right));
+            var actual = Describe(Apply(op, FromSingle(left), FromSingle(right)));
+            return expected == actual ? null : $"{left:R} {op} {right:R}: got {actual}, want {expected}";
+        }
+
+        private static string Mismatch(char op, double left, double right)
+        {
+            var expected = DescribeDouble(Apply(op, left, right));
+            var actual = Describe(Apply(op, FromDouble(left), FromDouble(right)));
+            return expected == actual ? null : $"{left:R} {op} {right:R}: got {actual}, want {expected}";
+        }
+
+        private static void AssertMatchesHardware(char op, float left, float right, string label = null)
+        {
+            Assert.IsNull(Mismatch(op, left, right), label ?? $"{left:R} {op} {right:R}");
+        }
+
+        /// <summary>
+        /// Asserts that a result is the subnormal with the given significand. Zero counts as significand 0.
+        /// </summary>
+        private static void AssertSubnormal(BigFloat value, BigInteger expectedSignificand, string label)
+        {
+            var (exponent, significand, _) = Internals(value);
+            Assert.AreEqual(BigInteger.Zero, exponent, $"{label}: should have stayed subnormal");
+            Assert.AreEqual(expectedSignificand, significand, label);
+        }
+
         /// <summary>
         /// If the two oracles disagree, no other result in this fixture means anything.
         /// </summary>
@@ -187,9 +239,8 @@ namespace BaseTypesTests
                     }
 
                     var exact = ExactRoundToNearestEven(a, b, SingleSignificand, SingleExponent);
-                    var (exponent, significand, _) = Internals(FromSingle(hardware));
 
-                    if (exact == null || exact.Value.exponent != exponent || exact.Value.significand != significand)
+                    if (exact != Internals(FromSingle(hardware)))
                     {
                         disagreements.Add($"{a}/{b}");
                     }
@@ -204,16 +255,20 @@ namespace BaseTypesTests
         /// <summary>
         /// Rationals whose correctly rounded value can be checked by hand, without trusting either oracle.
         /// For 1/15 at (24,8): 2^27/15 = 8947848 remainder 8; 2*8 > 15, so round up to 8947849; less the
-        /// implicit 2^23 that leaves a trailing significand of 559241.
+        /// implicit 2^23 that leaves a trailing significand of 559241. Rounding 1/15 twice gives 559240.
+        ///
+        /// The last case carries: 1 - 2^-25 has 24-bit significand exactly 16777215.5, a tie that rounds to
+        /// the even 2^24 and so lands on 1.0.
         /// </summary>
         private static IEnumerable<TestCaseData> HandCheckedRationals()
         {
-            yield return new TestCaseData(1, 15, 123, 559241).SetName("OneFifteenth");
-            yield return new TestCaseData(1, 3, 125, 2796203).SetName("OneThird");
-            yield return new TestCaseData(2, 3, 126, 2796203).SetName("TwoThirds");
-            yield return new TestCaseData(1, 10, 123, 5033165).SetName("OneTenth");
-            yield return new TestCaseData(1, 2, 126, 0).SetName("Half");
-            yield return new TestCaseData(3, 1, 128, 4194304).SetName("Three");
+            yield return new TestCaseData(1, 15, 123, 559241).SetArgDisplayNames("OneFifteenth");
+            yield return new TestCaseData(1, 3, 125, 2796203).SetArgDisplayNames("OneThird");
+            yield return new TestCaseData(2, 3, 126, 2796203).SetArgDisplayNames("TwoThirds");
+            yield return new TestCaseData(1, 10, 123, 5033165).SetArgDisplayNames("OneTenth");
+            yield return new TestCaseData(1, 2, 126, 0).SetArgDisplayNames("Half");
+            yield return new TestCaseData(3, 1, 128, 4194304).SetArgDisplayNames("Three");
+            yield return new TestCaseData(33554431, 33554432, 127, 0).SetArgDisplayNames("JustBelowOneCarries");
         }
 
         [TestCaseSource(nameof(HandCheckedRationals))]
@@ -229,41 +284,36 @@ namespace BaseTypesTests
                 $"{numerator}/{denominator}: wrong significand (off by {significand - expectedSignificand})");
         }
 
-        /// <summary>
-        /// The smallest case of the double-rounding defect: rounding once gives 559241, twice gives 559240.
-        /// </summary>
-        [Test]
-        public void FromRationalRoundsOneFifteenthCorrectly()
-        {
-            BigFloat.FromRational(1, 15, SingleSignificand, SingleExponent, out var actual);
-            var (exponent, significand, _) = Internals(actual);
-
-            Assert.AreEqual((BigInteger)123, exponent, "biased exponent of 1/15");
-            Assert.AreEqual((BigInteger)559241, significand, $"off by {significand - 559241}");
-        }
-
         [Test]
         public void FromRationalIsCorrectlyRounded()
         {
             var wrong = new List<string>();
 
-            for (var a = 1; a <= 200; a++)
+            // Both precisions, since the rate at which rounding goes wrong differs between them, and both
+            // signs, since the oracle carries the sign and FromRational derives it from both operands.
+            foreach (var (significandSize, exponentSize) in new[] { (SingleSignificand, SingleExponent), (53, 11) })
             {
-                for (var b = 1; b <= 200; b++)
+                foreach (var sign in new[] { 1, -1 })
                 {
-                    var exact = ExactRoundToNearestEven(a, b, SingleSignificand, SingleExponent);
-                    if (exact == null)
+                    for (var a = 1; a <= 200; a++)
                     {
-                        continue;
-                    }
+                        for (var b = 1; b <= 200; b++)
+                        {
+                            var exact = ExactRoundToNearestEven(sign * a, b, significandSize, exponentSize);
+                            if (exact == null)
+                            {
+                                continue;
+                            }
 
-                    BigFloat.FromRational(a, b, SingleSignificand, SingleExponent, out var actual);
-                    var (exponent, significand, _) = Internals(actual);
+                            BigFloat.FromRational(sign * a, b, significandSize, exponentSize, out var actual);
 
-                    if (exponent != exact.Value.exponent || significand != exact.Value.significand)
-                    {
-                        wrong.Add($"{a}/{b}: got (exp {exponent}, sig {significand}), "
-                                  + $"want (exp {exact.Value.exponent}, sig {exact.Value.significand})");
+                            if (Internals(actual) != exact)
+                            {
+                                wrong.Add($"({significandSize},{exponentSize}) {sign * a}/{b}: got "
+                                          + $"{Describe(actual)}, want (exp {exact.Value.exponent}, "
+                                          + $"sig {exact.Value.significand})");
+                            }
+                        }
                     }
                 }
             }
@@ -286,16 +336,7 @@ namespace BaseTypesTests
 
             foreach (var (left, right, op) in cases)
             {
-                var expected = op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
-                var actual = op switch
-                {
-                    '+' => FromSingle(left) + FromSingle(right),
-                    '-' => FromSingle(left) - FromSingle(right),
-                    '*' => FromSingle(left) * FromSingle(right),
-                    _ => FromSingle(left) / FromSingle(right)
-                };
-
-                Assert.AreEqual(DescribeSingle(expected), Describe(actual), $"{left} {op} {right}");
+                AssertMatchesHardware(op, left, right);
             }
         }
 
@@ -326,27 +367,17 @@ namespace BaseTypesTests
                 ("-0 - +0", -0f, 0f, '-'),
                 ("subnormal - subnormal", smallestSubnormal, smallestSubnormal, '-'),
                 ("-subnormal + subnormal", -smallestSubnormal, smallestSubnormal, '+'),
-                // Cancellation of equal magnitudes gives -0 only when both operands are negative
+                // Equal magnitudes cancelling to a zero, whose sign IEEE 754 fixes at +0
                 ("1 - 1", 1f, 1f, '-'),
                 ("-1 + 1", -1f, 1f, '+'),
                 ("-1 - -1", -1f, -1f, '-'),
-                ("-1 + -1 magnitudes cancel", -1f, 1f, '+'),
                 ("2 - 2", 2f, 2f, '-'),
                 ("-2.5 + 2.5", -2.5f, 2.5f, '+')
             };
 
             foreach (var (name, left, right, op) in cases)
             {
-                var expected = op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
-                var actual = op switch
-                {
-                    '+' => FromSingle(left) + FromSingle(right),
-                    '-' => FromSingle(left) - FromSingle(right),
-                    '*' => FromSingle(left) * FromSingle(right),
-                    _ => FromSingle(left) / FromSingle(right)
-                };
-
-                Assert.AreEqual(DescribeSingle(expected), Describe(actual), name);
+                AssertMatchesHardware(op, left, right, name);
             }
         }
 
@@ -361,17 +392,16 @@ namespace BaseTypesTests
 
             foreach (var addend in new[] { 1f, 2f, 3f, 5f })
             {
-                var actual = FromSingle(twoTo24) + FromSingle(addend);
-                Assert.AreEqual(DescribeSingle(twoTo24 + addend), Describe(actual), $"2^24 + {addend}");
+                AssertMatchesHardware('+', twoTo24, addend, $"2^24 + {addend}");
             }
         }
 
         private static IEnumerable<TestCaseData> Operators()
         {
-            yield return new TestCaseData('+').SetName("Addition");
-            yield return new TestCaseData('-').SetName("Subtraction");
-            yield return new TestCaseData('*').SetName("Multiplication");
-            yield return new TestCaseData('/').SetName("Division");
+            yield return new TestCaseData('+').SetArgDisplayNames("Addition");
+            yield return new TestCaseData('-').SetArgDisplayNames("Subtraction");
+            yield return new TestCaseData('*').SetArgDisplayNames("Multiplication");
+            yield return new TestCaseData('/').SetArgDisplayNames("Division");
         }
 
         /// <summary>
@@ -401,18 +431,10 @@ namespace BaseTypesTests
                 }
 
                 tested++;
-                var expected = op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
-                var actual = op switch
+                var mismatch = Mismatch(op, left, right);
+                if (mismatch != null)
                 {
-                    '+' => FromSingle(left) + FromSingle(right),
-                    '-' => FromSingle(left) - FromSingle(right),
-                    '*' => FromSingle(left) * FromSingle(right),
-                    _ => FromSingle(left) / FromSingle(right)
-                };
-
-                if (DescribeSingle(expected) != Describe(actual))
-                {
-                    wrong.Add($"{left:R} {op} {right:R}: got {Describe(actual)}, want {DescribeSingle(expected)}");
+                    wrong.Add(mismatch);
                 }
             }
 
@@ -449,22 +471,10 @@ namespace BaseTypesTests
                 }
 
                 tested++;
-                var expected = op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
-                var actual = op switch
+                var mismatch = Mismatch(op, left, right);
+                if (mismatch != null)
                 {
-                    '+' => FromDouble(left) + FromDouble(right),
-                    '-' => FromDouble(left) - FromDouble(right),
-                    '*' => FromDouble(left) * FromDouble(right),
-                    _ => FromDouble(left) / FromDouble(right)
-                };
-
-                var expectedText = double.IsInfinity(expected)
-                    ? (expected < 0 ? "-inf" : "+inf")
-                    : (double.IsNaN(expected) ? "NaN" : Describe(FromDouble(expected)));
-
-                if (expectedText != Describe(actual))
-                {
-                    wrong.Add($"{left:R} {op} {right:R}: got {Describe(actual)}, want {expectedText}");
+                    wrong.Add(mismatch);
                 }
             }
 
@@ -484,7 +494,7 @@ namespace BaseTypesTests
 
             for (var i = 0; i < 20000 && wrong.Count < 10; i++)
             {
-                var text = $"{random.Next(1, 1000000)}e{random.Next(-12, 13)}";
+                var text = $"{(random.Next(2) == 0 ? "-" : "")}{random.Next(1, 1000000)}e{random.Next(-12, 13)}";
                 BigDec value;
 
                 try
@@ -521,12 +531,11 @@ namespace BaseTypesTests
 
                 tested++;
                 BigFloat.FromBigDec(value, SingleSignificand, SingleExponent, out var actual);
-                var (exponent, significand, _) = Internals(actual);
 
-                if (exponent != exact.Value.exponent || significand != exact.Value.significand)
+                if (Internals(actual) != exact)
                 {
-                    wrong.Add($"{text}: got (exp {exponent}, sig {significand}), "
-                              + $"want (exp {exact.Value.exponent}, sig {exact.Value.significand})");
+                    wrong.Add($"{text}: got {Describe(actual)}, want (exp {exact.Value.exponent}, "
+                              + $"sig {exact.Value.significand})");
                 }
             }
 
@@ -541,7 +550,8 @@ namespace BaseTypesTests
         public void ChainedOperationsDoNotDrift()
         {
             var random = new Random(1234);
-            var worst = 0L;
+            var drifted = new List<string>();
+            var completed = 0;
 
             for (var trial = 0; trial < 500; trial++)
             {
@@ -577,12 +587,15 @@ namespace BaseTypesTests
                     continue;
                 }
 
-                var (exponent, significand, signBit) = Internals(actual);
-                var actualBits = ((signBit ? 1 : 0) << 31) | (((int)exponent & 0xFF) << 23) | ((int)significand & 0x7FFFFF);
-                worst = Math.Max(worst, Math.Abs((long)BitConverter.SingleToInt32Bits(expected) - actualBits));
+                completed++;
+                if (DescribeSingle(expected) != Describe(actual))
+                {
+                    drifted.Add($"trial {trial}: got {Describe(actual)}, want {DescribeSingle(expected)}");
+                }
             }
 
-            Assert.AreEqual(0L, worst, $"chained arithmetic drifted by up to {worst} ULP from hardware");
+            Assert.IsEmpty(drifted, $"of {completed} chains: {string.Join("; ", drifted)}");
+            Assert.Greater(completed, 400, "almost every chain should run to the end without leaving the range");
         }
 
         /// <summary>
@@ -623,12 +636,11 @@ namespace BaseTypesTests
                     }
 
                     BigFloat.FromRational(scaledNumerator, scaledDenominator, 53, 11, out var actual);
-                    var (exponent, significand, _) = Internals(actual);
 
-                    if (exponent != exact.Value.exponent || significand != exact.Value.significand)
+                    if (Internals(actual) != exact)
                     {
-                        wrong.Add($"2^{power} * (2^54-{nudge})/2^54: got (exp {exponent}, sig {significand}), "
-                                  + $"want (exp {exact.Value.exponent}, sig {exact.Value.significand})");
+                        wrong.Add($"2^{power} * (2^54-{nudge})/2^54: got {Describe(actual)}, want (exp "
+                                  + $"{exact.Value.exponent}, sig {exact.Value.significand})");
                     }
                 }
             }
@@ -637,32 +649,61 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// A wide exponent puts the subnormal boundary at a scale that cannot be shifted to directly: at a
-        /// 40-bit exponent the smallest normal is 2^-549755813886, so materializing 2^shift or the shifted
-        /// value overflows BigInteger. Needs both a wide exponent and a result that underflows.
+        /// Subnormals in one format share a single exponent, so arithmetic on them is exact integer
+        /// arithmetic on the significand, and the bias never enters -- every size must give the same answer.
+        /// The expectations are therefore closed forms, which they have to be: at a 40-bit exponent the
+        /// smallest normal is 2^-549755813886, so the oracle cannot reach these formats.
         /// </summary>
         [Test]
-        public void ArithmeticWorksAtWideExponentSizes()
+        public void SubnormalArithmeticIsBiasIndependent()
         {
-            foreach (var exponentSize in new[] { 16, 20, 33, 40, 64, 100 })
+            const int leftSignificand = 12345;
+            const int rightSignificand = 6789;
+            var largestSubnormal = (BigInteger.One << (SingleSignificand - 1)) - 1;
+
+            foreach (var exponentSize in new[] { 8, 16, 20, 33, 40, 64, 100 })
             {
-                // Two subnormals, whose product underflows far below the smallest representable value.
-                var left = new BigFloat(false, 12345, 0, SingleSignificand, exponentSize);
-                var right = new BigFloat(false, 6789, 0, SingleSignificand, exponentSize);
+                var left = new BigFloat(false, leftSignificand, 0, SingleSignificand, exponentSize);
+                var right = new BigFloat(false, rightSignificand, 0, SingleSignificand, exponentSize);
+                var two = new BigFloat(false, 0, BigFloat.GetBias(exponentSize) + 1, SingleSignificand, exponentSize);
+                var label = $"exponentSize {exponentSize}";
 
-                Assert.DoesNotThrow(() =>
+                AssertSubnormal(left + right, leftSignificand + rightSignificand, $"{label}: sum");
+                AssertSubnormal(left - right, leftSignificand - rightSignificand, $"{label}: difference");
+                AssertSubnormal(left * two, 2 * leftSignificand, $"{label}: doubled");
+
+                // Signs come through the same way, since only the significand is at stake.
+                var negatedLeft = new BigFloat(true, leftSignificand, 0, SingleSignificand, exponentSize);
+                Assert.AreEqual((BigInteger.Zero, (BigInteger)(leftSignificand - rightSignificand), true),
+                    Internals(negatedLeft + right), $"{label}: negative sum");
+
+                // The product falls below the grid entirely, however wide the exponent.
+                Assert.IsTrue((left * right).IsZero, $"{label}: subnormal product should underflow to zero");
+
+                // The quotient of two subnormals is a plain ratio, so it lands in [1,2) at the format's own
+                // bias, with a significand that does not depend on the exponent size either.
+                Assert.AreEqual((BigFloat.GetBias(exponentSize), (BigInteger)6865091, false),
+                    Internals(left / right), $"{label}: quotient");
+
+                // Halving lands between grid points, where a tie goes to the even neighbour.
+                foreach (var (significand, halved) in new[] { (1, 0), (3, 2), (5, 2), (7, 4) })
                 {
-                    var product = left * right;
-                    Assert.IsTrue(product.IsZero, $"exponentSize {exponentSize}: subnormal product should underflow to zero");
+                    var subnormal = new BigFloat(false, significand, 0, SingleSignificand, exponentSize);
+                    AssertSubnormal(subnormal / two, halved, $"{label}: {significand}/2 ties to even");
+                }
 
-                    var quotient = left / right;
-                    Assert.IsFalse(quotient.IsNaN, $"exponentSize {exponentSize}: subnormal quotient should be a number");
+                // Carrying out of the grid gives the smallest normal, at exponent 1 with no stored bits.
+                var carried = new BigFloat(false, largestSubnormal, 0, SingleSignificand, exponentSize)
+                    + new BigFloat(false, 1, 0, SingleSignificand, exponentSize);
+                Assert.AreEqual((BigInteger.One, BigInteger.Zero, false), Internals(carried),
+                    $"{label}: largest subnormal + 1 should be the smallest normal");
 
-                    var sum = left + right;
-                    Assert.IsFalse(sum.IsNaN, $"exponentSize {exponentSize}: subnormal sum should be a number");
-
-                    BigFloat.FromRational(1, 3, SingleSignificand, exponentSize, out _);
-                }, $"exponentSize {exponentSize}");
+                // Rounding a rational into a wide format must not attempt the oversized shift either. A
+                // wider exponent only relocates the range, so the significand is the one HandCheckedRationals
+                // derives for 1/3 at (24,8), whatever the exponent size.
+                Assert.IsFalse(BigFloat.FromRational(1, 3, SingleSignificand, exponentSize, out var third), label);
+                Assert.AreEqual((BigFloat.GetBias(exponentSize) - 2, (BigInteger)2796203, false), Internals(third),
+                    $"{label}: 1/3");
             }
         }
 
@@ -732,16 +773,245 @@ namespace BaseTypesTests
             Assert.IsEmpty(mismatches, string.Join("; ", mismatches));
         }
 
-        private static BigFloat Apply(char op, BigFloat left, BigFloat right)
+        /// <summary>
+        /// Printing and parsing must be inverse: <see cref="BigFloat.ToString"/> emits an exact literal, so
+        /// parsing it back has nothing to round and must reproduce the value in both modes. This is the only
+        /// check on the parser that reaches the wide formats, since it needs no oracle.
+        /// </summary>
+        [Test]
+        public void PrintingAndParsingAreInverse()
         {
-            return op switch
+            var random = new Random(1618);
+            var mismatches = new List<string>();
+
+            foreach (var exponentSize in new[] { SingleExponent, 11, 16, 40, 100 })
             {
-                '+' => left + right,
-                '-' => left - right,
-                '*' => left * right,
-                _ => right.IsZero ? left : left / right
-            };
+                var maxExponent = (BigInteger.One << exponentSize) - 1;
+
+                // ToString splits the binary exponent into hex digits and handles a negative remainder on
+                // its own, so at (24,8) every exponent is covered rather than a sample of them. Wider
+                // formats take subnormals, the smallest normals, the middle and the top of the range.
+                var exponents = new List<BigInteger>();
+                if (exponentSize == SingleExponent)
+                {
+                    for (var exponent = BigInteger.Zero; exponent < maxExponent; exponent++)
+                    {
+                        exponents.Add(exponent);
+                    }
+                }
+                else
+                {
+                    exponents.AddRange(new[]
+                    {
+                        BigInteger.Zero, BigInteger.One, BigInteger.One << 1,
+                        BigFloat.GetBias(exponentSize), maxExponent - 1
+                    });
+                }
+
+                foreach (var exponent in exponents)
+                {
+                    for (var i = 0; i < (exponents.Count > 8 ? 6 : 40) && mismatches.Count < 10; i++)
+                    {
+                        var significand = i switch
+                        {
+                            0 => BigInteger.Zero,
+                            1 => (BigInteger.One << (SingleSignificand - 1)) - 1,
+                            _ => new BigInteger(random.Next(1 << (SingleSignificand - 1)))
+                        };
+
+                        var value = new BigFloat(i % 2 == 0, significand, exponent, SingleSignificand, exponentSize);
+                        var text = value.ToString();
+
+                        if (!BigFloat.TryParse(text, out var loose) || Internals(loose) != Internals(value))
+                        {
+                            mismatches.Add($"{text} parsed back as {Describe(loose)}, want {Describe(value)}");
+                        }
+
+                        // An exact literal is precisely what strict mode exists to accept.
+                        if (!BigFloat.TryParseExact(text, out var strict) || Internals(strict) != Internals(value))
+                        {
+                            mismatches.Add($"{text} rejected or altered by strict parsing: {Describe(strict)}");
+                        }
+                    }
+                }
+
+                // The infinities round-trip with their sign. A NaN does not: it prints as 0NaN<s>e<e> with
+                // no sign, so parsing any NaN back gives the positive one.
+                foreach (var infinity in new[] { false, true })
+                {
+                    var value = BigFloat.CreateInfinity(infinity, SingleSignificand, exponentSize);
+                    Assert.IsTrue(BigFloat.TryParse(value.ToString(), out var back), value.ToString());
+                    Assert.AreEqual(Internals(value), Internals(back), $"{value} should round-trip");
+                }
+
+                var positiveNaN = BigFloat.CreateNaN(false, SingleSignificand, exponentSize);
+                foreach (var negative in new[] { false, true })
+                {
+                    var nan = BigFloat.CreateNaN(negative, SingleSignificand, exponentSize);
+                    Assert.IsTrue(BigFloat.TryParse(nan.ToString(), out var back), nan.ToString());
+                    Assert.AreEqual(Internals(positiveNaN), Internals(back),
+                        $"{nan} should round-trip to the positive NaN, since its sign is not printed");
+                }
+            }
+
+            Assert.IsEmpty(mismatches, string.Join("; ", mismatches));
         }
 
+        /// <summary>
+        /// A 24-bit significand occupies exactly six hex digits, so one further digit weighs that many
+        /// sixteenths of an ULP: below eight rounds down, above eight rounds up, and eight is an exact tie
+        /// that must go to the even neighbour. Every rounding decision in the parser is therefore a closed
+        /// form, with no oracle in the way -- and since only the significand's width matters, the same
+        /// construction checks the wide exponent sizes that no oracle can reach.
+        /// </summary>
+        [Test]
+        public void ParsedLiteralRoundsItsTailCorrectly()
+        {
+            const string hexDigits = "0123456789ABCDEF";
+            var random = new Random(2718);
+            var wrong = new List<string>();
+            var exercised = new List<string>();
+
+            foreach (var exponentSize in new[] { SingleExponent, 11, 16, 40 })
+            {
+                for (var i = 0; i < 6000 && wrong.Count < 10; i++)
+                {
+                    // The leading bit is set, so the value formats as exactly six hex digits.
+                    var significand = i switch
+                    {
+                        0 => 1 << (SingleSignificand - 1),           // 0x800000, even
+                        1 => (1 << (SingleSignificand - 1)) + 1,     // 0x800001, odd
+                        2 => (1 << SingleSignificand) - 1,           // 0xFFFFFF, the case that carries
+                        _ => (1 << (SingleSignificand - 1)) + random.Next(1 << (SingleSignificand - 1))
+                    };
+                    var tail = i < 3 ? 8 : random.Next(16);
+                    // Kept well inside the narrowest format's normal range, so no case here over- or
+                    // underflows; the boundaries have their own tests.
+                    var hexExponent = i < 3 ? 0 : random.Next(-25, 26);
+                    var negative = random.Next(2) == 0;
+
+                    var digits = significand.ToString("X6");
+                    var literal = $"{(negative ? "-" : "")}0x{digits[0]}.{digits[1..]}{hexDigits[tail]}"
+                                  + $"e{hexExponent}f{SingleSignificand}e{exponentSize}";
+
+                    // Ties to even, so an exact half only moves an odd significand.
+                    var roundsUp = tail > 8 || (tail == 8 && (significand & 1) != 0);
+                    var rounded = roundsUp ? significand + 1 : significand;
+
+                    // Bit 0 of the seven printed digits weighs 2^(4*hexExponent - 24), so the retained
+                    // significand weighs four bits more; a carry moves its leading bit up by one.
+                    var carried = rounded == 1 << SingleSignificand;
+                    var leadingBit = carried ? SingleSignificand : SingleSignificand - 1;
+                    var expected = (
+                        exponent: 4 * hexExponent - 20 + leadingBit + BigFloat.GetBias(exponentSize),
+                        significand: carried ? BigInteger.Zero : rounded - (1 << (SingleSignificand - 1)),
+                        signBit: negative);
+
+                    var rounding = carried ? "carry"
+                        : tail < 8 ? "down"
+                        : tail > 8 ? "up"
+                        : roundsUp ? "tie to even, upward" : "tie to even, downward";
+                    if (!exercised.Contains(rounding))
+                    {
+                        exercised.Add(rounding);
+                    }
+
+                    if (!BigFloat.TryParse(literal, out var actual) || Internals(actual) != expected)
+                    {
+                        wrong.Add($"{literal}: got {Describe(actual)}, want (exp {expected.exponent}, "
+                                  + $"sig {expected.significand})");
+                    }
+                }
+            }
+
+            Assert.IsEmpty(wrong, string.Join("; ", wrong));
+
+            // A sampled sweep is worth only the cases it happens to draw, so say which ones it needed.
+            foreach (var rounding in new[]
+                     { "down", "up", "tie to even, upward", "tie to even, downward", "carry" })
+            {
+                Assert.IsTrue(exercised.Contains(rounding), $"the sweep never exercised: {rounding}");
+            }
+
+            // Past the top of the range the same construction must give infinity rather than wrapping.
+            Assert.IsTrue(BigFloat.TryParse("0x8.000000e31f24e8", out var largest));
+            Assert.IsFalse(largest.IsInfinity, "0x8.000000e31f24e8 is still finite at (24,8)");
+            Assert.IsTrue(BigFloat.TryParse("0x8.000000e32f24e8", out var overflowed));
+            Assert.IsTrue(overflowed.IsInfinity, "0x8.000000e32f24e8 overflows at (24,8)");
+        }
+
+        /// <summary>
+        /// Literals below the subnormal grid round to nearest rather than flushing to zero. The smallest
+        /// subnormal at (24,8) is 2^-149, which 0x8.0e-38f24e8 names exactly, so each literal below is the
+        /// stated fraction of it: above half rounds up to it, half itself is a tie that goes to the even
+        /// zero, and below half rounds down.
+        ///
+        /// The band strictly between half and one is the whole of what this PR changes about parsing. The
+        /// old parser decided "below the grid" from the exponent before rounding, so it rejected all of
+        /// these in strict mode and flushed them to zero otherwise. Nothing the old parser accepted has
+        /// changed value, and nothing it accepted is now rejected.
+        /// </summary>
+        [Test]
+        public void LiteralsBelowTheSubnormalGridRoundToNearest()
+        {
+            foreach (var (literal, fraction, expected, strictAccepts) in new[]
+                     {
+                         ("0x2.0e-38f24e8", "a quarter", 0, false),
+                         ("0x4.0e-38f24e8", "half, an exact tie", 0, false),
+                         ("0x5.0e-38f24e8", "five eighths", 1, true),
+                         ("0x6.0e-38f24e8", "three quarters", 1, true),
+                         ("0x7.FFFFFFe-38f24e8", "a hair under one", 1, true),
+                         ("0x8.0e-38f24e8", "exactly one", 1, true),
+                         ("0xC.0e-38f24e8", "one and a half, an exact tie", 2, true)
+                     })
+            {
+                foreach (var sign in new[] { "", "-" })
+                {
+                    // Underflow keeps the sign, so a literal that flushes to zero gives a signed zero.
+                    Assert.IsTrue(BigFloat.TryParse(sign + literal, out var value), sign + literal);
+                    AssertSubnormal(value, expected, $"{sign}{literal} is {sign}{fraction} of 2^-149");
+                    Assert.AreEqual(sign == "-", Internals(value).signBit, $"{sign}{literal}: sign");
+
+                    // Strict mode rejects exactly those that lose everything, which is a consequence of the
+                    // rounding rather than a rule of its own: it accepts inexact subnormals either way.
+                    Assert.AreEqual(strictAccepts, BigFloat.TryParseExact(sign + literal, out _),
+                        $"{sign}{literal}: strict mode");
+                }
+            }
+        }
+
+        /// <summary>
+        /// The mirror of the case above, at the top of the subnormal range rather than the bottom. The
+        /// largest subnormal is (2^23-1)*2^-149 and the smallest normal is 2^-126, so (2^24-1)*2^-150 sits
+        /// exactly halfway between them and must tie to the even neighbour, which is the normal one. Strict
+        /// mode draws its line here too, rejecting a literal that rounds up out of the subnormal range.
+        /// </summary>
+        [Test]
+        public void LiteralsAtTheTopOfTheSubnormalRangeCarryIntoNormal()
+        {
+            var largestSubnormal = (BigInteger.One << (SingleSignificand - 1)) - 1;
+
+            foreach (var (literal, what, exponent, significand, strictAccepts) in new[]
+                     {
+                         ("0x3.FFFFF8e-32f24e8", "the largest subnormal exactly",
+                             0, largestSubnormal, true),
+                         ("0x3.FFFFFCe-32f24e8", "halfway to the smallest normal, so it ties to it",
+                             1, BigInteger.Zero, false),
+                         ("0x3.FFFFFEe-32f24e8", "past halfway, so it rounds up to the smallest normal",
+                             1, BigInteger.Zero, false)
+                     })
+            {
+                Assert.IsTrue(BigFloat.TryParse(literal, out var value), literal);
+                Assert.AreEqual(((BigInteger)exponent, significand, false), Internals(value),
+                    $"{literal} is {what}");
+                Assert.AreEqual(strictAccepts, BigFloat.TryParseExact(literal, out _),
+                    $"{literal}: strict mode");
+            }
+        }
+
+        private static BigFloat Apply(char op, BigFloat left, BigFloat right)
+        {
+            return op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
+        }
     }
 }

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -94,8 +94,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// The stored exponent, significand and sign, which no public member exposes. Comparing these is
-        /// what makes a 1-ULP difference visible without parsing it back out of ToString().
+        /// The stored exponent, significand and sign. Only ToSMTLibString exposes these publicly, and only
+        /// as text, so reading the fields is what makes a 1-ULP difference visible as a value.
         /// </summary>
         private static (BigInteger exponent, BigInteger significand, bool signBit) Internals(BigFloat value)
         {
@@ -680,8 +680,8 @@ namespace BaseTypesTests
                 // The product falls below the grid entirely, however wide the exponent.
                 Assert.IsTrue((left * right).IsZero, $"{label}: subnormal product should underflow to zero");
 
-                // The quotient of two subnormals is a plain ratio, so it lands in [1,2) at the format's own
-                // bias, with a significand that does not depend on the exponent size either.
+                // These two significands divide to a ratio in [1,2), so the quotient lands at the format's
+                // own bias, with a significand that does not depend on the exponent size either.
                 Assert.AreEqual((BigFloat.GetBias(exponentSize), (BigInteger)6865091, false),
                     Internals(left / right), $"{label}: quotient");
 
@@ -775,8 +775,8 @@ namespace BaseTypesTests
 
         /// <summary>
         /// Printing and parsing must be inverse: <see cref="BigFloat.ToString"/> emits an exact literal, so
-        /// parsing it back has nothing to round and must reproduce the value in both modes. This is the only
-        /// check on the parser that reaches the wide formats, since it needs no oracle.
+        /// parsing it back has nothing to round and must reproduce the value in both modes. Needing no
+        /// oracle, this reaches the wide formats.
         /// </summary>
         [Test]
         public void PrintingAndParsingAreInverse()

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -102,12 +102,31 @@ namespace BaseTypesTests
                 : (biasedExponent, quotient - (BigInteger.One << (significandSize - 1)));
         }
 
+        /// <summary>
+        /// The stored exponent, significand and sign, which no public member exposes. Comparing these
+        /// rather than ToString() is what makes a 1-ULP difference visible: ToString() is injective on
+        /// finite values, but a mis-rounded result and the correct one differ in the last bit, and reading
+        /// that back out of a formatted string is more fragile than reading the field.
+        /// </summary>
         private static (BigInteger exponent, BigInteger significand, bool signBit) Internals(BigFloat value)
         {
-            Type type = typeof(BigFloat);
-            return ((BigInteger)type.GetField("exponent", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(value),
-                    (BigInteger)type.GetField("significand", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(value),
-                    (bool)type.GetField("signBit", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(value));
+            return ((BigInteger)Field("exponent").GetValue(value),
+                    (BigInteger)Field("significand").GetValue(value),
+                    (bool)Field("signBit").GetValue(value));
+        }
+
+        /// <summary>
+        /// Looks up a private BigFloat field, failing with the field's name rather than a
+        /// NullReferenceException from the caller if it has been renamed.
+        /// </summary>
+        private static FieldInfo Field(string name)
+        {
+            var field = typeof(BigFloat).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field,
+                $"BigFloat has no private field '{name}'. This fixture reads the stored exponent, "
+                + "significand and sign directly, since no public member exposes them; update Internals "
+                + "if the fields were renamed.");
+            return field;
         }
 
         /// <summary>float is bit-for-bit BigFloat(24,8).</summary>
@@ -222,9 +241,9 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// The smallest hand-checkable case BigFloat currently gets wrong, kept separate so the exact
+        /// The smallest hand-checkable case of the double-rounding defect, kept separate so the exact
         /// arithmetic sits next to the expectation: 2^27/15 = 8947848 remainder 8, and 2*8 > 15, so the
-        /// correctly rounded significand is 8947849 - 2^23 = 559241.
+        /// correctly rounded significand is 8947849 - 2^23 = 559241. Rounding twice yields 559240.
         /// </summary>
         [Test]
         public void FromRationalRoundsOneFifteenthCorrectly()
@@ -232,7 +251,7 @@ namespace BaseTypesTests
             BigFloat.FromRational(1, 15, SingleSignificand, SingleExponent, out var actual);
             var (exponent, significand, _) = Internals(actual);
 
-            Assert.AreEqual((BigInteger)123, exponent);
+            Assert.AreEqual((BigInteger)123, exponent, "biased exponent of 1/15");
             Assert.AreEqual((BigInteger)559241, significand, $"off by {significand - 559241}");
         }
 
@@ -639,6 +658,120 @@ namespace BaseTypesTests
             }
 
             Assert.IsEmpty(wrong, string.Join("; ", wrong));
+        }
+
+
+        /// <summary>
+        /// Exponent sizes are unbounded, and a wide one puts the subnormal boundary at a scale that
+        /// cannot be shifted to directly: a 40-bit exponent field reaches 2^-549755813888, so any
+        /// attempt to materialize 2^shift or the shifted value overflows BigInteger itself.
+        ///
+        /// Nothing covered this before. BigFloatTests exercises 16-bit exponents at the top of their
+        /// range and 30-bit ones only by construction, and the defect needs both a wide exponent and a
+        /// result that underflows into the subnormal range.
+        /// </summary>
+        [Test]
+        public void ArithmeticWorksAtWideExponentSizes()
+        {
+            foreach (var exponentSize in new[] { 16, 20, 33, 40, 64, 100 })
+            {
+                // Two subnormals, whose product underflows far below the smallest representable value.
+                var left = new BigFloat(false, 12345, 0, SingleSignificand, exponentSize);
+                var right = new BigFloat(false, 6789, 0, SingleSignificand, exponentSize);
+
+                Assert.DoesNotThrow(() =>
+                {
+                    var product = left * right;
+                    Assert.IsTrue(product.IsZero, $"exponentSize {exponentSize}: subnormal product should underflow to zero");
+
+                    var quotient = left / right;
+                    Assert.IsFalse(quotient.IsNaN, $"exponentSize {exponentSize}: subnormal quotient should be a number");
+
+                    var sum = left + right;
+                    Assert.IsFalse(sum.IsNaN, $"exponentSize {exponentSize}: subnormal sum should be a number");
+
+                    BigFloat.FromRational(1, 3, SingleSignificand, exponentSize, out _);
+                }, $"exponentSize {exponentSize}");
+            }
+        }
+
+        /// <summary>
+        /// A wider exponent field only moves the range; it does not change how values inside that range
+        /// round. So the same operands, shifted by the difference in bias, must give the same significand
+        /// at any exponent size -- which checks the wide-format paths against hardware without needing an
+        /// oracle that can normalize across billions of binades.
+        /// </summary>
+        [Test]
+        public void WideExponentSizesRoundLikeSinglePrecision()
+        {
+            var random = new Random(777);
+            var mismatches = new List<string>();
+
+            foreach (var exponentSize in new[] { 9, 12, 16, 20, 33, 40, 64 })
+            {
+                var biasDifference = ((BigInteger.One << (exponentSize - 1)) - 1) - 127;
+
+                for (var i = 0; i < 2000 && mismatches.Count < 5; i++)
+                {
+                    var leftBits = random.Next(int.MinValue, int.MaxValue);
+                    var rightBits = random.Next(int.MinValue, int.MaxValue);
+                    var leftExponent = (leftBits >> 23) & 0xFF;
+                    var rightExponent = (rightBits >> 23) & 0xFF;
+
+                    // Keep both operands normal, so shifting the exponent is an exact relabelling.
+                    if (leftExponent == 0 || leftExponent == 0xFF || rightExponent == 0 || rightExponent == 0xFF)
+                    {
+                        continue;
+                    }
+
+                    var leftNegative = (leftBits >> 31) != 0;
+                    var rightNegative = (rightBits >> 31) != 0;
+                    var leftSignificand = leftBits & 0x7FFFFF;
+                    var rightSignificand = rightBits & 0x7FFFFF;
+
+                    var narrowLeft = new BigFloat(leftNegative, leftSignificand, leftExponent, SingleSignificand, SingleExponent);
+                    var narrowRight = new BigFloat(rightNegative, rightSignificand, rightExponent, SingleSignificand, SingleExponent);
+                    var wideLeft = new BigFloat(leftNegative, leftSignificand, leftExponent + biasDifference, SingleSignificand, exponentSize);
+                    var wideRight = new BigFloat(rightNegative, rightSignificand, rightExponent + biasDifference, SingleSignificand, exponentSize);
+
+                    foreach (var op in new[] { '+', '-', '*', '/' })
+                    {
+                        var narrow = Apply(op, narrowLeft, narrowRight);
+                        var wide = Apply(op, wideLeft, wideRight);
+
+                        // Only comparable where both are normal: at the edges the narrow format
+                        // underflows or overflows while the wide one still has room.
+                        if (!narrow.IsNormal || !wide.IsNormal)
+                        {
+                            continue;
+                        }
+
+                        var (narrowExponent, narrowFraction, narrowSign) = Internals(narrow);
+                        var (wideExponent, wideFraction, wideSign) = Internals(wide);
+
+                        if (narrowFraction != wideFraction || wideExponent - narrowExponent != biasDifference
+                            || narrowSign != wideSign)
+                        {
+                            mismatches.Add($"exponentSize {exponentSize}, {op}: (24,8) gave "
+                                + $"(exp {narrowExponent}, sig {narrowFraction}), wide gave "
+                                + $"(exp {wideExponent}, sig {wideFraction})");
+                        }
+                    }
+                }
+            }
+
+            Assert.IsEmpty(mismatches, string.Join("; ", mismatches));
+        }
+
+        private static BigFloat Apply(char op, BigFloat left, BigFloat right)
+        {
+            return op switch
+            {
+                '+' => left + right,
+                '-' => left - right,
+                '*' => left * right,
+                _ => right.IsZero ? left : left / right
+            };
         }
 
     }

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -376,6 +376,7 @@ namespace BaseTypesTests
         private static IEnumerable<TestCaseData> CorrectOperators()
         {
             yield return new TestCaseData('*').SetName("Multiplication");
+            yield return new TestCaseData('/').SetName("Division");
         }
 
         /// <summary>
@@ -386,7 +387,6 @@ namespace BaseTypesTests
         {
             yield return new TestCaseData('+').SetName("Addition");
             yield return new TestCaseData('-').SetName("Subtraction");
-            yield return new TestCaseData('/').SetName("Division");
         }
 
         /// <summary>
@@ -395,8 +395,8 @@ namespace BaseTypesTests
         /// that is where two of the known defects live.
         /// </summary>
         [TestCaseSource(nameof(OperatorsUnderRepair))]
-        [Ignore("Rounding is applied twice, so these disagree with IEEE 754 on a substantial fraction of "
-                + "inputs: / about 14%, + and - about 9% at (24,8). See FLOAT_AUDIT.md sections 1 and 2.")]
+        [Ignore("Addition truncates when aligning operands, so bits are lost before the sum is formed: "
+                + "about 9% of inputs disagree with IEEE 754 at (24,8). See FLOAT_AUDIT.md section 2.")]
         public void OperatorMatchesHardwareOverRandomInputs(char op)
         {
             var random = new Random(31415);
@@ -442,8 +442,8 @@ namespace BaseTypesTests
         /// (24,8) than at (53,11) - so a fix verified only at single precision proves less than it looks.
         /// </summary>
         [TestCaseSource(nameof(OperatorsUnderRepair))]
-        [Ignore("Same double-rounding defects as at single precision, with different rates: / about 14%, "
-                + "+ and - about 2.5% at (53,11). See FLOAT_AUDIT.md sections 1 and 2.")]
+        [Ignore("Same truncation defect as at single precision, with a different rate: + and - about "
+                + "2.5% at (53,11). See FLOAT_AUDIT.md section 2.")]
         public void OperatorMatchesHardwareAtDoublePrecision(char op)
         {
             var random = new Random(9001);

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -372,11 +372,20 @@ namespace BaseTypesTests
             }
         }
 
-        private static IEnumerable<TestCaseData> Operators()
+        /// <summary>Operators that round correctly and are held to it.</summary>
+        private static IEnumerable<TestCaseData> CorrectOperators()
+        {
+            yield return new TestCaseData('*').SetName("Multiplication");
+        }
+
+        /// <summary>
+        /// Operators that still round twice. Each moves to CorrectOperators as it is fixed, so this
+        /// list shrinking to empty is the measure of progress.
+        /// </summary>
+        private static IEnumerable<TestCaseData> OperatorsUnderRepair()
         {
             yield return new TestCaseData('+').SetName("Addition");
             yield return new TestCaseData('-').SetName("Subtraction");
-            yield return new TestCaseData('*').SetName("Multiplication");
             yield return new TestCaseData('/').SetName("Division");
         }
 
@@ -385,10 +394,9 @@ namespace BaseTypesTests
         /// fixed seed so a failure is reproducible. Subnormal operands and results are included, since
         /// that is where two of the known defects live.
         /// </summary>
-        [TestCaseSource(nameof(Operators))]
-        [Ignore("Every operator except * disagrees with IEEE 754 on a substantial fraction of inputs "
-                + "because rounding is applied twice: / about 14%, + and - about 9% at (24,8). * is at "
-                + "about 0.1%, entirely on subnormal results. See FLOAT_AUDIT.md sections 1, 2 and 7.")]
+        [TestCaseSource(nameof(OperatorsUnderRepair))]
+        [Ignore("Rounding is applied twice, so these disagree with IEEE 754 on a substantial fraction of "
+                + "inputs: / about 14%, + and - about 9% at (24,8). See FLOAT_AUDIT.md sections 1 and 2.")]
         public void OperatorMatchesHardwareOverRandomInputs(char op)
         {
             var random = new Random(31415);
@@ -433,7 +441,7 @@ namespace BaseTypesTests
         /// The same sweep at double precision. Rates differ by precision - addition is far worse at
         /// (24,8) than at (53,11) - so a fix verified only at single precision proves less than it looks.
         /// </summary>
-        [TestCaseSource(nameof(Operators))]
+        [TestCaseSource(nameof(OperatorsUnderRepair))]
         [Ignore("Same double-rounding defects as at single precision, with different rates: / about 14%, "
                 + "+ and - about 2.5% at (53,11). See FLOAT_AUDIT.md sections 1 and 2.")]
         public void OperatorMatchesHardwareAtDoublePrecision(char op)
@@ -603,5 +611,18 @@ namespace BaseTypesTests
 
             Assert.AreEqual(0L, worst, $"chained arithmetic drifted by up to {worst} ULP from hardware");
         }
+
+        [TestCaseSource(nameof(CorrectOperators))]
+        public void CorrectOperatorMatchesHardwareOverRandomInputs(char op)
+        {
+            OperatorMatchesHardwareOverRandomInputs(op);
+        }
+
+        [TestCaseSource(nameof(CorrectOperators))]
+        public void CorrectOperatorMatchesHardwareAtDoublePrecision(char op)
+        {
+            OperatorMatchesHardwareAtDoublePrecision(op);
+        }
+
     }
 }

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -944,12 +944,8 @@ namespace BaseTypesTests
         /// Literals below the subnormal grid round to nearest rather than flushing to zero. The smallest
         /// subnormal at (24,8) is 2^-149, which 0x8.0e-38f24e8 names exactly, so each literal below is the
         /// stated fraction of it: above half rounds up to it, half itself is a tie that goes to the even
-        /// zero, and below half rounds down.
-        ///
-        /// The band strictly between half and one is the whole of what this PR changes about parsing. The
-        /// old parser decided "below the grid" from the exponent before rounding, so it rejected all of
-        /// these in strict mode and flushed them to zero otherwise. Nothing the old parser accepted has
-        /// changed value, and nothing it accepted is now rejected.
+        /// zero, and below half rounds down. Deciding "below the grid" from the exponent before rounding
+        /// would flush the whole band to zero instead.
         /// </summary>
         [Test]
         public void LiteralsBelowTheSubnormalGridRoundToNearest()

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -1,0 +1,607 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Reflection;
+using NUnit.Framework;
+using Microsoft.BaseTypes;
+
+namespace BaseTypesTests
+{
+    /// <summary>
+    /// Compares BigFloat against an oracle that shares no code with it.
+    ///
+    /// This matters because BigFloat cannot check itself: FromRational, FromBigDec, FromString and all
+    /// four arithmetic operators route through the same rounding helpers, so a systematic error in those
+    /// helpers makes every one of them agree while all are wrong. Tests written against FromRational
+    /// expectations therefore cannot detect it, which is why BigFloatTests passes at full strength while
+    /// division disagrees with IEEE 754 on roughly one input in five.
+    ///
+    /// Two oracles are used, and cross-checked against each other before either is trusted:
+    ///
+    ///   1. ExactRoundToNearestEven - the correctly rounded value of a rational, computed entirely in
+    ///      BigInteger with exactly one rounding step. Independent of BigFloat and valid at any precision.
+    ///   2. Hardware - float is bit-for-bit BigFloat(24,8) and double is bit-for-bit BigFloat(53,11).
+    ///      Arithmetic must be done *in the target precision*: computing a float result via double
+    ///      ((float)((double)a / b)) rounds twice and reproduces the very defect under test.
+    /// </summary>
+    [TestFixture]
+    public class BigFloatDifferentialTests
+    {
+        private const int SingleSignificand = 24;
+        private const int SingleExponent = 8;
+
+        /// <summary>
+        /// Correctly rounded round-to-nearest-even value of numerator/denominator in the given format,
+        /// as (biasedExponent, trailingSignificand). Pure BigInteger, one rounding step, no floating
+        /// point anywhere. Returns null when the value overflows to infinity.
+        /// </summary>
+        private static (BigInteger exponent, BigInteger significand)? ExactRoundToNearestEven(
+            BigInteger numerator, BigInteger denominator, int significandSize, int exponentSize)
+        {
+            if (numerator.IsZero)
+            {
+                return (BigInteger.Zero, BigInteger.Zero);
+            }
+
+            BigInteger bias = (BigInteger.One << (exponentSize - 1)) - 1;
+            BigInteger maxExponent = (BigInteger.One << exponentSize) - 1;
+            var scale = 0;
+
+            // Scale until the quotient occupies exactly significandSize bits.
+            while (numerator / denominator >= BigInteger.One << significandSize)
+            {
+                denominator <<= 1;
+                scale++;
+            }
+
+            while (numerator / denominator < BigInteger.One << (significandSize - 1))
+            {
+                numerator <<= 1;
+                scale--;
+            }
+
+            // Below the smallest normal, every value shares one exponent, so clamp onto that grid.
+            var minScale = (int)(1 - bias - (significandSize - 1));
+            if (scale + significandSize - 1 < 1 - bias)
+            {
+                while (scale < minScale)
+                {
+                    denominator <<= 1;
+                    scale++;
+                }
+
+                while (scale > minScale)
+                {
+                    numerator <<= 1;
+                    scale--;
+                }
+            }
+
+            var quotient = BigInteger.DivRem(numerator, denominator, out var remainder);
+
+            // The single rounding, decided against the exact residual.
+            if (remainder * 2 > denominator || (remainder * 2 == denominator && !quotient.IsEven))
+            {
+                quotient++;
+            }
+
+            if (quotient >= BigInteger.One << significandSize)
+            {
+                quotient >>= 1;
+                scale++;
+            }
+
+            if (quotient < BigInteger.One << (significandSize - 1))
+            {
+                return (BigInteger.Zero, quotient); // subnormal
+            }
+
+            var biasedExponent = scale + significandSize - 1 + bias;
+            return biasedExponent >= maxExponent
+                ? null
+                : (biasedExponent, quotient - (BigInteger.One << (significandSize - 1)));
+        }
+
+        private static (BigInteger exponent, BigInteger significand, bool signBit) Internals(BigFloat value)
+        {
+            Type type = typeof(BigFloat);
+            return ((BigInteger)type.GetField("exponent", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(value),
+                    (BigInteger)type.GetField("significand", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(value),
+                    (bool)type.GetField("signBit", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(value));
+        }
+
+        /// <summary>float is bit-for-bit BigFloat(24,8).</summary>
+        private static BigFloat FromSingle(float value)
+        {
+            var bits = BitConverter.SingleToInt32Bits(value);
+            return new BigFloat((bits >> 31) != 0, bits & 0x7FFFFF, (bits >> 23) & 0xFF,
+                SingleSignificand, SingleExponent);
+        }
+
+        /// <summary>double is bit-for-bit BigFloat(53,11).</summary>
+        private static BigFloat FromDouble(double value)
+        {
+            var bits = BitConverter.DoubleToInt64Bits(value);
+            return new BigFloat(bits < 0, (BigInteger)(bits & 0xFFFFFFFFFFFFFL),
+                (BigInteger)((bits >> 52) & 0x7FF), 53, 11);
+        }
+
+        /// <summary>
+        /// Renders a value so that expected and actual are comparable and readable in failure output,
+        /// collapsing the special values that have no (exponent, significand) meaning.
+        /// </summary>
+        private static string Describe(BigFloat value)
+        {
+            if (value.IsNaN)
+            {
+                return "NaN";
+            }
+
+            if (value.IsInfinity)
+            {
+                return value.IsNegative ? "-inf" : "+inf";
+            }
+
+            var (exponent, significand, signBit) = Internals(value);
+            return $"{(signBit ? "-" : "+")}(exp {exponent}, sig {significand})";
+        }
+
+        private static string DescribeSingle(float value)
+        {
+            if (float.IsNaN(value))
+            {
+                return "NaN";
+            }
+
+            return float.IsInfinity(value)
+                ? (value < 0 ? "-inf" : "+inf")
+                : Describe(FromSingle(value));
+        }
+
+        /// <summary>
+        /// Neither oracle is trusted until they agree with each other. If this fails, every other
+        /// result in this fixture is meaningless, so it is the first thing to check.
+        /// </summary>
+        [Test]
+        public void OraclesAgreeWithEachOther()
+        {
+            var disagreements = new List<string>();
+
+            for (var a = 1; a <= 200; a++)
+            {
+                for (var b = 1; b <= 200; b++)
+                {
+                    var hardware = (float)a / b;
+                    if (hardware == 0 || float.IsInfinity(hardware))
+                    {
+                        continue;
+                    }
+
+                    var exact = ExactRoundToNearestEven(a, b, SingleSignificand, SingleExponent);
+                    var (exponent, significand, _) = Internals(FromSingle(hardware));
+
+                    if (exact == null || exact.Value.exponent != exponent || exact.Value.significand != significand)
+                    {
+                        disagreements.Add($"{a}/{b}");
+                    }
+                }
+            }
+
+            Assert.IsEmpty(disagreements,
+                $"the exact oracle and hardware disagree on {disagreements.Count} rationals; "
+                + "one of the two oracles is wrong, so no other test here means anything");
+        }
+
+        /// <summary>
+        /// Rationals whose correctly rounded value is hand-checkable, so a reader can confirm the
+        /// expectations without running or trusting either oracle. For 1/15 at (24,8):
+        /// 2^27/15 = 8947848 remainder 8; 2*8 > 15, so round up to 8947849; less the implicit
+        /// 2^23 that leaves a trailing significand of 559241.
+        /// </summary>
+        private static IEnumerable<TestCaseData> HandCheckedRationals()
+        {
+            yield return new TestCaseData(1, 3, 125, 2796203).SetName("OneThird");
+            yield return new TestCaseData(2, 3, 126, 2796203).SetName("TwoThirds");
+            yield return new TestCaseData(1, 10, 123, 5033165).SetName("OneTenth");
+            yield return new TestCaseData(1, 2, 126, 0).SetName("Half");
+            yield return new TestCaseData(3, 1, 128, 4194304).SetName("Three");
+        }
+
+        [TestCaseSource(nameof(HandCheckedRationals))]
+        public void FromRationalMatchesHandCheckedValue(int numerator, int denominator,
+            int expectedExponent, int expectedSignificand)
+        {
+            BigFloat.FromRational(numerator, denominator, SingleSignificand, SingleExponent, out var actual);
+            var (exponent, significand, _) = Internals(actual);
+
+            Assert.AreEqual((BigInteger)expectedExponent, exponent,
+                $"{numerator}/{denominator}: wrong exponent");
+            Assert.AreEqual((BigInteger)expectedSignificand, significand,
+                $"{numerator}/{denominator}: wrong significand (off by {significand - expectedSignificand})");
+        }
+
+        /// <summary>
+        /// The smallest hand-checkable case BigFloat currently gets wrong, kept separate so the exact
+        /// arithmetic sits next to the expectation: 2^27/15 = 8947848 remainder 8, and 2*8 > 15, so the
+        /// correctly rounded significand is 8947849 - 2^23 = 559241.
+        /// </summary>
+        [Test]
+        [Ignore("BigFloat.FromRational rounds twice, so the residual that breaks this tie is discarded "
+                + "before the second rounding sees it: 1/15 at (24,8) yields 559240, not 559241. "
+                + "See FLOAT_AUDIT.md section 3.")]
+        public void FromRationalRoundsOneFifteenthCorrectly()
+        {
+            BigFloat.FromRational(1, 15, SingleSignificand, SingleExponent, out var actual);
+            var (exponent, significand, _) = Internals(actual);
+
+            Assert.AreEqual((BigInteger)123, exponent);
+            Assert.AreEqual((BigInteger)559241, significand, $"off by {significand - 559241}");
+        }
+
+        [Test]
+        [Ignore("BigFloat.FromRational rounds twice: ApplyRoundToNearestEven discards the remainder that "
+                + "the later ApplyShiftWithRounding needs to break ties. 1/15 at (24,8) yields significand "
+                + "559240 where 559241 is correct; the rate over a,b in [1,200] is about 4.4%.")]
+        public void FromRationalIsCorrectlyRounded()
+        {
+            var wrong = new List<string>();
+
+            for (var a = 1; a <= 200; a++)
+            {
+                for (var b = 1; b <= 200; b++)
+                {
+                    var exact = ExactRoundToNearestEven(a, b, SingleSignificand, SingleExponent);
+                    if (exact == null)
+                    {
+                        continue;
+                    }
+
+                    BigFloat.FromRational(a, b, SingleSignificand, SingleExponent, out var actual);
+                    var (exponent, significand, _) = Internals(actual);
+
+                    if (exponent != exact.Value.exponent || significand != exact.Value.significand)
+                    {
+                        wrong.Add($"{a}/{b}: got (exp {exponent}, sig {significand}), "
+                                  + $"want (exp {exact.Value.exponent}, sig {exact.Value.significand})");
+                    }
+                }
+            }
+
+            Assert.IsEmpty(wrong, $"{wrong.Count} rationals mis-rounded, e.g. {string.Join("; ", wrong.GetRange(0, Math.Min(5, wrong.Count)))}");
+        }
+
+        /// <summary>
+        /// Exactly representable results, where no rounding is required and every operator should already
+        /// agree. Kept separate from the rounding tests so that a failure here means something much worse
+        /// than a last-bit disagreement.
+        /// </summary>
+        [Test]
+        public void ExactResultsNeedNoRounding()
+        {
+            var cases = new (float Left, float Right, char Op)[]
+            {
+                (1f, 1f, '+'), (2f, 3f, '*'), (1f, 2f, '/'), (0.5f, 0.25f, '+'),
+                (1000000f, 1f, '+'), (6f, 2f, '/'), (0.75f, 0.25f, '-'), (16777216f, 1f, '+')
+            };
+
+            foreach (var (left, right, op) in cases)
+            {
+                var expected = op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
+                var actual = op switch
+                {
+                    '+' => FromSingle(left) + FromSingle(right),
+                    '-' => FromSingle(left) - FromSingle(right),
+                    '*' => FromSingle(left) * FromSingle(right),
+                    _ => FromSingle(left) / FromSingle(right)
+                };
+
+                Assert.AreEqual(DescribeSingle(expected), Describe(actual), $"{left} {op} {right}");
+            }
+        }
+
+        /// <summary>
+        /// Special values, signed zeros and the range boundaries. These are structural rather than
+        /// rounding properties, and BigFloat gets all of them right - the point of pinning them is to
+        /// keep it that way while the rounding paths are rewritten.
+        /// </summary>
+        [Test]
+        public void BoundariesAndSignedZerosMatchHardware()
+        {
+            const float smallestSubnormal = float.Epsilon;
+            const float smallestNormal = 1.17549435e-38f;
+            var max = float.MaxValue;
+
+            var cases = new (string Name, float Left, float Right, char Op)[]
+            {
+                ("max + max", max, max, '+'),
+                ("-max - max", -max, max, '-'),
+                ("max * 2", max, 2f, '*'),
+                ("max / 0.5", max, 0.5f, '/'),
+                ("smallestSubnormal / 2", smallestSubnormal, 2f, '/'),
+                ("smallestNormal / 2", smallestNormal, 2f, '/'),
+                ("smallestNormal - smallestSubnormal", smallestNormal, smallestSubnormal, '-'),
+                ("smallestSubnormal + smallestSubnormal", smallestSubnormal, smallestSubnormal, '+'),
+                ("+0 + -0", 0f, -0f, '+'),
+                ("-0 + -0", -0f, -0f, '+'),
+                ("+0 - -0", 0f, -0f, '-'),
+                ("-0 - +0", -0f, 0f, '-'),
+                ("subnormal - subnormal", smallestSubnormal, smallestSubnormal, '-'),
+                ("-subnormal + subnormal", -smallestSubnormal, smallestSubnormal, '+'),
+                // Cancellation of equal magnitudes: IEEE 754 gives -0 only when both operands are
+                // negative, so these pin the sign that a naive "either operand negative" test gets wrong.
+                ("1 - 1", 1f, 1f, '-'),
+                ("-1 + 1", -1f, 1f, '+'),
+                ("-1 - -1", -1f, -1f, '-'),
+                ("-1 + -1 magnitudes cancel", -1f, 1f, '+'),
+                ("2 - 2", 2f, 2f, '-'),
+                ("-2.5 + 2.5", -2.5f, 2.5f, '+')
+            };
+
+            foreach (var (name, left, right, op) in cases)
+            {
+                var expected = op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
+                var actual = op switch
+                {
+                    '+' => FromSingle(left) + FromSingle(right),
+                    '-' => FromSingle(left) - FromSingle(right),
+                    '*' => FromSingle(left) * FromSingle(right),
+                    _ => FromSingle(left) / FromSingle(right)
+                };
+
+                Assert.AreEqual(DescribeSingle(expected), Describe(actual), name);
+            }
+        }
+
+        /// <summary>
+        /// Ties, where rounding to nearest-even is the only correct answer and off-by-one-ULP shows up
+        /// immediately. At 2^24 the gap between representable values is 2, so 2^24+1 is exactly halfway
+        /// and must round down to the even 2^24, while 2^24+3 must round up to 2^24+4.
+        /// </summary>
+        [Test]
+        [Ignore("BigFloat.operator+ truncates when aligning operands (BigIntegerMath.RightShift keeps no "
+                + "sticky bit), so bits are lost before the sum is formed and ties cannot be resolved. "
+                + "2^24 + 3 yields 2^24 + 2 where 2^24 + 4 is correct.")]
+        public void TiesRoundToEven()
+        {
+            const float twoTo24 = 16777216f;
+
+            foreach (var addend in new[] { 1f, 2f, 3f, 5f })
+            {
+                var actual = FromSingle(twoTo24) + FromSingle(addend);
+                Assert.AreEqual(DescribeSingle(twoTo24 + addend), Describe(actual), $"2^24 + {addend}");
+            }
+        }
+
+        private static IEnumerable<TestCaseData> Operators()
+        {
+            yield return new TestCaseData('+').SetName("Addition");
+            yield return new TestCaseData('-').SetName("Subtraction");
+            yield return new TestCaseData('*').SetName("Multiplication");
+            yield return new TestCaseData('/').SetName("Division");
+        }
+
+        /// <summary>
+        /// The broad sweep: random bit patterns through every operator, compared against hardware. Uses a
+        /// fixed seed so a failure is reproducible. Subnormal operands and results are included, since
+        /// that is where two of the known defects live.
+        /// </summary>
+        [TestCaseSource(nameof(Operators))]
+        [Ignore("Every operator except * disagrees with IEEE 754 on a substantial fraction of inputs "
+                + "because rounding is applied twice: / about 14%, + and - about 9% at (24,8). * is at "
+                + "about 0.1%, entirely on subnormal results. See FLOAT_AUDIT.md sections 1, 2 and 7.")]
+        public void OperatorMatchesHardwareOverRandomInputs(char op)
+        {
+            var random = new Random(31415);
+            var wrong = new List<string>();
+            var tested = 0;
+
+            for (var i = 0; i < 200000 && wrong.Count < 10; i++)
+            {
+                var left = BitConverter.Int32BitsToSingle(random.Next(int.MinValue, int.MaxValue));
+                var right = BitConverter.Int32BitsToSingle(random.Next(int.MinValue, int.MaxValue));
+
+                if (float.IsNaN(left) || float.IsNaN(right) || float.IsInfinity(left) || float.IsInfinity(right))
+                {
+                    continue;
+                }
+
+                if (op == '/' && right == 0)
+                {
+                    continue;
+                }
+
+                tested++;
+                var expected = op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
+                var actual = op switch
+                {
+                    '+' => FromSingle(left) + FromSingle(right),
+                    '-' => FromSingle(left) - FromSingle(right),
+                    '*' => FromSingle(left) * FromSingle(right),
+                    _ => FromSingle(left) / FromSingle(right)
+                };
+
+                if (DescribeSingle(expected) != Describe(actual))
+                {
+                    wrong.Add($"{left:R} {op} {right:R}: got {Describe(actual)}, want {DescribeSingle(expected)}");
+                }
+            }
+
+            Assert.IsEmpty(wrong, $"of {tested} inputs: {string.Join("; ", wrong)}");
+        }
+
+        /// <summary>
+        /// The same sweep at double precision. Rates differ by precision - addition is far worse at
+        /// (24,8) than at (53,11) - so a fix verified only at single precision proves less than it looks.
+        /// </summary>
+        [TestCaseSource(nameof(Operators))]
+        [Ignore("Same double-rounding defects as at single precision, with different rates: / about 14%, "
+                + "+ and - about 2.5% at (53,11). See FLOAT_AUDIT.md sections 1 and 2.")]
+        public void OperatorMatchesHardwareAtDoublePrecision(char op)
+        {
+            var random = new Random(9001);
+            var buffer = new byte[8];
+            var wrong = new List<string>();
+            var tested = 0;
+
+            for (var i = 0; i < 100000 && wrong.Count < 10; i++)
+            {
+                random.NextBytes(buffer);
+                var left = BitConverter.ToDouble(buffer, 0);
+                random.NextBytes(buffer);
+                var right = BitConverter.ToDouble(buffer, 0);
+
+                if (double.IsNaN(left) || double.IsNaN(right) || double.IsInfinity(left) || double.IsInfinity(right))
+                {
+                    continue;
+                }
+
+                if (op == '/' && right == 0)
+                {
+                    continue;
+                }
+
+                tested++;
+                var expected = op switch { '+' => left + right, '-' => left - right, '*' => left * right, _ => left / right };
+                var actual = op switch
+                {
+                    '+' => FromDouble(left) + FromDouble(right),
+                    '-' => FromDouble(left) - FromDouble(right),
+                    '*' => FromDouble(left) * FromDouble(right),
+                    _ => FromDouble(left) / FromDouble(right)
+                };
+
+                var expectedText = double.IsInfinity(expected)
+                    ? (expected < 0 ? "-inf" : "+inf")
+                    : (double.IsNaN(expected) ? "NaN" : Describe(FromDouble(expected)));
+
+                if (expectedText != Describe(actual))
+                {
+                    wrong.Add($"{left:R} {op} {right:R}: got {Describe(actual)}, want {expectedText}");
+                }
+            }
+
+            Assert.IsEmpty(wrong, $"of {tested} inputs: {string.Join("; ", wrong)}");
+        }
+
+        /// <summary>
+        /// Decimal literals are the most natural way to write a float value, and FromBigDec inherits
+        /// FromRational's rounding. Note that a handful of familiar decimals (0.1, 0.3, 3.14159) all
+        /// happen to round correctly, so only a sweep exposes this.
+        /// </summary>
+        [Test]
+        [Ignore("FromBigDec delegates to FromRational and inherits its double rounding: about 2.3% of "
+                + "decimals are off by one ULP, e.g. 272516e-5 yields significand 3041542 where 3041541 "
+                + "is correct. See FLOAT_AUDIT.md section 8.")]
+        public void FromBigDecIsCorrectlyRounded()
+        {
+            var random = new Random(8080);
+            var wrong = new List<string>();
+            var tested = 0;
+
+            for (var i = 0; i < 20000 && wrong.Count < 10; i++)
+            {
+                var text = $"{random.Next(1, 1000000)}e{random.Next(-12, 13)}";
+                BigDec value;
+
+                try
+                {
+                    value = BigDec.FromString(text);
+                }
+                catch (FormatException)
+                {
+                    continue;
+                }
+
+                BigInteger numerator, denominator;
+                if (value.Exponent >= 0)
+                {
+                    numerator = value.Mantissa * BigInteger.Pow(10, value.Exponent);
+                    denominator = BigInteger.One;
+                }
+                else
+                {
+                    numerator = value.Mantissa;
+                    denominator = BigInteger.Pow(10, -value.Exponent);
+                }
+
+                if (numerator.IsZero)
+                {
+                    continue;
+                }
+
+                var exact = ExactRoundToNearestEven(numerator, denominator, SingleSignificand, SingleExponent);
+                if (exact == null)
+                {
+                    continue;
+                }
+
+                tested++;
+                BigFloat.FromBigDec(value, SingleSignificand, SingleExponent, out var actual);
+                var (exponent, significand, _) = Internals(actual);
+
+                if (exponent != exact.Value.exponent || significand != exact.Value.significand)
+                {
+                    wrong.Add($"{text}: got (exp {exponent}, sig {significand}), "
+                              + $"want (exp {exact.Value.exponent}, sig {exact.Value.significand})");
+                }
+            }
+
+            Assert.IsEmpty(wrong, $"of {tested} decimals: {string.Join("; ", wrong)}");
+        }
+
+        /// <summary>
+        /// Single-operation error understates the effect on a consumer that chains arithmetic, which is
+        /// how the operators would be used if anything called them. Alternating multiply and divide lets
+        /// the per-operation errors accumulate.
+        /// </summary>
+        [Test]
+        [Ignore("Chained arithmetic accumulates the per-operation rounding error, reaching about 15 ULP "
+                + "over 50 operations. Follows from the defects in sections 1, 2 and 7; see section 9.")]
+        public void ChainedOperationsDoNotDrift()
+        {
+            var random = new Random(1234);
+            var worst = 0L;
+
+            for (var trial = 0; trial < 500; trial++)
+            {
+                var expected = 1.0f + (float)random.NextDouble() * 10f;
+                var actual = FromSingle(expected);
+                var bailed = false;
+
+                for (var step = 0; step < 50; step++)
+                {
+                    var factor = 1.0f + (float)random.NextDouble();
+                    var factorFloat = FromSingle(factor);
+
+                    if (step % 2 == 0)
+                    {
+                        expected *= factor;
+                        actual *= factorFloat;
+                    }
+                    else
+                    {
+                        expected /= factor;
+                        actual /= factorFloat;
+                    }
+
+                    if (float.IsNaN(expected) || float.IsInfinity(expected) || expected == 0)
+                    {
+                        bailed = true;
+                        break;
+                    }
+                }
+
+                if (bailed)
+                {
+                    continue;
+                }
+
+                var (exponent, significand, signBit) = Internals(actual);
+                var actualBits = ((signBit ? 1 : 0) << 31) | (((int)exponent & 0xFF) << 23) | ((int)significand & 0x7FFFFF);
+                worst = Math.Max(worst, Math.Abs((long)BitConverter.SingleToInt32Bits(expected) - actualBits));
+            }
+
+            Assert.AreEqual(0L, worst, $"chained arithmetic drifted by up to {worst} ULP from hardware");
+        }
+    }
+}

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -8,21 +8,15 @@ using Microsoft.BaseTypes;
 namespace BaseTypesTests
 {
     /// <summary>
-    /// Compares BigFloat against an oracle that shares no code with it.
+    /// Compares BigFloat against two oracles that share no code with it, since every conversion and
+    /// operator routes through the same rounding helpers and so cannot catch an error in them:
     ///
-    /// This matters because BigFloat cannot check itself: FromRational, FromBigDec, FromString and all
-    /// four arithmetic operators route through the same rounding helpers, so a systematic error in those
-    /// helpers makes every one of them agree while all are wrong. Tests written against FromRational
-    /// expectations therefore cannot detect it, which is why BigFloatTests passes at full strength while
-    /// division disagrees with IEEE 754 on roughly one input in five.
-    ///
-    /// Two oracles are used, and cross-checked against each other before either is trusted:
-    ///
-    ///   1. ExactRoundToNearestEven - the correctly rounded value of a rational, computed entirely in
-    ///      BigInteger with exactly one rounding step. Independent of BigFloat and valid at any precision.
+    ///   1. ExactRoundToNearestEven - a rational rounded in BigInteger with exactly one rounding step.
     ///   2. Hardware - float is bit-for-bit BigFloat(24,8) and double is bit-for-bit BigFloat(53,11).
-    ///      Arithmetic must be done *in the target precision*: computing a float result via double
-    ///      ((float)((double)a / b)) rounds twice and reproduces the very defect under test.
+    ///      Arithmetic must be done in the target precision, since computing a float result via double
+    ///      rounds twice and reproduces the defect under test.
+    ///
+    /// The two are cross-checked against each other in <see cref="OraclesAgreeWithEachOther"/>.
     /// </summary>
     [TestFixture]
     public class BigFloatDifferentialTests
@@ -31,9 +25,8 @@ namespace BaseTypesTests
         private const int SingleExponent = 8;
 
         /// <summary>
-        /// Correctly rounded round-to-nearest-even value of numerator/denominator in the given format,
-        /// as (biasedExponent, trailingSignificand). Pure BigInteger, one rounding step, no floating
-        /// point anywhere. Returns null when the value overflows to infinity.
+        /// Correctly rounded round-to-nearest-even value of numerator/denominator in the given format, as
+        /// (biasedExponent, trailingSignificand), or null if it overflows to infinity.
         /// </summary>
         private static (BigInteger exponent, BigInteger significand)? ExactRoundToNearestEven(
             BigInteger numerator, BigInteger denominator, int significandSize, int exponentSize)
@@ -103,10 +96,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// The stored exponent, significand and sign, which no public member exposes. Comparing these
-        /// rather than ToString() is what makes a 1-ULP difference visible: ToString() is injective on
-        /// finite values, but a mis-rounded result and the correct one differ in the last bit, and reading
-        /// that back out of a formatted string is more fragile than reading the field.
+        /// The stored exponent, significand and sign, which no public member exposes. Comparing these is
+        /// what makes a 1-ULP difference visible without parsing it back out of ToString().
         /// </summary>
         private static (BigInteger exponent, BigInteger significand, bool signBit) Internals(BigFloat value)
         {
@@ -146,8 +137,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// Renders a value so that expected and actual are comparable and readable in failure output,
-        /// collapsing the special values that have no (exponent, significand) meaning.
+        /// Renders a value for comparison and for failure output, collapsing the special values that have
+        /// no (exponent, significand) meaning.
         /// </summary>
         private static string Describe(BigFloat value)
         {
@@ -178,8 +169,7 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// Neither oracle is trusted until they agree with each other. If this fails, every other
-        /// result in this fixture is meaningless, so it is the first thing to check.
+        /// If the two oracles disagree, no other result in this fixture means anything.
         /// </summary>
         [Test]
         public void OraclesAgreeWithEachOther()
@@ -212,10 +202,9 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// Rationals whose correctly rounded value is hand-checkable, so a reader can confirm the
-        /// expectations without running or trusting either oracle. For 1/15 at (24,8):
-        /// 2^27/15 = 8947848 remainder 8; 2*8 > 15, so round up to 8947849; less the implicit
-        /// 2^23 that leaves a trailing significand of 559241.
+        /// Rationals whose correctly rounded value can be checked by hand, without trusting either oracle.
+        /// For 1/15 at (24,8): 2^27/15 = 8947848 remainder 8; 2*8 > 15, so round up to 8947849; less the
+        /// implicit 2^23 that leaves a trailing significand of 559241.
         /// </summary>
         private static IEnumerable<TestCaseData> HandCheckedRationals()
         {
@@ -241,9 +230,7 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// The smallest hand-checkable case of the double-rounding defect, kept separate so the exact
-        /// arithmetic sits next to the expectation: 2^27/15 = 8947848 remainder 8, and 2*8 > 15, so the
-        /// correctly rounded significand is 8947849 - 2^23 = 559241. Rounding twice yields 559240.
+        /// The smallest case of the double-rounding defect: rounding once gives 559241, twice gives 559240.
         /// </summary>
         [Test]
         public void FromRationalRoundsOneFifteenthCorrectly()
@@ -285,9 +272,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// Exactly representable results, where no rounding is required and every operator should already
-        /// agree. Kept separate from the rounding tests so that a failure here means something much worse
-        /// than a last-bit disagreement.
+        /// Exactly representable results, where no rounding is required, so a failure here is worse than a
+        /// last-bit disagreement.
         /// </summary>
         [Test]
         public void ExactResultsNeedNoRounding()
@@ -314,9 +300,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// Special values, signed zeros and the range boundaries. These are structural rather than
-        /// rounding properties, and BigFloat gets all of them right - the point of pinning them is to
-        /// keep it that way while the rounding paths are rewritten.
+        /// Special values, signed zeros and the range boundaries, pinned so that rewriting the rounding
+        /// paths cannot disturb them.
         /// </summary>
         [Test]
         public void BoundariesAndSignedZerosMatchHardware()
@@ -341,8 +326,7 @@ namespace BaseTypesTests
                 ("-0 - +0", -0f, 0f, '-'),
                 ("subnormal - subnormal", smallestSubnormal, smallestSubnormal, '-'),
                 ("-subnormal + subnormal", -smallestSubnormal, smallestSubnormal, '+'),
-                // Cancellation of equal magnitudes: IEEE 754 gives -0 only when both operands are
-                // negative, so these pin the sign that a naive "either operand negative" test gets wrong.
+                // Cancellation of equal magnitudes gives -0 only when both operands are negative
                 ("1 - 1", 1f, 1f, '-'),
                 ("-1 + 1", -1f, 1f, '+'),
                 ("-1 - -1", -1f, -1f, '-'),
@@ -367,9 +351,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// Ties, where rounding to nearest-even is the only correct answer and off-by-one-ULP shows up
-        /// immediately. At 2^24 the gap between representable values is 2, so 2^24+1 is exactly halfway
-        /// and must round down to the even 2^24, while 2^24+3 must round up to 2^24+4.
+        /// At 2^24 the gap between representable values is 2, so 2^24+1 is exactly halfway and must round
+        /// down to the even 2^24, while 2^24+3 must round up to 2^24+4.
         /// </summary>
         [Test]
         public void TiesRoundToEven()
@@ -392,9 +375,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// The broad sweep: random bit patterns through every operator, compared against hardware. Uses a
-        /// fixed seed so a failure is reproducible. Subnormal operands and results are included, since
-        /// that is where two of the known defects live.
+        /// Random bit patterns through every operator, including subnormals, against hardware. The seed is
+        /// fixed so a failure is reproducible.
         /// </summary>
         [TestCaseSource(nameof(Operators))]
         public void OperatorMatchesHardwareOverRandomInputs(char op)
@@ -438,8 +420,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// The same sweep at double precision. Rates differ by precision - addition is far worse at
-        /// (24,8) than at (53,11) - so a fix verified only at single precision proves less than it looks.
+        /// The same sweep at double precision, where the error rates differ enough that single precision
+        /// alone would not settle the question.
         /// </summary>
         [TestCaseSource(nameof(Operators))]
         public void OperatorMatchesHardwareAtDoublePrecision(char op)
@@ -490,9 +472,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// Decimal literals are the most natural way to write a float value, and FromBigDec inherits
-        /// FromRational's rounding. Note that a handful of familiar decimals (0.1, 0.3, 3.14159) all
-        /// happen to round correctly, so only a sweep exposes this.
+        /// FromBigDec inherits FromRational's rounding. A sweep is needed because the familiar decimals
+        /// (0.1, 0.3, 3.14159) all happen to round correctly.
         /// </summary>
         [Test]
         public void FromBigDecIsCorrectlyRounded()
@@ -553,9 +534,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// Single-operation error understates the effect on a consumer that chains arithmetic, which is
-        /// how the operators would be used if anything called them. Alternating multiply and divide lets
-        /// the per-operation errors accumulate.
+        /// Alternating multiply and divide, so that per-operation errors accumulate the way they would in
+        /// a consumer that chains arithmetic.
         /// </summary>
         [Test]
         public void ChainedOperationsDoNotDrift()
@@ -605,13 +585,9 @@ namespace BaseTypesTests
             Assert.AreEqual(0L, worst, $"chained arithmetic drifted by up to {worst} ULP from hardware");
         }
 
-
         /// <summary>
-        /// FromRational at double precision, and specifically over values whose rounding carries the
-        /// significand from all-ones into the next binade. The (24,8) sweep above does not reach these:
-        /// a carry needs the retained bits to be exactly 111...1 and the tail to round up, which is rare
-        /// enough that random sampling at one precision misses it. BigFloatTests covers one such value
-        /// (2.220446049250313e-16, from the fix in #1043); this covers the family.
+        /// FromRational over values whose rounding carries the significand from all-ones into the next
+        /// binade. Random sampling rarely hits these, so they are constructed rather than sampled.
         /// </summary>
         [Test]
         public void FromRationalIsCorrectlyRoundedAtDoublePrecision()
@@ -633,8 +609,8 @@ namespace BaseTypesTests
                     denominator = BigInteger.Pow(2, -power);
                 }
 
-                // Approach the power from below by a hair, so the retained bits fill with ones and the
-                // discarded tail decides whether they carry.
+                // Approach the power from below, so the retained bits fill with ones and the discarded
+                // tail decides whether they carry.
                 foreach (var nudge in new[] { 1, 3, 7, 1023, 1048575 })
                 {
                     var scaledNumerator = numerator * ((BigInteger.One << 54) - nudge);
@@ -660,15 +636,10 @@ namespace BaseTypesTests
             Assert.IsEmpty(wrong, string.Join("; ", wrong));
         }
 
-
         /// <summary>
-        /// Exponent sizes are unbounded, and a wide one puts the subnormal boundary at a scale that
-        /// cannot be shifted to directly: a 40-bit exponent field reaches 2^-549755813888, so any
-        /// attempt to materialize 2^shift or the shifted value overflows BigInteger itself.
-        ///
-        /// Nothing covered this before. BigFloatTests exercises 16-bit exponents at the top of their
-        /// range and 30-bit ones only by construction, and the defect needs both a wide exponent and a
-        /// result that underflows into the subnormal range.
+        /// A wide exponent puts the subnormal boundary at a scale that cannot be shifted to directly: at a
+        /// 40-bit exponent the smallest normal is 2^-549755813886, so materializing 2^shift or the shifted
+        /// value overflows BigInteger. Needs both a wide exponent and a result that underflows.
         /// </summary>
         [Test]
         public void ArithmeticWorksAtWideExponentSizes()
@@ -696,10 +667,8 @@ namespace BaseTypesTests
         }
 
         /// <summary>
-        /// A wider exponent field only moves the range; it does not change how values inside that range
-        /// round. So the same operands, shifted by the difference in bias, must give the same significand
-        /// at any exponent size -- which checks the wide-format paths against hardware without needing an
-        /// oracle that can normalize across billions of binades.
+        /// A wider exponent field moves the range without changing how values inside it round, so the same
+        /// operands shifted by the difference in bias must give the same significand at any exponent size.
         /// </summary>
         [Test]
         public void WideExponentSizesRoundLikeSinglePrecision()

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -586,5 +586,60 @@ namespace BaseTypesTests
             Assert.AreEqual(0L, worst, $"chained arithmetic drifted by up to {worst} ULP from hardware");
         }
 
+
+        /// <summary>
+        /// FromRational at double precision, and specifically over values whose rounding carries the
+        /// significand from all-ones into the next binade. The (24,8) sweep above does not reach these:
+        /// a carry needs the retained bits to be exactly 111...1 and the tail to round up, which is rare
+        /// enough that random sampling at one precision misses it. BigFloatTests covers one such value
+        /// (2.220446049250313e-16, from the fix in #1043); this covers the family.
+        /// </summary>
+        [Test]
+        public void FromRationalIsCorrectlyRoundedAtDoublePrecision()
+        {
+            var wrong = new List<string>();
+
+            // Values just below each power of two, where the significand is all ones before rounding.
+            for (var power = -60; power <= 60 && wrong.Count < 10; power++)
+            {
+                BigInteger numerator, denominator;
+                if (power >= 0)
+                {
+                    numerator = BigInteger.Pow(2, power);
+                    denominator = BigInteger.One;
+                }
+                else
+                {
+                    numerator = BigInteger.One;
+                    denominator = BigInteger.Pow(2, -power);
+                }
+
+                // Approach the power from below by a hair, so the retained bits fill with ones and the
+                // discarded tail decides whether they carry.
+                foreach (var nudge in new[] { 1, 3, 7, 1023, 1048575 })
+                {
+                    var scaledNumerator = numerator * ((BigInteger.One << 54) - nudge);
+                    var scaledDenominator = denominator << 54;
+
+                    var exact = ExactRoundToNearestEven(scaledNumerator, scaledDenominator, 53, 11);
+                    if (exact == null)
+                    {
+                        continue;
+                    }
+
+                    BigFloat.FromRational(scaledNumerator, scaledDenominator, 53, 11, out var actual);
+                    var (exponent, significand, _) = Internals(actual);
+
+                    if (exponent != exact.Value.exponent || significand != exact.Value.significand)
+                    {
+                        wrong.Add($"2^{power} * (2^54-{nudge})/2^54: got (exp {exponent}, sig {significand}), "
+                                  + $"want (exp {exact.Value.exponent}, sig {exact.Value.significand})");
+                    }
+                }
+            }
+
+            Assert.IsEmpty(wrong, string.Join("; ", wrong));
+        }
+
     }
 }

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -358,9 +358,6 @@ namespace BaseTypesTests
         /// and must round down to the even 2^24, while 2^24+3 must round up to 2^24+4.
         /// </summary>
         [Test]
-        [Ignore("BigFloat.operator+ truncates when aligning operands (BigIntegerMath.RightShift keeps no "
-                + "sticky bit), so bits are lost before the sum is formed and ties cannot be resolved. "
-                + "2^24 + 3 yields 2^24 + 2 where 2^24 + 4 is correct.")]
         public void TiesRoundToEven()
         {
             const float twoTo24 = 16777216f;
@@ -372,21 +369,12 @@ namespace BaseTypesTests
             }
         }
 
-        /// <summary>Operators that round correctly and are held to it.</summary>
-        private static IEnumerable<TestCaseData> CorrectOperators()
-        {
-            yield return new TestCaseData('*').SetName("Multiplication");
-            yield return new TestCaseData('/').SetName("Division");
-        }
-
-        /// <summary>
-        /// Operators that still round twice. Each moves to CorrectOperators as it is fixed, so this
-        /// list shrinking to empty is the measure of progress.
-        /// </summary>
-        private static IEnumerable<TestCaseData> OperatorsUnderRepair()
+        private static IEnumerable<TestCaseData> Operators()
         {
             yield return new TestCaseData('+').SetName("Addition");
             yield return new TestCaseData('-').SetName("Subtraction");
+            yield return new TestCaseData('*').SetName("Multiplication");
+            yield return new TestCaseData('/').SetName("Division");
         }
 
         /// <summary>
@@ -394,9 +382,7 @@ namespace BaseTypesTests
         /// fixed seed so a failure is reproducible. Subnormal operands and results are included, since
         /// that is where two of the known defects live.
         /// </summary>
-        [TestCaseSource(nameof(OperatorsUnderRepair))]
-        [Ignore("Addition truncates when aligning operands, so bits are lost before the sum is formed: "
-                + "about 9% of inputs disagree with IEEE 754 at (24,8). See FLOAT_AUDIT.md section 2.")]
+        [TestCaseSource(nameof(Operators))]
         public void OperatorMatchesHardwareOverRandomInputs(char op)
         {
             var random = new Random(31415);
@@ -441,9 +427,7 @@ namespace BaseTypesTests
         /// The same sweep at double precision. Rates differ by precision - addition is far worse at
         /// (24,8) than at (53,11) - so a fix verified only at single precision proves less than it looks.
         /// </summary>
-        [TestCaseSource(nameof(OperatorsUnderRepair))]
-        [Ignore("Same truncation defect as at single precision, with a different rate: + and - about "
-                + "2.5% at (53,11). See FLOAT_AUDIT.md section 2.")]
+        [TestCaseSource(nameof(Operators))]
         public void OperatorMatchesHardwareAtDoublePrecision(char op)
         {
             var random = new Random(9001);
@@ -610,18 +594,6 @@ namespace BaseTypesTests
             }
 
             Assert.AreEqual(0L, worst, $"chained arithmetic drifted by up to {worst} ULP from hardware");
-        }
-
-        [TestCaseSource(nameof(CorrectOperators))]
-        public void CorrectOperatorMatchesHardwareOverRandomInputs(char op)
-        {
-            OperatorMatchesHardwareOverRandomInputs(op);
-        }
-
-        [TestCaseSource(nameof(CorrectOperators))]
-        public void CorrectOperatorMatchesHardwareAtDoublePrecision(char op)
-        {
-            OperatorMatchesHardwareAtDoublePrecision(op);
         }
 
     }

--- a/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatDifferentialTests.cs
@@ -200,6 +200,7 @@ namespace BaseTypesTests
         /// </summary>
         private static IEnumerable<TestCaseData> HandCheckedRationals()
         {
+            yield return new TestCaseData(1, 15, 123, 559241).SetName("OneFifteenth");
             yield return new TestCaseData(1, 3, 125, 2796203).SetName("OneThird");
             yield return new TestCaseData(2, 3, 126, 2796203).SetName("TwoThirds");
             yield return new TestCaseData(1, 10, 123, 5033165).SetName("OneTenth");
@@ -226,9 +227,6 @@ namespace BaseTypesTests
         /// correctly rounded significand is 8947849 - 2^23 = 559241.
         /// </summary>
         [Test]
-        [Ignore("BigFloat.FromRational rounds twice, so the residual that breaks this tie is discarded "
-                + "before the second rounding sees it: 1/15 at (24,8) yields 559240, not 559241. "
-                + "See FLOAT_AUDIT.md section 3.")]
         public void FromRationalRoundsOneFifteenthCorrectly()
         {
             BigFloat.FromRational(1, 15, SingleSignificand, SingleExponent, out var actual);
@@ -239,9 +237,6 @@ namespace BaseTypesTests
         }
 
         [Test]
-        [Ignore("BigFloat.FromRational rounds twice: ApplyRoundToNearestEven discards the remainder that "
-                + "the later ApplyShiftWithRounding needs to break ties. 1/15 at (24,8) yields significand "
-                + "559240 where 559241 is correct; the rate over a,b in [1,200] is about 4.4%.")]
         public void FromRationalIsCorrectlyRounded()
         {
             var wrong = new List<string>();
@@ -481,9 +476,6 @@ namespace BaseTypesTests
         /// happen to round correctly, so only a sweep exposes this.
         /// </summary>
         [Test]
-        [Ignore("FromBigDec delegates to FromRational and inherits its double rounding: about 2.3% of "
-                + "decimals are off by one ULP, e.g. 272516e-5 yields significand 3041542 where 3041541 "
-                + "is correct. See FLOAT_AUDIT.md section 8.")]
         public void FromBigDecIsCorrectlyRounded()
         {
             var random = new Random(8080);
@@ -547,8 +539,6 @@ namespace BaseTypesTests
         /// the per-operation errors accumulate.
         /// </summary>
         [Test]
-        [Ignore("Chained arithmetic accumulates the per-operation rounding error, reaching about 15 ULP "
-                + "over 50 operations. Follows from the defects in sections 1, 2 and 7; see section 9.")]
         public void ChainedOperationsDoNotDrift()
         {
             var random = new Random(1234);

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -989,6 +989,12 @@ namespace BaseTypesTests
             three.FloorCeiling(out floor, out ceiling);
             Assert.AreEqual(BigInteger.Parse("3"), floor);
             Assert.AreEqual(BigInteger.Parse("3"), ceiling);
+
+            // A negative exact integer has nothing to carry, so its floor and ceiling are both itself.
+            var negFour = BigFloat.FromInt(-4, 24, 8);
+            negFour.FloorCeiling(out floor, out ceiling);
+            Assert.AreEqual(new BigInteger(-4), floor, "floor of -4.0");
+            Assert.AreEqual(new BigInteger(-4), ceiling, "ceiling of -4.0");
         }
         [Test]
         public void TestFloorCeilingSpecialValues()
@@ -1354,6 +1360,16 @@ namespace BaseTypesTests
                 Assert.AreEqual(floor, ceiling, $"e{exponentSize}: and its ceiling is the same");
                 Assert.AreEqual(BigFloat.MaxFloorCeilingBits, (int)floor.GetBitLength(),
                     $"e{exponentSize}: which is the widest the limit allows");
+
+                // The same value negated is an exact negative integer, which is the one shape that reaches
+                // the branch where a negative value has no fractional part to carry.
+                var negated = new BigFloat(true, 0, BigFloat.MaxFloorCeilingBits - 1 + bias, 24, exponentSize);
+                Assert.IsTrue(negated.TryFloorCeiling(out var negFloor, out var negCeiling),
+                    $"e{exponentSize}: the limit does not depend on the sign");
+                Assert.AreEqual(-(BigInteger.One << (BigFloat.MaxFloorCeilingBits - 1)), negFloor,
+                    $"e{exponentSize}: floor of the negated boundary value");
+                Assert.AreEqual(negFloor, negCeiling,
+                    $"e{exponentSize}: an exact integer floors and ceilings to itself");
 
                 // Declining has to be cheap, which is the whole point of deciding it from the exponent.
                 var before = GC.GetTotalAllocatedBytes(precise: true);

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -732,19 +732,17 @@ namespace BaseTypesTests
         [Test]
         public void TestExactHalfwayRounding()
         {
-            // Create values that produce exact halfway cases for rounding
-            // For 24-bit significand, we need 25 bits with the LSB = 1
-
-            // Create 1.5 * 2^24 + 0.5 = exact halfway case
+            // (3 * 2^23 + 1) / 2 is 1.5 * 2^23 + 0.5. The gap between representable values in that binade
+            // is 1, so the value sits exactly halfway and must round to the even neighbour, 1.5 * 2^23.
             var num = (BigInteger)(3 * (1 << 23) + 1);  // Binary: 1 1000...001
             var denom = BigInteger.One << 1;
 
-            BigFloat.FromRational(num, denom, 24, 8, out var result);
+            var exact = BigFloat.FromRational(num, denom, 24, 8, out var result);
+            var (sig, exp, _) = GetBigFloatInternals(result);
 
-            // This should round to nearest even
-            // The value needs rounding, so FromRational returns false
-            // but we should verify the rounding was correct
-            Assert.IsNotNull(result);
+            Assert.IsFalse(exact, "the value is not representable, so the conversion is inexact");
+            Assert.AreEqual(new BigInteger(150), exp, "biased exponent of 1.5 * 2^23");
+            Assert.AreEqual(new BigInteger(4194304), sig, "should tie down to 1.5 * 2^23, whose stored significand is 2^22");
         }
         #endregion
 
@@ -2530,22 +2528,8 @@ namespace BaseTypesTests
             BigFloat.FromRational(11, 8, 2, 8, out var elevenEighths);
             var (sig118, exp118, sign118) = GetBigFloatInternals(elevenEighths);
 
-            // Let's also test 13/8 = 1.625 = 1.101 binary
-            BigFloat.FromRational(13, 8, 2, 8, out var thirteenEighths);
-            var (sig138, exp138, sign138) = GetBigFloatInternals(thirteenEighths);
-
-            // And the actual tie case: 12/8 = 1.5 = 1.1 binary (fits exactly)
-            BigFloat.FromRational(12, 8, 2, 8, out var twelveEighths);
-            var (sig128, exp128, sign128) = GetBigFloatInternals(twelveEighths);
-
-            // For a true tie with 2-bit significand, I need a value that's exactly between
-            // two representable values. Let me think...
-            // With 2 bits, we can represent: 1.0, 1.1 (1.5), and then 10.0 (2.0), 10.1 (2.5), etc.
-
-            // Actually, let me create a simpler test that definitely creates a tie
-            // Use 3-bit significand (2 bits stored) to have more control
-            // We can represent: 1.00, 1.01, 1.10, 1.11
-            // A tie would be exactly between any two of these
+            // A 3-bit significand stores 2 bits, so it represents 1.00, 1.01, 1.10 and 1.11, which puts a
+            // tie exactly between any two neighbours.
 
             // 9/8 = 1.125 = 1.001 binary
             // With 3-bit significand, this is exactly between 1.00 and 1.01
@@ -2561,47 +2545,21 @@ namespace BaseTypesTests
             var (sig118_3, exp118_3, sign118_3) = GetBigFloatInternals(elevenEighths3);
             Assert.AreEqual(new BigInteger(2), sig118_3, "11/8 with 3-bit significand should round to even (2)");
 
-            // Now the main test with 24-bit significand
-            // I need to be very careful about what constitutes a tie
-            // For significand size S, we have S-1 stored bits
-            // So with 24-bit significand, we store 23 bits
+            // Now with a 24-bit significand, which stores 23 bits. (2^24 + 1) / 2^23 is 2 + 2^-23, and the
+            // gap above 2.0 is 2^-22, so the value lies exactly halfway between 2.0 and its successor. The
+            // even neighbour is 2.0, whose stored significand is 0.
+            numerator = (BigInteger.One << 24) + 1;
+            denominator = BigInteger.One << 23;
 
-            // Let me manually trace through (2^24 + 1) / 2^23
-            numerator = (BigInteger.One << 24) + 1;  // 16777217
-            denominator = BigInteger.One << 23;      // 8388608
-
-            // scaleBitsLong = 24 + 3 + (24 - 25) = 24 + 3 - 1 = 26
-            // scaledNumerator = 16777217 << 26 = 1125899973951488
-            // quotient = 1125899973951488 / 8388608 = 134217729
-            // remainder = 1125899973951488 - 134217729 * 8388608 = 8388608
-
-            // So remainder = 8388608 = denominator / 2 * 2 = denominator!
-            // Wait, that's not right. Let me recalculate...
-
-            // Actually, let me just test if my expectation is correct
             BigFloat.FromRational(numerator, denominator, 24, 8, out var midpoint);
             var two24 = BigFloat.FromInt(2, 24, 8);
-
-            // Create next value after 2.0
-            // In IEEE format with 24-bit significand, 2.0 has stored bits = 0
-            // Next value has stored bits = 1
             var nextAfterTwo = new BigFloat(false, 1, 128, 24, 8);
+            var (midSig, midExp, _) = GetBigFloatInternals(midpoint);
 
-            // Check which one midpoint equals
-            var equalsTwo = midpoint.Equals(two24);
-            var equalsNext = midpoint.Equals(nextAfterTwo);
-
-            var (midSig, midExp, midSign) = GetBigFloatInternals(midpoint);
-
-            // Good, that shows BigFloat rounds to even (sig=0) correctly
-            // Let me test another tie case where even is the higher value
-
-            // Create a tie between values where the higher one has even last bit
-            // 3.0 has sig=4194304 (binary ...10000000000000000000000, last bit 0 = even)
-            // Next value has sig=4194305 (binary ...10000000000000000000001, last bit 1 = odd)
-            // Midpoint between them should round UP to 3.0
-
-            // Actually, that's not right. Let me think more carefully.
+            Assert.AreEqual(new BigInteger(128), midExp, "biased exponent of 2.0");
+            Assert.AreEqual(BigInteger.Zero, midSig, "2 + 2^-23 should tie down to 2.0");
+            Assert.IsTrue(midpoint.Equals(two24), "the tie should land on 2.0");
+            Assert.IsFalse(midpoint.Equals(nextAfterTwo), "the tie should not land on 2.0's successor");
             // In IEEE format with implicit leading 1:
             // 3.0 = 1.1 × 2^1, stored sig = 0x400000 = 4194304
             // Next = 1.10000000000000000000001 × 2^1, stored sig = 4194305
@@ -2626,26 +2584,6 @@ namespace BaseTypesTests
 
             Assert.AreEqual(new BigInteger(2), tieSig1, "21/16 should round to even (sig=2)");
             Assert.AreEqual(new BigInteger(4), tieSig2, "23/16 should round to even (sig=4)");
-
-            // The original test already proved correctness
-            Assert.Pass($"BigFloat correctly implements round-to-nearest-even. Midpoint sig={midSig} (even)");
-
-            // According to IEEE 754 round-to-nearest-even:
-            // If the value is exactly between two representable values,
-            // choose the one with even least significant bit
-            // 2.0 has sig=0 (even), next has sig=1 (odd)
-            // So it should round to 2.0
-
-            if (!equalsTwo && equalsNext) {
-                // This would indicate BigFloat is NOT doing round-to-even correctly
-                Assert.Fail($"BigFloat appears to round ties away from even. Midpoint sig={midSig} (should be 0)");
-            } else if (equalsTwo) {
-                // This is correct behavior
-                Assert.Pass("BigFloat correctly implements round-to-nearest-even");
-            } else {
-                // Neither? That's unexpected
-                Assert.Fail($"Midpoint doesn't equal either expected value. Sig={midSig}, Exp={midExp}");
-            }
         }
 
         [Test]
@@ -3509,7 +3447,7 @@ namespace BaseTypesTests
         [Test]
         public void TestSubnormalRoundingOverflowToNormal()
         {
-            // This test catches bug 1: When rounding a subnormal causes it to need significandSize bits,
+            // When rounding a subnormal causes it to need significandSize bits,
             // it should become the smallest normal number, not get truncated
 
             // For a 24-bit significand (23 stored + 1 implicit), test various sizes
@@ -4044,7 +3982,7 @@ namespace BaseTypesTests
         [Test]
         public void TestHexParsingRoundingNonStrictMode()
         {
-            // This test catches bug 2: Non-strict hex parsing should apply IEEE 754 rounding,
+            // Non-strict hex parsing should apply IEEE 754 rounding,
             // not truncation
 
             // Create hex values that need rounding
@@ -4750,28 +4688,25 @@ namespace BaseTypesTests
         [Test]
         public void TestHexUnderflowRounding()
         {
-            // This test catches bug 3: Hex parsing of subnormal values should round,
+            // Hex parsing of subnormal values should round,
             // not truncate
 
-            // Create a hex value that will underflow to subnormal range
-            // and needs rounding. For sigSize=24, expSize=8:
-            // - Smallest subnormal: 2^-149 = 0x0.8e-37
-            // - To test rounding, use a value between 0 and smallest subnormal
-            // - 0x0.ce-37 = 12/16 * 16^-37 = 0.75 * smallest subnormal
-            // - This should round UP to the smallest subnormal (0x0.8e-37)
-            // But hex parsing gives 0x1.0e-37 instead due to a bug
-            string underflowHex = "0x0.ce-37f24e8";  // 0.75 * smallest subnormal
+            // Create a hex value that underflows into the subnormal range and needs rounding. For
+            // sigSize=24, expSize=8 the smallest subnormal is 2^-149, which 0x0.8e-37 names exactly.
+            // 0x0.ce-37 is 12/16 * 16^-37, and since 16^-37 is 2^-148 that comes to 1.5 * 2^-149: exactly
+            // halfway between the first two subnormals, so it ties to the even one, 2 * 2^-149 = 0x1.0e-37.
+            string underflowHex = "0x0.ce-37f24e8";  // 1.5 * smallest subnormal
 
             bool parsed = BigFloat.TryParse(underflowHex, out var result);
             Assert.IsTrue(parsed, "Should parse underflow value");
 
             // This should round to a subnormal, not truncate to zero
             Assert.IsTrue(result.IsSubnormal, "Should be subnormal, not zero");
-
-            // The hex parsing has a bug where it rounds 0x0.ce-37 to 0x1.0e-37
-            // instead of 0x0.8e-37 (smallest subnormal)
-            // For now, just verify it didn't truncate to zero
             Assert.IsFalse(result.IsZero, "Should not truncate to zero");
+
+            var (underflowSig, underflowExp, _) = GetBigFloatInternals(result);
+            Assert.AreEqual(BigInteger.Zero, underflowExp, "a subnormal is stored at exponent 0");
+            Assert.AreEqual(new BigInteger(2), underflowSig, "1.5 * 2^-149 ties to the even 2 * 2^-149");
         }
 
         [Test]
@@ -5402,7 +5337,6 @@ namespace BaseTypesTests
         [Test]
         public void TestExtremelyLargeNegativeExponentHandling()
         {
-            // Fix for test at line 2909 - verify what the value actually is
             var extreme = BigFloat.FromRational(BigInteger.One, BigInteger.Pow(2, 1000000), 24, 30, out var result);
 
             // With 30-bit exponent, this value is exactly representable as 2^(-1000000)

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -1363,6 +1363,36 @@ namespace BaseTypesTests
         }
 
         [Test]
+        public void TestSizeMismatchInEitherDimensionIsRejected()
+        {
+            // The size-rejection tests above pair (24,8) with (53,11), where both dimensions differ, so
+            // either half of the compatibility check on its own would satisfy them all. These pairs differ
+            // in one dimension at a time.
+            var reference = BigFloat.FromInt(1, 24, 8);
+            var wideExponent = BigFloat.FromInt(1, 24, 11);    // same significand size
+            var wideSignificand = BigFloat.FromInt(1, 53, 8);  // same exponent size
+
+            foreach (var (other, dimension) in new[]
+                     { (wideExponent, "exponent size"), (wideSignificand, "significand size") })
+            {
+                Assert.Throws<ArgumentException>(() => { var _ = reference + other; },
+                    $"addition should reject a differing {dimension}");
+                Assert.Throws<ArgumentException>(() => { var _ = reference - other; },
+                    $"subtraction should reject a differing {dimension}");
+                Assert.Throws<ArgumentException>(() => { var _ = reference * other; },
+                    $"multiplication should reject a differing {dimension}");
+                Assert.Throws<ArgumentException>(() => { var _ = reference / other; },
+                    $"division should reject a differing {dimension}");
+                Assert.Throws<ArgumentException>(() => reference.CompareTo(other),
+                    $"CompareTo should reject a differing {dimension}");
+                Assert.Throws<ArgumentException>(() => { var _ = reference < other; },
+                    $"comparison should reject a differing {dimension}");
+                Assert.Throws<ArgumentException>(() => BigFloat.CopySign(reference, other),
+                    $"CopySign should reject a differing {dimension}");
+            }
+        }
+
+        [Test]
         public void TestCompareToValidatesCompatibleSizes()
         {
             // Test that CompareTo now validates size compatibility

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -834,15 +834,9 @@ namespace BaseTypesTests
             // Multiply back to check rounding
             var result = oneThird * three;
 
-            // Due to rounding, might not get exactly 1
-            var diff = BigFloat.Abs(result - one);
-
-            // Should be very close - within rounding error
-            // For 24-bit significand, the error should be very small
-            // Create the comparison value with the same size parameters
-            BigFloat.FromRational(1, 1 << 20, 24, 8, out var epsilon);
-            Assert.IsTrue(diff.IsZero || diff < epsilon,
-                         "1/3 * 3 should be very close to 1");
+            // Rounding 1/3 up and multiplying by 3 comes back to exactly 1.0 at this precision, so there is
+            // no tolerance to allow: anything else is a rounding defect.
+            Assert.AreEqual(one, result, "1/3 * 3 should be exactly 1");
         }
 
         [Test]
@@ -2659,19 +2653,14 @@ namespace BaseTypesTests
             var product2 = oneSeventh * eleven;
             var result2 = product1 + product2;
 
-            // These may differ due to cascading rounding
-            var diff = BigFloat.Abs(result1 - result2);
-
-            // The difference should be small but may not be zero
-            if (!diff.IsZero)
-            {
-                // Verify the error is within expected bounds
-                // For 24-bit precision, relative error should be < 2^(-22) per operation
-                // With 3 operations, cumulative error < 3 * 2^(-22)
-                BigFloat.FromRational(3, BigInteger.One << 22, 24, 8, out var maxError);
-                Assert.IsTrue(diff < maxError,
-                    "Cascading rounding error should be within bounds");
-            }
+            // The two orderings differ by exactly one unit in the last place, which is what makes the point:
+            // a bound of "small enough" would hold whatever the rounding did, so pin both results instead.
+            var (sig1, exp1, _) = GetBigFloatInternals(result1);
+            var (sig2, exp2, _) = GetBigFloatInternals(result2);
+            Assert.AreEqual(new BigInteger(129), exp1, "(1/3 + 1/7) * 11");
+            Assert.AreEqual(new BigInteger(2596475), sig1, "(1/3 + 1/7) * 11");
+            Assert.AreEqual(new BigInteger(129), exp2, "1/3 * 11 + 1/7 * 11");
+            Assert.AreEqual(new BigInteger(2596474), sig2, "1/3 * 11 + 1/7 * 11, one ULP lower");
 
             // Test case with many operations
             // To ensure rounding errors, we need a value that doesn't align perfectly
@@ -2690,17 +2679,12 @@ namespace BaseTypesTests
             var hundred = BigFloat.FromInt(100, 24, 8);
             var expected = x + hundred;
 
-            // Accumulated rounding errors
-            diff = BigFloat.Abs(accumulated - expected);
-
-            // Error should exist due to repeated rounding of 1/3
-            Assert.IsFalse(diff.IsZero,
-                "300 additions of 1/3 should show rounding error compared to adding 100");
-
-            // But error should still be reasonable
-            BigFloat.FromRational(1, BigInteger.One << 10, 24, 8, out var reasonableError);
-            Assert.IsTrue(diff < reasonableError,
-                "Accumulated error should be reasonable");
+            // Repeated rounding of 1/3 leaves the sum 24 units in the last place above 101, deterministically.
+            var (accSig, accExp, _) = GetBigFloatInternals(accumulated);
+            var (expSig, expExp, _) = GetBigFloatInternals(expected);
+            Assert.AreEqual(expExp, accExp, "the accumulated sum lands in the same binade as 101");
+            Assert.AreEqual(new BigInteger(4849664), expSig, "1 + 100");
+            Assert.AreEqual(new BigInteger(4849688), accSig, "1 + 300 * (1/3), 24 ULP higher");
         }
 
         #endregion
@@ -4501,23 +4485,12 @@ namespace BaseTypesTests
 
             // This number cannot be exactly represented in 24 bits
             // The current implementation appears to round rather than fail
+            // Only the low bit is discarded and it is below half, so 2^25 + 1 rounds down to 2^25 exactly.
+            // The conversion still reports itself inexact, since the input was not representable.
             var success = BigFloat.FromRational(value, 1, 24, 8, out var bf);
-
-            if (!success)
-            {
-                // If it fails (strict mode), verify the exact value succeeds
-                success = BigFloat.FromRational(BigInteger.One << 25, 1, 24, 8, out var exact);
-                Assert.IsTrue(success, "2^25 should be exactly representable");
-            }
-            else
-            {
-                // If it succeeds (rounding mode), verify it rounded correctly
-                var exact = BigFloat.FromBigInt(BigInteger.One << 25, 24, 8);
-                // The difference should be minimal (lost the +1)
-                var diff = BigFloat.Abs(bf - exact);
-                Assert.IsTrue(diff.IsZero || diff <= BigFloat.FromInt(1),
-                            "Rounding should lose at most the least significant bit");
-            }
+            Assert.IsFalse(success, "2^25 + 1 is not representable in 24 bits");
+            Assert.AreEqual(BigFloat.FromBigInt(BigInteger.One << 25, 24, 8), bf,
+                "2^25 + 1 should round down to 2^25, losing exactly the low bit");
         }
         [Test]
         public void TestConstructorWithVariousSignificandAndExponentSizes()
@@ -4578,15 +4551,25 @@ namespace BaseTypesTests
         [Test]
         public void TestRoundingBehaviorWhenLosingPrecision()
         {
-            // Test IEEE 754 round-to-nearest-even
-            // These values test rounding at the bit boundary
-            var roundDown = BigFloat.FromString("0x1.fffff8e0f24e8");
-            var roundUp = BigFloat.FromString("0x1.fffffce0f24e8");
+            // A 24-bit significand is six hex digits, so a seventh digit is the one that gets rounded away:
+            // below 8 rounds down, 8 is an exact tie that goes to the even neighbour, and above 8 rounds up.
+            // 0x1.fffff8 and 0x1.fffffc, which this test used to use, are both exactly representable and so
+            // exercise no rounding at all.
+            var roundDown = BigFloat.FromString("0xF.FFFFF7e0f24e8");   // tail 7, below half
+            var tieUp = BigFloat.FromString("0xF.FFFFF8e0f24e8");       // tail 8 on an odd significand
+            var tieDown = BigFloat.FromString("0x8.000008e0f24e8");     // tail 8 on an even significand
 
-            Assert.IsFalse(roundDown.IsZero);
-            Assert.IsFalse(roundUp.IsZero);
+            var (downSig, downExp, _) = GetBigFloatInternals(roundDown);
+            Assert.AreEqual(new BigInteger(130), downExp, "0xFFFFFF keeps its exponent");
+            Assert.AreEqual(new BigInteger(8388607), downSig, "and its significand, the tail being below half");
 
-            // Both should be valid but potentially rounded
+            var (upSig, upExp, _) = GetBigFloatInternals(tieUp);
+            Assert.AreEqual(new BigInteger(131), upExp, "the tie carries 0xFFFFFF into the next binade");
+            Assert.AreEqual(BigInteger.Zero, upSig, "leaving no stored significand");
+
+            var (evenSig, evenExp, _) = GetBigFloatInternals(tieDown);
+            Assert.AreEqual(new BigInteger(130), evenExp, "an even significand stays put on a tie");
+            Assert.AreEqual(BigInteger.Zero, evenSig, "at 0x800000");
         }
 
         [Test]

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -2177,20 +2177,22 @@ namespace BaseTypesTests
         [Test]
         public void TestToStringTrailingZeros()
         {
-            // Values that might have trailing zeros in hex representation
-            BigFloat.FromRational(1, 1, 24, 8, out var one);
-            var str = one.ToString();
-
-            // Check that the string representation is reasonable
-            // For the value 1.0, we expect something like "0x1.0e0f24e8"
-            Assert.IsTrue(str.StartsWith("0x"));
-            Assert.IsTrue(str.Contains("e"));
-            Assert.IsTrue(str.Contains("f"));
-
-            // The exact format may include trailing zeros for alignment
-            // Just verify it's parseable
-            var parsed = BigFloat.FromString(str);
-            Assert.AreEqual(one, parsed);
+            // A 24-bit significand is six hex digits, but ToString trims trailing zeros from the fraction.
+            // An all-zero fraction keeps a single "0" rather than emptying: the grammar requires a digit
+            // after the point, so the printer must not emit what the parser would reject.
+            foreach (var (numerator, denominator, expected, trimmed) in new[]
+                     {
+                         (1, 1, "0x1.0e0f24e8", "000000 -> 0"),
+                         (17, 16, "0x1.1e0f24e8", "100000 -> 1"),
+                         (3, 2, "0x1.8e0f24e8", "800000 -> 8"),
+                         (255, 256, "0x0.FFe0f24e8", "FF0000 -> FF")
+                     })
+            {
+                BigFloat.FromRational(numerator, denominator, 24, 8, out var value);
+                var str = value.ToString();
+                Assert.AreEqual(expected, str, $"{numerator}/{denominator}: {trimmed}");
+                Assert.AreEqual(value, BigFloat.FromString(str), $"{str} should parse back unchanged");
+            }
         }
 
         #endregion

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -2482,24 +2482,21 @@ namespace BaseTypesTests
         [Test]
         public void TestBoundaryRounding()
         {
-            // Test rounding at normal/subnormal boundary
+            // The first value above the normal/subnormal boundary. (2^23 + 1) / 2^149 is 2^-126 + 2^-149,
+            // and 2^23 + 1 occupies exactly 24 bits, so it needs no rounding at all: it lands on the
+            // smallest normal plus one unit in the last place, not on the smallest normal itself.
             var minNormalExp = 1;
             var bias = (1 << 7) - 1;
-
-            // Create value just above minimum normal
             var numerator = (BigInteger.One << 23) + 1;
             var denominator = BigInteger.One << (bias + 22);
 
-            BigFloat.FromRational(numerator, denominator, 24, 8, out var result);
-
-            // Should round to minimum normal
+            var exact = BigFloat.FromRational(numerator, denominator, 24, 8, out var result);
             var (sig, exp, _) = GetBigFloatInternals(result);
 
-            // The value (2^23 + 1) / 2^(127+22) = (2^23 + 1) / 2^149
-            // This is slightly larger than 2^(-126) (minimum normal)
-            // It should round to the minimum normal value
+            Assert.IsTrue(exact, "2^-126 + 2^-149 is representable, so no rounding occurs");
             Assert.IsTrue(result.IsNormal);
-            Assert.AreEqual((BigInteger)minNormalExp, exp);
+            Assert.AreEqual((BigInteger)minNormalExp, exp, "the smallest normal exponent");
+            Assert.AreEqual(BigInteger.One, sig, "one ULP above the smallest normal, whose significand is 0");
         }
 
         [Test]

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -155,8 +155,8 @@ namespace BaseTypesTests
             }
             catch (FormatException)
             {
-                // Strict mode may reject all extreme underflow, even representable subnormals
-                // This is noted in the documentation as "arguably overly restrictive"
+                // Strict mode rejects a literal that underflows to zero, which this one does; see
+                // TryParseExact for what it does and does not accept.
             }
         }
 
@@ -669,9 +669,9 @@ namespace BaseTypesTests
         [Test]
         public void TestAdditionBugWithExtremeDifferenceOppositeSigns()
         {
-            // This test verifies the fix for a bug where adding a large negative number
-            // to a very small positive number produces an invalid BigFloat
-            // with significand=0 and normal exponent (should be impossible)
+            // Adding a very small positive number to a large negative one used to lose the significand
+            // altogether, leaving the exponent of the large operand with a zero significand: a power of two
+            // rather than the operand itself.
 
             // Create a very large negative number (near max normal)
             var negLarge = new BigFloat(true, ((BigInteger)1 << 52) - 1, 2046, 53, 11);
@@ -689,15 +689,10 @@ namespace BaseTypesTests
             var resultSig = (BigInteger)sigField.GetValue(result);
             var resultExp = (BigInteger)expField.GetValue(result);
 
-            // Verify no invalid normal number is produced
-            if (resultExp > 0 && resultExp < BigFloat.GetMaxExponent(11))
-            {
-                // This is a normal number - should not have sig=0
-                Assert.AreNotEqual(BigInteger.Zero, resultSig,
-                    "Normal numbers must have non-zero significand (implicit leading 1 bit)");
-            }
-
-            // The result should equal negLarge (the larger operand)
+            // A normal number may perfectly well store a zero significand -- every power of two does -- so
+            // the invariant worth checking is that the operand came through intact.
+            Assert.AreEqual(((BigInteger)1 << 52) - 1, resultSig, "the large operand's significand survives");
+            Assert.AreEqual(new BigInteger(2046), resultExp, "and so does its exponent");
             Assert.AreEqual(negLarge.ToString(), result.ToString(),
                 "Result should equal the larger operand when difference is extreme");
         }
@@ -4402,14 +4397,11 @@ namespace BaseTypesTests
             Console.WriteLine($"negLarge string: {negLarge}");
             Console.WriteLine($"diff string:     {diff}");
 
-            // The issue is that diff has sig=0 with exp=2046
-            // This is INVALID - a normal number cannot have significand 0
-            if (diffSig == 0 && diffExp > 0 && diffExp < BigFloat.GetMaxExponent(diff.ExponentSize))
-            {
-                Assert.Fail($"BUG: Addition produced invalid normal number with sig=0, exp={diffExp}");
-            }
-
-            // If we get here, internal representations are identical
+            // The subtraction used to drop the significand, leaving the large operand's exponent with a
+            // zero significand. A zero significand is legitimate on its own -- every power of two has one --
+            // so what this checks is that the operand came through unchanged.
+            Assert.AreEqual(negLargeSig, diffSig, "the large operand's significand survives");
+            Assert.AreEqual(negLargeExp, diffExp, "and so does its exponent");
             Assert.AreEqual(negLarge, diff,
                 "Result should equal the larger operand");
 
@@ -4999,10 +4991,7 @@ namespace BaseTypesTests
             var result2 = minusZero + plusZero;
             var (_, _, isNeg2) = GetBigFloatInternals(result2);
 
-            // Current behavior: (-0) + (+0) = +0 (Correct)
             Assert.IsFalse(isNeg2, "(-0) + (+0) correctly returns +0");
-
-            // The bug is asymmetric - only affects (+0) + (-0), not (-0) + (+0)
         }
 
         [Test]

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -2577,13 +2577,10 @@ namespace BaseTypesTests
             Assert.AreEqual(BigInteger.Zero, midSig, "2 + 2^-23 should tie down to 2.0");
             Assert.IsTrue(midpoint.Equals(two24), "the tie should land on 2.0");
             Assert.IsFalse(midpoint.Equals(nextAfterTwo), "the tie should not land on 2.0's successor");
-            // In IEEE format with implicit leading 1:
-            // 3.0 = 1.1 × 2^1, stored sig = 0x400000 = 4194304
-            // Next = 1.10000000000000000000001 × 2^1, stored sig = 4194305
 
-            // Let's create a simpler test with smaller significand
-            // Use 4-bit significand (3 bits stored)
-            // Can represent: 1.000, 1.001, 1.010, 1.011, 1.100, 1.101, 1.110, 1.111
+            // A 4-bit significand stores 3 bits and so represents 1.000 through 1.111, which makes the
+            // two cases below easy to read off: a tie whose even neighbour is the lower one, and a tie
+            // whose even neighbour is the higher.
 
             // Test tie between 1.010 and 1.011 (stored as 010=2 and 011=3)
             // The exact middle is 1.0101, which should round to 1.010 (even)
@@ -4582,8 +4579,8 @@ namespace BaseTypesTests
         {
             // A 24-bit significand is six hex digits, so a seventh digit is the one that gets rounded away:
             // below 8 rounds down, 8 is an exact tie that goes to the even neighbour, and above 8 rounds up.
-            // 0x1.fffff8 and 0x1.fffffc, which this test used to use, are both exactly representable and so
-            // exercise no rounding at all.
+            // A literal with only six fractional digits, such as 0x1.fffff8, is exactly representable and
+            // exercises no rounding at all.
             var roundDown = BigFloat.FromString("0xF.FFFFF7e0f24e8");   // tail 7, below half
             var tieUp = BigFloat.FromString("0xF.FFFFF8e0f24e8");       // tail 8 on an odd significand
             var tieDown = BigFloat.FromString("0x8.000008e0f24e8");     // tail 8 on an even significand

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -871,10 +871,11 @@ namespace BaseTypesTests
             var result1 = (hundred / five) / four;
             var result2 = hundred / (five * four);
 
-            // Should be equal (or very close due to rounding)
-            var diff = BigFloat.Abs(result1 - result2);
-            Assert.IsTrue(diff.IsZero || diff < BigFloat.FromInt(1) / BigFloat.FromInt(1 << 20),
-                         "Division should be approximately associative");
+            // Every step here is exact -- 100/5 is 20, 20/4 is 5, 5*4 is 20, 100/20 is 5 -- so the two
+            // orderings agree outright and there is no tolerance to allow. The comparison this replaced
+            // could not have run: BigFloat.FromInt(1) is (53,11) while diff is (24,8), so had the results
+            // differed it would have thrown on the size mismatch rather than reporting the difference.
+            Assert.AreEqual(result1, result2, "(100/5)/4 and 100/(5*4) are both exactly 5");
         }
 
         [Test]
@@ -2042,6 +2043,7 @@ namespace BaseTypesTests
             Assert.IsTrue(zero.IsZero);
             Assert.IsFalse(one.IsZero);
             Assert.IsTrue(negOne.IsNegative);
+            Assert.AreEqual("1000000", large.ToDecimalString(), "1000000 is exact at double precision");
 
             // Test with custom precision
             var customOne = BigFloat.FromInt(1, 16, 5);

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -1331,6 +1331,55 @@ namespace BaseTypesTests
         }
 
         [Test]
+        public void TestTryFloorCeilingSitsExactlyOnItsLimit()
+        {
+            // The limit is a width in bits, and a normal value's integer part is one bit wider than its
+            // unbiased exponent, so the last accepted value is the one whose unbiased exponent is
+            // MaxFloorCeilingBits - 1. A 22-bit exponent field is the narrowest that reaches that far: its
+            // bias is 2^21 - 1, so the two exponents either side of the limit are both finite normals.
+            // The limit is on the width, not on the format, so it falls at the same unbiased exponent
+            // whatever the exponent field.
+            foreach (var exponentSize in new[] { 22, 23, 30 })
+            {
+                var bias = BigFloat.GetBias(exponentSize);
+                var lastAccepted =
+                    new BigFloat(false, 0, BigFloat.MaxFloorCeilingBits - 1 + bias, 24, exponentSize);
+                var firstDeclined =
+                    new BigFloat(false, 0, BigFloat.MaxFloorCeilingBits + bias, 24, exponentSize);
+
+                Assert.IsTrue(lastAccepted.TryFloorCeiling(out var floor, out var ceiling),
+                    $"e{exponentSize}: an integer part of exactly MaxFloorCeilingBits bits is still produced");
+                Assert.AreEqual(BigInteger.One << (BigFloat.MaxFloorCeilingBits - 1), floor,
+                    $"e{exponentSize}: the value is a power of two, so its floor is exact");
+                Assert.AreEqual(floor, ceiling, $"e{exponentSize}: and its ceiling is the same");
+                Assert.AreEqual(BigFloat.MaxFloorCeilingBits, (int)floor.GetBitLength(),
+                    $"e{exponentSize}: which is the widest the limit allows");
+
+                // Declining has to be cheap, which is the whole point of deciding it from the exponent.
+                var before = GC.GetTotalAllocatedBytes(precise: true);
+                Assert.IsFalse(firstDeclined.TryFloorCeiling(out _, out _),
+                    $"e{exponentSize}: one binade further and the integer part no longer fits");
+                Assert.Less(GC.GetTotalAllocatedBytes(precise: true) - before, 1024 * 1024,
+                    $"e{exponentSize}: declining should not compute the value first");
+            }
+
+            // The limit exempts zero, whose integer part is zero however wide the exponent field. A
+            // subnormal is exempt in effect too, since its actual exponent is 1 rather than its stored 0.
+            foreach (var (value, floorExpected, ceilingExpected, what) in new[]
+                     {
+                         (BigFloat.CreateZero(false, 24, 22), 0, 0, "+0"),
+                         (BigFloat.CreateZero(true, 24, 22), 0, 0, "-0"),
+                         (new BigFloat(false, 1, 0, 24, 22), 0, 1, "the smallest subnormal"),
+                         (new BigFloat(true, 1, 0, 24, 22), -1, 0, "its negation")
+                     })
+            {
+                Assert.IsTrue(value.TryFloorCeiling(out var f, out var c), $"{what} is never declined");
+                Assert.AreEqual((BigInteger)floorExpected, f, $"floor of {what}");
+                Assert.AreEqual((BigInteger)ceilingExpected, c, $"ceiling of {what}");
+            }
+        }
+
+        [Test]
         public void TestTryFloorCeilingAgreesWithFloorCeiling()
         {
             foreach (var literal in new[]

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -5152,18 +5152,13 @@ namespace BaseTypesTests
             Assert.IsFalse(result1.IsZero, "2^(-149) should not be zero");
             Assert.IsTrue(result1.IsSubnormal, "2^(-149) should be subnormal");
 
-            // Test Case 2: 2^(-150) should underflow to zero
+            // Test Case 2: 2^(-150) is exactly half the smallest subnormal, so it ties to the even zero,
+            // and the conversion reports itself inexact because the input was not zero.
             var num2 = BigInteger.One;
             var den2 = BigInteger.One << 150;
-            if (BigFloat.FromRational(num2, den2, 24, 8, out var result2))
-            {
-                Assert.IsTrue(result2.IsZero, "2^(-150) should underflow to zero");
-            }
-            else
-            {
-                // Also acceptable - return false for unrepresentable value
-                Assert.Pass("FromRational correctly returned false for 2^(-150)");
-            }
+            Assert.IsFalse(BigFloat.FromRational(num2, den2, 24, 8, out var result2),
+                "2^(-150) is not representable, so the conversion is inexact");
+            Assert.IsTrue(result2.IsZero, "2^(-150) should underflow to zero");
         }
         #endregion
 

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -2204,15 +2204,16 @@ namespace BaseTypesTests
         [Test]
         public void TestToSMTLibStringNormalNumbers()
         {
-            var one = BigFloat.FromInt(1, 24, 8);
-            var smtStr = one.ToSMTLibString();
-
-            // Should produce: fp (_ bv0 1) (_ bv127 8) (_ bv0 23)
-            // Sign bit: 0, Exponent: 127 (bias for 1.0), Significand: 0 (implicit 1.0)
-            Assert.IsTrue(smtStr.StartsWith("fp (_ bv"));
-            Assert.IsTrue(smtStr.Contains(" 1) (_ bv")); // 1-bit sign
-            Assert.IsTrue(smtStr.Contains(" 8) (_ bv")); // 8-bit exponent
-            Assert.IsTrue(smtStr.Contains(" 23)"));      // 23-bit significand
+            // This is the form SMTLibLineariser writes into the query, so the fields have to be right and
+            // not merely present: sign, then the biased exponent, then the stored significand.
+            Assert.AreEqual("fp (_ bv0 1) (_ bv127 8) (_ bv0 23)",
+                BigFloat.FromInt(1, 24, 8).ToSMTLibString(), "1.0");
+            Assert.AreEqual("fp (_ bv1 1) (_ bv127 8) (_ bv0 23)",
+                BigFloat.FromInt(-1, 24, 8).ToSMTLibString(), "-1.0 differs only in the sign bit");
+            Assert.AreEqual("fp (_ bv1 1) (_ bv0 8) (_ bv0 23)",
+                BigFloat.CreateZero(true, 24, 8).ToSMTLibString(), "negative zero");
+            Assert.AreEqual("fp (_ bv1 1) (_ bv0 8) (_ bv1 23)",
+                new BigFloat(true, 1, 0, 24, 8).ToSMTLibString(), "the negative smallest subnormal");
         }
 
         [Test]

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -4428,13 +4428,15 @@ namespace BaseTypesTests
             // We need a denominator with GetBitLength() > int.MaxValue / 0.31 ≈ 6.9 billion bits
             // This is impractical to create directly, so let's test the calculation logic
 
-            // For now, let's verify that extremely small numbers produce "0.0"
-            // Create the smallest possible subnormal for a large exponent size
+            // The smallest subnormal at a 16-bit exponent is 2^-32818, so ToDecimalString does not collapse
+            // it to "0.0": the scale it derives from the denominator's width gives an expansion thousands
+            // of digits long, ending in significant figures rather than in zeros.
             var extremeFormat = new BigFloat(false, 1, 0, 53, 16); // 16-bit exponent allows much smaller values
 
             var decimalStr = extremeFormat.ToDecimalString();
-            // This should work without overflow
-            Assert.IsNotNull(decimalStr);
+            Assert.IsTrue(decimalStr.StartsWith("0."), "a subnormal lies between 0 and 1");
+            Assert.Greater(decimalStr.Length, 10000, "the scale should track the exponent rather than truncate");
+            Assert.AreNotEqual('0', decimalStr[^1], "the expansion should end in a significant digit");
 
             // Note: Testing the actual overflow case where scale > int.MaxValue would require
             // a denominator with billions of bits, which is impractical in a unit test

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -872,9 +872,7 @@ namespace BaseTypesTests
             var result2 = hundred / (five * four);
 
             // Every step here is exact -- 100/5 is 20, 20/4 is 5, 5*4 is 20, 100/20 is 5 -- so the two
-            // orderings agree outright and there is no tolerance to allow. The comparison this replaced
-            // could not have run: BigFloat.FromInt(1) is (53,11) while diff is (24,8), so had the results
-            // differed it would have thrown on the size mismatch rather than reporting the difference.
+            // orderings agree outright and there is no tolerance to allow.
             Assert.AreEqual(result1, result2, "(100/5)/4 and 100/(5*4) are both exactly 5");
         }
 
@@ -1341,10 +1339,8 @@ namespace BaseTypesTests
         {
             // The limit is a width in bits, and a normal value's integer part is one bit wider than its
             // unbiased exponent, so the last accepted value is the one whose unbiased exponent is
-            // MaxFloorCeilingBits - 1. A 22-bit exponent field is the narrowest that reaches that far: its
-            // bias is 2^21 - 1, so the two exponents either side of the limit are both finite normals.
-            // The limit is on the width, not on the format, so it falls at the same unbiased exponent
-            // whatever the exponent field.
+            // MaxFloorCeilingBits - 1, at any exponent size. A 22-bit field is the narrowest that reaches
+            // that far, its bias being 2^21 - 1, so both exponents either side of the limit are normal.
             foreach (var exponentSize in new[] { 22, 23, 30 })
             {
                 var bias = BigFloat.GetBias(exponentSize);
@@ -4577,10 +4573,8 @@ namespace BaseTypesTests
             // Create a number that requires more than 24 bits
             var value = (BigInteger.One << 25) + 1; // 2^25 + 1
 
-            // This number cannot be exactly represented in 24 bits
-            // The current implementation appears to round rather than fail
-            // Only the low bit is discarded and it is below half, so 2^25 + 1 rounds down to 2^25 exactly.
-            // The conversion still reports itself inexact, since the input was not representable.
+            // Only the low bit is discarded and it is below half, so 2^25 + 1 rounds down to 2^25 exactly,
+            // and the conversion reports itself inexact because the input was not representable.
             var success = BigFloat.FromRational(value, 1, 24, 8, out var bf);
             Assert.IsFalse(success, "2^25 + 1 is not representable in 24 bits");
             Assert.AreEqual(BigFloat.FromBigInt(BigInteger.One << 25, 24, 8), bf,

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -3197,7 +3197,7 @@ namespace BaseTypesTests
         [Test]
         public void TestSubnormalArithmeticUnderflowBoundary()
         {
-            // Test the underflow threshold fix in HandleExponentBounds
+            // Test the underflow threshold handling in RoundToFormat
             // This is used internally by arithmetic operations
 
             // Create 2^(-126) (smallest normal) and divide by 2^20 to get 2^(-146)
@@ -3491,7 +3491,7 @@ namespace BaseTypesTests
         public void TestSubnormalRoundingUpToNormal()
         {
             // Test the edge case where arithmetic on subnormals can produce normal results
-            // This tests the fix in HandleExponentBounds
+            // This exercises the subnormal-to-normal carry in RoundToFormat
 
             // The largest subnormal is (2^23 - 1) × 2^(-149)
             var maxSubnormal = new BigFloat(false, (BigInteger)(1 << 23) - 1, 0, 24, 8);

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -101,7 +101,7 @@ namespace BaseTypesTests
         [Test]
         public void TestInvalidStringFormats()
         {
-            // All parsing errors now throw FormatException consistently
+            // FromString throws FormatException for every rejected input; TryParse returns false instead.
             Assert.Throws<FormatException>(() => BigFloat.FromString("invalid"));
             Assert.Throws<FormatException>(() => BigFloat.FromString("0x1.0")); // Missing exponent and sizes
             Assert.Throws<FormatException>(() => BigFloat.FromString("0x1.0e0")); // Missing sizes
@@ -326,8 +326,7 @@ namespace BaseTypesTests
                 "TryParseExact should parse -infinity");
             Assert.IsTrue(result.IsInfinity && result.IsNegative);
 
-            // Test whitespace handling with exact parsing
-            // TryParseExact likely rejects whitespace (unlike TryParse)
+            // Whitespace is rejected in both modes; the check sits outside the strict/lenient split.
             Assert.IsFalse(BigFloat.TryParseExact(" 0x1.0e0f24e8", out result),
                 "TryParseExact should reject leading whitespace");
 
@@ -371,8 +370,8 @@ namespace BaseTypesTests
             // Test hex strings that require rounding during parsing
             // Create a hex string with more precision than can be represented in 24 bits
 
-            // 24-bit significand can represent 6 hex digits after the point precisely
-            // Let's create one with 8 hex digits that will require rounding
+            // A 24-bit significand is six hex digits in total, and this literal supplies fourteen after
+            // the point, so most of them have to be rounded away.
             var longHexString = "0x1.123456789abcdee0f24e8";
 
             Assert.IsTrue(BigFloat.TryParse(longHexString, out var result),
@@ -3400,7 +3399,7 @@ namespace BaseTypesTests
         [Test]
         public void TestAllSubnormalSignificandValues()
         {
-            // Test creating subnormals with all valid significand values
+            // Test creating subnormals across the significand's width, one bit at a time
             for (int i = 1; i < 24; i++)
             {
                 var sig = (BigInteger)1 << i;
@@ -3941,7 +3940,7 @@ namespace BaseTypesTests
 
             // Valid format requires at least one digit after decimal point
             var result = BigFloat.FromString("0x1.0e0f24e8");
-            Assert.IsNotNull(result);
+            Assert.AreEqual(BigFloat.FromInt(1, 24, 8), result, "0x1.0e0f24e8 is 1.0");
         }
 
         [Test]
@@ -3954,7 +3953,6 @@ namespace BaseTypesTests
 
             // Valid format requires at least one digit before decimal point
             var half = BigFloat.FromString("0x0.8e0f24e8");
-            Assert.IsNotNull(half);
 
             // Verify it's actually 0.5
             var expectedHalf = BigFloat.FromRational(1, 2, 24, 8, out var h);
@@ -4136,17 +4134,11 @@ namespace BaseTypesTests
                 }
                 else
                 {
-                    // Debug output for failures
-                    if (original != parsed)
-                    {
-                        var (origSig, origExp, origSign) = GetBigFloatInternals(original);
-                        var (parsedSig, parsedExp, parsedSign) = GetBigFloatInternals(parsed);
-                        Console.WriteLine($"Round-trip failure for: {stringForm}");
-                        Console.WriteLine($"  Original: sig={origSig}, exp={origExp}, sign={origSign}");
-                        Console.WriteLine($"  Parsed:   sig={parsedSig}, exp={parsedExp}, sign={parsedSign}");
-                        Console.WriteLine($"  Exp diff: {parsedExp - origExp}");
-                    }
-                    Assert.AreEqual(original, parsed, $"Round-trip failed for: {stringForm}");
+                    var (origSig, origExp, origSign) = GetBigFloatInternals(original);
+                    var (parsedSig, parsedExp, parsedSign) = GetBigFloatInternals(parsed);
+                    Assert.AreEqual(original, parsed,
+                        $"Round-trip failed for {stringForm}: was (sig={origSig}, exp={origExp}, "
+                        + $"sign={origSign}), came back as (sig={parsedSig}, exp={parsedExp}, sign={parsedSign})");
                 }
             }
 
@@ -4244,8 +4236,9 @@ namespace BaseTypesTests
 
             // 1. Precision loss - IEEE mode rounds, strict mode rejects
             var precisionLoss = "0x1.ffffffe0f24e8"; // Too many bits for 24-bit significand
+            // 2 - 2^-24 is a tie between 2 - 2^-23 and 2, so IEEE mode rounds it to the even 2.0.
             var ieee1 = BigFloat.FromString(precisionLoss);
-            Assert.IsNotNull(ieee1); // IEEE mode accepts and rounds
+            Assert.AreEqual(BigFloat.FromInt(2, 24, 8), ieee1, "IEEE mode accepts and rounds");
             Assert.Throws<FormatException>(() => BigFloat.FromStringStrict(precisionLoss));
 
             // 2. Extreme underflow - IEEE mode returns zero, strict mode rejects
@@ -4300,13 +4293,12 @@ namespace BaseTypesTests
             var num = (BigInteger.One << 24) + 1; // 2^24 + 1
             var inexactSuccess = BigFloat.FromRational(num, BigInteger.One << 24, 53, 11, out var inexact);
 
-            // The behavior here depends on whether FromRational rounds or fails for inexact values
-            // Current implementation appears to round, so we test that behavior
-            if (inexactSuccess)
-            {
-                // If it succeeds, it should have rounded
-                Assert.IsNotNull(inexact);
-            }
+            // 2^24 + 1 needs 25 bits, which a 53-bit significand holds outright, so this is exact and
+            // 1 + 2^-24 stores a trailing significand of 2^28.
+            Assert.IsTrue(inexactSuccess, "(2^24 + 1) / 2^24 is representable at double precision");
+            var (inexactSig, inexactExp, _) = GetBigFloatInternals(inexact);
+            Assert.AreEqual(new BigInteger(1023), inexactExp, "1 + 2^-24 sits at the bias");
+            Assert.AreEqual(new BigInteger(268435456), inexactSig, "with 2^28 in the trailing significand");
         }
         [Test]
         public void TestMultiplicationAndDivisionOverflow()
@@ -4390,12 +4382,6 @@ namespace BaseTypesTests
             var diffSign = (bool)signField.GetValue(diff);
 
             // Check what's happening
-            Console.WriteLine($"\n=== Test Results ===");
-            Console.WriteLine($"negLarge: sign={negLargeSign}, sig={negLargeSig:X}, exp={negLargeExp}");
-            Console.WriteLine($"posSmall: created with sig=1, exp=0");
-            Console.WriteLine($"diff:     sign={diffSign}, sig={diffSig:X}, exp={diffExp}");
-            Console.WriteLine($"negLarge string: {negLarge}");
-            Console.WriteLine($"diff string:     {diff}");
 
             // The subtraction used to drop the significand, leaving the large operand's exponent with a
             // zero significand. A zero significand is legitimate on its own -- every power of two has one --
@@ -4496,10 +4482,13 @@ namespace BaseTypesTests
             var sum = medium1 + medium2;
             Assert.IsFalse(sum.IsInfinity, "Addition of equal numbers shouldn't overflow");
 
-            // Test with maximum allowed exponent size (30 bits)
+            // A 30-bit exponent is nothing special -- there is no upper bound on the size -- but it is wide
+            // enough that the bias no longer fits in a short int, so pin the value it produces.
             var extreme = BigFloat.FromInt(1, 24, 30);
-            Assert.IsNotNull(extreme, "Should be able to create BigFloat with 30-bit exponent");
+            var (extremeSig, extremeExp, _) = GetBigFloatInternals(extreme);
             Assert.IsFalse(extreme.IsInfinity, "FromInt(1) should not be infinity");
+            Assert.AreEqual(BigFloat.GetBias(30), extremeExp, "1.0 sits at the bias, whatever its width");
+            Assert.AreEqual(BigInteger.Zero, extremeSig, "and stores no significand bits");
         }
 
         [Test]
@@ -4559,8 +4548,8 @@ namespace BaseTypesTests
             var ieee = BigFloat.FromString("0x1.ffffffe0f24e8");  // Should round
             Assert.IsFalse(ieee.IsZero);
 
-            // In strict mode, this would throw (but we don't have access to FromStringStrict here)
-            // So we just verify IEEE mode handles it
+            Assert.Throws<FormatException>(() => BigFloat.FromStringStrict("0x1.ffffffe0f24e8"),
+                "strict mode rejects the precision loss that IEEE mode rounds away");
         }
 
         [Test]
@@ -4709,7 +4698,6 @@ namespace BaseTypesTests
 
             // Test 1: Exactly 0.5 × smallest subnormal = 2^(-150)
             var isExact = BigFloat.FromRational(BigInteger.One, BigInteger.Pow(2, 150), 24, 8, out var half);
-            Console.WriteLine($"0.5 × smallest subnormal: {half}, isZero: {half.IsZero}");
             Assert.IsTrue(half.IsZero, "Should round to zero (banker's rounding)");
 
             // Test 2: Slightly more than 0.5 × smallest subnormal
@@ -4718,18 +4706,15 @@ namespace BaseTypesTests
             var num = new BigInteger(50001);
             var den = new BigInteger(100000) * BigInteger.Pow(2, 149);
             isExact = BigFloat.FromRational(num, den, 24, 8, out var slightlyMore);
-            Console.WriteLine($"Slightly > 0.5 × smallest: {slightlyMore}, isSubnormal: {slightlyMore.IsSubnormal}");
             Assert.IsTrue(slightlyMore.IsSubnormal, "Should round to smallest subnormal");
             Assert.AreEqual("0x0.8e-37f24e8", slightlyMore.ToString());
 
             // Test 3: 0.75 × smallest subnormal
             isExact = BigFloat.FromRational(new BigInteger(3), BigInteger.Pow(2, 151), 24, 8, out var threeQuarters);
-            Console.WriteLine($"0.75 × smallest subnormal: {threeQuarters}");
             Assert.IsTrue(threeQuarters.IsSubnormal, "Should round to smallest subnormal");
 
             // Test 4: 1.5 × smallest subnormal
             isExact = BigFloat.FromRational(new BigInteger(3), BigInteger.Pow(2, 150), 24, 8, out var oneAndHalf);
-            Console.WriteLine($"1.5 × smallest subnormal: {oneAndHalf}");
             Assert.IsTrue(oneAndHalf.IsSubnormal, "Should round to 2 × smallest subnormal");
             Assert.AreEqual("0x1.0e-37f24e8", oneAndHalf.ToString());
         }
@@ -5208,39 +5193,31 @@ namespace BaseTypesTests
         [Test]
         public void TestBiasedExponentAtBoundaries()
         {
-            // Test all values where biasedExp is near critical boundaries
-            // This tests the specific range where the original bug occurred
-
-            // For double precision: bias = 1023, significandSize = 53
-            // minBiasedExp = 2 - 53 = -51
-            // Bug occurred when biasedExp == -52
-
-            // Create values that will have biasedExp in [-54, -50]
+            // Walks the boundary between what the subnormal grid can hold and what underflows to zero.
+            // The quantity that decides it is the biased exponent a value would have if normalized where it
+            // stands, which for 2^k is k + bias. At double precision the smallest such value still
+            // representable is that of the smallest subnormal, 2^(1 - bias - 52), which comes to
+            // 2 - significandSize = -51. So 2^(targetBiasedExp - 1023) is representable down to -51,
+            // exactly half the smallest subnormal at -52, and smaller still below that.
             for (int targetBiasedExp = -54; targetBiasedExp <= -50; targetBiasedExp++)
             {
-                // For a value 2^k, biasedExp = bias + 1 - scaleBits - 1 = 1023 - scaleBits
-                // So for biasedExp = targetBiasedExp, we need scaleBits = 1023 - targetBiasedExp
-                var exponent = targetBiasedExp - 1023; // Actual exponent
-
-                // Test exact power of 2
+                var exponent = targetBiasedExp - 1023;
                 var num = BigInteger.One;
-                var denom = BigInteger.One << (-exponent); // 2^(-exponent)
+                var denom = BigInteger.One << (-exponent);
 
                 BigFloat.FromRational(num, denom, 53, 11, out var result);
 
                 if (targetBiasedExp >= -51)
                 {
-                    // Should be subnormal or normal
-                    Assert.IsFalse(result.IsZero, $"2^({exponent}) should not underflow to zero");
+                    Assert.IsFalse(result.IsZero, $"2^({exponent}) is on the subnormal grid");
                 }
                 else if (targetBiasedExp == -52)
                 {
-                    // This is exactly 0.5 * smallest subnormal - should round to zero
-                    Assert.IsTrue(result.IsZero, $"2^({exponent}) = 0.5 * smallest should round to zero");
+                    // Exactly half the smallest subnormal, so a tie, so it goes to the even zero.
+                    Assert.IsTrue(result.IsZero, $"2^({exponent}) = 0.5 * smallest should tie to zero");
                 }
                 else
                 {
-                    // Should underflow to zero
                     Assert.IsTrue(result.IsZero, $"2^({exponent}) should underflow to zero");
                 }
             }


### PR DESCRIPTION
`BigFloat`'s arithmetic rounds twice. The first rounding discards the remainder the second needs to tell "exactly halfway" from "just above halfway", so round-to-nearest-even breaks ties the wrong way. IEEE-754 requires one rounding against the exact residual.

Against an oracle that computes in `BigInteger` and rounds once, over 40000 random operand pairs:

| | before | after |
|---|---|---|
| `operator/` at (24,8) | 18.67 % wrong by ≥1 ULP | **0.00 %** |
| `operator/` at (53,11) | 18.88 % | **0.00 %** |
| `FromRational` at (24,8) | 4.65 % | **0.00 %** |
| `FromRational` at (53,11) | 4.65 % | **0.00 %** |

`operator+`/`-`/`*` truncate rather than carry a sticky bit, also 0.00 % after. That rate depends on the operands: the harness above uses integers, which do not trigger it, while subnormal and widely-separated ones do.

## Scope

The four operators are unreachable from `.bpl` input — only `BinaryOperator.Evaluate` reaches them, and nothing in the product calls it. Real float arithmetic happens in the solver, on `fp.*` terms.

`FromRational` **is** reachable. Under `/infer:j` a float variable live across a loop head acquires integer bounds from `TryFloorCeiling`, and `Node.ToExpr`'s float branch renders them back through `NumberToExpr` → `FromBigInt` → `FromRational`.

It cannot observe the defect. Those bounds are floors and ceilings of floats, whose integer parts always fit their own format, so nothing is rounded — exact for every bound emitted across 400 `Test/` files, one of them `2^72`. An inexact bound would hold anyway: a float variable takes only representable values, so `Lo <= f` with adjacent representables `a < Lo < b` already gives `f >= b`, and either neighbour is true.

Not a soundness bug, then, but for a narrower reason than "nothing calls it". Wiring up `Evaluate`, or handing the domain a bound that is not a float's own floor, would change that.

## Fix

`RoundToFormat` is the only place that rounds. Callers compute with guard bits, record a sticky bit via `WithStickyBit`, and hand the result over once. `NormalizeAndRound`, `ApplyRoundToNearestEven` and `HandleExponentBounds` are gone; `HandleUnderflow` delegates rather than rounding for itself.

`FromRational` no longer infers exactness from what the rounding did — that is what tangled the two jobs. Exactness is a property of the input, which `RepresentsExactly` settles by cross-multiplying the result back against the original fraction in integers.

Wide formats never materialise astronomical values: a 40-bit exponent puts the smallest subnormal at `2^-549755813909`, where neither `2^shift` nor the shifted value fits a `BigInteger`, so those cases are decided by comparison. `SubnormalArithmeticIsBiasIndependent` throws `OverflowException` if that path goes.

## Parsing

One behaviour change is visible from `.bpl` input. The old parser decided "below the subnormal grid" from the exponent *before* rounding, so it flushed the band between half and one times the smallest subnormal to zero, and rejected it in strict mode. Of 11664 literals swept through both modes on both branches, 22 differ, all in that band: `0x6.0e-38f24e8` is three quarters of `2^-149` and now rounds up to it. Nothing the old parser accepted changed value and nothing it accepted is now rejected — some former parse errors work. `BoogiePL.atg` takes the strict path, so that is the side users see.

## Testing

`BigFloatDifferentialTests.cs` is the prerequisite, not the follow-up: perturbing division by 1 ULP failed 3 of the existing tests, and a correct fix (18.67 % → 0.00 %) failed none. Two oracles — exact `BigInteger`, and hardware `float`/`double` — are cross-checked by `OraclesAgreeWithEachOther` first, since a `(float)((double)n/d)` reference double-rounds and reproduces the very bug. Coverage spans significand sizes 2–113 and exponent sizes 5–100.

Stryker.NET over `BigFloat.cs` puts the suite at **87.78 %**: 562 of 663 mutants killed. Most of the 81 survivors are exception-message text, `Contract.Requires` this build compiles out, or boundary flips where both branches provably agree.

Test counts rise 200 → 231. Full `lit`: 671 tests, failing only `z3-hard-timeout`, `CaptureInlineUnroll` and `InterestingExamples4`, which fail identically on pristine `master`.

## Not addressed

- **No rounding-mode parameter.** Every operator hardcodes RNE, so every rate above is RNE only. Modes reach the solver directly and never touch `BigFloat`, but retrofitting one changes every signature.
- **Whether `BigFloat` arithmetic should exist**, given it has one caller that cannot tell the difference. That needs either a rounding-sensitive consumer or deletion in favour of a value/parse/print type; this PR fixes the arithmetic without settling it.
