### PR TITLE
Fix interval transfer functions that report unreachable bounds

### DIFF
--- a/Source/AbstractInterpretation/IntervalDomain.cs
+++ b/Source/AbstractInterpretation/IntervalDomain.cs
@@ -1298,8 +1298,9 @@ namespace Microsoft.Boogie.AbstractInterpretation
                   // A product over a box is extremal at a corner. With both intervals reaching
                   // below zero the maximum is at the two lower bounds or at the two upper bounds
                   // (a corner mixing the two has a non-positive factor pairing, which cannot beat
-                  // lo0 * lo1 > 0). An unbounded upper end therefore leaves the product unbounded
-                  // above: taking lo0 * lo1 there claims a bound that x = y = 100 already exceeds.
+                  // lo0 * lo1 > 0). Without both upper bounds, decline to infer one: some such
+                  // intervals are still bounded above, but recognizing them requires more sign
+                  // cases than this incomplete approximation handles.
                   if (hi0 != null && hi1 != null)
                   {
                     var upper0 = isReal ? (BigInteger) hi0 : (BigInteger) hi0 - 1;
@@ -1353,16 +1354,8 @@ namespace Microsoft.Boogie.AbstractInterpretation
 
               break;
             case BinaryOperator.Opcode.Pow:
-              // this uses an incomplete approximation that could be tightened up.
-              // The exponent's upper bound says nothing about the size of the power, so there is
-              // no upper bound to report: with y <= 3, 2.0 ** y still reaches 8.0. The result is
-              // at least one only when the base is, since 0 ** 1 is 0.
-              if (lo0 != null && lo1 != null && 0 <= (BigInteger) lo0 && 0 <= (BigInteger) lo1)
-              {
-                Lo = 1 <= (BigInteger) lo0 ? BigInteger.One : BigInteger.Zero;
-                Hi = null;
-              }
-
+              // Real exponentiation is encoded as an uninterpreted function without axioms, so
+              // no result bound follows from bounds on its operands.
               break;
             default:
               break;

--- a/Source/AbstractInterpretation/IntervalDomain.cs
+++ b/Source/AbstractInterpretation/IntervalDomain.cs
@@ -1296,14 +1296,31 @@ namespace Microsoft.Boogie.AbstractInterpretation
                 else if ((BigInteger) lo0 < 0 && (BigInteger) lo1 < 0)
                 {
                   Lo = null; // approximation
-                  Hi = isReal ? lo0 * lo1 : lo0 * lo1 + 1;
+                  // A product over a box is extremal at a corner. With both intervals reaching
+                  // below zero the maximum is at the two lower bounds or at the two upper bounds
+                  // (a corner mixing the two has a non-positive factor pairing, which cannot beat
+                  // lo0 * lo1 > 0). An unbounded upper end therefore leaves the product unbounded
+                  // above: taking lo0 * lo1 there claims a bound that x = y = 100 already exceeds.
+                  if (hi0 != null && hi1 != null)
+                  {
+                    var upper0 = isReal ? (BigInteger) hi0 : (BigInteger) hi0 - 1;
+                    var upper1 = isReal ? (BigInteger) hi1 : (BigInteger) hi1 - 1;
+                    var max = BigInteger.Max((BigInteger) lo0 * (BigInteger) lo1, upper0 * upper1);
+                    Hi = isReal ? max : max + 1;
+                  }
+                  else
+                  {
+                    Hi = null;
+                  }
                 }
               }
 
               break;
             case BinaryOperator.Opcode.Div:
-              // this uses an incomplete approximation that could be tightened up
-              if (lo0 != null && lo1 != null && 0 <= (BigInteger) lo0 && 0 <= (BigInteger) lo1)
+              // this uses an incomplete approximation that could be tightened up.
+              // The divisor must be kept away from zero: division by zero is uninterpreted in
+              // SMT-LIB, so "x div 0" is not bounded by anything the operands say.
+              if (lo0 != null && lo1 != null && 0 <= (BigInteger) lo0 && 1 <= (BigInteger) lo1)
               {
                 Lo = BigInteger.Zero;
                 Hi = hi0;
@@ -1311,8 +1328,9 @@ namespace Microsoft.Boogie.AbstractInterpretation
 
               break;
             case BinaryOperator.Opcode.Mod:
-              // this uses an incomplete approximation that could be tightened up
-              if (lo0 != null && lo1 != null && 0 <= (BigInteger) lo0 && 0 <= (BigInteger) lo1)
+              // this uses an incomplete approximation that could be tightened up.
+              // As for Div, a divisor of zero leaves the result uninterpreted.
+              if (lo0 != null && lo1 != null && 0 <= (BigInteger) lo0 && 1 <= (BigInteger) lo1)
               {
                 Lo = BigInteger.Zero;
                 Hi = hi1;
@@ -1325,20 +1343,25 @@ namespace Microsoft.Boogie.AbstractInterpretation
 
               break;
             case BinaryOperator.Opcode.RealDiv:
-              // this uses an incomplete approximation that could be tightened up
-              if (lo0 != null && lo1 != null && 0 <= (BigInteger) lo0 && 0 <= (BigInteger) lo1)
+              // this uses an incomplete approximation that could be tightened up.
+              // The guard rules out a zero divisor, so the upper bound no longer needs to
+              // re-test it: with 1 <= y and 0 <= x, x / y <= x.
+              if (lo0 != null && lo1 != null && 0 <= (BigInteger) lo0 && 1 <= (BigInteger) lo1)
               {
                 Lo = BigInteger.Zero;
-                Hi = 1 <= (BigInteger) lo1 ? hi0 : null;
+                Hi = hi0;
               }
 
               break;
             case BinaryOperator.Opcode.Pow:
-              // this uses an incomplete approximation that could be tightened up
+              // this uses an incomplete approximation that could be tightened up.
+              // The exponent's upper bound says nothing about the size of the power, so there is
+              // no upper bound to report: with y <= 3, 2.0 ** y still reaches 8.0. The result is
+              // at least one only when the base is, since 0 ** 1 is 0.
               if (lo0 != null && lo1 != null && 0 <= (BigInteger) lo0 && 0 <= (BigInteger) lo1)
               {
-                Lo = 1 <= (BigInteger) lo1 ? BigInteger.One : BigInteger.Zero;
-                Hi = hi1;
+                Lo = 1 <= (BigInteger) lo0 ? BigInteger.One : BigInteger.Zero;
+                Hi = null;
               }
 
               break;

--- a/Test/aitest0/UnsoundTransferFunctions.bpl
+++ b/Test/aitest0/UnsoundTransferFunctions.bpl
@@ -1,0 +1,74 @@
+// RUN: %parallel-boogie -infer:j /errorTrace:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Inferred invariants are injected as `assume {:inferred} ...` and never discharged, so an
+// interval transfer function that reports a bound the operation can exceed is unsound: the
+// assumption makes the path vacuous and false assertions verify.
+
+// Mul: with both intervals reaching below zero, the maximum is at the two lower bounds OR at
+// the two upper bounds. Taking the lower-bound product alone claimed x * y < 2 here, which
+// x == y == 100 exceeds.
+procedure MulBothNegativeLowerBounds(x: int, y: int)
+  requires -1 <= x;
+  requires -1 <= y;
+{
+  var r: int;
+  var i: int;
+  r := x * y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+  if (x == 100 && y == 100) {
+    assert false;  // error
+  }
+}
+
+// Div and Mod: division by zero is uninterpreted in SMT-LIB, so with a divisor that may be
+// zero the result is not bounded by anything the operands say.
+procedure DivByPossiblyZero(x: int, y: int) returns (r: int)
+  requires 0 <= x;
+  requires 0 <= y;
+  ensures 0 <= r;  // error
+{
+  var i: int;
+  r := x div y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+}
+
+procedure ModByPossiblyZero(x: int, y: int) returns (r: int)
+  requires 0 <= x;
+  requires 0 <= y;
+  ensures 0 <= r;  // error
+{
+  var i: int;
+  r := x mod y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+}
+
+// The bounds are still inferred when the divisor is known to be positive.
+procedure DivByPositive(x: int, y: int) returns (r: int)
+  requires 0 <= x;
+  requires x < 100;
+  requires 1 <= y;
+  ensures 0 <= r;
+{
+  var i: int;
+  r := x div y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+}
+
+// And Mul keeps its bound when both intervals are bounded above.
+procedure MulBothNegativeBounded(x: int, y: int) returns (r: int)
+  requires -5 <= x;
+  requires x <= -1;
+  requires -5 <= y;
+  requires y <= -1;
+  ensures r <= 25;
+{
+  var i: int;
+  r := x * y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+}

--- a/Test/aitest0/UnsoundTransferFunctions.bpl
+++ b/Test/aitest0/UnsoundTransferFunctions.bpl
@@ -46,6 +46,33 @@ procedure ModByPossiblyZero(x: int, y: int) returns (r: int)
   while (i < 1) { i := i + 1; }
 }
 
+// RealDiv needs the same zero-divisor guard. With only y >= 0, the SMT encoding permits
+// a negative value for x / 0 even when x is nonnegative.
+procedure RealDivByPossiblyZero(x: real, y: real) returns (r: real)
+  requires 0.0 <= x;
+  requires 0.0 <= y;
+  ensures 0.0 <= r;  // error
+{
+  var i: int;
+  r := x / y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+}
+
+// A divisor of at least one still gives both the lower bound and r <= x.
+procedure RealDivByAtLeastOne(x: real, y: real) returns (r: real)
+  requires 0.0 <= x;
+  requires x <= 100.0;
+  requires 1.0 <= y;
+  ensures 0.0 <= r;
+  ensures r <= 100.0;
+{
+  var i: int;
+  r := x / y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+}
+
 // The bounds are still inferred when the divisor is known to be positive.
 procedure DivByPositive(x: int, y: int) returns (r: int)
   requires 0 <= x;

--- a/Test/aitest0/UnsoundTransferFunctions.bpl.expect
+++ b/Test/aitest0/UnsoundTransferFunctions.bpl.expect
@@ -1,0 +1,7 @@
+UnsoundTransferFunctions.bpl(21,5): Error: this assertion could not be proved
+UnsoundTransferFunctions.bpl(35,3): Error: a postcondition could not be proved on this return path
+UnsoundTransferFunctions.bpl(30,3): Related location: this is the postcondition that could not be proved
+UnsoundTransferFunctions.bpl(46,3): Error: a postcondition could not be proved on this return path
+UnsoundTransferFunctions.bpl(41,3): Related location: this is the postcondition that could not be proved
+
+Boogie program verifier finished with 2 verified, 3 errors

--- a/Test/aitest0/UnsoundTransferFunctions.bpl.expect
+++ b/Test/aitest0/UnsoundTransferFunctions.bpl.expect
@@ -3,5 +3,7 @@ UnsoundTransferFunctions.bpl(35,3): Error: a postcondition could not be proved o
 UnsoundTransferFunctions.bpl(30,3): Related location: this is the postcondition that could not be proved
 UnsoundTransferFunctions.bpl(46,3): Error: a postcondition could not be proved on this return path
 UnsoundTransferFunctions.bpl(41,3): Related location: this is the postcondition that could not be proved
+UnsoundTransferFunctions.bpl(59,3): Error: a postcondition could not be proved on this return path
+UnsoundTransferFunctions.bpl(54,3): Related location: this is the postcondition that could not be proved
 
-Boogie program verifier finished with 2 verified, 3 errors
+Boogie program verifier finished with 3 verified, 4 errors

--- a/Test/aitest1/Linear5.bpl.expect
+++ b/Test/aitest1/Linear5.bpl.expect
@@ -30,11 +30,11 @@ implementation p()
   C:
     assume {:inferred} -1 <= x && 0 <= y;
     x := x * x;
-    assume {:inferred} x < 2 && 0 <= y;
+    assume {:inferred} 0 <= y;
     goto D, E;
 
   D:
-    assume {:inferred} x < 2 && 0 <= y;
+    assume {:inferred} 0 <= y;
     x := y;
     assume {:inferred} 0 <= x && 0 <= y;
     return;

--- a/Test/aitest1/PowBounds.bpl
+++ b/Test/aitest1/PowBounds.bpl
@@ -1,0 +1,27 @@
+// RUN: %parallel-boogie -infer:j -instrumentInfer:e -printInstrumented -noVerify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Pow is encoded as an uninterpreted function without axioms. Bounds on its operands
+// therefore imply no bound on its result.
+procedure PowNonnegativeOperands(x: real, y: real)
+  requires 0.0 <= x;
+  requires 0.0 <= y;
+{
+  var r: real;
+  var i: int;
+  r := x ** y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+}
+
+// Even a base of at least one does not imply a bound without axioms for Pow.
+procedure PowBaseAtLeastOne(x: real, y: real)
+  requires 1.0 <= x;
+  requires 0.0 <= y;
+{
+  var r: real;
+  var i: int;
+  r := x ** y;
+  i := 0;
+  while (i < 1) { i := i + 1; }
+}

--- a/Test/aitest1/PowBounds.bpl.expect
+++ b/Test/aitest1/PowBounds.bpl.expect
@@ -1,0 +1,79 @@
+procedure PowNonnegativeOperands(x: real, y: real);
+  requires 0e0 <= x;
+  requires 0e0 <= y;
+
+
+
+implementation PowNonnegativeOperands(x: real, y: real)
+{
+  var r: real;
+  var i: int;
+
+  anon0:
+    assume {:inferred} 0e0 <= x && 0e0 <= y;
+    r := x ** y;
+    i := 0;
+    assume {:inferred} i == 0 && 0e0 <= x && 0e0 <= y;
+    goto anon2_LoopHead;
+
+  anon2_LoopHead:  // cut point
+    assume {:inferred} 0 <= i && i < 2 && 0e0 <= x && 0e0 <= y;
+    assume {:inferred} 0 <= i && i < 2 && 0e0 <= x && 0e0 <= y;
+    goto anon2_LoopDone, anon2_LoopBody;
+
+  anon2_LoopBody:
+    assume {:inferred} 0 <= i && i < 2 && 0e0 <= x && 0e0 <= y;
+    assume {:partition} i < 1;
+    i := i + 1;
+    assume {:inferred} i == 1 && 0e0 <= x && 0e0 <= y;
+    goto anon2_LoopHead;
+
+  anon2_LoopDone:
+    assume {:inferred} 0 <= i && i < 2 && 0e0 <= x && 0e0 <= y;
+    assume {:partition} 1 <= i;
+    assume {:inferred} i == 1 && 0e0 <= x && 0e0 <= y;
+    return;
+}
+
+
+
+procedure PowBaseAtLeastOne(x: real, y: real);
+  requires 1e0 <= x;
+  requires 0e0 <= y;
+
+
+
+implementation PowBaseAtLeastOne(x: real, y: real)
+{
+  var r: real;
+  var i: int;
+
+  anon0:
+    assume {:inferred} 1e0 <= x && 0e0 <= y;
+    r := x ** y;
+    i := 0;
+    assume {:inferred} i == 0 && 1e0 <= x && 0e0 <= y;
+    goto anon2_LoopHead;
+
+  anon2_LoopHead:  // cut point
+    assume {:inferred} 0 <= i && i < 2 && 1e0 <= x && 0e0 <= y;
+    assume {:inferred} 0 <= i && i < 2 && 1e0 <= x && 0e0 <= y;
+    goto anon2_LoopDone, anon2_LoopBody;
+
+  anon2_LoopBody:
+    assume {:inferred} 0 <= i && i < 2 && 1e0 <= x && 0e0 <= y;
+    assume {:partition} i < 1;
+    i := i + 1;
+    assume {:inferred} i == 1 && 1e0 <= x && 0e0 <= y;
+    goto anon2_LoopHead;
+
+  anon2_LoopDone:
+    assume {:inferred} 0 <= i && i < 2 && 1e0 <= x && 0e0 <= y;
+    assume {:partition} 1 <= i;
+    assume {:inferred} i == 1 && 1e0 <= x && 0e0 <= y;
+    return;
+}
+
+
+
+Boogie program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
## Why this matters

With `-infer:j`, Boogie's interval analysis inserts loop invariants as `assume {:inferred} ...`. These assumptions are not proved later, so every inferred interval must contain every reachable value. A bound that is too tight is therefore a soundness bug: it can remove a real execution and make a false assertion verify.

I intend to land this fix. My motivation is to keep Boogie sound for downstream verification tools that rely on inferred invariants.

## Concrete example

```boogie
procedure P(x: int, y: int)
  requires -1 <= x;
  requires -1 <= y;
{
  var r: int;
  var i: int;
  r := x * y;
  i := 0;
  while (i < 1) { i := i + 1; }
  if (x == 100 && y == 100) {
    assert false;
  }
}
```

The interval domain represents an integer upper bound as an exclusive endpoint, `r < Hi`. On `master`, the multiplication rule computes `Hi = lo(x) * lo(y) + 1`. With `lo(x) = lo(y) = -1`, this gives `Hi = (-1) * (-1) + 1 = 2`, so Boogie infers `r < 2` (equivalently, `r <= 1`).

That calculation incorrectly treats the product of the lower bounds as the maximum product. In this example, `x = y = 100` satisfies the preconditions and gives `r = 10000`. The inferred `r < 2` assumption makes that execution unreachable, so the false assertion is incorrectly reported as verified.

With this PR, no upper bound is inferred in this case, and Boogie correctly reports the assertion as an error.

## What changes

The patch fixes three patterns in five arithmetic transfer-function branches:

| Operation | Problem with the old rule | New rule |
| --- | --- | --- |
| `x * y` when both lower bounds are negative | Used `lo(x) * lo(y)` as the upper bound, ignoring large positive operands. | If both upper bounds exist, use the maximum of the two relevant corner products. Otherwise, infer no upper bound. |
| `div`, `mod`, and real division | Inferred bounds when the divisor could be zero. Division by zero is unconstrained in the SMT encoding. For real division, `x / y <= x` also requires `y >= 1`. | Require the divisor's lower bound to be at least one before inferring these bounds. |
| `x ** y` | Inferred bounds from the operands even though Boogie encodes exponentiation as the uninterpreted function `real_pow` without axioms. | Infer no lower or upper bound. |

These changes deliberately prefer a weaker interval over an incorrect one. Losing precision may produce an extra verification error; inventing a bound can incorrectly verify a program.

## Tests

`UnsoundTransferFunctions.bpl` checks that:

- the multiplication example above now reports an error;
- integer division and modulo with a possibly-zero divisor no longer prove a nonnegative result;
- real division with a possibly-zero divisor no longer proves a nonnegative result;
- positive integer and real divisors still yield useful bounds; and
- multiplication still gets an upper bound when both operands are bounded above.

`PowBounds.bpl` is an inference-only test. It prints the instrumented program with `-noVerify` and checks that no bound on the power result is introduced, both for nonnegative operands and for a base of at least one. This directly tests the transfer function without asking the solver to interpret the otherwise-unaxiomatized `real_pow` function.

The existing `Linear5.bpl.expect` is updated because it previously pinned the invalid `x < 2` multiplication bound.

Validation with Z3 5.1.0: the solution builds with no warnings or errors, all 17 abstract-interpretation tests pass, and all 516 unit tests pass.

AI assistance: Claude Code helped investigate and implement the original change; I reviewed and extended the code and tests and intend to maintain it.
