### PR TITLE
fix: Crash on wide-exponent floats in abstract interpretation, and a missing size check

### DIFF
--- a/Source/AbstractInterpretation/IntervalDomain.cs
+++ b/Source/AbstractInterpretation/IntervalDomain.cs
@@ -958,18 +958,19 @@ namespace Microsoft.Boogie.AbstractInterpretation
         }
         else if (node.Val is BigFloat)
         {
+          // NaN and the infinities have no integer bounds, and a float with a wide exponent has bounds
+          // too large to be worth computing -- the floor of the largest float24e32 is a 256 MB integer.
+          // Both are "no useful bound", which the interval domain already represents as null.
           var bf = (BigFloat) node.Val;
-          if (bf.IsNaN || bf.IsInfinity)
+          if (bf.TryFloorCeiling(out var floor, out var ceiling))
           {
-            // NaN and infinity have no meaningful integer bounds
-            Lo = null;
-            Hi = null;
+            Lo = floor;
+            Hi = ceiling;
           }
           else
           {
-            bf.FloorCeiling(out var floor, out var ceiling);
-            Lo = floor;
-            Hi = ceiling;
+            Lo = null;
+            Hi = null;
           }
         }
         else if (node.Val is bool)

--- a/Source/AbstractInterpretation/IntervalDomain.cs
+++ b/Source/AbstractInterpretation/IntervalDomain.cs
@@ -958,9 +958,6 @@ namespace Microsoft.Boogie.AbstractInterpretation
         }
         else if (node.Val is BigFloat)
         {
-          // NaN and the infinities have no integer bounds, and a float with a wide exponent has bounds
-          // too large to be worth computing -- the floor of the largest float24e32 is a 256 MB integer.
-          // Both are "no useful bound", which the interval domain already represents as null.
           var bf = (BigFloat) node.Val;
           if (bf.TryFloorCeiling(out var floor, out var ceiling))
           {
@@ -969,6 +966,7 @@ namespace Microsoft.Boogie.AbstractInterpretation
           }
           else
           {
+            // NaN, an infinity, or bounds too wide to compute
             Lo = null;
             Hi = null;
           }

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -579,22 +579,7 @@ namespace Microsoft.BaseTypes
     [Pure] public static BigFloat Max(BigFloat x, BigFloat y) => x.IsNaN || y.IsNaN ? (x.IsNaN ? x : y) : (x >= y ? x : y);
     [Pure] public static BigFloat Min(BigFloat x, BigFloat y) => x.IsNaN || y.IsNaN ? (x.IsNaN ? x : y) : (x <= y ? x : y);
     /// <summary>
-    /// "x" with the sign of "y", which must have the same format.
-    ///
-    /// The arithmetic operators validate unconditionally: <see cref="operator +"/>,
-    /// <see cref="operator *"/> and <see cref="operator /"/> call
-    /// <see cref="ValidateSizeCompatibility"/> before touching the operands, and
-    /// <see cref="operator -(BigFloat, BigFloat)"/> inherits that through addition. CopySign had no such
-    /// check; copying a sign does not itself need the formats to agree, so this call buys uniformity
-    /// rather than correctness -- but an operation that quietly accepts what its neighbours reject is the
-    /// one a size confusion travels through.
-    ///
-    /// The comparisons, <see cref="Equals(object)"/>, <see cref="Max"/> and <see cref="Min"/> only reach
-    /// the check via <see cref="CompareTo(BigFloat)"/>, and they all test for NaN first, so a mismatch
-    /// involving a NaN is never checked. For the comparisons that is harmless -- IEEE 754 makes every
-    /// NaN comparison false whatever the formats -- but Max(float24e8, NaN53e11) returns the NaN itself,
-    /// so the result's format depends on the operands' values rather than their types. Fixing that
-    /// belongs with the special-value handling rather than with a sign copy.
+    /// Returns "x" with the sign of "y". Both must have the same format.
     /// </summary>
     [Pure] public static BigFloat CopySign(BigFloat x, BigFloat y)
     {
@@ -874,27 +859,15 @@ namespace Microsoft.BaseTypes
     #region Mathematical Operations
 
     /// <summary>
-    /// Widest floor/ceiling <see cref="TryFloorCeiling"/> will produce, in bits.
-    ///
-    /// Exponent sizes are unbounded, so a float's integer part is too: at float24e32 the floor of the
-    /// largest finite value is a 256 MB integer, and at float24e40 it exceeds what BigInteger can
-    /// represent at all. Both are faithful answers to the question asked -- the cost is proportional to
-    /// the result, not wasted -- which is why the limit belongs to callers that cannot use an answer that
-    /// large rather than to the computation.
-    ///
-    /// The cap has to clear the widest integer part a standard format can have, which is set by the
-    /// exponent field: 2^bias needs bias + 1 bits, so single needs 128, double 1024, quad 16384 and
-    /// octuple 262144. A million bits leaves 4x headroom over octuple and still bounds the work at a few
-    /// hundred KB. The narrowest format it declines is float*e22, wider than anything IEEE 754 names.
+    /// Bound on the width of the integers <see cref="TryFloorCeiling"/> will produce. Since exponent sizes
+    /// are unbounded, so are integer parts: the floor of a large float24e32 has 256 million bits. The bound
+    /// is well above the widest standard format's integer part, which is bias + 1 bits (262144 for octuple).
     /// </summary>
     public const int MaxFloorCeilingBits = 1 << 20;
 
     /// <summary>
-    /// As <see cref="FloorCeiling"/>, but returns false instead of producing a result wider than
-    /// <see cref="MaxFloorCeilingBits"/>, and false rather than throwing on NaN and the infinities.
-    ///
-    /// For callers that want an integer bound only if it is small enough to be worth having; a caller
-    /// that needs the exact value regardless should use FloorCeiling and accept the size.
+    /// As <see cref="FloorCeiling"/>, but returns false instead of throwing on NaN and the infinities or
+    /// producing a result wider than <see cref="MaxFloorCeilingBits"/>.
     /// </summary>
     public bool TryFloorCeiling(out BigInteger floor, out BigInteger ceiling)
     {
@@ -904,8 +877,7 @@ namespace Microsoft.BaseTypes
         return false;
       }
 
-      // The value's magnitude is below 2^(exponent - bias + 1), so that exponent bounds the width of its
-      // integer part. Checking it here keeps the oversized shift from being attempted at all.
+      // The magnitude is below 2^(exponent - bias + 1), so that bounds the width of the integer part.
       if (!IsZero && GetActualExponent() - bias + 1 > MaxFloorCeilingBits) {
         return false;
       }
@@ -917,9 +889,7 @@ namespace Microsoft.BaseTypes
     /// <summary>
     /// Computes the floor and ceiling of this BigFloat. Note the choice of rounding towards negative
     /// infinity rather than zero for floor is because SMT-LIBv2's to_int function floors this way.
-    ///
-    /// Both can be enormous, since exponent sizes are unbounded -- see <see cref="TryFloorCeiling"/> for
-    /// the variant that declines instead.
+    /// See <see cref="TryFloorCeiling"/> for a variant that declines instead of returning huge integers.
     /// </summary>
     /// <param name="floor">Floor (rounded towards negative infinity)</param>
     /// <param name="ceiling">Ceiling (rounded towards positive infinity)</param>

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -579,9 +579,22 @@ namespace Microsoft.BaseTypes
     [Pure] public static BigFloat Max(BigFloat x, BigFloat y) => x.IsNaN || y.IsNaN ? (x.IsNaN ? x : y) : (x >= y ? x : y);
     [Pure] public static BigFloat Min(BigFloat x, BigFloat y) => x.IsNaN || y.IsNaN ? (x.IsNaN ? x : y) : (x <= y ? x : y);
     /// <summary>
-    /// "x" with the sign of "y". Takes two operands of the same format, as every other binary operation
-    /// here does: nothing about copying a sign needs the formats to agree, but silently accepting a
-    /// mismatch would let a size confusion through the one operation that does not check.
+    /// "x" with the sign of "y", which must have the same format.
+    ///
+    /// The arithmetic operators validate unconditionally: <see cref="operator +"/>,
+    /// <see cref="operator *"/> and <see cref="operator /"/> call
+    /// <see cref="ValidateSizeCompatibility"/> before touching the operands, and
+    /// <see cref="operator -(BigFloat, BigFloat)"/> inherits that through addition. CopySign had no such
+    /// check; copying a sign does not itself need the formats to agree, so this call buys uniformity
+    /// rather than correctness -- but an operation that quietly accepts what its neighbours reject is the
+    /// one a size confusion travels through.
+    ///
+    /// The comparisons, <see cref="Equals(object)"/>, <see cref="Max"/> and <see cref="Min"/> only reach
+    /// the check via <see cref="CompareTo(BigFloat)"/>, and they all test for NaN first, so a mismatch
+    /// involving a NaN is never checked. For the comparisons that is harmless -- IEEE 754 makes every
+    /// NaN comparison false whatever the formats -- but Max(float24e8, NaN53e11) returns the NaN itself,
+    /// so the result's format depends on the operands' values rather than their types. Fixing that
+    /// belongs with the special-value handling rather than with a sign copy.
     /// </summary>
     [Pure] public static BigFloat CopySign(BigFloat x, BigFloat y)
     {
@@ -861,8 +874,52 @@ namespace Microsoft.BaseTypes
     #region Mathematical Operations
 
     /// <summary>
+    /// Widest floor/ceiling <see cref="TryFloorCeiling"/> will produce, in bits.
+    ///
+    /// Exponent sizes are unbounded, so a float's integer part is too: at float24e32 the floor of the
+    /// largest finite value is a 256 MB integer, and at float24e40 it exceeds what BigInteger can
+    /// represent at all. Both are faithful answers to the question asked -- the cost is proportional to
+    /// the result, not wasted -- which is why the limit belongs to callers that cannot use an answer that
+    /// large rather than to the computation.
+    ///
+    /// The cap has to clear the widest integer part a standard format can have, which is set by the
+    /// exponent field: 2^bias needs bias + 1 bits, so single needs 128, double 1024, quad 16384 and
+    /// octuple 262144. A million bits leaves 4x headroom over octuple and still bounds the work at a few
+    /// hundred KB. The narrowest format it declines is float*e22, wider than anything IEEE 754 names.
+    /// </summary>
+    public const int MaxFloorCeilingBits = 1 << 20;
+
+    /// <summary>
+    /// As <see cref="FloorCeiling"/>, but returns false instead of producing a result wider than
+    /// <see cref="MaxFloorCeilingBits"/>, and false rather than throwing on NaN and the infinities.
+    ///
+    /// For callers that want an integer bound only if it is small enough to be worth having; a caller
+    /// that needs the exact value regardless should use FloorCeiling and accept the size.
+    /// </summary>
+    public bool TryFloorCeiling(out BigInteger floor, out BigInteger ceiling)
+    {
+      floor = ceiling = BigInteger.Zero;
+
+      if (IsNaN || IsInfinity) {
+        return false;
+      }
+
+      // The value's magnitude is below 2^(exponent - bias + 1), so that exponent bounds the width of its
+      // integer part. Checking it here keeps the oversized shift from being attempted at all.
+      if (!IsZero && GetActualExponent() - bias + 1 > MaxFloorCeilingBits) {
+        return false;
+      }
+
+      FloorCeiling(out floor, out ceiling);
+      return true;
+    }
+
+    /// <summary>
     /// Computes the floor and ceiling of this BigFloat. Note the choice of rounding towards negative
     /// infinity rather than zero for floor is because SMT-LIBv2's to_int function floors this way.
+    ///
+    /// Both can be enormous, since exponent sizes are unbounded -- see <see cref="TryFloorCeiling"/> for
+    /// the variant that declines instead.
     /// </summary>
     /// <param name="floor">Floor (rounded towards negative infinity)</param>
     /// <param name="ceiling">Ceiling (rounded towards positive infinity)</param>

--- a/Source/BaseTypes/BigFloat.cs
+++ b/Source/BaseTypes/BigFloat.cs
@@ -578,7 +578,16 @@ namespace Microsoft.BaseTypes
     [Pure] public static BigFloat Abs(BigFloat x) => x.signBit ? -x : x;
     [Pure] public static BigFloat Max(BigFloat x, BigFloat y) => x.IsNaN || y.IsNaN ? (x.IsNaN ? x : y) : (x >= y ? x : y);
     [Pure] public static BigFloat Min(BigFloat x, BigFloat y) => x.IsNaN || y.IsNaN ? (x.IsNaN ? x : y) : (x <= y ? x : y);
-    [Pure] public static BigFloat CopySign(BigFloat x, BigFloat y) => x.signBit == y.signBit ? x : -x;
+    /// <summary>
+    /// "x" with the sign of "y". Takes two operands of the same format, as every other binary operation
+    /// here does: nothing about copying a sign needs the formats to agree, but silently accepting a
+    /// mismatch would let a size confusion through the one operation that does not check.
+    /// </summary>
+    [Pure] public static BigFloat CopySign(BigFloat x, BigFloat y)
+    {
+      ValidateSizeCompatibility(x, y);
+      return x.signBit == y.signBit ? x : -x;
+    }
 
     /// <summary>
     /// Returns the sign: -1 for negative, 0 for zero/NaN, 1 for positive

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -1317,11 +1317,66 @@ namespace BaseTypesTests
             }, "Less than operator should validate size compatibility");
         }
 
+        /// <summary>
+        /// Exponent sizes are unbounded, so a float's integer part is too. TryFloorCeiling exists for
+        /// callers that want a bound only when it is small enough to use, and it must decide that without
+        /// first computing the oversized value -- at float24e40 the floor exceeds what BigInteger can hold,
+        /// which reached the abstract interpreter as an unhandled OverflowException.
+        /// </summary>
+        [Test]
+        public void TestTryFloorCeilingDeclinesOversizedBounds()
+        {
+            foreach (var exponentSize in new[] { 24, 32, 40, 60 })
+            {
+                var literal = $"0x1.0e{((BigInteger.One << (exponentSize - 1)) - 1) / 4}f24e{exponentSize}";
+                Assert.IsTrue(BigFloat.TryParse(literal, out var huge), literal);
+                Assert.IsFalse(huge.IsInfinity, $"{literal} should be finite");
+
+                var before = GC.GetTotalAllocatedBytes(precise: true);
+                Assert.IsFalse(huge.TryFloorCeiling(out _, out _),
+                    $"{literal} has bounds too wide to be worth computing");
+                var allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+
+                Assert.Less(allocated, 1024 * 1024,
+                    $"declining {literal} allocated {allocated / 1024.0 / 1024.0:F1} MB, so it computed the value first");
+            }
+
+            // NaN and the infinities have no integer bounds either, and decline rather than throwing.
+            foreach (var special in new[] { "0NaN24e8", "0+oo24e8", "0-oo24e8" })
+            {
+                Assert.IsFalse(BigFloat.FromString(special).TryFloorCeiling(out _, out _), special);
+            }
+        }
+
+        /// <summary>
+        /// Whenever TryFloorCeiling accepts, it must give exactly what FloorCeiling gives; the limit may
+        /// only decide whether to answer, never change the answer.
+        /// </summary>
+        [Test]
+        public void TestTryFloorCeilingAgreesWithFloorCeiling()
+        {
+            foreach (var literal in new[]
+                     {
+                         "0x0.0e0f24e8", "-0x0.0e0f24e8", "0x1.0e0f24e8", "-0x1.8e0f24e8",
+                         "0x0.8e-126f24e8", "0x0.000002e-126f24e8", "0x1.fffffee31f24e8",
+                         "0x1.0e0f53e11", "-0x1.921fb6e1f24e8"
+                     })
+            {
+                var value = BigFloat.FromString(literal);
+                Assert.IsTrue(value.TryFloorCeiling(out var floor, out var ceiling), literal);
+
+                value.FloorCeiling(out var expectedFloor, out var expectedCeiling);
+                Assert.AreEqual(expectedFloor, floor, $"floor of {literal}");
+                Assert.AreEqual(expectedCeiling, ceiling, $"ceiling of {literal}");
+            }
+        }
+
         [Test]
         public void TestCopySignRejectsIncompatibleSizes()
         {
-            // CopySign was the one binary operation that accepted mismatched formats, so a size confusion
-            // passed through it silently while every sibling rejected it.
+            // CopySign accepted mismatched formats while the arithmetic operators and comparisons all
+            // rejected them, so a size confusion passed through it silently. Max and Min have a separate
+            // gap for NaN operands, which this does not cover.
             var float24bit = BigFloat.FromInt(10, 24, 8);
             var float53bit = BigFloat.FromInt(10, 53, 11);
 

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -1318,6 +1318,22 @@ namespace BaseTypesTests
         }
 
         [Test]
+        public void TestCopySignRejectsIncompatibleSizes()
+        {
+            // CopySign was the one binary operation that accepted mismatched formats, so a size confusion
+            // passed through it silently while every sibling rejected it.
+            var float24bit = BigFloat.FromInt(10, 24, 8);
+            var float53bit = BigFloat.FromInt(10, 53, 11);
+
+            Assert.Throws<ArgumentException>(() => BigFloat.CopySign(float24bit, float53bit),
+                "CopySign should validate size compatibility");
+
+            // Matching formats still work, and the sign is taken from the second operand.
+            Assert.AreEqual(-float24bit, BigFloat.CopySign(float24bit, BigFloat.FromInt(-1, 24, 8)),
+                "CopySign(10, -1) should be -10");
+        }
+
+        [Test]
         public void TestCompareToValidatesCompatibleSizes()
         {
             // Test that CompareTo now validates size compatibility

--- a/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
+++ b/Source/UnitTests/BaseTypesTests/BigFloatTests.cs
@@ -1317,12 +1317,6 @@ namespace BaseTypesTests
             }, "Less than operator should validate size compatibility");
         }
 
-        /// <summary>
-        /// Exponent sizes are unbounded, so a float's integer part is too. TryFloorCeiling exists for
-        /// callers that want a bound only when it is small enough to use, and it must decide that without
-        /// first computing the oversized value -- at float24e40 the floor exceeds what BigInteger can hold,
-        /// which reached the abstract interpreter as an unhandled OverflowException.
-        /// </summary>
         [Test]
         public void TestTryFloorCeilingDeclinesOversizedBounds()
         {
@@ -1332,26 +1326,23 @@ namespace BaseTypesTests
                 Assert.IsTrue(BigFloat.TryParse(literal, out var huge), literal);
                 Assert.IsFalse(huge.IsInfinity, $"{literal} should be finite");
 
+                // The oversized bounds must be declined without being computed first, which the
+                // allocation check verifies
                 var before = GC.GetTotalAllocatedBytes(precise: true);
-                Assert.IsFalse(huge.TryFloorCeiling(out _, out _),
-                    $"{literal} has bounds too wide to be worth computing");
+                Assert.IsFalse(huge.TryFloorCeiling(out _, out _), $"{literal} has bounds too wide to compute");
                 var allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
 
                 Assert.Less(allocated, 1024 * 1024,
-                    $"declining {literal} allocated {allocated / 1024.0 / 1024.0:F1} MB, so it computed the value first");
+                    $"declining {literal} allocated {allocated / 1024.0 / 1024.0:F1} MB");
             }
 
-            // NaN and the infinities have no integer bounds either, and decline rather than throwing.
+            // NaN and the infinities decline rather than throwing
             foreach (var special in new[] { "0NaN24e8", "0+oo24e8", "0-oo24e8" })
             {
                 Assert.IsFalse(BigFloat.FromString(special).TryFloorCeiling(out _, out _), special);
             }
         }
 
-        /// <summary>
-        /// Whenever TryFloorCeiling accepts, it must give exactly what FloorCeiling gives; the limit may
-        /// only decide whether to answer, never change the answer.
-        /// </summary>
         [Test]
         public void TestTryFloorCeilingAgreesWithFloorCeiling()
         {
@@ -1374,16 +1365,13 @@ namespace BaseTypesTests
         [Test]
         public void TestCopySignRejectsIncompatibleSizes()
         {
-            // CopySign accepted mismatched formats while the arithmetic operators and comparisons all
-            // rejected them, so a size confusion passed through it silently. Max and Min have a separate
-            // gap for NaN operands, which this does not cover.
             var float24bit = BigFloat.FromInt(10, 24, 8);
             var float53bit = BigFloat.FromInt(10, 53, 11);
 
             Assert.Throws<ArgumentException>(() => BigFloat.CopySign(float24bit, float53bit),
                 "CopySign should validate size compatibility");
 
-            // Matching formats still work, and the sign is taken from the second operand.
+            // Matching formats still work, taking the sign from the second operand
             Assert.AreEqual(-float24bit, BigFloat.CopySign(float24bit, BigFloat.FromInt(-1, 24, 8)),
                 "CopySign(10, -1) should be -10");
         }

--- a/Test/floats/WideExponentBounds.bpl
+++ b/Test/floats/WideExponentBounds.bpl
@@ -1,12 +1,8 @@
 // RUN: %parallel-boogie -infer:j "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-// Abstract interpretation asks a float literal for integer bounds. Exponent sizes are unbounded, so
-// those bounds can be enormous: at float24e32 the floor of a large value is a 256 MB integer, and at
-// float24e40 it exceeds what BigInteger can represent -- which surfaced here as an unhandled
-// OverflowException rather than as a verification result.
-//
-// -infer:j is what reaches the interval domain; without it these literals are only parsed and printed.
+// The interval domain (-infer:j) asks float literals for integer bounds, which used to crash on floats
+// whose exponent makes those bounds huge.
 
 procedure large24e32() returns (r: int) {
   var f: float24e32;
@@ -20,15 +16,14 @@ procedure large24e40() returns (r: int) {
   if (f == 0x1.0e137438953471f24e40) { r := 1; } else { r := 0; }
 }
 
-// A tiny value at a wide exponent bounds to 0/1 cheaply, so declining the wide case must not have made
-// the whole format unusable.
+// A small value in a wide format still gets its bounds
 procedure small24e32() returns (r: int) {
   var f: float24e32;
   f := 0x1.0e-536870911f24e32;
   if (f == 0x1.0e-536870911f24e32) { r := 1; } else { r := 0; }
 }
 
-// Ordinary formats keep their bounds; this is the behaviour the size limit must leave alone.
+// Ordinary formats are unaffected
 procedure ordinary() returns (r: int) {
   var f: float24e8;
   f := 0x1.8e0f24e8;

--- a/Test/floats/WideExponentBounds.bpl
+++ b/Test/floats/WideExponentBounds.bpl
@@ -1,0 +1,36 @@
+// RUN: %parallel-boogie -infer:j "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Abstract interpretation asks a float literal for integer bounds. Exponent sizes are unbounded, so
+// those bounds can be enormous: at float24e32 the floor of a large value is a 256 MB integer, and at
+// float24e40 it exceeds what BigInteger can represent -- which surfaced here as an unhandled
+// OverflowException rather than as a verification result.
+//
+// -infer:j is what reaches the interval domain; without it these literals are only parsed and printed.
+
+procedure large24e32() returns (r: int) {
+  var f: float24e32;
+  f := 0x1.0e536870911f24e32;
+  if (f == 0x1.0e536870911f24e32) { r := 1; } else { r := 0; }
+}
+
+procedure large24e40() returns (r: int) {
+  var f: float24e40;
+  f := 0x1.0e137438953471f24e40;
+  if (f == 0x1.0e137438953471f24e40) { r := 1; } else { r := 0; }
+}
+
+// A tiny value at a wide exponent bounds to 0/1 cheaply, so declining the wide case must not have made
+// the whole format unusable.
+procedure small24e32() returns (r: int) {
+  var f: float24e32;
+  f := 0x1.0e-536870911f24e32;
+  if (f == 0x1.0e-536870911f24e32) { r := 1; } else { r := 0; }
+}
+
+// Ordinary formats keep their bounds; this is the behaviour the size limit must leave alone.
+procedure ordinary() returns (r: int) {
+  var f: float24e8;
+  f := 0x1.8e0f24e8;
+  if (f == 0x1.8e0f24e8) { r := 1; } else { r := 0; }
+}

--- a/Test/floats/WideExponentBounds.bpl.expect
+++ b/Test/floats/WideExponentBounds.bpl.expect
@@ -1,0 +1,2 @@
+
+Boogie program verifier finished with 4 verified, 0 errors


### PR DESCRIPTION
Two independent `BigFloat` fixes, one commit each. Both apply to `master` directly.

## 1. Abstract interpretation crashes on a wide-exponent float literal

Abstract interpretation asks every literal for integer bounds. Exponent sizes are unbounded, so for a float those bounds are too. From five lines of `.bpl` under `-infer:j`:

```boogie
procedure main() returns (r: int) {
  var f: float24e40;
  f := 0x1.0e137438953471f24e40;
  if (f == 0x1.0e137438953471f24e40) { r := 1; } else { r := 0; }
}
```

```
Unhandled exception. System.OverflowException: Arithmetic operation resulted in an overflow.
  at System.Numerics.BigInteger.op_LeftShift(BigInteger, Int32)
  at Microsoft.BaseTypes.BigFloat.FloorCeiling(BigInteger&, BigInteger&)
  at ...NativeIntervalDomain.PEVisitor.VisitLiteralExpr(LiteralExpr) IntervalDomain.cs:970
```

| | before | after |
|---|---|---|
| `float24e32`, peak RSS | 1.4 GB | **80 MB** |
| `float24e40` | **unhandled `OverflowException`** | verifies |
| `float24e8` (ordinary) | 80 MB | 80 MB |

**The allocation is not waste.** `FloorCeiling` allocates a constant 3× the size of the answer it returns, and `floor(2^2147483644)` genuinely *is* a 256 MB integer. So the limit belongs to callers that cannot use a bound that large, not to the computation.

`TryFloorCeiling` declines above a width bound, **deciding from the exponent alone** so the oversized value is never built, and returns false rather than throwing on NaN and the infinities. The interval domain treats declining as "no bound" — what it already does for NaN and infinity two lines above. `FloorCeiling` keeps its exact contract.

**Testing.** `TryFloorCeiling` agrees with `FloorCeiling` on all **96695 values it accepts** across five formats, 0 mismatches: the limit decides whether to answer, never what the answer is. Declining costs 0 MB at exponent sizes 24, 32, 40 and 60. `Test/floats/WideExponentBounds.bpl` covers the end-to-end path, since the unit tests cannot reach `IntervalDomain`; it **fails on a pristine `master` worktree** and passes here. Removing the width guard is caught by both tests.

## 2. `CopySign` skips the size-compatibility check every sibling enforces

```
CopySign(float24e8, float53e11)   // returns -0x1.0e0f24e8, no exception
```

The diff only shows the line being added, so to be explicit about what was already there. Enumerating every public two-operand entry point by reflection and calling each with mismatched formats across plain, NaN, infinity and zero operands:

| operation | plain | either operand NaN |
|---|---|---|
| `+` `-` `*` `/`, `CompareTo` | reject | reject |
| `CopySign` (**this change**) | reject | reject |
| `==` `!=` `<` `>` `<=` `>=`, `Equals` | reject | **accept** |
| `Max`, `Min` | reject | **accept** |

Nothing about copying a sign *needs* matching formats, so this buys uniformity rather than correctness — but an operation that quietly accepts what its neighbours reject is the one a size confusion travels through.

**The NaN column is a pre-existing gap, left for a separate change.** Everything except the arithmetic operators reaches the check only through `CompareTo`, and all of them test for NaN first, short-circuiting before it. For the comparisons this is harmless: IEEE 754 makes every NaN comparison false regardless of format, and the returned answers are correct. `Max`/`Min` are the real defect —

```
Max(float24e8, NaN53e11)  ->  0NaN53e11    (a float24e8 operand yields a float53e11)
```

— so the result's format depends on the operands' *values* rather than their types. The arithmetic operators avoid this by validating before `HandleSpecialValues`; fixing `Max`/`Min` belongs with that special-value handling rather than in a sign-copy commit.

## Verification

Both commits build and pass individually. 200 `BaseTypesTests`, 59 `CoreTests`, 29 `ExecutionEngineTests`. Full `lit`: 669 tests, failing only `z3-hard-timeout`, `CaptureInlineUnroll` and `InterestingExamples4`, which fail identically on a pristine `master` worktree.

Merging all three float PRs together was checked in a scratch worktree: no conflicts, 234 `BaseTypesTests`, 670 `lit` tests, same three pre-existing failures.
