### PR TITLE
Fix stack overflow on a recursive polymorphic inlined procedure

### DIFF
--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -1288,11 +1288,6 @@ namespace Microsoft.Boogie
     private Dictionary<Function, Dictionary<List<Type>, Function>> functionInstantiations;
     private Dictionary<Procedure, Dictionary<List<Type>, Procedure>> procInstantiations;
     private Dictionary<Implementation, Dictionary<List<Type>, Implementation>> implInstantiations;
-
-    // Instantiations whose body is currently being walked. An instantiation is not entered into
-    // implInstantiations until its body is complete, so this is what tells InlineCallCmd that a
-    // call it is about to inline leads back into an instantiation that is already being built.
-    private Dictionary<Implementation, HashSet<List<Type>>> implInstantiationsInProgress;
     private Dictionary<TypeCtorDecl, Dictionary<List<Type>, TypeCtorDecl>> typeInstantiations;
     private HashSet<Declaration> newInstantiatedDeclarations;
     private List<BinderExprMonomorphizer> binderExprMonomorphizers;
@@ -1317,14 +1312,12 @@ namespace Microsoft.Boogie
       originalAxiomToSplitAxioms = program.Axioms.ToDictionary(ax => ax, _ => new HashSet<Axiom>());
       originalAxiomToOriginalSymbols = program.Axioms.ToDictionary(ax => ax, ax => new FunctionAndConstantCollector(ax));
       implInstantiations = new Dictionary<Implementation, Dictionary<List<Type>, Implementation>>();
-      implInstantiationsInProgress = new Dictionary<Implementation, HashSet<List<Type>>>();
       nameToImplementation = new Dictionary<string, Implementation>();
       program.TopLevelDeclarations.OfType<Implementation>().Where(impl => impl.TypeParameters.Count > 0).ForEach(
         impl =>
         {
           nameToImplementation.Add(impl.Name, impl);
           implInstantiations.Add(impl, new Dictionary<List<Type>, Implementation>(new ListComparer<Type>()));
-          implInstantiationsInProgress.Add(impl, new HashSet<List<Type>>(new ListComparer<Type>()));
         });
       procInstantiations = new Dictionary<Procedure, Dictionary<List<Type>, Procedure>>();
       nameToProcedure = new Dictionary<string, Procedure>();
@@ -1593,11 +1586,9 @@ namespace Microsoft.Boogie
       if (procToImpl.ContainsKey(callCmd.Proc))
       {
         var impl = procToImpl[callCmd.Proc];
-        // Inlining a call whose target instantiation is still being built would walk that body a
-        // second time and re-enter here on the same call, so a recursive inlined procedure would
-        // recurse without bound and overflow the stack. The instantiation already under
-        // construction is the one this call needs; it is completed by the frame that started it.
-        if (IsInlined(impl) && !implInstantiationsInProgress[impl].Contains(actualTypeParams))
+        // The dictionary contains a null sentinel while an instantiation's body is being walked.
+        // That prevents recursive inlined calls from trying to build the same instantiation again.
+        if (IsInlined(impl) && !implInstantiations[impl].ContainsKey(actualTypeParams))
         {
           InstantiateImplementation(impl, actualTypeParams);
         }
@@ -1725,12 +1716,14 @@ namespace Microsoft.Boogie
     {
       if (!implInstantiations[impl].ContainsKey(actualTypeParams))
       {
-        implInstantiationsInProgress[impl].Add(actualTypeParams);
         var implTypeParamInstantiation = impl.TypeParameters.MapTo(actualTypeParams);
         var instantiatedInParams = InstantiateFormals(impl.InParams, implTypeParamInstantiation);
         var instantiatedOutParams = InstantiateFormals(impl.OutParams, implTypeParamInstantiation);
         var instantiatedLocalVariables = InstantiateLocalVariables(impl.LocVars, implTypeParamInstantiation);
         var variableMapping = impl.InParams.Union(impl.OutParams).Union(impl.LocVars).MapTo(instantiatedInParams.Union(instantiatedOutParams).Union(instantiatedLocalVariables));
+        // Record the key before walking the blocks, since an inlined call in the body can lead
+        // back to this instantiation. The completed implementation replaces the sentinel below.
+        implInstantiations[impl][actualTypeParams] = null;
         var blocks = impl.Blocks
           .Select(block => (Block)InstantiateAbsy(block, implTypeParamInstantiation, variableMapping)).ToList();
         var blockMapping = impl.Blocks.MapTo(blocks);
@@ -1751,7 +1744,6 @@ namespace Microsoft.Boogie
         implInstantiations[impl][actualTypeParams] = instantiatedImpl;
         declWithFormalsToTypeInstantiation[instantiatedImpl] =
           impl.TypeParameters.Select(x => x.Name).MapTo(actualTypeParams);
-        implInstantiationsInProgress[impl].Remove(actualTypeParams);
       }
       return implInstantiations[impl][actualTypeParams];
     }

--- a/Source/Core/Monomorphization.cs
+++ b/Source/Core/Monomorphization.cs
@@ -1288,6 +1288,11 @@ namespace Microsoft.Boogie
     private Dictionary<Function, Dictionary<List<Type>, Function>> functionInstantiations;
     private Dictionary<Procedure, Dictionary<List<Type>, Procedure>> procInstantiations;
     private Dictionary<Implementation, Dictionary<List<Type>, Implementation>> implInstantiations;
+
+    // Instantiations whose body is currently being walked. An instantiation is not entered into
+    // implInstantiations until its body is complete, so this is what tells InlineCallCmd that a
+    // call it is about to inline leads back into an instantiation that is already being built.
+    private Dictionary<Implementation, HashSet<List<Type>>> implInstantiationsInProgress;
     private Dictionary<TypeCtorDecl, Dictionary<List<Type>, TypeCtorDecl>> typeInstantiations;
     private HashSet<Declaration> newInstantiatedDeclarations;
     private List<BinderExprMonomorphizer> binderExprMonomorphizers;
@@ -1312,12 +1317,14 @@ namespace Microsoft.Boogie
       originalAxiomToSplitAxioms = program.Axioms.ToDictionary(ax => ax, _ => new HashSet<Axiom>());
       originalAxiomToOriginalSymbols = program.Axioms.ToDictionary(ax => ax, ax => new FunctionAndConstantCollector(ax));
       implInstantiations = new Dictionary<Implementation, Dictionary<List<Type>, Implementation>>();
+      implInstantiationsInProgress = new Dictionary<Implementation, HashSet<List<Type>>>();
       nameToImplementation = new Dictionary<string, Implementation>();
       program.TopLevelDeclarations.OfType<Implementation>().Where(impl => impl.TypeParameters.Count > 0).ForEach(
         impl =>
         {
           nameToImplementation.Add(impl.Name, impl);
           implInstantiations.Add(impl, new Dictionary<List<Type>, Implementation>(new ListComparer<Type>()));
+          implInstantiationsInProgress.Add(impl, new HashSet<List<Type>>(new ListComparer<Type>()));
         });
       procInstantiations = new Dictionary<Procedure, Dictionary<List<Type>, Procedure>>();
       nameToProcedure = new Dictionary<string, Procedure>();
@@ -1586,7 +1593,11 @@ namespace Microsoft.Boogie
       if (procToImpl.ContainsKey(callCmd.Proc))
       {
         var impl = procToImpl[callCmd.Proc];
-        if (IsInlined(impl))
+        // Inlining a call whose target instantiation is still being built would walk that body a
+        // second time and re-enter here on the same call, so a recursive inlined procedure would
+        // recurse without bound and overflow the stack. The instantiation already under
+        // construction is the one this call needs; it is completed by the frame that started it.
+        if (IsInlined(impl) && !implInstantiationsInProgress[impl].Contains(actualTypeParams))
         {
           InstantiateImplementation(impl, actualTypeParams);
         }
@@ -1714,6 +1725,7 @@ namespace Microsoft.Boogie
     {
       if (!implInstantiations[impl].ContainsKey(actualTypeParams))
       {
+        implInstantiationsInProgress[impl].Add(actualTypeParams);
         var implTypeParamInstantiation = impl.TypeParameters.MapTo(actualTypeParams);
         var instantiatedInParams = InstantiateFormals(impl.InParams, implTypeParamInstantiation);
         var instantiatedOutParams = InstantiateFormals(impl.OutParams, implTypeParamInstantiation);
@@ -1739,6 +1751,7 @@ namespace Microsoft.Boogie
         implInstantiations[impl][actualTypeParams] = instantiatedImpl;
         declWithFormalsToTypeInstantiation[instantiatedImpl] =
           impl.TypeParameters.Select(x => x.Name).MapTo(actualTypeParams);
+        implInstantiationsInProgress[impl].Remove(actualTypeParams);
       }
       return implInstantiations[impl][actualTypeParams];
     }

--- a/Test/monomorphize/issue-1147.bpl
+++ b/Test/monomorphize/issue-1147.bpl
@@ -1,0 +1,115 @@
+// RUN: %parallel-boogie /errorTrace:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// The execution traces are suppressed because they name inlined monomorphic instances
+// (inline$Rec_65$0$...), and that numbering shifts whenever type allocation elsewhere
+// changes, which would make the expected output brittle for reasons unrelated to this test.
+
+// Instantiating the body of a recursive polymorphic inlined procedure re-entered
+// InstantiateImplementation with the same (implementation, type arguments) pair before
+// that pair had been registered, so the guard on implInstantiations never fired and the
+// monomorphizer recursed until the stack overflowed and the process aborted. The
+// recursion in the source is bounded, but the monomorphizer recurses on the syntactic
+// call rather than on the value, so the bound is irrelevant.
+//
+// Every inlining depth below exceeds the recursion depth of the corresponding call, so
+// the base case is reached and the assertions are not discharged vacuously. That matters
+// for the error cases: under the default /inline:assume a call still standing at the
+// depth bound is replaced by "assume false", which would make the false assertions in
+// RecError and MutualError verify instead of reporting an error.
+
+procedure {:inline 3} Rec<T>(x: T, n: int) returns (y: T)
+{
+  if (n > 0) { call y := Rec(x, n - 1); } else { y := x; }
+}
+
+procedure RecInt()
+{
+  var a: int;
+  var b: int;
+  a := 3;
+  call b := Rec(a, 2);
+  assert b == 3;
+}
+
+// A second instantiation of the same implementation. The registration is keyed by the
+// type arguments, so this one must be built independently of the first.
+
+procedure RecBool()
+{
+  var p: bool;
+  var q: bool;
+  p := true;
+  call q := Rec(p, 2);
+  assert q;
+}
+
+// A cycle spanning two implementations rather than a self-call.
+
+procedure {:inline 3} Ping<T>(x: T, n: int) returns (y: T)
+{
+  if (n > 0) { call y := Pong(x, n - 1); } else { y := x; }
+}
+
+procedure {:inline 3} Pong<T>(x: T, n: int) returns (y: T)
+{
+  if (n > 0) { call y := Ping(x, n - 1); } else { y := x; }
+}
+
+procedure Mutual()
+{
+  var a: int;
+  var b: int;
+  a := 5;
+  call b := Ping(a, 2);
+  assert b == 5;
+}
+
+// A nested instantiation: while Nest is being instantiated at int, its own body asks for Nest at
+// bool. An instantiation under construction is identified by the implementation together with its
+// type arguments, so the inner request has to be built rather than mistaken for the outer one; a
+// check that looked only at the implementation would drop it.
+
+procedure {:inline 3} Nest<T>(x: T, n: int) returns (y: T)
+{
+  var c: bool;
+  if (n > 0) { call c := Nest(true, 0); call y := Nest(x, n - 1); } else { y := x; }
+}
+
+procedure Nested()
+{
+  var a: int;
+  var b: int;
+  a := 7;
+  call b := Nest(a, 2);
+  assert b == 7;
+}
+
+// The obligations above are really checked, not vacuously discharged.
+
+procedure RecError()
+{
+  var a: int;
+  var b: int;
+  a := 3;
+  call b := Rec(a, 2);
+  assert b == 4;  // error
+}
+
+procedure MutualError()
+{
+  var a: int;
+  var b: int;
+  a := 5;
+  call b := Ping(a, 2);
+  assert b == 6;  // error
+}
+
+procedure NestedError()
+{
+  var a: int;
+  var b: int;
+  a := 7;
+  call b := Nest(a, 2);
+  assert b == 8;  // error
+}

--- a/Test/monomorphize/issue-1147.bpl.expect
+++ b/Test/monomorphize/issue-1147.bpl.expect
@@ -1,0 +1,5 @@
+issue-1147.bpl(96,3): Error: this assertion could not be proved
+issue-1147.bpl(105,3): Error: this assertion could not be proved
+issue-1147.bpl(114,3): Error: this assertion could not be proved
+
+Boogie program verifier finished with 4 verified, 3 errors


### PR DESCRIPTION
Fixes #1147.

A recursive polymorphic `{:inline}` procedure sent the monomorphizer into unbounded recursion, aborting the process with empty stdout:

```boogie
procedure {:inline 1} P<T>(x: T, n: int) returns (y: T)
{
  if (n > 0) { call y := P(x, n-1); } else { y := x; }
}
procedure main() { var a: int; var b: int; a := 3; call b := P(a, 2); assert b == 3; }
```

An inlined callee is instantiated at the point of the call, so the body being walked asks for its own instantiation — and that instantiation is not entered into `implInstantiations` until the walk completes, so the guard in `InstantiateImplementation` never fires. Mutual recursion and longer cycles trigger it too. `ExpandingTypeCycle` does not catch it, since the type argument never grows.

Fix: track the instantiations whose body is being walked, and have `InlineCallCmd` skip a call that leads back into one. The set is keyed by the implementation *and* its type arguments, because a different instantiation of the same implementation can legitimately be built while one is in progress.

Hoisting the `Implementation` construction above the block walk also breaks the recursion, but `Absy`'s constructor draws from a process-global id counter that feeds `MkInstanceName`, so allocating it earlier renames every generated instance — changing `/print` output, the SMT-LIB handed to the solver, and inlined labels in execution traces, for programs that never had the bug. Guarding the call site instead leaves all of that byte-identical.

The test covers self-recursion, a second type instantiation, mutual recursion, and a nested instantiation. Its error cases use an inlining depth that reaches the base case, so they are not vacuously discharged by the `assume false` that `/inline:assume` inserts at the depth bound.
